### PR TITLE
fix(ci): remove redundant nuxi prepare from app test/typecheck scripts

### DIFF
--- a/apps/openape-agent-mail/package.json
+++ b/apps/openape-agent-mail/package.json
@@ -13,10 +13,10 @@
     "dev": "nuxt dev --port 3003",
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",
-    "typecheck": "nuxi prepare && nuxt typecheck",
+    "typecheck": "nuxt typecheck",
     "lint": "eslint .",
-    "test": "nuxi prepare && vitest --config vitest.config.ts",
-    "test:run": "nuxi prepare && vitest run --config vitest.config.ts",
+    "test": "vitest --config vitest.config.ts",
+    "test:run": "vitest run --config vitest.config.ts",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:push": "drizzle-kit push"

--- a/apps/openape-agent-proxy/package.json
+++ b/apps/openape-agent-proxy/package.json
@@ -13,7 +13,7 @@
     "dev": "nuxt dev --port 3004",
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",
-    "typecheck": "nuxi prepare && nuxt typecheck",
+    "typecheck": "nuxt typecheck",
     "lint": "eslint ."
   },
   "dependencies": {

--- a/apps/openape-free-idp/package.json
+++ b/apps/openape-free-idp/package.json
@@ -13,9 +13,9 @@
     "dev": "nuxt dev --port 3002",
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",
-    "typecheck": "nuxi prepare && nuxt typecheck",
+    "typecheck": "nuxt typecheck",
     "lint": "eslint .",
-    "test": "nuxi prepare && vitest run"
+    "test": "vitest run"
   },
   "dependencies": {
     "@iconify-json/lucide": "^1.2.90",


### PR DESCRIPTION
## Root cause

Recurring flaky CI failure:

\`\`\`
TSConfckParseError: failed to resolve "extends":"./.nuxt/tsconfig.json"
  in apps/openape-agent-mail/tsconfig.json
\`\`\`

The Nuxt apps (\`openape-agent-mail\`, \`openape-agent-proxy\`, \`openape-free-idp\`) each had scripts like \`nuxi prepare && nuxt typecheck\` and \`nuxi prepare && vitest\`. Under \`turbo --concurrency=4\`, the \`test\` and \`typecheck\` tasks of the same app run in parallel, both invoking \`nuxi prepare\`. Nuxi clears \`.nuxt/\` before regenerating it, so one task can observe a missing \`tsconfig.json\` while the other is in the middle of prepare — causing vitest to fail loading \`tsconfig.json\`, which extends \`.nuxt/tsconfig.json\`.

## Why the double-prepare is safe to remove

- Each app already has \`postinstall: nuxt prepare\` — local dev gets \`.nuxt/\` generated on \`pnpm install\`.
- The CI workflow (\`.github/workflows/ci.yml\`) explicitly runs \`npx nuxi prepare\` for all three apps before the test/typecheck step.
- No other caller relies on \`test\` or \`typecheck\` regenerating \`.nuxt/\`.

Removing the redundant inline prepare eliminates the race without changing functional behavior.

## Scope of the fix

Only the \`scripts\` block in three \`package.json\` files:

- \`apps/openape-agent-mail/package.json\`
- \`apps/openape-agent-proxy/package.json\`
- \`apps/openape-free-idp/package.json\`

No lockfile change, no source change.

## Test plan
- [x] \`pnpm turbo run lint typecheck --filter=@openape/apes\` still clean
- [x] Local \`pnpm --filter openape-agent-mail test\` still works (postinstall already generated .nuxt/)
- [ ] CI: validate step should go green on this PR and on the stacked #65 once rebased