### PR TITLE
feat(grants): incremental capability grants (#24)

### DIFF
--- a/modules/nuxt-auth-idp/src/runtime/pages/grant-approval.vue
+++ b/modules/nuxt-auth-idp/src/runtime/pages/grant-approval.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { computed, onMounted, ref } from 'vue'
 import { navigateTo, useIdpAuth, useRoute } from '#imports'
-import { formatCliResourceChain, getCliAuthorizationDetails, summarizeCliGrant } from '../utils/cli-grants'
+import { formatCliResourceChain, formatWidenedPreview, getCliAuthorizationDetails, summarizeCliGrant } from '../utils/cli-grants'
 
 const { user, loading: authLoading, fetchUser } = useIdpAuth()
 const route = useRoute()
@@ -9,9 +9,19 @@ const grant = ref(null)
 const loading = ref(true)
 const error = ref('')
 const processing = ref(false)
+const selectedExtendMode = ref('separate')
 const grantId = computed(() => route.query.grant_id)
 const callbackUrl = computed(() => route.query.callback)
 const isDelegate = computed(() => grant.value?.request?.permissions?.includes('delegate'))
+const hasSimilarGrants = computed(() => grant.value?.similar_grants?.similar_grants?.length > 0)
+const similarGrants = computed(() => grant.value?.similar_grants?.similar_grants ?? [])
+const widenedPreview = computed(() => formatWidenedPreview(grant.value?.similar_grants?.widened_details ?? []))
+const mergedPreview = computed(() => formatWidenedPreview(grant.value?.similar_grants?.merged_details ?? []))
+const EXTEND_MODE_OPTIONS = [
+  { label: 'Extend to wildcard', value: 'widen', description: 'Widen scope with wildcards (replaces existing grant)' },
+  { label: 'Add this value', value: 'merge', description: 'Merge into single grant keeping specific selectors' },
+  { label: 'Approve as separate', value: 'separate', description: 'Create a new independent grant' },
+]
 const cliDetails = computed(() => getCliAuthorizationDetails(grant.value?.request?.authorization_details))
 const cliSummary = computed(() => summarizeCliGrant(grant.value?.request?.authorization_details))
 const delegateDuration = computed(() => {
@@ -63,13 +73,20 @@ onMounted(async () => {
 async function handleApprove() {
   processing.value = true
   try {
+    const extendBody = hasSimilarGrants.value && selectedExtendMode.value !== 'separate'
+      ? {
+          extend_mode: selectedExtendMode.value,
+          extend_grant_ids: similarGrants.value.map(s => s.grant.id),
+        }
+      : {}
     const result = await $fetch(
       `/api/grants/${grantId.value}/approve`,
       {
         method: 'POST',
         body: {
           grant_type: selectedGrantType.value,
-          ...selectedGrantType.value === 'timed' ? { duration: effectiveDuration.value } : {}
+          ...selectedGrantType.value === 'timed' ? { duration: effectiveDuration.value } : {},
+          ...extendBody,
         }
       }
     )
@@ -253,6 +270,54 @@ function isExactCommand(detail) {
                   </dd>
                 </div>
               </dl>
+            </template>
+          </UAlert>
+
+          <UAlert
+            v-if="hasSimilarGrants"
+            color="info"
+            title="Similar grant(s) exist"
+          >
+            <template #description>
+              <div class="text-sm space-y-2 mt-2">
+                <div v-for="similar in similarGrants" :key="similar.grant.id">
+                  <p class="text-muted">
+                    Existing grant: <span class="font-mono text-xs">{{ similar.grant.id.slice(0, 8) }}...</span>
+                  </p>
+                  <div
+                    v-for="detail in getCliAuthorizationDetails(similar.grant.request.authorization_details)"
+                    :key="detail.permission"
+                    class="font-mono text-xs text-dimmed break-all"
+                  >
+                    {{ detail.permission }}
+                  </div>
+                </div>
+                <div class="mt-2 space-y-1">
+                  <p class="text-muted font-medium">
+                    Extension options:
+                  </p>
+                  <URadioGroup
+                    v-model="selectedExtendMode"
+                    :items="EXTEND_MODE_OPTIONS"
+                  />
+                  <div v-if="selectedExtendMode === 'widen'" class="mt-1 rounded bg-gray-950/50 px-2 py-1">
+                    <p class="text-xs text-muted">
+                      Result:
+                    </p>
+                    <p v-for="perm in widenedPreview" :key="perm" class="font-mono text-xs text-green-400">
+                      {{ perm }}
+                    </p>
+                  </div>
+                  <div v-if="selectedExtendMode === 'merge'" class="mt-1 rounded bg-gray-950/50 px-2 py-1">
+                    <p class="text-xs text-muted">
+                      Result:
+                    </p>
+                    <p v-for="perm in mergedPreview" :key="perm" class="font-mono text-xs text-blue-400">
+                      {{ perm }}
+                    </p>
+                  </div>
+                </div>
+              </div>
             </template>
           </UAlert>
 

--- a/modules/nuxt-auth-idp/src/runtime/pages/grants.vue
+++ b/modules/nuxt-auth-idp/src/runtime/pages/grants.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { computed, onMounted, ref } from 'vue'
 import { navigateTo, useIdpAuth } from '#imports'
-import { formatCliResourceChain, getCliAuthorizationDetails, summarizeCliGrant } from '../utils/cli-grants'
+import { formatCliResourceChain, formatWidenedPreview, getCliAuthorizationDetails, summarizeCliGrant } from '../utils/cli-grants'
 
 const { user, loading: authLoading, fetchUser } = useIdpAuth()
 const activeAndPending = ref([])
@@ -14,6 +14,8 @@ const actionError = ref('')
 const grantTypeSelections = ref({})
 const durationPresetSelections = ref({})
 const customDurations = ref({})
+const extendModeSelections = ref({})
+const similarGrantsData = ref({})
 const DURATION_PRESETS = [
   { label: '1 hour', value: '3600' },
   { label: '4 hours', value: '14400' },
@@ -26,6 +28,28 @@ const GRANT_TYPE_OPTIONS = [
   { label: 'Timed', value: 'timed', description: 'Time-limited' },
   { label: 'Always', value: 'always', description: 'Until revoked' }
 ]
+const EXTEND_MODE_OPTIONS = [
+  { label: 'Extend to wildcard', value: 'widen', description: 'Widen scope with wildcards' },
+  { label: 'Add this value', value: 'merge', description: 'Merge keeping specific selectors' },
+  { label: 'Approve as separate', value: 'separate', description: 'New independent grant' },
+]
+async function loadSimilarGrants(grantId) {
+  if (similarGrantsData.value[grantId]) return
+  try {
+    const data = await $fetch(`/api/grants/${grantId}`)
+    if (data.similar_grants) {
+      similarGrantsData.value[grantId] = data.similar_grants
+      if (!extendModeSelections.value[grantId]) {
+        extendModeSelections.value[grantId] = 'separate'
+      }
+    }
+  } catch {
+    // ignore
+  }
+}
+function hasSimilar(grantId) {
+  return !!similarGrantsData.value[grantId]?.similar_grants?.length
+}
 function getEffectiveDuration(grantId) {
   if (grantTypeSelections.value[grantId] !== 'timed') return void 0
   const preset = durationPresetSelections.value[grantId] ?? '3600'
@@ -57,6 +81,9 @@ async function loadGrants() {
         grantTypeSelections.value[g.id] = 'once'
         durationPresetSelections.value[g.id] = '3600'
         customDurations.value[g.id] = 3600
+        if (getCliAuthorizationDetails(g.request?.authorization_details).length > 0) {
+          loadSimilarGrants(g.id)
+        }
       }
     }
   } catch {
@@ -84,11 +111,20 @@ async function approveGrant(id) {
   actionError.value = ''
   try {
     const grantType = grantTypeSelections.value[id] ?? 'once'
+    const extendMode = extendModeSelections.value[id]
+    const similar = similarGrantsData.value[id]
+    const extendBody = extendMode && extendMode !== 'separate' && similar?.similar_grants?.length
+      ? {
+          extend_mode: extendMode,
+          extend_grant_ids: similar.similar_grants.map(s => s.grant.id),
+        }
+      : {}
     await $fetch(`/api/grants/${id}/approve`, {
       method: 'POST',
       body: {
         grant_type: grantType,
-        ...grantType === 'timed' ? { duration: getEffectiveDuration(id) } : {}
+        ...grantType === 'timed' ? { duration: getEffectiveDuration(id) } : {},
+        ...extendBody,
       }
     })
     await loadGrants()
@@ -234,6 +270,54 @@ function isExactCommand(detail) {
                   <p class="text-xs text-dimmed">
                     Created: {{ formatTime(grant.created_at) }}
                   </p>
+                </div>
+                <div v-if="hasSimilar(grant.id)" class="rounded border border-info/30 bg-info/5 px-3 py-2 space-y-2">
+                  <div class="flex items-center gap-2">
+                    <UBadge color="info" variant="soft" label="Similar grants exist" />
+                  </div>
+                  <div
+                    v-for="similar in similarGrantsData[grant.id]?.similar_grants ?? []"
+                    :key="similar.grant.id"
+                    class="text-xs"
+                  >
+                    <span class="text-muted">Existing:</span>
+                    <span class="font-mono text-dimmed">{{ similar.grant.id.slice(0, 8) }}...</span>
+                    <div
+                      v-for="detail in getCliAuthorizationDetails(similar.grant.request.authorization_details)"
+                      :key="detail.permission"
+                      class="font-mono text-dimmed break-all"
+                    >
+                      {{ detail.permission }}
+                    </div>
+                  </div>
+                  <URadioGroup
+                    v-model="extendModeSelections[grant.id]"
+                    :items="EXTEND_MODE_OPTIONS"
+                  />
+                  <div v-if="extendModeSelections[grant.id] === 'widen'" class="rounded bg-gray-950/50 px-2 py-1">
+                    <p class="text-xs text-muted">
+                      Result:
+                    </p>
+                    <p
+                      v-for="perm in formatWidenedPreview(similarGrantsData[grant.id]?.widened_details ?? [])"
+                      :key="perm"
+                      class="font-mono text-xs text-green-400"
+                    >
+                      {{ perm }}
+                    </p>
+                  </div>
+                  <div v-if="extendModeSelections[grant.id] === 'merge'" class="rounded bg-gray-950/50 px-2 py-1">
+                    <p class="text-xs text-muted">
+                      Result:
+                    </p>
+                    <p
+                      v-for="perm in formatWidenedPreview(similarGrantsData[grant.id]?.merged_details ?? [])"
+                      :key="perm"
+                      class="font-mono text-xs text-blue-400"
+                    >
+                      {{ perm }}
+                    </p>
+                  </div>
                 </div>
                 <div class="space-y-2">
                   <div>

--- a/modules/nuxt-auth-idp/src/runtime/server/api/grants/[id].get.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/api/grants/[id].get.ts
@@ -1,7 +1,14 @@
-import { introspectGrant } from '@openape/grants'
+import type { OpenApeCliAuthorizationDetail } from '@openape/core'
+import { findSimilarCliGrants, introspectGrant } from '@openape/grants'
 import { defineEventHandler, getRequestHeader, getRouterParam, setResponseHeader, setResponseStatus } from 'h3'
 import { useGrantStores } from '../../utils/grant-stores'
 import { createProblemError } from '../../utils/problem'
+
+function hasStructuredCliGrant(details?: unknown[]): boolean {
+  return (details ?? []).some((d): d is OpenApeCliAuthorizationDetail =>
+    typeof d === 'object' && d !== null && (d as Record<string, unknown>).type === 'openape_cli',
+  )
+}
 
 export default defineEventHandler(async (event) => {
   const id = getRouterParam(event, 'id')
@@ -24,6 +31,15 @@ export default defineEventHandler(async (event) => {
   if (ifNoneMatch === etag) {
     setResponseStatus(event, 304)
     return ''
+  }
+
+  // Attach similar grants for pending CLI grants
+  if (grant.status === 'pending' && hasStructuredCliGrant(grant.request.authorization_details)) {
+    const existingGrants = await grantStore.findByRequester(grant.request.requester)
+    const similarResult = findSimilarCliGrants(grant.request, existingGrants)
+    if (similarResult) {
+      return { ...grant, similar_grants: similarResult }
+    }
   }
 
   return grant

--- a/modules/nuxt-auth-idp/src/runtime/server/api/grants/[id]/approve.post.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/api/grants/[id]/approve.post.ts
@@ -1,6 +1,6 @@
 import type { GrantType } from '@openape/core'
-import type { ApproveGrantOverrides } from '@openape/grants'
-import { approveGrant, issueAuthzJWT } from '@openape/grants'
+import type { ApproveGrantOverrides, ExtendMode } from '@openape/grants'
+import { approveGrant, approveGrantWithExtension, issueAuthzJWT } from '@openape/grants'
 import { defineEventHandler, getRouterParam, readBody } from 'h3'
 import { requireAuth } from '../../../utils/admin'
 import { useGrantStores } from '../../../utils/grant-stores'
@@ -50,17 +50,35 @@ export default defineEventHandler(async (event) => {
     }
   }
 
-  const overrides: ApproveGrantOverrides | undefined = body.grant_type
-    ? { grant_type: body.grant_type as GrantType, duration: body.duration as number | undefined }
-    : undefined
-
   try {
-    const approved = await approveGrant(id, email, grantStore, overrides)
+    let approved
+
+    if (body.extend_mode && Array.isArray(body.extend_grant_ids) && body.extend_grant_ids.length > 0) {
+      const validModes: ExtendMode[] = ['widen', 'merge']
+      if (!validModes.includes(body.extend_mode as ExtendMode)) {
+        throw createProblemError({ status: 400, title: 'Invalid extend_mode. Must be "widen" or "merge"' })
+      }
+
+      approved = await approveGrantWithExtension(id, email, grantStore, {
+        grant_type: body.grant_type as GrantType | undefined,
+        duration: body.duration as number | undefined,
+        extend_mode: body.extend_mode as ExtendMode,
+        extend_grant_ids: body.extend_grant_ids as string[],
+      })
+    }
+    else {
+      const overrides: ApproveGrantOverrides | undefined = body.grant_type
+        ? { grant_type: body.grant_type as GrantType, duration: body.duration as number | undefined }
+        : undefined
+      approved = await approveGrant(id, email, grantStore, overrides)
+    }
+
     const signingKey = await keyStore.getSigningKey()
     const authzJwt = await issueAuthzJWT(approved, getIdpIssuer(), signingKey.privateKey, signingKey.kid)
     return { grant: approved, authz_jwt: authzJwt }
   }
   catch (err: unknown) {
+    if (err && typeof err === 'object' && 'statusCode' in err) throw err
     const message = err instanceof Error ? err.message : 'Failed to approve grant'
     throw createProblemError({ status: 400, title: message, type: 'https://openape.org/errors/grant_already_decided' })
   }

--- a/modules/nuxt-auth-idp/src/runtime/server/api/grants/index.post.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/api/grants/index.post.ts
@@ -1,6 +1,6 @@
 import type { GrantType, OpenApeAuthorizationDetail, OpenApeCliAuthorizationDetail, OpenApeGrantRequest } from '@openape/core'
 import { canonicalizeCliPermission, cliAuthorizationDetailsCover, computeArgvHash, computeCmdHash, isCliAuthorizationDetailExact, validateCliAuthorizationDetail } from '@openape/core'
-import { createGrant } from '@openape/grants'
+import { createGrant, findSimilarCliGrants } from '@openape/grants'
 import { defineEventHandler, readBody, setResponseStatus } from 'h3'
 import { tryAgentAuth } from '../../utils/agent-auth'
 import { useGrantStores } from '../../utils/grant-stores'
@@ -168,6 +168,17 @@ export default defineEventHandler(async (event) => {
     })
     if (reusable) {
       return reusable
+    }
+
+    // Similarity check: find approved CLI grants that overlap but don't cover
+    const incomingCliDetails = cliDetails(body.authorization_details)
+    if (incomingCliDetails.length > 0) {
+      const similarResult = findSimilarCliGrants(body, existingGrants)
+      if (similarResult) {
+        const grant = await createGrant(body, grantStore)
+        setResponseStatus(event, 201)
+        return { ...grant, similar_grants: similarResult }
+      }
     }
   }
 

--- a/modules/nuxt-auth-idp/src/runtime/utils/cli-grants.ts
+++ b/modules/nuxt-auth-idp/src/runtime/utils/cli-grants.ts
@@ -27,3 +27,21 @@ export function summarizeCliGrant(details?: OpenApeAuthorizationDetail[]): strin
   const first = cliDetails[0]!
   return `${first.cli_id}: ${cliDetails.length} requested operations`
 }
+
+export function formatWidenedPreview(details: OpenApeCliAuthorizationDetail[]): string[] {
+  return details.map(d => d.permission)
+}
+
+export function describeExtension(
+  original: OpenApeCliAuthorizationDetail[],
+  widened: OpenApeCliAuthorizationDetail[],
+): string[] {
+  const descriptions: string[] = []
+  for (const w of widened) {
+    const match = original.find(o => o.cli_id === w.cli_id && o.action === w.action)
+    if (match && match.permission !== w.permission) {
+      descriptions.push(`${match.permission} → ${w.permission}`)
+    }
+  }
+  return descriptions
+}

--- a/packages/apes/src/commands/run.ts
+++ b/packages/apes/src/commands/run.ts
@@ -131,6 +131,17 @@ async function runAdapterMode(
   consola.info(`Grant requested: ${grant.id}`)
   consola.info(`Approve at: ${idp}/grant-approval?grant_id=${grant.id}`)
 
+  if (grant.similar_grants?.similar_grants?.length) {
+    const n = grant.similar_grants.similar_grants.length
+    consola.info('')
+    consola.info(`  Similar grant(s) found (${n}). Your approver can extend an existing grant to cover this request.`)
+    if (grant.similar_grants.widened_details?.length) {
+      const wider = grant.similar_grants.widened_details.map(d => d.permission).join(', ')
+      consola.info(`  Broader scope: ${wider}`)
+    }
+    consola.info('')
+  }
+
   const status = await waitForGrantStatus(idp, grant.id)
   if (status !== 'approved')
     throw new Error(`Grant ${status}`)

--- a/packages/core/src/__tests__/cli-grants.test.ts
+++ b/packages/core/src/__tests__/cli-grants.test.ts
@@ -3,10 +3,15 @@ import type { OpenApeCliAuthorizationDetail } from '../types/index.js'
 import {
   canonicalizeCliPermission,
   cliAuthorizationDetailCovers,
+  cliAuthorizationDetailIsSimilar,
   cliAuthorizationDetailsCover,
   computeArgvHash,
+  findDifferingSelectors,
   isCliAuthorizationDetailExact,
+  mergeCliAuthorizationDetails,
+  resourceChainsStructurallyMatch,
   validateCliAuthorizationDetail,
+  widenCliAuthorizationDetail,
 } from '../validation/index.js'
 
 describe('cli grant helpers', () => {
@@ -150,5 +155,242 @@ describe('cli grant helpers', () => {
     const second = await computeArgvHash(['gh', 'repo', 'list', 'openape'])
     expect(first).toBe(second)
     expect(first).toMatch(/^SHA-256:/)
+  })
+
+  // -- similarity detection tests --
+
+  describe('resourceChainsStructurallyMatch', () => {
+    it('matches identical chains', () => {
+      const a: OpenApeCliAuthorizationDetail['resource_chain'] = [{ resource: 'owner', selector: { login: 'a' } }, { resource: 'repo' }]
+      const b: OpenApeCliAuthorizationDetail['resource_chain'] = [{ resource: 'owner', selector: { login: 'b' } }, { resource: 'repo', selector: { name: 'x' } }]
+      expect(resourceChainsStructurallyMatch(a, b)).toBe(true)
+    })
+
+    it('rejects different lengths', () => {
+      const a: OpenApeCliAuthorizationDetail['resource_chain'] = [{ resource: 'owner' }]
+      const b: OpenApeCliAuthorizationDetail['resource_chain'] = [{ resource: 'owner' }, { resource: 'repo' }]
+      expect(resourceChainsStructurallyMatch(a, b)).toBe(false)
+    })
+
+    it('rejects different resource names', () => {
+      const a: OpenApeCliAuthorizationDetail['resource_chain'] = [{ resource: 'owner' }, { resource: 'repo' }]
+      const b: OpenApeCliAuthorizationDetail['resource_chain'] = [{ resource: 'owner' }, { resource: 'issue' }]
+      expect(resourceChainsStructurallyMatch(a, b)).toBe(false)
+    })
+
+    it('matches empty chains', () => {
+      expect(resourceChainsStructurallyMatch([], [])).toBe(true)
+    })
+  })
+
+  describe('findDifferingSelectors', () => {
+    it('finds no differences for identical selectors', () => {
+      const a: OpenApeCliAuthorizationDetail['resource_chain'] = [{ resource: 'owner', selector: { login: 'openape' } }]
+      const b: OpenApeCliAuthorizationDetail['resource_chain'] = [{ resource: 'owner', selector: { login: 'openape' } }]
+      expect(findDifferingSelectors(a, b)).toEqual([])
+    })
+
+    it('finds one differing position', () => {
+      const a: OpenApeCliAuthorizationDetail['resource_chain'] = [
+        { resource: 'owner', selector: { login: 'openape' } },
+        { resource: 'repo', selector: { name: 'cli' } },
+      ]
+      const b: OpenApeCliAuthorizationDetail['resource_chain'] = [
+        { resource: 'owner', selector: { login: 'openape' } },
+        { resource: 'repo', selector: { name: 'docs' } },
+      ]
+      expect(findDifferingSelectors(a, b)).toEqual([1])
+    })
+
+    it('finds multiple differing positions', () => {
+      const a: OpenApeCliAuthorizationDetail['resource_chain'] = [
+        { resource: 'owner', selector: { login: 'alice' } },
+        { resource: 'repo', selector: { name: 'cli' } },
+      ]
+      const b: OpenApeCliAuthorizationDetail['resource_chain'] = [
+        { resource: 'owner', selector: { login: 'bob' } },
+        { resource: 'repo', selector: { name: 'docs' } },
+      ]
+      expect(findDifferingSelectors(a, b)).toEqual([0, 1])
+    })
+
+    it('detects wildcard vs concrete as different', () => {
+      const a: OpenApeCliAuthorizationDetail['resource_chain'] = [{ resource: 'repo' }]
+      const b: OpenApeCliAuthorizationDetail['resource_chain'] = [{ resource: 'repo', selector: { name: 'cli' } }]
+      expect(findDifferingSelectors(a, b)).toEqual([0])
+    })
+  })
+
+  describe('cliAuthorizationDetailIsSimilar', () => {
+    const detailA = makeDetail({
+      resource_chain: [
+        { resource: 'owner', selector: { login: 'openape' } },
+        { resource: 'repo', selector: { name: 'cli' } },
+      ],
+    })
+    const detailB = makeDetail({
+      resource_chain: [
+        { resource: 'owner', selector: { login: 'openape' } },
+        { resource: 'repo', selector: { name: 'docs' } },
+      ],
+    })
+
+    it('returns true for same structure, different selectors', () => {
+      expect(cliAuthorizationDetailIsSimilar(detailA, detailB)).toBe(true)
+    })
+
+    it('returns false for different cli_id', () => {
+      expect(cliAuthorizationDetailIsSimilar(
+        detailA,
+        makeDetail({ ...detailB, cli_id: 'npm' }),
+      )).toBe(false)
+    })
+
+    it('returns false for different action', () => {
+      expect(cliAuthorizationDetailIsSimilar(
+        detailA,
+        makeDetail({ ...detailB, action: 'delete' }),
+      )).toBe(false)
+    })
+
+    it('returns false when existing already covers incoming', () => {
+      const wildcard = makeDetail({
+        resource_chain: [
+          { resource: 'owner', selector: { login: 'openape' } },
+          { resource: 'repo' },
+        ],
+      })
+      const concrete = makeDetail({
+        resource_chain: [
+          { resource: 'owner', selector: { login: 'openape' } },
+          { resource: 'repo', selector: { name: 'cli' } },
+        ],
+      })
+      expect(cliAuthorizationDetailIsSimilar(wildcard, concrete)).toBe(false)
+    })
+
+    it('returns false for identical details', () => {
+      expect(cliAuthorizationDetailIsSimilar(detailA, detailA)).toBe(false)
+    })
+
+    it('returns false for different chain lengths', () => {
+      const short = makeDetail({
+        resource_chain: [{ resource: 'owner', selector: { login: 'openape' } }],
+      })
+      expect(cliAuthorizationDetailIsSimilar(short, detailA)).toBe(false)
+    })
+  })
+
+  describe('widenCliAuthorizationDetail', () => {
+    it('widens differing selector positions to wildcard', () => {
+      const existing = makeDetail({
+        resource_chain: [
+          { resource: 'owner', selector: { login: 'openape' } },
+          { resource: 'repo', selector: { name: 'cli' } },
+        ],
+      })
+      const incoming = makeDetail({
+        resource_chain: [
+          { resource: 'owner', selector: { login: 'openape' } },
+          { resource: 'repo', selector: { name: 'docs' } },
+        ],
+      })
+
+      const widened = widenCliAuthorizationDetail(existing, incoming)
+      expect(widened.resource_chain[0]!.selector).toEqual({ login: 'openape' })
+      expect(widened.resource_chain[1]!.selector).toBeUndefined()
+      expect(widened.permission).toBe('gh.owner[login=openape].repo[*]#list')
+    })
+
+    it('widens multiple differing positions', () => {
+      const existing = makeDetail({
+        resource_chain: [
+          { resource: 'owner', selector: { login: 'alice' } },
+          { resource: 'repo', selector: { name: 'cli' } },
+        ],
+      })
+      const incoming = makeDetail({
+        resource_chain: [
+          { resource: 'owner', selector: { login: 'bob' } },
+          { resource: 'repo', selector: { name: 'docs' } },
+        ],
+      })
+
+      const widened = widenCliAuthorizationDetail(existing, incoming)
+      expect(widened.resource_chain[0]!.selector).toBeUndefined()
+      expect(widened.resource_chain[1]!.selector).toBeUndefined()
+      expect(widened.permission).toBe('gh.owner[*].repo[*]#list')
+    })
+
+    it('preserves non-differing selectors', () => {
+      const existing = makeDetail({
+        resource_chain: [
+          { resource: 'owner', selector: { login: 'openape' } },
+          { resource: 'repo', selector: { name: 'cli' } },
+          { resource: 'issue', selector: { number: '1' } },
+        ],
+      })
+      const incoming = makeDetail({
+        resource_chain: [
+          { resource: 'owner', selector: { login: 'openape' } },
+          { resource: 'repo', selector: { name: 'docs' } },
+          { resource: 'issue', selector: { number: '1' } },
+        ],
+      })
+
+      const widened = widenCliAuthorizationDetail(existing, incoming)
+      expect(widened.resource_chain[0]!.selector).toEqual({ login: 'openape' })
+      expect(widened.resource_chain[1]!.selector).toBeUndefined()
+      expect(widened.resource_chain[2]!.selector).toEqual({ number: '1' })
+    })
+  })
+
+  describe('mergeCliAuthorizationDetails', () => {
+    it('unions two non-overlapping sets', () => {
+      const setA = [makeDetail({
+        resource_chain: [{ resource: 'owner', selector: { login: 'openape' } }, { resource: 'repo', selector: { name: 'cli' } }],
+        permission: 'gh.owner[login=openape].repo[name=cli]#list',
+      })]
+      const setB = [makeDetail({
+        resource_chain: [{ resource: 'owner', selector: { login: 'openape' } }, { resource: 'repo', selector: { name: 'docs' } }],
+        permission: 'gh.owner[login=openape].repo[name=docs]#list',
+      })]
+
+      const merged = mergeCliAuthorizationDetails(setA, setB)
+      expect(merged).toHaveLength(2)
+    })
+
+    it('deduplicates by canonical permission', () => {
+      const detailA = makeDetail({
+        resource_chain: [{ resource: 'owner', selector: { login: 'openape' } }, { resource: 'repo', selector: { name: 'cli' } }],
+        permission: 'gh.owner[login=openape].repo[name=cli]#list',
+      })
+
+      const merged = mergeCliAuthorizationDetails([detailA], [detailA])
+      expect(merged).toHaveLength(1)
+    })
+
+    it('keeps broader entry on duplicate', () => {
+      const specific = makeDetail({
+        resource_chain: [{ resource: 'owner', selector: { login: 'openape' } }, { resource: 'repo' }],
+        permission: 'gh.owner[login=openape].repo[*]#list',
+      })
+      const alsoSpecific = makeDetail({
+        resource_chain: [{ resource: 'owner', selector: { login: 'openape' } }, { resource: 'repo' }],
+        permission: 'gh.owner[login=openape].repo[*]#list',
+      })
+
+      const merged = mergeCliAuthorizationDetails([specific], [alsoSpecific])
+      expect(merged).toHaveLength(1)
+    })
+
+    it('merges three sets', () => {
+      const a = [makeDetail({ resource_chain: [{ resource: 'repo', selector: { name: 'a' } }], permission: 'gh.repo[name=a]#list' })]
+      const b = [makeDetail({ resource_chain: [{ resource: 'repo', selector: { name: 'b' } }], permission: 'gh.repo[name=b]#list' })]
+      const c = [makeDetail({ resource_chain: [{ resource: 'repo', selector: { name: 'c' } }], permission: 'gh.repo[name=c]#list' })]
+
+      const merged = mergeCliAuthorizationDetails(a, b, c)
+      expect(merged).toHaveLength(3)
+    })
   })
 })

--- a/packages/core/src/validation/cli-grants.ts
+++ b/packages/core/src/validation/cli-grants.ts
@@ -152,6 +152,114 @@ export function cliAuthorizationDetailsCover(
   )
 }
 
+/**
+ * Check if two resource chains have the same structure
+ * (same resource names, same order, same length).
+ */
+export function resourceChainsStructurallyMatch(
+  a: OpenApeCliResourceRef[],
+  b: OpenApeCliResourceRef[],
+): boolean {
+  if (a.length !== b.length)
+    return false
+  return a.every((resource, index) => resource.resource === b[index]!.resource)
+}
+
+/**
+ * Find indices where selectors differ between two structurally matching resource chains.
+ * Both chains must have the same length (call resourceChainsStructurallyMatch first).
+ */
+export function findDifferingSelectors(
+  a: OpenApeCliResourceRef[],
+  b: OpenApeCliResourceRef[],
+): number[] {
+  const indices: number[] = []
+  for (let i = 0; i < a.length; i++) {
+    const sA = selectorString(a[i]!.selector)
+    const sB = selectorString(b[i]!.selector)
+    if (sA !== sB)
+      indices.push(i)
+  }
+  return indices
+}
+
+/**
+ * Check if two CLI authorization details are "similar" — same structure but different selectors.
+ * Returns true when cli_id and action match, chains structurally match,
+ * at least one selector differs, and the existing detail does NOT already cover the incoming one.
+ */
+export function cliAuthorizationDetailIsSimilar(
+  existing: OpenApeCliAuthorizationDetail,
+  incoming: OpenApeCliAuthorizationDetail,
+): boolean {
+  if (existing.type !== 'openape_cli' || incoming.type !== 'openape_cli')
+    return false
+  if (existing.cli_id !== incoming.cli_id)
+    return false
+  if (existing.action !== incoming.action)
+    return false
+  if (!resourceChainsStructurallyMatch(existing.resource_chain, incoming.resource_chain))
+    return false
+  if (cliAuthorizationDetailCovers(existing, incoming))
+    return false
+  const differing = findDifferingSelectors(existing.resource_chain, incoming.resource_chain)
+  return differing.length > 0
+}
+
+/**
+ * Widen a CLI authorization detail by removing selectors at positions where they differ
+ * between existing and incoming, effectively making those positions wildcards.
+ */
+export function widenCliAuthorizationDetail(
+  existing: OpenApeCliAuthorizationDetail,
+  incoming: OpenApeCliAuthorizationDetail,
+): OpenApeCliAuthorizationDetail {
+  const differing = findDifferingSelectors(existing.resource_chain, incoming.resource_chain)
+  const widenedChain: OpenApeCliResourceRef[] = existing.resource_chain.map((resource, index) => {
+    if (differing.includes(index)) {
+      return { resource: resource.resource }
+    }
+    return { ...resource }
+  })
+
+  const permission = canonicalizeCliPermission({ cli_id: existing.cli_id, resource_chain: widenedChain, action: existing.action })
+  return {
+    ...existing,
+    resource_chain: widenedChain,
+    permission,
+    display: `${existing.display} (widened)`,
+  }
+}
+
+/**
+ * Merge multiple sets of CLI authorization details into a single deduplicated array.
+ * Deduplicates by canonical permission string. When duplicates exist, the broader
+ * entry (fewer non-wildcard selectors) is kept.
+ */
+export function mergeCliAuthorizationDetails(
+  ...detailSets: OpenApeCliAuthorizationDetail[][]
+): OpenApeCliAuthorizationDetail[] {
+  const all = detailSets.flat()
+  const byPermission = new Map<string, OpenApeCliAuthorizationDetail>()
+
+  for (const detail of all) {
+    const key = canonicalizeCliPermission(detail)
+    const current = byPermission.get(key)
+    if (!current) {
+      byPermission.set(key, { ...detail, permission: key })
+    }
+    else {
+      const currentSpecificity = current.resource_chain.filter(r => normalizeSelector(r.selector)).length
+      const newSpecificity = detail.resource_chain.filter(r => normalizeSelector(r.selector)).length
+      if (newSpecificity < currentSpecificity) {
+        byPermission.set(key, { ...detail, permission: key })
+      }
+    }
+  }
+
+  return Array.from(byPermission.values())
+}
+
 export async function computeArgvHash(argv: string[]): Promise<string> {
   const encoder = new TextEncoder()
   const data = encoder.encode(JSON.stringify(argv))

--- a/packages/core/src/validation/index.ts
+++ b/packages/core/src/validation/index.ts
@@ -7,11 +7,16 @@ export {
 export {
   canonicalizeCliPermission,
   cliAuthorizationDetailCovers,
+  cliAuthorizationDetailIsSimilar,
   cliAuthorizationDetailsCover,
   computeArgvHash,
+  findDifferingSelectors,
   isCliAuthorizationDetailExact,
+  mergeCliAuthorizationDetails,
+  resourceChainsStructurallyMatch,
   type CliAuthorizationDetailValidationResult,
   validateCliAuthorizationDetail,
+  widenCliAuthorizationDetail,
 } from './cli-grants.js'
 
 export {

--- a/packages/grants/src/__tests__/grants.test.ts
+++ b/packages/grants/src/__tests__/grants.test.ts
@@ -1,7 +1,8 @@
-import type { OpenApeGrantRequest } from '@openape/core'
+import type { OpenApeCliAuthorizationDetail, OpenApeGrantRequest } from '@openape/core'
 import { beforeEach, describe, expect, it } from 'vitest'
 import {
   approveGrant,
+  approveGrantWithExtension,
   createDelegation,
   createGrant,
   denyGrant,
@@ -553,6 +554,189 @@ describe('grant lifecycle', () => {
       const grants = await store.findByDelegator('patrick@hofmann.eco')
       expect(grants).toHaveLength(1)
       expect(grants[0].request.delegate).toBe('agent+patrick@id.openape.at')
+    })
+  })
+
+  describe('approveGrantWithExtension', () => {
+    function makeCliDetail(overrides: Partial<OpenApeCliAuthorizationDetail> = {}): OpenApeCliAuthorizationDetail {
+      return {
+        type: 'openape_cli',
+        cli_id: 'gh',
+        operation_id: 'repo.list',
+        resource_chain: [],
+        action: 'list',
+        permission: '',
+        display: 'List repos',
+        risk: 'low',
+        ...overrides,
+      }
+    }
+
+    const oldRequest: OpenApeGrantRequest = {
+      requester: 'agent@example.com',
+      target_host: 'macmini',
+      audience: 'shapes',
+      grant_type: 'always',
+      authorization_details: [makeCliDetail({
+        resource_chain: [
+          { resource: 'owner', selector: { login: 'openape' } },
+          { resource: 'repo', selector: { name: 'cli' } },
+        ],
+        permission: 'gh.owner[login=openape].repo[name=cli]#list',
+      })],
+    }
+
+    const newRequest: OpenApeGrantRequest = {
+      requester: 'agent@example.com',
+      target_host: 'macmini',
+      audience: 'shapes',
+      grant_type: 'always',
+      authorization_details: [makeCliDetail({
+        resource_chain: [
+          { resource: 'owner', selector: { login: 'openape' } },
+          { resource: 'repo', selector: { name: 'docs' } },
+        ],
+        permission: 'gh.owner[login=openape].repo[name=docs]#list',
+      })],
+    }
+
+    it('widen: revokes old grant and approves pending with wildcard', async () => {
+      const oldGrant = await createGrant(oldRequest, store)
+      await approveGrant(oldGrant.id, 'admin@example.com', store, { grant_type: 'always' })
+
+      const pendingGrant = await createGrant(newRequest, store)
+
+      const result = await approveGrantWithExtension(
+        pendingGrant.id,
+        'admin@example.com',
+        store,
+        { extend_mode: 'widen', extend_grant_ids: [oldGrant.id], grant_type: 'always' },
+      )
+
+      expect(result.status).toBe('approved')
+      const perms = result.request.permissions ?? []
+      expect(perms).toContain('gh.owner[login=openape].repo[*]#list')
+
+      const revokedOld = await store.findById(oldGrant.id)
+      expect(revokedOld!.status).toBe('revoked')
+    })
+
+    it('merge: revokes old grant and approves pending with combined details', async () => {
+      const oldGrant = await createGrant(oldRequest, store)
+      await approveGrant(oldGrant.id, 'admin@example.com', store, { grant_type: 'always' })
+
+      const pendingGrant = await createGrant(newRequest, store)
+
+      const result = await approveGrantWithExtension(
+        pendingGrant.id,
+        'admin@example.com',
+        store,
+        { extend_mode: 'merge', extend_grant_ids: [oldGrant.id], grant_type: 'always' },
+      )
+
+      expect(result.status).toBe('approved')
+      const perms = result.request.permissions ?? []
+      expect(perms).toContain('gh.owner[login=openape].repo[name=cli]#list')
+      expect(perms).toContain('gh.owner[login=openape].repo[name=docs]#list')
+
+      const revokedOld = await store.findById(oldGrant.id)
+      expect(revokedOld!.status).toBe('revoked')
+    })
+
+    it('rejects if extend_grant_id not found', async () => {
+      const pendingGrant = await createGrant(newRequest, store)
+
+      await expect(
+        approveGrantWithExtension(pendingGrant.id, 'admin@example.com', store, {
+          extend_mode: 'widen',
+          extend_grant_ids: ['nonexistent'],
+          grant_type: 'always',
+        }),
+      ).rejects.toThrow('Extend grant not found')
+    })
+
+    it('rejects if extend_grant_id is not approved', async () => {
+      const oldGrant = await createGrant(oldRequest, store)
+      const pendingGrant = await createGrant(newRequest, store)
+
+      await expect(
+        approveGrantWithExtension(pendingGrant.id, 'admin@example.com', store, {
+          extend_mode: 'widen',
+          extend_grant_ids: [oldGrant.id],
+          grant_type: 'always',
+        }),
+      ).rejects.toThrow('Extend grant is not approved')
+    })
+
+    it('rejects if pending grant is not pending', async () => {
+      const oldGrant = await createGrant(oldRequest, store)
+      await approveGrant(oldGrant.id, 'admin@example.com', store, { grant_type: 'always' })
+
+      const alreadyApproved = await createGrant(newRequest, store)
+      await approveGrant(alreadyApproved.id, 'admin@example.com', store, { grant_type: 'always' })
+
+      await expect(
+        approveGrantWithExtension(alreadyApproved.id, 'admin@example.com', store, {
+          extend_mode: 'widen',
+          extend_grant_ids: [oldGrant.id],
+          grant_type: 'always',
+        }),
+      ).rejects.toThrow('Grant is not pending')
+    })
+
+    it('rejects if extend grant has different audience', async () => {
+      const mismatchRequest: OpenApeGrantRequest = {
+        ...oldRequest,
+        audience: 'proxy',
+      }
+      const oldGrant = await createGrant(mismatchRequest, store)
+      await approveGrant(oldGrant.id, 'admin@example.com', store, { grant_type: 'always' })
+
+      const pendingGrant = await createGrant(newRequest, store)
+
+      await expect(
+        approveGrantWithExtension(pendingGrant.id, 'admin@example.com', store, {
+          extend_mode: 'widen',
+          extend_grant_ids: [oldGrant.id],
+          grant_type: 'always',
+        }),
+      ).rejects.toThrow('audience mismatch')
+    })
+
+    it('handles multiple extend_grant_ids', async () => {
+      const oldGrant1 = await createGrant(oldRequest, store)
+      await approveGrant(oldGrant1.id, 'admin@example.com', store, { grant_type: 'always' })
+
+      const oldRequest2: OpenApeGrantRequest = {
+        ...oldRequest,
+        authorization_details: [makeCliDetail({
+          resource_chain: [
+            { resource: 'owner', selector: { login: 'openape' } },
+            { resource: 'repo', selector: { name: 'api' } },
+          ],
+          permission: 'gh.owner[login=openape].repo[name=api]#list',
+        })],
+      }
+      const oldGrant2 = await createGrant(oldRequest2, store)
+      await approveGrant(oldGrant2.id, 'admin@example.com', store, { grant_type: 'always' })
+
+      const pendingGrant = await createGrant(newRequest, store)
+
+      const result = await approveGrantWithExtension(
+        pendingGrant.id,
+        'admin@example.com',
+        store,
+        { extend_mode: 'merge', extend_grant_ids: [oldGrant1.id, oldGrant2.id], grant_type: 'always' },
+      )
+
+      expect(result.status).toBe('approved')
+      const perms = result.request.permissions ?? []
+      expect(perms).toContain('gh.owner[login=openape].repo[name=cli]#list')
+      expect(perms).toContain('gh.owner[login=openape].repo[name=docs]#list')
+      expect(perms).toContain('gh.owner[login=openape].repo[name=api]#list')
+
+      expect((await store.findById(oldGrant1.id))!.status).toBe('revoked')
+      expect((await store.findById(oldGrant2.id))!.status).toBe('revoked')
     })
   })
 })

--- a/packages/grants/src/__tests__/similarity.test.ts
+++ b/packages/grants/src/__tests__/similarity.test.ts
@@ -1,0 +1,176 @@
+import type { OpenApeCliAuthorizationDetail, OpenApeGrant, OpenApeGrantRequest } from '@openape/core'
+import { describe, expect, it } from 'vitest'
+import { findSimilarCliGrants } from '../similarity.js'
+
+function makeCliDetail(overrides: Partial<OpenApeCliAuthorizationDetail> = {}): OpenApeCliAuthorizationDetail {
+  return {
+    type: 'openape_cli',
+    cli_id: 'gh',
+    operation_id: 'repo.list',
+    resource_chain: [],
+    action: 'list',
+    permission: '',
+    display: 'List repos',
+    risk: 'low',
+    ...overrides,
+  }
+}
+
+function makeGrant(overrides: Partial<OpenApeGrant> & { request: OpenApeGrantRequest }): OpenApeGrant {
+  return {
+    id: crypto.randomUUID(),
+    status: 'approved',
+    created_at: Math.floor(Date.now() / 1000),
+    ...overrides,
+  }
+}
+
+describe('findSimilarCliGrants', () => {
+  const baseRequest: OpenApeGrantRequest = {
+    requester: 'agent@example.com',
+    target_host: 'macmini',
+    audience: 'shapes',
+    grant_type: 'always',
+    authorization_details: [makeCliDetail({
+      resource_chain: [
+        { resource: 'owner', selector: { login: 'openape' } },
+        { resource: 'repo', selector: { name: 'docs' } },
+      ],
+      permission: 'gh.owner[login=openape].repo[name=docs]#list',
+    })],
+  }
+
+  const existingGrant = makeGrant({
+    request: {
+      requester: 'agent@example.com',
+      target_host: 'macmini',
+      audience: 'shapes',
+      grant_type: 'always',
+      authorization_details: [makeCliDetail({
+        resource_chain: [
+          { resource: 'owner', selector: { login: 'openape' } },
+          { resource: 'repo', selector: { name: 'cli' } },
+        ],
+        permission: 'gh.owner[login=openape].repo[name=cli]#list',
+      })],
+    },
+  })
+
+  it('finds similar grant with different selector', () => {
+    const result = findSimilarCliGrants(baseRequest, [existingGrant])
+    expect(result).not.toBeNull()
+    expect(result!.similar_grants).toHaveLength(1)
+    expect(result!.similar_grants[0]!.grant.id).toBe(existingGrant.id)
+  })
+
+  it('returns widened preview with wildcard', () => {
+    const result = findSimilarCliGrants(baseRequest, [existingGrant])
+    expect(result).not.toBeNull()
+    const widenedPerms = result!.widened_details.map(d => d.permission)
+    expect(widenedPerms).toContain('gh.owner[login=openape].repo[*]#list')
+  })
+
+  it('returns merged preview with both specific values', () => {
+    const result = findSimilarCliGrants(baseRequest, [existingGrant])
+    expect(result).not.toBeNull()
+    const mergedPerms = result!.merged_details.map(d => d.permission)
+    expect(mergedPerms).toContain('gh.owner[login=openape].repo[name=cli]#list')
+    expect(mergedPerms).toContain('gh.owner[login=openape].repo[name=docs]#list')
+  })
+
+  it('returns null when no similar grants exist', () => {
+    const differentGrant = makeGrant({
+      request: {
+        requester: 'agent@example.com',
+        target_host: 'macmini',
+        audience: 'shapes',
+        grant_type: 'always',
+        authorization_details: [makeCliDetail({
+          cli_id: 'npm',
+          resource_chain: [{ resource: 'package', selector: { name: 'foo' } }],
+          permission: 'npm.package[name=foo]#list',
+        })],
+      },
+    })
+    expect(findSimilarCliGrants(baseRequest, [differentGrant])).toBeNull()
+  })
+
+  it('excludes expired grants', () => {
+    const expired = makeGrant({
+      ...existingGrant,
+      id: crypto.randomUUID(),
+      expires_at: Math.floor(Date.now() / 1000) - 100,
+      request: { ...existingGrant.request, grant_type: 'timed' },
+    })
+    expect(findSimilarCliGrants(baseRequest, [expired])).toBeNull()
+  })
+
+  it('excludes once grants', () => {
+    const once = makeGrant({
+      ...existingGrant,
+      id: crypto.randomUUID(),
+      request: { ...existingGrant.request, grant_type: 'once' },
+    })
+    expect(findSimilarCliGrants(baseRequest, [once])).toBeNull()
+  })
+
+  it('excludes grants with different requester', () => {
+    const differentRequester = makeGrant({
+      ...existingGrant,
+      id: crypto.randomUUID(),
+      request: { ...existingGrant.request, requester: 'other@example.com' },
+    })
+    expect(findSimilarCliGrants(baseRequest, [differentRequester])).toBeNull()
+  })
+
+  it('excludes grants with different audience', () => {
+    const differentAudience = makeGrant({
+      ...existingGrant,
+      id: crypto.randomUUID(),
+      request: { ...existingGrant.request, audience: 'proxy' },
+    })
+    expect(findSimilarCliGrants(baseRequest, [differentAudience])).toBeNull()
+  })
+
+  it('excludes non-approved grants', () => {
+    const pending = makeGrant({
+      ...existingGrant,
+      id: crypto.randomUUID(),
+      status: 'pending',
+    })
+    expect(findSimilarCliGrants(baseRequest, [pending])).toBeNull()
+  })
+
+  it('returns null for requests without CLI details', () => {
+    const nonCliRequest: OpenApeGrantRequest = {
+      requester: 'agent@example.com',
+      target_host: 'macmini',
+      audience: 'proxy',
+      permissions: ['read'],
+    }
+    expect(findSimilarCliGrants(nonCliRequest, [existingGrant])).toBeNull()
+  })
+
+  it('handles multiple similar grants', () => {
+    const grant2 = makeGrant({
+      id: crypto.randomUUID(),
+      request: {
+        requester: 'agent@example.com',
+        target_host: 'macmini',
+        audience: 'shapes',
+        grant_type: 'always',
+        authorization_details: [makeCliDetail({
+          resource_chain: [
+            { resource: 'owner', selector: { login: 'openape' } },
+            { resource: 'repo', selector: { name: 'api' } },
+          ],
+          permission: 'gh.owner[login=openape].repo[name=api]#list',
+        })],
+      },
+    })
+
+    const result = findSimilarCliGrants(baseRequest, [existingGrant, grant2])
+    expect(result).not.toBeNull()
+    expect(result!.similar_grants).toHaveLength(2)
+  })
+})

--- a/packages/grants/src/grants.ts
+++ b/packages/grants/src/grants.ts
@@ -1,9 +1,14 @@
-import type { GrantType, OpenApeGrant, OpenApeGrantRequest } from '@openape/core'
+import type { GrantType, OpenApeCliAuthorizationDetail, OpenApeGrant, OpenApeGrantRequest } from '@openape/core'
+import { canonicalizeCliPermission, cliAuthorizationDetailIsSimilar, mergeCliAuthorizationDetails, widenCliAuthorizationDetail } from '@openape/core'
 import type { GrantStore } from './stores.js'
+
+export type ExtendMode = 'widen' | 'merge'
 
 export interface ApproveGrantOverrides {
   grant_type?: GrantType
   duration?: number
+  extend_mode?: ExtendMode
+  extend_grant_ids?: string[]
 }
 
 /**
@@ -207,6 +212,87 @@ export async function createDelegation(
 
   // Auto-approve since the delegator is creating it
   return approveGrant(grant.id, params.delegator, store)
+}
+
+function cliDetails(details?: unknown[]): OpenApeCliAuthorizationDetail[] {
+  return (details ?? []).filter((d): d is OpenApeCliAuthorizationDetail =>
+    typeof d === 'object' && d !== null && (d as Record<string, unknown>).type === 'openape_cli',
+  )
+}
+
+/**
+ * Approve a grant with extension: revokes specified old grants and modifies
+ * the pending grant's authorization_details before approving.
+ */
+export async function approveGrantWithExtension(
+  grantId: string,
+  approver: string,
+  store: GrantStore,
+  overrides: ApproveGrantOverrides & Required<Pick<ApproveGrantOverrides, 'extend_mode' | 'extend_grant_ids'>>,
+): Promise<OpenApeGrant> {
+  const pendingGrant = await store.findById(grantId)
+  if (!pendingGrant)
+    throw new Error(`Grant not found: ${grantId}`)
+  if (pendingGrant.status !== 'pending')
+    throw new Error(`Grant is not pending: ${pendingGrant.status}`)
+
+  const oldGrants: OpenApeGrant[] = []
+  for (const oldId of overrides.extend_grant_ids) {
+    const old = await store.findById(oldId)
+    if (!old)
+      throw new Error(`Extend grant not found: ${oldId}`)
+    if (old.status !== 'approved')
+      throw new Error(`Extend grant is not approved: ${old.status}`)
+    if (old.request.target_host !== pendingGrant.request.target_host)
+      throw new Error(`Extend grant target_host mismatch`)
+    if (old.request.audience !== pendingGrant.request.audience)
+      throw new Error(`Extend grant audience mismatch`)
+    oldGrants.push(old)
+  }
+
+  const pendingCliDetails = cliDetails(pendingGrant.request.authorization_details)
+  let newDetails: OpenApeCliAuthorizationDetail[]
+
+  if (overrides.extend_mode === 'widen') {
+    const allOldDetails = oldGrants.flatMap(g => cliDetails(g.request.authorization_details))
+    const widened: OpenApeCliAuthorizationDetail[] = [...pendingCliDetails]
+    for (const existingDetail of allOldDetails) {
+      for (const incomingDetail of pendingCliDetails) {
+        if (cliAuthorizationDetailIsSimilar(existingDetail, incomingDetail)) {
+          widened.push(widenCliAuthorizationDetail(existingDetail, incomingDetail))
+        }
+      }
+    }
+    newDetails = mergeCliAuthorizationDetails(widened)
+  }
+  else {
+    newDetails = mergeCliAuthorizationDetails(
+      pendingCliDetails,
+      ...oldGrants.map(g => cliDetails(g.request.authorization_details)),
+    )
+  }
+
+  // Update the pending grant's request with the new authorization details
+  const modifiedRequest: OpenApeGrantRequest = {
+    ...pendingGrant.request,
+    authorization_details: newDetails,
+    permissions: newDetails.map(d => canonicalizeCliPermission(d)),
+    // Clear command/cmd_hash when widening — the original narrow command no longer
+    // represents the broader scope of the extended grant
+    ...(overrides.extend_mode === 'widen' ? { command: undefined, cmd_hash: undefined } : {}),
+  }
+  await store.updateStatus(grantId, 'pending', { request: modifiedRequest })
+
+  // Revoke old grants
+  for (const old of oldGrants) {
+    await revokeGrant(old.id, store)
+  }
+
+  // Approve the modified pending grant
+  return approveGrant(grantId, approver, store, {
+    grant_type: overrides.grant_type,
+    duration: overrides.duration,
+  })
 }
 
 /**

--- a/packages/grants/src/index.ts
+++ b/packages/grants/src/index.ts
@@ -5,13 +5,16 @@ export {
 } from './authz-jwt.js'
 export {
   approveGrant,
+  approveGrantWithExtension,
   type ApproveGrantOverrides,
   createDelegation,
   createGrant,
   denyGrant,
+  type ExtendMode,
   introspectGrant,
   revokeGrant,
   useGrant,
   validateDelegation,
 } from './grants.js'
+export { findSimilarCliGrants, type SimilarGrantMatch, type SimilarGrantsResult } from './similarity.js'
 export { type GrantListParams, type GrantStore, InMemoryGrantStore } from './stores.js'

--- a/packages/grants/src/similarity.ts
+++ b/packages/grants/src/similarity.ts
@@ -1,0 +1,101 @@
+import type { OpenApeCliAuthorizationDetail, OpenApeGrant, OpenApeGrantRequest } from '@openape/core'
+import { cliAuthorizationDetailIsSimilar, mergeCliAuthorizationDetails, widenCliAuthorizationDetail } from '@openape/core'
+
+export interface SimilarGrantMatch {
+  grant: OpenApeGrant
+  similar_detail_indices: number[]
+}
+
+export interface SimilarGrantsResult {
+  similar_grants: SimilarGrantMatch[]
+  widened_details: OpenApeCliAuthorizationDetail[]
+  merged_details: OpenApeCliAuthorizationDetail[]
+}
+
+function cliDetails(details?: unknown[]): OpenApeCliAuthorizationDetail[] {
+  return (details ?? []).filter((d): d is OpenApeCliAuthorizationDetail =>
+    typeof d === 'object' && d !== null && (d as Record<string, unknown>).type === 'openape_cli',
+  )
+}
+
+/**
+ * Find existing approved CLI grants that are similar (but not covering) to the incoming request.
+ * Returns null if no similar grants are found.
+ */
+export function findSimilarCliGrants(
+  incomingRequest: OpenApeGrantRequest,
+  existingGrants: OpenApeGrant[],
+): SimilarGrantsResult | null {
+  const incomingCliDetails = cliDetails(incomingRequest.authorization_details)
+  if (incomingCliDetails.length === 0)
+    return null
+
+  const now = Math.floor(Date.now() / 1000)
+  const matches: SimilarGrantMatch[] = []
+
+  for (const grant of existingGrants) {
+    if (grant.status !== 'approved')
+      continue
+    if ((grant.request.grant_type ?? 'once') === 'once')
+      continue
+    if (grant.expires_at && grant.expires_at <= now)
+      continue
+    if (grant.request.requester !== incomingRequest.requester)
+      continue
+    if (grant.request.target_host !== incomingRequest.target_host)
+      continue
+    if (grant.request.audience !== incomingRequest.audience)
+      continue
+    if (grant.request.run_as !== (incomingRequest.run_as ?? undefined))
+      continue
+    if (incomingRequest.delegator !== (grant.request.delegator ?? undefined))
+      continue
+    if (incomingRequest.delegate !== (grant.request.delegate ?? undefined))
+      continue
+    if ((grant.request.execution_context?.adapter_digest ?? undefined) !== (incomingRequest.execution_context?.adapter_digest ?? undefined))
+      continue
+
+    const existingCliDetails = cliDetails(grant.request.authorization_details)
+    if (existingCliDetails.length === 0)
+      continue
+
+    const similarIndices: number[] = []
+    for (let i = 0; i < existingCliDetails.length; i++) {
+      const existingDetail = existingCliDetails[i]!
+      if (incomingCliDetails.some(incoming => cliAuthorizationDetailIsSimilar(existingDetail, incoming))) {
+        similarIndices.push(i)
+      }
+    }
+
+    if (similarIndices.length > 0) {
+      matches.push({ grant, similar_detail_indices: similarIndices })
+    }
+  }
+
+  if (matches.length === 0)
+    return null
+
+  // Compute widened preview: for each similar pair, widen to wildcard
+  const allExistingDetails = matches.flatMap(m => cliDetails(m.grant.request.authorization_details))
+  let widenedDetails = [...incomingCliDetails]
+  for (const existingDetail of allExistingDetails) {
+    for (const incomingDetail of incomingCliDetails) {
+      if (cliAuthorizationDetailIsSimilar(existingDetail, incomingDetail)) {
+        widenedDetails.push(widenCliAuthorizationDetail(existingDetail, incomingDetail))
+      }
+    }
+  }
+  widenedDetails = mergeCliAuthorizationDetails(widenedDetails)
+
+  // Compute merged preview: union of all details
+  const mergedDetails = mergeCliAuthorizationDetails(
+    incomingCliDetails,
+    ...matches.map(m => cliDetails(m.grant.request.authorization_details)),
+  )
+
+  return {
+    similar_grants: matches,
+    widened_details: widenedDetails,
+    merged_details: mergedDetails,
+  }
+}

--- a/packages/shapes/src/grants.ts
+++ b/packages/shapes/src/grants.ts
@@ -15,6 +15,12 @@ function decodePayload(token: string): Record<string, unknown> {
   return JSON.parse(Buffer.from(payload, 'base64url').toString('utf-8')) as Record<string, unknown>
 }
 
+interface SimilarGrantsInfo {
+  similar_grants: Array<{ grant: { id: string }, similar_detail_indices: number[] }>
+  widened_details: Array<{ permission: string }>
+  merged_details: Array<{ permission: string }>
+}
+
 export async function createShapesGrant(
   resolved: ResolvedCommand,
   params: {
@@ -22,13 +28,13 @@ export async function createShapesGrant(
     approval: 'once' | 'timed' | 'always'
     reason?: string
   },
-): Promise<{ id: string, status: string }> {
+): Promise<{ id: string, status: string, similar_grants?: SimilarGrantsInfo }> {
   const grantsEndpoint = await getGrantsEndpoint(params.idp)
   const requester = getRequesterIdentity()
   if (!requester) {
     throw new Error('No requester identity available. Run `apes login` first.')
   }
-  return apiFetch<{ id: string, status: string }>(grantsEndpoint, {
+  return apiFetch<{ id: string, status: string, similar_grants?: SimilarGrantsInfo }>(grantsEndpoint, {
     method: 'POST',
     idp: params.idp,
     body: {


### PR DESCRIPTION
## Summary

- When a new CLI grant request is similar to an existing approved grant, the approver can **extend** the existing grant instead of creating a separate one
- Approver gets three choices: **Extend to wildcard** (widen), **Add this value** (merge), or **Approve as separate** (existing behavior)
- Old grant is revoked, pending grant is approved with wider/merged scope — clean audit trail
- CLI (`apes run`) shows a hint when similar grants are detected

## Changes

### Core (`@openape/core`)
- 5 new functions in `cli-grants.ts`: similarity detection, widening, merging
- 16 new test cases

### Grants (`@openape/grants`)
- `findSimilarCliGrants()` — discovers overlapping approved CLI grants
- `approveGrantWithExtension()` — revokes old grants, approves pending with modified scope
- 18 new test cases (11 similarity + 7 extension)

### API (`@openape/nuxt-auth-idp`)
- `POST /api/grants` returns `similar_grants` metadata when overlaps detected
- `GET /api/grants/{id}` computes similar grants for pending CLI grants
- `POST /api/grants/{id}/approve` accepts `extend_mode` + `extend_grant_ids`

### Web UI
- `grant-approval.vue` — similar grants info, extend mode radio group, previews
- `grants.vue` — badge + lazy-loaded extend options in inbox

### CLI
- `apes run` displays hint about broader scope when similar grants exist

## Test plan

- [ ] `npx turbo run test --filter=@openape/core` — 92 tests pass
- [ ] `npx turbo run test --filter=@openape/grants` — 77 tests pass
- [ ] `npx turbo run lint` — all clean
- [ ] `npx turbo run typecheck` — all clean
- [ ] Manual: create grant for `repo[name=cli]#list`, then request `repo[name=docs]#list` → similar grant detected, extend options shown

Closes #24