### PR TITLE
fix(apes): add args to request-capability for --help output

### DIFF
--- a/packages/apes/src/commands/grants/request-capability.ts
+++ b/packages/apes/src/commands/grants/request-capability.ts
@@ -153,6 +153,55 @@ export const requestCapabilityCommand = defineCommand({
     name: 'request-capability',
     description: 'Request a structured CLI capability grant',
   },
+  args: {
+    'cliId': {
+      type: 'positional',
+      description: 'CLI adapter identifier (e.g. docker, kubectl)',
+      required: true,
+    },
+    'resource': {
+      type: 'string',
+      description: 'Resource scope (repeatable)',
+    },
+    'selector': {
+      type: 'string',
+      description: 'Selector filter (repeatable)',
+    },
+    'action': {
+      type: 'string',
+      description: 'Action to permit (repeatable)',
+    },
+    'adapter': {
+      type: 'string',
+      description: 'Explicit path to adapter TOML file',
+    },
+    'idp': {
+      type: 'string',
+      description: 'IdP URL',
+    },
+    'approval': {
+      type: 'string',
+      description: 'Approval type: once, timed, always',
+      default: 'once',
+    },
+    'reason': {
+      type: 'string',
+      description: 'Reason for the request',
+    },
+    'duration': {
+      type: 'string',
+      description: 'Duration for timed grants (e.g. 30m, 1h, 7d)',
+    },
+    'run-as': {
+      type: 'string',
+      description: 'Execute as this user (e.g. root)',
+    },
+    'wait': {
+      type: 'boolean',
+      description: 'Wait for approval before returning',
+      default: false,
+    },
+  },
   async run({ rawArgs }) {
     const auth = loadAuth()
     if (!auth) {


### PR DESCRIPTION
## Summary
- Add `args` field to `grants request-capability` command so `--help` shows all accepted options
- Previously `--help` showed no options despite accepting 10+ parameters (`--resource`, `--action`, `--approval`, etc.)
- All other commands already had correct `args` definitions

Closes #23

## Test plan
- [x] `pnpm build --filter=@openape/apes` passes
- [x] `pnpm lint --filter=@openape/apes` passes
- [x] `pnpm typecheck --filter=@openape/apes` passes
- [x] `apes grants request-capability --help` shows all 11 options with descriptions