### PR TITLE
fix(grants): allow agents to revoke own grants

### DIFF
--- a/modules/nuxt-auth-idp/src/runtime/server/api/grants/[id]/revoke.post.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/api/grants/[id]/revoke.post.ts
@@ -1,6 +1,7 @@
 import { revokeGrant } from '@openape/grants'
 import { defineEventHandler, getRouterParam } from 'h3'
 import { isAdmin, requireAuth } from '../../../utils/admin'
+import { tryAgentAuth } from '../../../utils/agent-auth'
 import { useGrantStores } from '../../../utils/grant-stores'
 import { useIdpStores } from '../../../utils/stores'
 import { createProblemError } from '../../../utils/problem'
@@ -14,16 +15,21 @@ export default defineEventHandler(async (event) => {
     throw createProblemError({ status: 400, title: 'Grant ID is required' })
   }
 
-  const email = await requireAuth(event)
+  // Accept both agent token and session auth
+  const agentPayload = await tryAgentAuth(event)
+  const identity = agentPayload?.sub ?? await requireAuth(event)
 
   const grant = await grantStore.findById(id)
   if (!grant) {
     throw createProblemError({ status: 404, title: 'Grant not found', type: 'https://openape.org/errors/grant_not_found' })
   }
 
+  // Authorize: requester, approver, or admin
+  const isRequester = grant.request.requester === identity
   const agent = await agentStore.findByEmail(grant.request.requester)
-  if (agent && agent.approver !== email && !isAdmin(email)) {
-    throw createProblemError({ status: 403, title: 'Only the agent approver or admin can revoke this grant' })
+  const isApprover = agent && agent.approver === identity
+  if (!isRequester && !isApprover && !isAdmin(identity)) {
+    throw createProblemError({ status: 403, title: 'Only the requester, agent approver, or admin can revoke this grant' })
   }
 
   try {

--- a/packages/grants/src/__tests__/grants.test.ts
+++ b/packages/grants/src/__tests__/grants.test.ts
@@ -198,11 +198,19 @@ describe('grant lifecycle', () => {
       expect(revoked.status).toBe('revoked')
     })
 
-    it('rejects revocation of non-approved grant', async () => {
+    it('revokes a pending grant', async () => {
       const grant = await createGrant(onceRequest, store)
+      const revoked = await revokeGrant(grant.id, store)
+
+      expect(revoked.status).toBe('revoked')
+    })
+
+    it('rejects revocation of denied grant', async () => {
+      const grant = await createGrant(onceRequest, store)
+      await denyGrant(grant.id, 'admin@example.com', store)
 
       await expect(revokeGrant(grant.id, store)).rejects.toThrow(
-        'Grant is not approved',
+        'Grant cannot be revoked',
       )
     })
   })

--- a/packages/grants/src/grants.ts
+++ b/packages/grants/src/grants.ts
@@ -107,8 +107,8 @@ export async function revokeGrant(
   if (!grant) {
     throw new Error(`Grant not found: ${grantId}`)
   }
-  if (grant.status !== 'approved') {
-    throw new Error(`Grant is not approved: ${grant.status}`)
+  if (grant.status !== 'pending' && grant.status !== 'approved') {
+    throw new Error(`Grant cannot be revoked (status: ${grant.status})`)
   }
 
   await store.updateStatus(grantId, 'revoked')


### PR DESCRIPTION
## Summary
- Accept agent bearer tokens on the revoke endpoint alongside session auth (dual-auth pattern from `token.post.ts`)
- Allow revoking both `pending` and `approved` grants (agents can withdraw stale requests)
- Unified authorization: requester, agent approver, or admin can revoke

## Changed files
- `packages/grants/src/grants.ts` — `revokeGrant()` accepts pending + approved
- `packages/grants/src/__tests__/grants.test.ts` — new test for pending revoke, denied rejection
- `modules/nuxt-auth-idp/.../revoke.post.ts` — dual-auth + unified authorization

## Test plan
- [x] `pnpm turbo run test --filter=@openape/grants` — 59/59 passing
- [x] `pnpm turbo run typecheck` — clean
- [x] `pnpm lint` — clean
- [ ] Manual: `apes login` → `apes grants revoke <pending-id>` → success

Closes #7