### PR TITLE
fix(apes): normalize basename before resolveCommand in ape-shell

### DIFF
--- a/.changeset/apes-run-shell-basename-resolvecommand.md
+++ b/.changeset/apes-run-shell-basename-resolvecommand.md
@@ -1,0 +1,9 @@
+---
+'@openape/apes': patch
+---
+
+fix(apes): normalize basename before resolveCommand in ape-shell routing
+
+Follow-up to the previous adapter-lookup fix. `tryAdapterModeFromShell` in `apes run --shell` still passed the raw first token from the parsed shell command into `resolveCommand`, which does a strict comparison against `adapter.cli.executable`. Commands that started with an absolute path like `/usr/local/bin/o365-cli` loaded the adapter correctly but then threw inside `resolveCommand`, and the error was swallowed into `consola.debug` — silently falling back to a generic `bash -c` session grant.
+
+The call site now normalizes `parsed.executable` via `basename()` before passing it into `resolveCommand`. `resolveCommand` itself stays strict.

--- a/packages/apes/src/commands/run.ts
+++ b/packages/apes/src/commands/run.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from 'node:child_process'
 import { hostname } from 'node:os'
+import { basename } from 'node:path'
 import { defineCommand } from 'citty'
 import {
   createShapesGrant,
@@ -193,9 +194,14 @@ async function tryAdapterModeFromShell(
   const loaded = await loadOrInstallAdapter(parsed.executable)
   if (!loaded) return false
 
+  // resolveCommand does a strict comparison against `adapter.cli.executable`,
+  // which is always the bare binary name. When the user typed an absolute
+  // path we must pass the basename, not the full path.
+  const normalizedExecutable = basename(parsed.executable)
+
   let resolved
   try {
-    resolved = await resolveCommand(loaded, [parsed.executable, ...parsed.argv])
+    resolved = await resolveCommand(loaded, [normalizedExecutable, ...parsed.argv])
   }
   catch (err) {
     consola.debug(`ape-shell: adapter resolve failed for "${parsed.raw}":`, err)

--- a/packages/apes/test/resolve-command-absolute-path.test.ts
+++ b/packages/apes/test/resolve-command-absolute-path.test.ts
@@ -1,0 +1,65 @@
+import { basename } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { parseShellCommand } from '../src/shapes/shell-parser.js'
+import { resolveCommand } from '../src/shapes/parser.js'
+import type { LoadedAdapter } from '../src/shapes/types.js'
+
+// Minimal hand-rolled adapter that matches `foo list [--flag value]*`.
+// Only the fields `resolveCommand` actually reads are populated.
+function makeFooAdapter(): LoadedAdapter {
+  return {
+    source: '/tmp/test/foo.toml',
+    digest: 'sha256:test',
+    adapter: {
+      schema: 'openape-shapes/v1',
+      cli: {
+        id: 'foo',
+        executable: 'foo',
+        audience: 'shapes',
+      },
+      operations: [
+        {
+          id: 'list',
+          command: ['list'],
+          display: 'foo list',
+          resource_chain: [],
+          action: 'list',
+          risk: 'low',
+        },
+      ],
+    },
+  } as unknown as LoadedAdapter
+}
+
+describe('resolveCommand invariant: strict executable comparison', () => {
+  it('accepts argv with the bare binary name', async () => {
+    const loaded = makeFooAdapter()
+    const resolved = await resolveCommand(loaded, ['foo', 'list'])
+    expect(resolved.detail.cli_id).toBe('foo')
+  })
+
+  it('rejects argv starting with an absolute path — callers must normalize', async () => {
+    const loaded = makeFooAdapter()
+    await expect(
+      resolveCommand(loaded, ['/usr/local/bin/foo', 'list']),
+    ).rejects.toThrow(/expects executable foo, got \/usr\/local\/bin\/foo/)
+  })
+})
+
+describe('shell routing: parseShellCommand + basename normalization', () => {
+  it('normalizes an absolute path from a bash -c string so resolveCommand accepts it', async () => {
+    const loaded = makeFooAdapter()
+
+    // Replays the exact pattern from tryAdapterModeFromShell in run.ts
+    const parsed = parseShellCommand('/usr/local/bin/foo list')
+    expect(parsed).not.toBeNull()
+    expect(parsed!.executable).toBe('/usr/local/bin/foo')
+
+    const normalized = basename(parsed!.executable)
+    expect(normalized).toBe('foo')
+
+    const resolved = await resolveCommand(loaded, [normalized, ...parsed!.argv])
+    expect(resolved.detail.cli_id).toBe('foo')
+    expect(resolved.detail.operation_id).toBe('list')
+  })
+})


### PR DESCRIPTION
Closes #58

## Summary
Follow-up to #57. After fixing the adapter **lookup** to handle absolute paths, \`tryAdapterModeFromShell\` still passed the raw first token (e.g. \`/usr/local/bin/o365-cli\`) into \`resolveCommand\`, which does a strict equality check against \`adapter.cli.executable\`. The adapter loaded correctly but \`resolveCommand\` threw — and the error was caught into \`consola.debug\` (invisible without \`--debug\`), so the flow silently fell back to a generic \`bash -c\` session grant.

## Fix
\`packages/apes/src/commands/run.ts\` — call site normalizes \`parsed.executable\` via \`basename()\` before passing into \`resolveCommand\`. \`resolveCommand\` itself stays strict (it only knows about logical binary names).

## Regression repro (the motivation)

\`\`\`
apes run --shell -- bash -c "/usr/local/bin/o365-cli mail list --account foo@bar.baz --unread --limit 10"
\`\`\`

Before: silently falls back to a generic ape-shell session grant.
After: routes through the \`o365\` shapes adapter as expected.

## Tests added

\`packages/apes/test/resolve-command-absolute-path.test.ts\` — three cases:
1. \`resolveCommand\` accepts the bare binary name (happy path)
2. \`resolveCommand\` rejects an absolute path — documents the strict invariant the call site must honor
3. End-to-end pattern: \`parseShellCommand('/usr/local/bin/foo list')\` → \`basename\` → \`resolveCommand\` succeeds

## Test plan
- [x] \`pnpm turbo run lint typecheck --filter=@openape/apes\` clean
- [x] \`pnpm --filter @openape/apes test\` — 302/302 pass (299 + 3 new)