### PR TITLE
feat(apes): M1 PtyBridge — persistent bash child with marker-based prompt detection

### DIFF
--- a/.changeset/apes-shell-pty-bridge.md
+++ b/.changeset/apes-shell-pty-bridge.md
@@ -1,0 +1,13 @@
+---
+'@openape/apes': minor
+---
+
+feat(apes): add PtyBridge — pty wrapper around a persistent bash child
+
+First milestone (M1) of the interactive `ape-shell` REPL feature (#62).
+
+`PtyBridge` spawns a persistent bash child via `node-pty` with a random-hex marker embedded in `PROMPT_COMMAND` + `PS1`. It detects marker occurrences in the output stream, strips them before they reach the consumer, and fires `onLineDone` with the accumulated output + exit code once bash has finished each command.
+
+Full shell state (cwd, environment variables, aliases, functions) persists across calls because a single bash process stays alive between commands.
+
+This lands as internal infrastructure only — no user-visible command or REPL loop is wired up yet. That follows in later milestones.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
       "@parcel/watcher",
       "better-sqlite3",
       "esbuild",
+      "node-pty",
       "sharp",
       "unrs-resolver",
       "vue-demi"

--- a/packages/apes/package.json
+++ b/packages/apes/package.json
@@ -27,7 +27,8 @@
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --coverage",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "postinstall": "node scripts/fix-node-pty-perms.mjs"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
@@ -36,6 +37,7 @@
     "citty": "^0.1.6",
     "consola": "^3.4.2",
     "giget": "^2.0.0",
+    "node-pty": "^1.1.0",
     "shell-quote": "^1.8.3",
     "zod": "^4.3.6"
   },

--- a/packages/apes/scripts/fix-node-pty-perms.mjs
+++ b/packages/apes/scripts/fix-node-pty-perms.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+/**
+ * Workaround for pnpm 10 losing execute permissions on `spawn-helper`
+ * binaries shipped in node-pty prebuilds.
+ *
+ * Without exec bit, `pty.spawn(...)` fails at runtime with
+ *   Error: posix_spawnp failed.
+ *
+ * This script runs after `pnpm install` and chmods the helper for every
+ * platform's prebuild directory that it can find. Missing directories are
+ * ignored silently so it's safe to run on any host.
+ */
+import { chmodSync, existsSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { dirname, join } from 'node:path'
+
+const require = createRequire(import.meta.url)
+
+let ptyRoot
+try {
+  ptyRoot = dirname(require.resolve('node-pty/package.json'))
+}
+catch {
+  // node-pty not installed yet (prepare runs before install in some flows) — nothing to do.
+  process.exit(0)
+}
+
+const platforms = ['darwin-arm64', 'darwin-x64', 'linux-x64', 'linux-arm64']
+for (const platform of platforms) {
+  const helper = join(ptyRoot, 'prebuilds', platform, 'spawn-helper')
+  if (existsSync(helper)) {
+    try {
+      chmodSync(helper, 0o755)
+    }
+    catch (err) {
+      console.warn(`[fix-node-pty-perms] failed to chmod ${helper}:`, err instanceof Error ? err.message : String(err))
+    }
+  }
+}

--- a/packages/apes/src/shell/pty-bridge.ts
+++ b/packages/apes/src/shell/pty-bridge.ts
@@ -1,0 +1,214 @@
+import { randomBytes } from 'node:crypto'
+import type { IPty } from 'node-pty'
+import * as pty from 'node-pty'
+
+/**
+ * Frame returned when the bash child finishes executing a line and is ready
+ * for the next one. The `output` is everything bash printed since the last
+ * frame, with the marker line stripped.
+ */
+export interface CompletedLineFrame {
+  output: string
+  exitCode: number
+}
+
+/**
+ * Callbacks the PtyBridge delivers to its owner. `onOutput` fires with
+ * streaming pty output chunks (marker content already stripped). `onLineDone`
+ * fires once per completed shell line with the cumulative output and the
+ * exit code extracted from the prompt marker. `onExit` fires when the bash
+ * child itself has terminated (user typed `exit`, or the process died).
+ */
+export interface PtyBridgeEvents {
+  onOutput: (chunk: string) => void
+  onLineDone: (frame: CompletedLineFrame) => void
+  onExit: (exitCode: number, signal: number | undefined) => void
+}
+
+/**
+ * Wraps a persistent bash child running inside a pty. Each time the frontend
+ * feeds a line via `writeLine`, the bridge streams bash's stdout back through
+ * `onOutput` until it detects the marker-bearing PS1 — at which point the
+ * line is considered complete and `onLineDone` fires with the captured
+ * output and the exit code.
+ *
+ * The marker format embedded in PS1 is:
+ *   __APES_<random-hex>__:<exit-code>:__END__
+ * The leading token is a 32-char random hex so output collisions are
+ * effectively impossible. `<exit-code>` is `$?` at prompt render time.
+ *
+ * The marker itself is stripped from the output stream before it is
+ * forwarded to the caller, so consumers never see it on their terminal.
+ */
+export class PtyBridge {
+  private readonly marker: string
+  /** Compiled once. Captures the exit code in group 1. */
+  private readonly markerRegex: RegExp
+  private readonly term: IPty
+  private readonly events: PtyBridgeEvents
+  /** Bytes received since the last completed line. Searched for the marker. */
+  private pending = ''
+  /**
+   * Accumulated output for the current in-flight line. Streams to `onOutput`
+   * live as chunks arrive, and is handed to `onLineDone` in full when the
+   * marker is matched. Resets at that point.
+   */
+  private currentLineBuffer = ''
+  /** True until bash prints its first marker-prompt. */
+  private readyForFirstLine = false
+  private awaitingInitialPrompt: ((value: void) => void) | null = null
+
+  constructor(events: PtyBridgeEvents, options: { cols?: number, rows?: number, cwd?: string } = {}) {
+    this.events = events
+    this.marker = randomBytes(16).toString('hex')
+    // Example match: __APES_abc123…__:0:__END__
+    // The `\r?\n?` tolerates line endings around the marker depending on
+    // how bash renders PS1 on a fresh line.
+    this.markerRegex = new RegExp(
+      `__APES_${this.marker}__:(-?\\d+):__END__\\r?\\n?`,
+    )
+
+    const cols = options.cols ?? process.stdout.columns ?? 80
+    const rows = options.rows ?? process.stdout.rows ?? 24
+
+    // We spawn bash as `--login -i` so the user's ~/.bash_profile / ~/.bashrc
+    // runs and they get their aliases/functions. Trade-off: if the user
+    // overrides PS1 in their rcfile, our marker detection breaks. We protect
+    // against that by re-exporting PS1 via PROMPT_COMMAND on every prompt.
+    this.term = pty.spawn('bash', ['--login', '-i'], {
+      name: 'xterm-256color',
+      cols,
+      rows,
+      cwd: options.cwd ?? process.cwd(),
+      env: {
+        ...process.env,
+        // Force our marker PS1 on every prompt — survives .bashrc overrides.
+        PROMPT_COMMAND: `PS1='__APES_${this.marker}__:$?:__END__'`,
+        // Also set it initially so the very first prompt carries the marker.
+        PS1: `__APES_${this.marker}__:$?:__END__`,
+        PS2: '> ',
+        // Silence bash-specific onboarding that would pollute our output.
+        BASH_SILENCE_DEPRECATION_WARNING: '1',
+      },
+    })
+
+    this.term.onData(chunk => this.handleData(chunk))
+    this.term.onExit(({ exitCode, signal }) => {
+      this.events.onExit(exitCode, signal)
+    })
+  }
+
+  /**
+   * Resolves once bash has printed its very first marker-bearing prompt,
+   * which means it has finished sourcing ~/.bashrc and is ready to accept
+   * input. Callers should await this before sending the first line.
+   */
+  waitForReady(): Promise<void> {
+    if (this.readyForFirstLine)
+      return Promise.resolve()
+    return new Promise((resolve) => {
+      this.awaitingInitialPrompt = resolve
+    })
+  }
+
+  /**
+   * Write a shell command line to bash's stdin. The caller must ensure the
+   * line has already been approved by the grant flow. The bridge does NOT
+   * validate or filter the line.
+   */
+  writeLine(line: string): void {
+    // Trim trailing newlines and always append exactly one, so pasting a
+    // multi-line string works naturally.
+    const clean = line.replace(/\r?\n+$/, '')
+    this.term.write(`${clean}\n`)
+  }
+
+  /**
+   * Raw passthrough write — used for forwarding user keystrokes during
+   * interactive output mode (e.g. while vim is running).
+   */
+  writeRaw(data: string): void {
+    this.term.write(data)
+  }
+
+  /** Resize the underlying pty. Called on SIGWINCH. */
+  resize(cols: number, rows: number): void {
+    this.term.resize(cols, rows)
+  }
+
+  /** Kill the bash child. Called on Ctrl-D / shell exit. */
+  kill(signal?: string): void {
+    this.term.kill(signal)
+  }
+
+  /** Process id of the bash child, for logging / debugging. */
+  get pid(): number {
+    return this.term.pid
+  }
+
+  /** Exposed for tests that want to look at the raw marker. */
+  getMarkerForTest(): string {
+    return this.marker
+  }
+
+  // ----- internals -----
+
+  private handleData(chunk: string): void {
+    this.pending += chunk
+
+    // Walk through any complete marker matches. Each marker ends the current
+    // in-flight line; the `before` slice is its final output.
+    for (;;) {
+      const match = this.pending.match(this.markerRegex)
+      if (!match || match.index === undefined)
+        break
+
+      const before = this.pending.slice(0, match.index)
+      const exitCode = Number(match[1])
+      // Stream the pre-marker portion live (for REPL display) AND fold it
+      // into the per-line buffer so the `onLineDone` frame is complete.
+      if (before.length > 0) {
+        this.currentLineBuffer += before
+        if (this.readyForFirstLine)
+          this.events.onOutput(before)
+      }
+      // Drop the matched marker and everything before it from the buffer
+      this.pending = this.pending.slice(match.index + match[0].length)
+
+      if (!this.readyForFirstLine) {
+        // Bootstrap prompt: discard any bash startup noise we captured and
+        // signal readiness. onLineDone does NOT fire for the implicit
+        // first prompt — that would confuse consumers.
+        this.readyForFirstLine = true
+        this.currentLineBuffer = ''
+        const resolve = this.awaitingInitialPrompt
+        this.awaitingInitialPrompt = null
+        if (resolve)
+          resolve()
+        continue
+      }
+
+      // Real command completion: hand over the accumulated line buffer.
+      const frame = { output: this.currentLineBuffer, exitCode }
+      this.currentLineBuffer = ''
+      this.events.onLineDone(frame)
+    }
+
+    // No more markers in the buffer. If we're past bootstrap, stream any
+    // complete lines that have accumulated so the user sees live output,
+    // and keep any partial tail in `pending` in case the marker is still
+    // mid-chunk.
+    if (!this.readyForFirstLine)
+      return
+
+    const lastNewline = this.pending.lastIndexOf('\n')
+    if (lastNewline >= 0) {
+      const ready = this.pending.slice(0, lastNewline + 1)
+      this.pending = this.pending.slice(lastNewline + 1)
+      if (ready.length > 0) {
+        this.currentLineBuffer += ready
+        this.events.onOutput(ready)
+      }
+    }
+  }
+}

--- a/packages/apes/test/shell-pty-bridge.test.ts
+++ b/packages/apes/test/shell-pty-bridge.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { PtyBridge } from '../src/shell/pty-bridge.js'
+
+/**
+ * Drive a PtyBridge through a sequence of lines and collect everything the
+ * callbacks emit. Helper to keep individual tests readable.
+ */
+function createHarness() {
+  const outputChunks: string[] = []
+  const completedLines: Array<{ output: string, exitCode: number }> = []
+  let exitInfo: { exitCode: number, signal: number | undefined } | null = null
+
+  const bridge = new PtyBridge({
+    onOutput: chunk => outputChunks.push(chunk),
+    onLineDone: frame => completedLines.push({ output: frame.output, exitCode: frame.exitCode }),
+    onExit: (exitCode, signal) => { exitInfo = { exitCode, signal } },
+  }, { cols: 120, rows: 30 })
+
+  return {
+    bridge,
+    outputChunks,
+    completedLines,
+    get exitInfo() { return exitInfo },
+  }
+}
+
+/**
+ * Wait for a predicate to become true by polling every 10ms. Used because
+ * pty data arrives asynchronously and we don't get deterministic events.
+ */
+async function waitUntil(condition: () => boolean, timeoutMs = 5000): Promise<void> {
+  const start = Date.now()
+  while (!condition()) {
+    if (Date.now() - start > timeoutMs)
+      throw new Error('Timed out waiting for condition')
+    await new Promise(r => setTimeout(r, 10))
+  }
+}
+
+describe('PtyBridge', () => {
+  const harnesses: Array<ReturnType<typeof createHarness>> = []
+
+  afterEach(() => {
+    // Clean up all bash children spawned during tests
+    for (const h of harnesses) {
+      try {
+        h.bridge.kill()
+      }
+      catch {}
+    }
+    harnesses.length = 0
+  })
+
+  it('reports ready once bash prints its first prompt marker', async () => {
+    const h = createHarness()
+    harnesses.push(h)
+
+    await h.bridge.waitForReady()
+    // By contract: no lines completed yet (bootstrap prompt is implicit),
+    // and the marker was never visible in the output chunks.
+    expect(h.completedLines).toEqual([])
+    for (const chunk of h.outputChunks) {
+      expect(chunk).not.toContain('__APES_')
+      expect(chunk).not.toContain('__END__')
+    }
+  })
+
+  it('executes a simple command and returns output + exit code', async () => {
+    const h = createHarness()
+    harnesses.push(h)
+
+    await h.bridge.waitForReady()
+    h.bridge.writeLine('echo hello-from-bash')
+    await waitUntil(() => h.completedLines.length >= 1)
+
+    expect(h.completedLines).toHaveLength(1)
+    expect(h.completedLines[0]!.exitCode).toBe(0)
+    // Output should contain the expected line. PTY echoes the input too, so
+    // the output contains both the typed line and its result.
+    expect(h.completedLines[0]!.output).toContain('hello-from-bash')
+    // Marker must never appear in the output we hand to the consumer
+    expect(h.completedLines[0]!.output).not.toContain('__APES_')
+  })
+
+  it('persists shell state across lines (cd then pwd)', async () => {
+    const h = createHarness()
+    harnesses.push(h)
+
+    await h.bridge.waitForReady()
+    h.bridge.writeLine('cd /tmp')
+    await waitUntil(() => h.completedLines.length >= 1)
+
+    h.bridge.writeLine('pwd')
+    await waitUntil(() => h.completedLines.length >= 2)
+
+    expect(h.completedLines[1]!.exitCode).toBe(0)
+    expect(h.completedLines[1]!.output).toContain('/tmp')
+  })
+
+  it('persists environment variables across lines', async () => {
+    const h = createHarness()
+    harnesses.push(h)
+
+    await h.bridge.waitForReady()
+    h.bridge.writeLine('export APES_TEST_FOO=bar')
+    await waitUntil(() => h.completedLines.length >= 1)
+
+    h.bridge.writeLine('echo "$APES_TEST_FOO"')
+    await waitUntil(() => h.completedLines.length >= 2)
+
+    expect(h.completedLines[1]!.exitCode).toBe(0)
+    expect(h.completedLines[1]!.output).toContain('bar')
+  })
+
+  it('reports non-zero exit code when a command fails', async () => {
+    const h = createHarness()
+    harnesses.push(h)
+
+    await h.bridge.waitForReady()
+    h.bridge.writeLine('false')
+    await waitUntil(() => h.completedLines.length >= 1)
+
+    expect(h.completedLines[0]!.exitCode).toBe(1)
+  })
+
+  it('kill() terminates the bash child and fires onExit', async () => {
+    const h = createHarness()
+    harnesses.push(h)
+
+    await h.bridge.waitForReady()
+    h.bridge.kill()
+    await waitUntil(() => h.exitInfo !== null)
+
+    expect(h.exitInfo).not.toBeNull()
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -519,6 +519,9 @@ importers:
       giget:
         specifier: ^2.0.0
         version: 2.0.0
+      node-pty:
+        specifier: ^1.1.0
+        version: 1.1.0
       shell-quote:
         specifier: ^1.8.3
         version: 1.8.3
@@ -7743,6 +7746,9 @@ packages:
 
   node-mock-http@1.0.4:
     resolution: {integrity: sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==}
+
+  node-pty@1.1.0:
+    resolution: {integrity: sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==}
 
   node-releases@2.0.36:
     resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
@@ -18878,6 +18884,10 @@ snapshots:
   node-gyp-build@4.8.4: {}
 
   node-mock-http@1.0.4: {}
+
+  node-pty@1.1.0:
+    dependencies:
+      node-addon-api: 7.1.1
 
   node-releases@2.0.36: {}
 


### PR DESCRIPTION
Part of #62. First of 7 milestones for the interactive \`ape-shell\` REPL.

## Summary
- New \`PtyBridge\` class wrapping a persistent bash child via \`node-pty\`
- 16-byte random-hex marker embedded in \`PROMPT_COMMAND\` + \`PS1\` so the bridge can detect when bash is ready for the next line, even if the user's \`.bashrc\` redefines PS1
- Marker is stripped from the output stream before it reaches the consumer — never visible in the user's terminal
- \`onOutput\` streams pty chunks live; \`onLineDone\` fires once per completed shell line with accumulated output + exit code
- Full shell state (cwd, env, aliases, functions) persists across lines because one bash stays alive

## Files
- **\`packages/apes/src/shell/pty-bridge.ts\`** — new PtyBridge class
- **\`packages/apes/test/shell-pty-bridge.test.ts\`** — 6 unit tests (readiness, simple command, cd persistence, export persistence, exit code, clean shutdown)
- **\`packages/apes/package.json\`** — adds \`node-pty@^1.1.0\` dep + \`postinstall\` script
- **\`packages/apes/scripts/fix-node-pty-perms.mjs\`** — workaround for a pnpm 10 regression that drops the execute bit on node-pty's prebuilt \`spawn-helper\` binary; without it \`pty.spawn\` fails with \`posix_spawnp failed\`
- **Root \`package.json\`** — \`node-pty\` added to \`pnpm.onlyBuiltDependencies\` so its native build runs

## Test plan
- [x] \`pnpm turbo run lint typecheck --filter=@openape/apes\` clean
- [x] \`pnpm --filter @openape/apes test\` — 308/308 pass (302 existing + 6 new)
- [x] Verified locally: \`cd /tmp\` → \`pwd\` shows \`/tmp\` (state persists). \`export FOO=bar\` → \`echo \$FOO\` shows \`bar\`.

## No user-visible change yet
This PR lands only the internal pty bridge infrastructure. The REPL loop, readline integration, grant dispatch, and login-shell wiring follow in M2–M7. No existing functionality changes.

## Known limitations (addressed in later milestones)
- No REPL loop yet — the bridge can only be exercised from code or tests
- No grant-flow integration — any line passed to \`writeLine\` is executed by bash
- Streaming output via \`onOutput\` arrives line-by-line (not character-by-character); fine for typical interactive use, may need refinement for TUI apps in M3