### PR TITLE
fix(nuxt-auth-sp): clean stale stubs before build to fix mkdist crash

### DIFF
--- a/modules/nuxt-auth-idp/package.json
+++ b/modules/nuxt-auth-idp/package.json
@@ -17,8 +17,9 @@
     "dist"
   ],
   "scripts": {
+    "clean:stubs": "find src/runtime \\( -name '*.d.ts' -o -name '*.d.vue.ts' -o -name '*.js' \\) -delete 2>/dev/null; true",
     "prepack": "nuxt-module-build build",
-    "prebuild": "find src/runtime \\( -name '*.d.ts' -o -name '*.d.vue.ts' -o -name '*.js' \\) -delete 2>/dev/null; true",
+    "prebuild": "pnpm clean:stubs",
     "build": "nuxt-module-build build",
     "dev": "nuxt-module-build build --stub",
     "prepare": "nuxt-module-build build --stub && nuxi prepare playground",

--- a/modules/nuxt-auth-sp/package.json
+++ b/modules/nuxt-auth-sp/package.json
@@ -21,8 +21,9 @@
     "dist"
   ],
   "scripts": {
+    "clean:stubs": "find src/runtime \\( -name '*.d.ts' -o -name '*.d.vue.ts' -o -name '*.js' \\) -delete 2>/dev/null; true",
     "prepack": "nuxt-module-build build",
-    "prebuild": "find src/runtime \\( -name '*.d.ts' -o -name '*.d.vue.ts' -o -name '*.js' \\) -delete 2>/dev/null; true",
+    "prebuild": "pnpm clean:stubs",
     "build": "nuxt-module-build build",
     "dev": "nuxt-module-build build --stub",
     "prepare": "nuxt-module-build build --stub && nuxi prepare playground",


### PR DESCRIPTION
Closes #15

## Problem

`nuxt-auth-sp` Build crashed mit `Cannot read properties of undefined (reading 'errors')` in mkdist 2.4.1. Ursache: alte `.d.ts`/`.js`-Stubs von einer früheren `nuxt-module-build --stub`-Version im `src/runtime/`-Verzeichnis, die mkdist bei der DTS-Generierung verwirren.

## Fix

`prebuild`-Script in beiden Nuxt-Modulen das veraltete Stubs (`.d.ts`, `.d.vue.ts`, `.js`) aus `src/runtime/` löscht bevor `nuxt-module-build build` läuft. Auch präventiv in `nuxt-auth-idp` hinzugefügt.

## Verifizierung

- `pnpm turbo run build --filter=@openape/nuxt-auth-sp` — erfolgreich
- `pnpm typecheck` — 25/25 Tasks bestanden