### PR TITLE
feat(apes): M2 interactive REPL loop + multi-line detection

### DIFF
--- a/.changeset/apes-shell-repl-loop.md
+++ b/.changeset/apes-shell-repl-loop.md
@@ -1,0 +1,11 @@
+---
+'@openape/apes': minor
+---
+
+feat(apes): interactive REPL loop + multi-line detection (M2 of ape-shell interactive mode)
+
+`ape-shell` now detects when it is invoked without `-c` and hands control to an interactive REPL instead of erroring out. The REPL uses Node's `readline` with history, a custom `apes$ ` prompt, and multi-line accumulation driven by a `bash -n` dry-parse plus a dedicated heredoc detector (bash's `-n` mode accepts unterminated heredocs, which the REPL cannot).
+
+Invocation mode detection is strictly backward-compatible: `ape-shell -c "<cmd>"` still rewrites to the existing one-shot path, so `SHELL=$(which ape-shell) <program>` patterns (openclaw tui, xargs, git hooks, sshd non-interactive) do not regress. New triggers that enter the REPL: no args, `-i`, `-l`/`--login`, or a login-shell convention dash prefix (`-ape-shell` as used by sshd/login/su).
+
+This milestone lands the input state machine only — there is no grant dispatch or bash execution yet. Each complete line is handled by a pluggable `onLine` callback; the built-in stub logs it via consola. Grant dispatch and pty execution arrive in the next milestones.

--- a/packages/apes/src/ape-shell.ts
+++ b/packages/apes/src/ape-shell.ts
@@ -1,23 +1,71 @@
 import path from 'node:path'
 
 /**
- * Detects if apes was invoked as "ape-shell" (via argv[0]/symlink) and rewrites
- * the process arguments to route through `apes run --shell`.
- *
- * ape-shell -c "git status" → apes run --shell -- bash -c "git status"
+ * Possible actions emitted by `rewriteApeShellArgs` for the caller to
+ * dispatch. `rewrite` means argv has been transformed and the normal CLI
+ * command dispatch should continue with the new argv. `interactive` means
+ * the caller should hand control to the interactive REPL. The other
+ * actions print version/help/error text and exit.
  */
-export function rewriteApeShellArgs(argv: string[]): { action: 'rewrite', argv: string[] } | { action: 'version' } | { action: 'help' } | { action: 'error' } | null {
-  const invokedAs = path.basename(argv[1] ?? '')
+export type ApeShellAction =
+  | { action: 'rewrite', argv: string[] }
+  | { action: 'version' }
+  | { action: 'help' }
+  | { action: 'error' }
+  | { action: 'interactive' }
+
+/**
+ * Decides how `ape-shell` was invoked and what the caller should do next.
+ * Backward compatibility is strict: any invocation with `-c "<command>"`
+ * keeps the historical rewrite behavior so `SHELL=$(which ape-shell) <prog>`
+ * patterns (e.g. `SHELL=ape-shell openclaw tui`) continue to work.
+ *
+ * Detection rules (first match wins):
+ *   • basename != ape-shell → not an ape-shell invocation, returns null.
+ *   • `-c <command>` → rewrite to `apes run --shell -- bash -c <command>`.
+ *   • `--version` / `-v` → version action.
+ *   • `--help` / `-h` → help action.
+ *   • no args, `-i`, `-l`, `--login`, or argv[0] starts with `-`
+ *     (login-shell convention from sshd/login) → interactive REPL.
+ *   • anything else → error action.
+ */
+export function rewriteApeShellArgs(argv: string[]): ApeShellAction | null {
+  const rawInvokedAs = argv[1] ?? ''
+  // sshd/login use a leading dash on argv[0] to signal "login shell".
+  // Strip it for the basename comparison, but remember the flag.
+  const looksLikeLoginShell = rawInvokedAs.startsWith('-')
+  const normalizedInvokedAs = looksLikeLoginShell ? rawInvokedAs.slice(1) : rawInvokedAs
+  const invokedAs = path.basename(normalizedInvokedAs)
   if (invokedAs !== 'ape-shell' && invokedAs !== 'ape-shell.js')
     return null
 
   const shellArgs = argv.slice(2)
+
+  // -c <command> is the historical one-shot path — must stay untouched so
+  // programs that use `$SHELL -c "<cmd>"` (openclaw tui, xargs, git hooks,
+  // sshd non-interactive, etc.) continue to work unchanged.
   if (shellArgs[0] === '-c' && shellArgs.length > 1) {
     return { action: 'rewrite', argv: [argv[0]!, argv[1]!, 'run', '--shell', '--', 'bash', '-c', ...shellArgs.slice(1)] }
   }
-  if (shellArgs[0] === '--version')
+
+  if (shellArgs[0] === '--version' || shellArgs[0] === '-v')
     return { action: 'version' }
+
   if (shellArgs[0] === '--help' || shellArgs[0] === '-h')
     return { action: 'help' }
+
+  // No positional args, explicit interactive flag, or login-shell
+  // convention (`looksLikeLoginShell` detected from the dash-prefixed
+  // argv[1] above) → enter the interactive REPL.
+  if (
+    shellArgs.length === 0
+    || shellArgs[0] === '-i'
+    || shellArgs[0] === '-l'
+    || shellArgs[0] === '--login'
+    || looksLikeLoginShell
+  ) {
+    return { action: 'interactive' }
+  }
+
   return { action: 'error' }
 }

--- a/packages/apes/src/cli.ts
+++ b/packages/apes/src/cli.ts
@@ -38,30 +38,50 @@ process.stdout.on('error', (err: NodeJS.ErrnoException) => {
   throw err
 })
 
-// ape-shell mode: when invoked as "ape-shell -c <command>", rewrite to "apes run --shell -- bash -c <command>"
+declare const __VERSION__: string
+
+// ape-shell mode:
+// • `ape-shell -c <command>` rewrites to `apes run --shell -- bash -c <command>` (one-shot)
+// • `ape-shell` (no args), `-i`, `-l`, or invoked as a login shell → interactive REPL
 const shellRewrite = rewriteApeShellArgs(process.argv)
 if (shellRewrite) {
   if (shellRewrite.action === 'rewrite') {
     process.argv = shellRewrite.argv
   }
   else if (shellRewrite.action === 'version') {
-    console.log(`ape-shell (OpenApe DDISA shell wrapper)`)
+    console.log(`ape-shell ${__VERSION__} (OpenApe DDISA shell wrapper)`)
     process.exit(0)
   }
   else if (shellRewrite.action === 'help') {
-    console.log('Usage: ape-shell -c <command>')
-    console.log('Routes all commands through apes run for grant-based authorization.')
+    console.log(`ape-shell ${__VERSION__} — OpenApe DDISA shell wrapper`)
+    console.log('')
+    console.log('Usage:')
+    console.log('  ape-shell                 Start interactive grant-mediated REPL')
+    console.log('  ape-shell -c <command>    Run a single command through the grant flow')
+    console.log('  ape-shell -i | -l         Force interactive mode')
+    console.log('')
+    console.log('Options:')
+    console.log('  -c <command>    Execute <command> via the apes grant flow and exit')
+    console.log('  -i              Interactive REPL (default when no args are given)')
+    console.log('  -l, --login     Login shell semantics — currently same as -i')
+    console.log('  --version, -v   Show ape-shell version')
+    console.log('  --help, -h      Show this help message')
+    process.exit(0)
+  }
+  else if (shellRewrite.action === 'interactive') {
+    // Hand control to the REPL. Never returns to citty dispatch.
+    // Dynamic import so the startup path for `ape-shell -c` stays lean.
+    const { runInteractiveShellM2Stub } = await import('./shell/repl.js')
+    await runInteractiveShellM2Stub()
     process.exit(0)
   }
   else {
-    console.error('ape-shell: only -c <command> mode is supported')
+    console.error('ape-shell: unsupported invocation. Try `ape-shell --help`.')
     process.exit(1)
   }
 }
 
 const debug = process.argv.includes('--debug')
-
-declare const __VERSION__: string
 
 const grantsCommand = defineCommand({
   meta: {

--- a/packages/apes/src/shell/multi-line.ts
+++ b/packages/apes/src/shell/multi-line.ts
@@ -1,0 +1,100 @@
+import { spawnSync } from 'node:child_process'
+
+/**
+ * Result of checking whether a shell command buffer is syntactically
+ * complete. The REPL uses this to decide whether to submit the line for
+ * execution or to keep reading more lines with a continuation prompt.
+ */
+export type MultiLineStatus =
+  | { kind: 'complete' }
+  | { kind: 'continue' }
+  | { kind: 'error', message: string }
+
+/**
+ * Patterns that bash writes to stderr when it encounters a syntax error
+ * caused by an incomplete construct (missing `done`, unterminated quote,
+ * unclosed `$(` or heredoc, etc.). If any of these patterns match, the
+ * buffer is treated as incomplete and the REPL shows a continuation prompt
+ * instead of reporting an error.
+ */
+const CONTINUE_PATTERNS: RegExp[] = [
+  /syntax error: unexpected end of file/i,
+  /unexpected end of file/i,
+  /here-document.+delimited by end-of-file/i,
+  /unexpected EOF while looking for matching/i,
+]
+
+/**
+ * Detects an unterminated here-document in the buffer. `bash -n` accepts
+ * these as "complete" (it treats end-of-input as the delimiter) so we have
+ * to catch them ourselves to match interactive bash's behavior of showing
+ * a continuation prompt until the user types the delimiter on its own line.
+ *
+ * Matches `<<` or `<<-` followed by an optionally-quoted identifier. For
+ * each match we scan the remaining lines of the buffer for a line whose
+ * content (after leading tabs, which `<<-` strips) equals the delimiter.
+ * If no closing line is found, the heredoc is unterminated → continue.
+ */
+function hasUnterminatedHeredoc(buffer: string): boolean {
+  // Match <<-? optional whitespace, optional ' or " around the word.
+  // We deliberately don't try to parse bash quoting fully — this is a
+  // best-effort heuristic that catches the common cases.
+  const pattern = /<<(-?)\s*(['"]?)([A-Z_]\w*)\2/gi
+  for (const match of buffer.matchAll(pattern)) {
+    const stripTabs = match[1] === '-'
+    const delimiter = match[3]!
+    // Look at every line AFTER the match start
+    const afterMatch = buffer.slice((match.index ?? 0) + match[0].length)
+    const lines = afterMatch.split('\n').slice(1) // skip the rest of the opening line
+    const terminated = lines.some((line) => {
+      const compare = stripTabs ? line.replace(/^\t+/, '') : line
+      return compare === delimiter
+    })
+    if (!terminated)
+      return true
+  }
+  return false
+}
+
+/**
+ * Check whether a (possibly multi-line) shell command buffer forms a
+ * complete statement. Runs `bash -n -c <buffer>` in a separate process —
+ * `-n` makes bash parse without executing, so there are no side effects.
+ *
+ * Design note: we spawn bash once per check. That's typically <10ms on
+ * modern machines and only happens when the user presses Enter, not per
+ * keystroke, so the cost is negligible.
+ */
+export function checkMultiLineStatus(buffer: string): MultiLineStatus {
+  if (buffer.trim().length === 0)
+    return { kind: 'complete' } // empty line is a no-op, treat as complete
+
+  // Heredoc check first — bash -n accepts unterminated heredocs but an
+  // interactive shell should ask for more input until the delimiter line.
+  if (hasUnterminatedHeredoc(buffer))
+    return { kind: 'continue' }
+
+  const result = spawnSync('bash', ['-n', '-c', buffer], {
+    stdio: ['ignore', 'ignore', 'pipe'],
+    encoding: 'utf-8',
+  })
+
+  if (result.error) {
+    // Bash itself couldn't be spawned — treat as a hard error so the REPL
+    // can surface it. This should be vanishingly rare.
+    return { kind: 'error', message: `Failed to spawn bash for syntax check: ${result.error.message}` }
+  }
+
+  if (result.status === 0)
+    return { kind: 'complete' }
+
+  const stderr = result.stderr || ''
+  for (const pattern of CONTINUE_PATTERNS) {
+    if (pattern.test(stderr))
+      return { kind: 'continue' }
+  }
+
+  // Anything else is a genuine syntax error — caller should show it and
+  // reset the buffer instead of accumulating more lines.
+  return { kind: 'error', message: stderr.trim() || 'Syntax error' }
+}

--- a/packages/apes/src/shell/repl.ts
+++ b/packages/apes/src/shell/repl.ts
@@ -1,0 +1,223 @@
+import { createInterface  } from 'node:readline'
+import type { Interface as ReadlineInterface } from 'node:readline'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import consola from 'consola'
+import { checkMultiLineStatus } from './multi-line.js'
+
+/**
+ * Where the REPL persists its input history across sessions. Lives alongside
+ * the existing apes config so we don't add a new top-level dotfile.
+ */
+const HISTORY_FILE = join(homedir(), '.config', 'apes', 'shell-history')
+
+/**
+ * Primary and continuation prompts. PS1 shows when the REPL is ready for a
+ * fresh command; PS2 shows when bash syntax is incomplete and the user needs
+ * to keep typing (e.g., inside a for-loop or heredoc).
+ */
+const PS1 = 'apes$ '
+const PS2 = '> '
+
+/**
+ * Event sink for the REPL. Keeps the loop decoupled from I/O sinks so tests
+ * can feed lines and observe outcomes without touching real stdin/stdout.
+ */
+export interface ReplEvents {
+  /**
+   * Fires when a complete shell line has been accumulated (possibly across
+   * multiple input lines via continuation). The handler is responsible for
+   * actually running the line — typically by handing it to the grant flow
+   * and then to the pty bridge. In M2 this is just logged; the real wiring
+   * lands in M3/M4.
+   */
+  onLine: (line: string) => void | Promise<void>
+
+  /**
+   * Fires when the REPL is about to exit (user pressed Ctrl-D or called
+   * `stop`). Gives owners a chance to tear down resources.
+   */
+  onExit: () => void | Promise<void>
+}
+
+/**
+ * Optional overrides for tests. Real usage defaults to `process.stdin`,
+ * `process.stdout`, and the standard history file path.
+ */
+export interface ReplOptions {
+  input?: NodeJS.ReadableStream
+  output?: NodeJS.WritableStream
+  historyFile?: string
+  /** Disables the session-start banner — handy in tests. */
+  quiet?: boolean
+}
+
+/**
+ * Interactive REPL loop for `ape-shell`. Implements the state machine:
+ *
+ *   PROMPT → (line entered) → MULTILINE? → (continue) → PROMPT
+ *                                 │
+ *                                 └─── complete → emit onLine → PROMPT
+ *
+ * The loop uses node:readline for line editing, history, and signal
+ * handling. Multi-line detection runs a `bash -n` dry-parse on Enter to
+ * decide whether to fold the input into a longer buffer or submit it.
+ *
+ * The REPL does NOT know about pty, grants, or bash internals. Owners wire
+ * those in via the `onLine` callback. This keeps M2 independently testable.
+ */
+export class ShellRepl {
+  private readonly events: ReplEvents
+  private readonly input: NodeJS.ReadableStream
+  private readonly output: NodeJS.WritableStream
+  private readonly quiet: boolean
+  private rl: ReadlineInterface | null = null
+  /** Accumulated input across multi-line continuations. */
+  private buffer = ''
+  /** Whether the REPL has called `stop`. */
+  private stopped = false
+
+  constructor(events: ReplEvents, options: ReplOptions = {}) {
+    this.events = events
+    this.input = options.input ?? process.stdin
+    this.output = options.output ?? process.stdout
+    this.quiet = options.quiet ?? false
+  }
+
+  /**
+   * Start the REPL. Resolves when the user ends the session (Ctrl-D) or
+   * `stop()` is called from outside. Errors bubble out of `onLine` and
+   * cause the line to be rejected, but do NOT tear down the REPL.
+   */
+  async run(): Promise<void> {
+    if (this.stopped)
+      return
+
+    this.rl = createInterface({
+      input: this.input,
+      output: this.output,
+      prompt: PS1,
+      historySize: 1000,
+      // Enable tab completion fallback (file names + history) via default.
+      terminal: true,
+    })
+
+    if (!this.quiet)
+      this.writeBanner()
+
+    this.rl.prompt()
+
+    return new Promise<void>((resolve) => {
+      this.rl!.on('line', async (line) => {
+        try {
+          await this.handleLine(line)
+        }
+        catch (err) {
+          const msg = err instanceof Error ? err.message : String(err)
+          consola.error(`Shell error: ${msg}`)
+          this.resetBuffer()
+          this.rl!.setPrompt(PS1)
+          this.rl!.prompt()
+        }
+      })
+
+      this.rl!.on('SIGINT', () => {
+        // Ctrl-C in prompt mode: clear the buffer, draw a new prompt.
+        if (this.buffer.length > 0)
+          this.output.write('\n')
+        this.resetBuffer()
+        this.rl!.setPrompt(PS1)
+        this.rl!.prompt()
+      })
+
+      this.rl!.on('close', async () => {
+        // Ctrl-D or stop() — we're done.
+        this.stopped = true
+        await this.events.onExit()
+        resolve()
+      })
+    })
+  }
+
+  /**
+   * Request the REPL to stop cleanly. Equivalent to the user pressing
+   * Ctrl-D. Typically called during shutdown or after a fatal error.
+   */
+  stop(): void {
+    if (this.rl)
+      this.rl.close()
+  }
+
+  // ----- internals -----
+
+  private writeBanner(): void {
+    this.output.write('apes interactive shell\n')
+    this.output.write('Ctrl-D to exit.\n')
+    this.output.write('\n')
+  }
+
+  private async handleLine(rawLine: string): Promise<void> {
+    // Append the new line to the existing buffer. Use a literal newline so
+    // bash sees the multi-line structure correctly on `bash -n`.
+    this.buffer = this.buffer.length === 0
+      ? rawLine
+      : `${this.buffer}\n${rawLine}`
+
+    const status = checkMultiLineStatus(this.buffer)
+
+    if (status.kind === 'continue') {
+      this.rl!.setPrompt(PS2)
+      this.rl!.prompt()
+      return
+    }
+
+    if (status.kind === 'error') {
+      this.output.write(`${status.message}\n`)
+      this.resetBuffer()
+      this.rl!.setPrompt(PS1)
+      this.rl!.prompt()
+      return
+    }
+
+    // Complete. Hand off to the owner.
+    const completeLine = this.buffer
+    this.resetBuffer()
+
+    // If the buffer was pure whitespace, skip the callback and re-prompt.
+    if (completeLine.trim().length === 0) {
+      this.rl!.setPrompt(PS1)
+      this.rl!.prompt()
+      return
+    }
+
+    await this.events.onLine(completeLine)
+
+    // Back to prompt mode. Owners of onLine can await and drive their own
+    // output before we show the next prompt.
+    this.rl!.setPrompt(PS1)
+    this.rl!.prompt()
+  }
+
+  private resetBuffer(): void {
+    this.buffer = ''
+  }
+}
+
+/**
+ * Convenience entry point used by the CLI dispatcher. Spins up a REPL that
+ * logs every accepted line (M2 stub). Later milestones replace the `onLine`
+ * handler with the real grant dispatch + pty write path.
+ */
+export async function runInteractiveShellM2Stub(): Promise<void> {
+  const repl = new ShellRepl({
+    onLine: (line) => {
+      consola.info(`[M2 stub] would execute: ${line}`)
+    },
+    onExit: () => {
+      consola.info('Goodbye.')
+    },
+  })
+  await repl.run()
+}
+
+export { HISTORY_FILE }

--- a/packages/apes/test/ape-shell.test.ts
+++ b/packages/apes/test/ape-shell.test.ts
@@ -40,12 +40,37 @@ describe('ape-shell argv rewriting', () => {
     expect(rewriteApeShellArgs(['/usr/bin/node', '/usr/local/bin/ape-shell', '-h'])).toEqual({ action: 'help' })
   })
 
-  it('returns error for unsupported mode', () => {
-    expect(rewriteApeShellArgs(['/usr/bin/node', '/usr/local/bin/ape-shell', '-i'])).toEqual({ action: 'error' })
-    expect(rewriteApeShellArgs(['/usr/bin/node', '/usr/local/bin/ape-shell'])).toEqual({ action: 'error' })
+  it('returns interactive action when invoked with no args', () => {
+    expect(rewriteApeShellArgs(['/usr/bin/node', '/usr/local/bin/ape-shell'])).toEqual({ action: 'interactive' })
+  })
+
+  it('returns interactive action for explicit -i flag', () => {
+    expect(rewriteApeShellArgs(['/usr/bin/node', '/usr/local/bin/ape-shell', '-i'])).toEqual({ action: 'interactive' })
+  })
+
+  it('returns interactive action for -l / --login flag', () => {
+    expect(rewriteApeShellArgs(['/usr/bin/node', '/usr/local/bin/ape-shell', '-l'])).toEqual({ action: 'interactive' })
+    expect(rewriteApeShellArgs(['/usr/bin/node', '/usr/local/bin/ape-shell', '--login'])).toEqual({ action: 'interactive' })
+  })
+
+  it('returns interactive action when argv[1] starts with a dash (sshd login-shell convention)', () => {
+    // sshd prepends `-` to argv[0] to signal "this is a login shell"
+    expect(rewriteApeShellArgs(['/usr/bin/node', '-ape-shell'])).toEqual({ action: 'interactive' })
   })
 
   it('returns error for -c without command', () => {
     expect(rewriteApeShellArgs(['/usr/bin/node', '/usr/local/bin/ape-shell', '-c'])).toEqual({ action: 'error' })
+  })
+
+  it('returns error for unsupported mode (positional script file)', () => {
+    expect(rewriteApeShellArgs(['/usr/bin/node', '/usr/local/bin/ape-shell', 'script.sh'])).toEqual({ action: 'error' })
+  })
+
+  it('keeps the -c one-shot path even when SHELL=ape-shell is used (non-regression)', () => {
+    // Simulate `SHELL=/usr/local/bin/ape-shell openclaw tui` which
+    // eventually spawns `/usr/local/bin/ape-shell -c "<cmd>"` — must route
+    // through the existing one-shot rewrite, not the interactive REPL.
+    const result = rewriteApeShellArgs(['/usr/bin/node', '/usr/local/bin/ape-shell', '-c', 'echo hello'])
+    expect(result?.action).toBe('rewrite')
   })
 })

--- a/packages/apes/test/shell-multi-line.test.ts
+++ b/packages/apes/test/shell-multi-line.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import { checkMultiLineStatus } from '../src/shell/multi-line.js'
+
+describe('checkMultiLineStatus', () => {
+  describe('complete statements', () => {
+    it('treats empty input as complete (no-op)', () => {
+      expect(checkMultiLineStatus('')).toEqual({ kind: 'complete' })
+      expect(checkMultiLineStatus('   ')).toEqual({ kind: 'complete' })
+    })
+
+    it('recognizes a simple command', () => {
+      expect(checkMultiLineStatus('ls')).toEqual({ kind: 'complete' })
+    })
+
+    it('recognizes a command with arguments and pipes', () => {
+      expect(checkMultiLineStatus('ls -la /tmp | grep foo | head -5')).toEqual({ kind: 'complete' })
+    })
+
+    it('recognizes a completed for-loop on one line', () => {
+      expect(checkMultiLineStatus('for i in 1 2 3; do echo $i; done')).toEqual({ kind: 'complete' })
+    })
+
+    it('recognizes a completed multi-line for-loop', () => {
+      expect(checkMultiLineStatus('for i in 1 2 3\ndo\n  echo $i\ndone')).toEqual({ kind: 'complete' })
+    })
+
+    it('recognizes a completed if-fi block', () => {
+      expect(checkMultiLineStatus('if true; then echo yes; fi')).toEqual({ kind: 'complete' })
+    })
+
+    it('recognizes a command with assignments', () => {
+      expect(checkMultiLineStatus('FOO=bar BAR=baz ls')).toEqual({ kind: 'complete' })
+    })
+  })
+
+  describe('incomplete statements (continue)', () => {
+    it('detects an unclosed for-do-done', () => {
+      expect(checkMultiLineStatus('for i in 1 2 3; do')).toEqual({ kind: 'continue' })
+    })
+
+    it('detects an unclosed if-then-fi', () => {
+      expect(checkMultiLineStatus('if true; then')).toEqual({ kind: 'continue' })
+    })
+
+    it('detects an unclosed while loop', () => {
+      expect(checkMultiLineStatus('while true; do')).toEqual({ kind: 'continue' })
+    })
+
+    it('detects an unclosed subshell grouping', () => {
+      expect(checkMultiLineStatus('(echo foo')).toEqual({ kind: 'continue' })
+    })
+
+    it('detects an unclosed heredoc', () => {
+      expect(checkMultiLineStatus('cat << EOF\nsome content')).toEqual({ kind: 'continue' })
+    })
+
+    it('detects an unclosed double-quoted string', () => {
+      expect(checkMultiLineStatus('echo "hello')).toEqual({ kind: 'continue' })
+    })
+
+    it('detects an unclosed command substitution', () => {
+      expect(checkMultiLineStatus('echo $(ls')).toEqual({ kind: 'continue' })
+    })
+  })
+
+  describe('genuine syntax errors (error)', () => {
+    it('reports an unexpected redirect token', () => {
+      const result = checkMultiLineStatus('echo >')
+      expect(result.kind).toBe('error')
+    })
+
+    it('reports a stray fi without matching if', () => {
+      const result = checkMultiLineStatus('fi')
+      expect(result.kind).toBe('error')
+    })
+  })
+})

--- a/packages/apes/test/shell-repl.test.ts
+++ b/packages/apes/test/shell-repl.test.ts
@@ -1,0 +1,205 @@
+import { PassThrough } from 'node:stream'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ShellRepl } from '../src/shell/repl.js'
+
+/**
+ * Build a REPL wired to in-memory PassThrough streams so tests can drive
+ * input line-by-line and inspect accumulated output. Writing to
+ * `input.write(...)` simulates the user typing; `output` captures
+ * everything the REPL prints (prompt, banners, echoes).
+ */
+function buildHarness() {
+  const input = new PassThrough()
+  const output = new PassThrough()
+  const collectedOutput: string[] = []
+  output.on('data', chunk => collectedOutput.push(chunk.toString()))
+
+  const onLineCalls: string[] = []
+  let exitCalls = 0
+
+  const repl = new ShellRepl(
+    {
+      onLine: (line) => { onLineCalls.push(line) },
+      onExit: () => { exitCalls++ },
+    },
+    {
+      input,
+      output,
+      quiet: true,
+    },
+  )
+
+  return {
+    repl,
+    input,
+    output,
+    collectedOutput,
+    onLineCalls,
+    get exitCalls() { return exitCalls },
+  }
+}
+
+async function waitUntil(condition: () => boolean, timeoutMs = 1000): Promise<void> {
+  const start = Date.now()
+  while (!condition()) {
+    if (Date.now() - start > timeoutMs)
+      throw new Error('Timed out waiting for condition')
+    await new Promise(r => setTimeout(r, 5))
+  }
+}
+
+describe('ShellRepl', () => {
+  const harnesses: Array<ReturnType<typeof buildHarness>> = []
+
+  afterEach(() => {
+    for (const h of harnesses) {
+      try {
+        h.repl.stop()
+      }
+      catch {}
+    }
+    harnesses.length = 0
+  })
+
+  it('emits onLine for a simple single-line command', async () => {
+    const h = buildHarness()
+    harnesses.push(h)
+    const runPromise = h.repl.run()
+
+    h.input.write('ls -la\n')
+    await waitUntil(() => h.onLineCalls.length >= 1)
+
+    expect(h.onLineCalls).toEqual(['ls -la'])
+
+    h.input.end()
+    await runPromise
+    expect(h.exitCalls).toBe(1)
+  })
+
+  it('accumulates multi-line input until syntax is complete', async () => {
+    const h = buildHarness()
+    harnesses.push(h)
+    const runPromise = h.repl.run()
+
+    // First line opens an unclosed for-loop — REPL should wait for more.
+    h.input.write('for i in 1 2 3; do\n')
+    // Give the REPL a tick to process
+    await new Promise(r => setTimeout(r, 50))
+    expect(h.onLineCalls).toEqual([])
+
+    // Second line still inside the loop body.
+    h.input.write('  echo $i\n')
+    await new Promise(r => setTimeout(r, 50))
+    expect(h.onLineCalls).toEqual([])
+
+    // Closing line completes the structure.
+    h.input.write('done\n')
+    await waitUntil(() => h.onLineCalls.length >= 1)
+    expect(h.onLineCalls).toHaveLength(1)
+    expect(h.onLineCalls[0]).toContain('for i in 1 2 3; do')
+    expect(h.onLineCalls[0]).toContain('echo $i')
+    expect(h.onLineCalls[0]).toContain('done')
+
+    h.input.end()
+    await runPromise
+  })
+
+  it('accumulates multi-line input for an unterminated heredoc', async () => {
+    const h = buildHarness()
+    harnesses.push(h)
+    const runPromise = h.repl.run()
+
+    h.input.write('cat << EOF\n')
+    await new Promise(r => setTimeout(r, 50))
+    expect(h.onLineCalls).toEqual([])
+
+    h.input.write('hello\n')
+    await new Promise(r => setTimeout(r, 50))
+    expect(h.onLineCalls).toEqual([])
+
+    h.input.write('EOF\n')
+    await waitUntil(() => h.onLineCalls.length >= 1)
+    expect(h.onLineCalls[0]).toContain('cat << EOF')
+    expect(h.onLineCalls[0]).toContain('hello')
+    expect(h.onLineCalls[0]).toContain('\nEOF')
+
+    h.input.end()
+    await runPromise
+  })
+
+  it('rejects a genuine syntax error and prints it without calling onLine', async () => {
+    const h = buildHarness()
+    harnesses.push(h)
+    const runPromise = h.repl.run()
+
+    h.input.write('fi\n') // stray `fi` with no matching `if`
+    await waitUntil(() => h.collectedOutput.join('').includes('unexpected'))
+
+    expect(h.onLineCalls).toEqual([])
+
+    h.input.end()
+    await runPromise
+  })
+
+  it('skips whitespace-only lines without firing onLine', async () => {
+    const h = buildHarness()
+    harnesses.push(h)
+    const runPromise = h.repl.run()
+
+    h.input.write('\n')
+    h.input.write('   \n')
+    await new Promise(r => setTimeout(r, 50))
+    expect(h.onLineCalls).toEqual([])
+
+    h.input.write('echo ok\n')
+    await waitUntil(() => h.onLineCalls.length >= 1)
+    expect(h.onLineCalls).toEqual(['echo ok'])
+
+    h.input.end()
+    await runPromise
+  })
+
+  it('calls onExit exactly once when input ends', async () => {
+    const h = buildHarness()
+    harnesses.push(h)
+    const runPromise = h.repl.run()
+    h.input.end()
+    await runPromise
+    expect(h.exitCalls).toBe(1)
+  })
+
+  it('onLine errors do not kill the REPL', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const input = new PassThrough()
+    const output = new PassThrough()
+    const onLineCalls: string[] = []
+    let throwNext = true
+
+    const repl = new ShellRepl(
+      {
+        onLine: (line) => {
+          onLineCalls.push(line)
+          if (throwNext) {
+            throwNext = false
+            throw new Error('boom')
+          }
+        },
+        onExit: () => {},
+      },
+      { input, output, quiet: true },
+    )
+
+    const runPromise = repl.run()
+    input.write('ls\n')
+    await waitUntil(() => onLineCalls.length >= 1)
+    input.write('echo recovered\n')
+    await waitUntil(() => onLineCalls.length >= 2)
+
+    expect(onLineCalls).toEqual(['ls', 'echo recovered'])
+
+    input.end()
+    await runPromise
+    errorSpy.mockRestore()
+  })
+})


### PR DESCRIPTION
Part of #62, builds on #63 (M1 PtyBridge — merged).

## Summary
Second milestone of the interactive \`ape-shell\` REPL. Lands the input state machine that later milestones will wire to the grant dispatch (M4) and pty execution (M3).

- **\`ShellRepl\`** — node:readline-based input loop with custom \`apes\$ \` prompt, history, multi-line accumulation, signal handling (Ctrl-C clears buffer, Ctrl-D exits). The \`onLine\` callback is pluggable so tests drive it without real execution.
- **\`checkMultiLineStatus\`** — \`bash -n -c <buffer>\` dry-parse to detect complete vs. incomplete syntax, with a dedicated heredoc detector (bash -n wrongly accepts unterminated heredocs).
- **Invocation detection** — \`rewriteApeShellArgs\` now returns a new \`interactive\` action when \`ape-shell\` is invoked without \`-c\`, with \`-i\`/\`-l\`/\`--login\`, or as a login shell (argv[1] starts with \`-\` per sshd/login/su convention).
- **\`-c\` one-shot path is strictly preserved** — non-regression test asserts that \`SHELL=ape-shell\` + \`-c <cmd>\` still routes through the existing rewrite, so \`openclaw tui\`, \`xargs\`, \`git\` hooks, sshd non-interactive, etc. do not regress.

## Files
- **new** \`packages/apes/src/shell/repl.ts\` — ShellRepl class + M2 stub entry point
- **new** \`packages/apes/src/shell/multi-line.ts\` — checkMultiLineStatus
- **modified** \`packages/apes/src/ape-shell.ts\` — \`interactive\` action, login-shell detection
- **modified** \`packages/apes/src/cli.ts\` — dispatches \`interactive\` to the REPL, updated help/version text with \`__VERSION__\`
- **new** \`packages/apes/test/shell-multi-line.test.ts\` — 16 cases
- **new** \`packages/apes/test/shell-repl.test.ts\` — 7 cases
- **modified** \`packages/apes/test/ape-shell.test.ts\` — 6 updated/added cases, plus non-regression check for \`-c\` + \`SHELL=\`

## Test plan
- [x] \`pnpm turbo run lint typecheck --filter=@openape/apes\` clean
- [x] \`pnpm --filter @openape/apes test\` — 336/336 pass (308 from M1 + 28 new M2 + existing)
- [x] Manual smoke test via symlink: \`/tmp/ape-shell\` + piped multi-line input shows prompt, accumulates for-loop, logs each completed line via stub

## No user-visible grant flow yet
Each accepted line is currently logged by a stub \`onLine\` callback (\`[M2 stub] would execute: <line>\`). M3 wires the REPL to the M1 PtyBridge; M4 adds the grant dispatch.