### PR TITLE
fix(apes): process all positional args in adapter install/remove

### DIFF
--- a/packages/apes/src/commands/adapter/index.ts
+++ b/packages/apes/src/commands/adapter/index.ts
@@ -107,25 +107,30 @@ export const adapterCommand = defineCommand({
         },
       },
       async run({ args }) {
-        const id = String(args.id)
+        const ids = [String(args.id), ...args._].filter(Boolean)
         const local = Boolean(args.local)
         const index = await fetchRegistry(Boolean(args.refresh))
-        const entry = findAdapter(index, id)
-        if (!entry)
-          throw new Error(`Adapter "${id}" not found in registry. Use \`apes adapter search ${id}\` to search.`)
 
-        const conflicts = findConflictingAdapters(entry.executable, id)
-        if (conflicts.length > 0) {
-          for (const c of conflicts) {
-            consola.warn(`Conflicting adapter found: ${c.path} (id: ${c.adapterId}, executable: ${c.executable})`)
-            consola.warn(`  Remove it with: apes adapter remove ${c.adapterId}`)
+        for (const id of ids) {
+          const entry = findAdapter(index, id)
+          if (!entry) {
+            consola.error(`Adapter "${id}" not found in registry. Use \`apes adapter search ${id}\` to search.`)
+            continue
           }
-        }
 
-        const result = await installAdapter(entry, { local })
-        const verb = result.updated ? 'Updated' : 'Installed'
-        consola.success(`${verb} ${result.id} → ${result.path}`)
-        consola.info(`Digest: ${result.digest}`)
+          const conflicts = findConflictingAdapters(entry.executable, id)
+          if (conflicts.length > 0) {
+            for (const c of conflicts) {
+              consola.warn(`Conflicting adapter found: ${c.path} (id: ${c.adapterId}, executable: ${c.executable})`)
+              consola.warn(`  Remove it with: apes adapter remove ${c.adapterId}`)
+            }
+          }
+
+          const result = await installAdapter(entry, { local })
+          const verb = result.updated ? 'Updated' : 'Installed'
+          consola.success(`${verb} ${result.id} → ${result.path}`)
+          consola.info(`Digest: ${result.digest}`)
+        }
       },
     }),
 
@@ -147,15 +152,22 @@ export const adapterCommand = defineCommand({
         },
       },
       async run({ args }) {
-        const id = String(args.id)
+        const ids = [String(args.id), ...args._].filter(Boolean)
         const local = Boolean(args.local)
-        if (removeAdapter(id, local)) {
-          consola.success(`Removed adapter: ${id}`)
+        let failed = false
+
+        for (const id of ids) {
+          if (removeAdapter(id, local)) {
+            consola.success(`Removed adapter: ${id}`)
+          }
+          else {
+            consola.error(`Adapter "${id}" is not installed${local ? ' locally' : ''}`)
+            failed = true
+          }
         }
-        else {
-          consola.error(`Adapter "${id}" is not installed${local ? ' locally' : ''}`)
+
+        if (failed)
           process.exit(1)
-        }
       },
     }),
 

--- a/packages/apes/test/adapter-install.test.ts
+++ b/packages/apes/test/adapter-install.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Tests for multi-ID argument collection used by `apes adapter install` and
+ * `apes adapter remove`. The helper mirrors the logic inside the run() handlers.
+ */
+
+function collectIds(argsId: string, argsRest: string[]): string[] {
+  return [String(argsId), ...argsRest].filter(Boolean)
+}
+
+describe('adapter install — multi-ID argument collection', () => {
+  it('collects a single ID', () => {
+    expect(collectIds('gh', [])).toEqual(['gh'])
+  })
+
+  it('collects multiple IDs from positional + rest args', () => {
+    expect(collectIds('gh', ['git', 'ls', 'cat'])).toEqual(['gh', 'git', 'ls', 'cat'])
+  })
+
+  it('filters out empty strings', () => {
+    expect(collectIds('gh', ['', 'git', ''])).toEqual(['gh', 'git'])
+  })
+
+  it('handles empty rest args', () => {
+    expect(collectIds('az', [])).toEqual(['az'])
+  })
+})


### PR DESCRIPTION
## Summary
- `apes adapter install` and `apes adapter remove` now process **all** positional arguments, not just the first one
- Unknown adapter IDs log an error and continue with the remaining adapters instead of aborting
- Registry is fetched once per invocation, not per adapter

Closes #8

## Test plan
- [x] Unit tests for multi-ID argument collection (4 new tests)
- [x] Build, typecheck, lint all pass
- [ ] Manual: `apes adapter install gh git` installs both adapters