### PR TITLE
feat(apes): M3 wire REPL to persistent bash child

### DIFF
--- a/.changeset/apes-shell-orchestrator.md
+++ b/.changeset/apes-shell-orchestrator.md
@@ -1,0 +1,11 @@
+---
+'@openape/apes': minor
+---
+
+feat(apes): wire interactive REPL to persistent bash child (M3 of ape-shell interactive mode)
+
+Adds `runInteractiveShell` — the orchestrator that glues the M2 `ShellRepl` to the M1 `PtyBridge`. Each accepted line is now written to a real bash pty, output streams back live to the user's terminal, and the REPL waits for the prompt marker before accepting the next line. Raw-mode stdin forwarding makes interactive TUI apps (`vim`, `less`, `top`) work inside the session. SIGWINCH is forwarded to the pty so TUI apps re-render correctly on terminal resize.
+
+State (cwd, environment variables, aliases, functions) persists across lines because a single bash process stays alive for the whole session. An integration test suite (`shell-orchestrator.test.ts`) exercises the full flow against a real bash child: simple commands, sequential state persistence, environment variable persistence, multi-line for-loops, and an assertion that the prompt marker never leaks into visible output.
+
+No grant flow yet — every line executes unconditionally. That arrives in M4.

--- a/packages/apes/src/cli.ts
+++ b/packages/apes/src/cli.ts
@@ -69,10 +69,11 @@ if (shellRewrite) {
     process.exit(0)
   }
   else if (shellRewrite.action === 'interactive') {
-    // Hand control to the REPL. Never returns to citty dispatch.
-    // Dynamic import so the startup path for `ape-shell -c` stays lean.
-    const { runInteractiveShellM2Stub } = await import('./shell/repl.js')
-    await runInteractiveShellM2Stub()
+    // Hand control to the interactive REPL orchestrator. Never returns to
+    // citty dispatch. Dynamic import so the startup path for `ape-shell -c`
+    // stays lean (node-pty native module is only loaded when needed).
+    const { runInteractiveShell } = await import('./shell/orchestrator.js')
+    await runInteractiveShell()
     process.exit(0)
   }
   else {

--- a/packages/apes/src/shell/orchestrator.ts
+++ b/packages/apes/src/shell/orchestrator.ts
@@ -1,0 +1,134 @@
+import consola from 'consola'
+import { PtyBridge } from './pty-bridge.js'
+import { ShellRepl } from './repl.js'
+
+/**
+ * Orchestrates the interactive ape-shell session by wiring the user-facing
+ * REPL to a persistent bash child via the PtyBridge. Keeps both components
+ * decoupled so each can be unit-tested in isolation.
+ *
+ * Flow per user-entered line:
+ *   1. ShellRepl emits onLine with the completed (possibly multi-line) buffer
+ *   2. We switch the REPL into "output mode" (pauses readline, turns on raw
+ *      stdin forwarding so TUI apps like vim receive raw keystrokes)
+ *   3. The line is written to the bash pty
+ *   4. bash output streams back to stdout live via PtyBridge.onOutput
+ *   5. When the marker-bearing PS1 reappears we fire a resolve() that lets
+ *      the REPL's onLine promise settle → readline takes back the terminal
+ *      and shows the next prompt
+ *
+ * M3 does NOT yet integrate the grant flow — every line is executed
+ * unconditionally. M4 inserts grant-dispatch before the pty.write call.
+ */
+export async function runInteractiveShell(): Promise<void> {
+  /**
+   * When a line is written into the bash pty, handleLine stashes a
+   * resolver here so the PtyBridge's onLineDone can wake it up.
+   */
+  let pendingResolve: (() => void) | null = null
+  let lastExitCode = 0
+  let shuttingDown = false
+  // Forward reference to the REPL so the bridge's onExit can stop it when
+  // bash dies. Assigned after construction below.
+  let repl: ShellRepl | null = null
+
+  // Spawn the bash child up-front so the REPL can write to it as soon as the
+  // first line is accepted. Output from bash goes straight to the terminal.
+  const bridge = new PtyBridge(
+    {
+      onOutput: (chunk) => {
+        // Live streaming to the user's terminal. Always written straight
+        // through so TUI apps (vim, less, top) get their escape sequences
+        // on time.
+        process.stdout.write(chunk)
+      },
+      onLineDone: (frame) => {
+        if (pendingResolve) {
+          const r = pendingResolve
+          pendingResolve = null
+          lastExitCode = frame.exitCode
+          r()
+        }
+      },
+      onExit: (exitCode) => {
+        // bash itself died — typically because the user ran `exit`.
+        // Tear down the REPL so run() returns cleanly.
+        if (!shuttingDown) {
+          process.stdout.write(`\n[bash exited with code ${exitCode}]\n`)
+          repl?.stop()
+        }
+      },
+    },
+  )
+
+  await bridge.waitForReady()
+
+  repl = new ShellRepl(
+    {
+      onLine: async (line) => {
+        // Switch stdin to raw mode so interactive TUI apps work. We route
+        // raw bytes from process.stdin directly into bash's pty.
+        // We also stop readline from consuming input during this window.
+        const wasRaw = process.stdin.isTTY && (process.stdin as NodeJS.ReadStream).isRaw
+        if (process.stdin.isTTY && !wasRaw)
+          (process.stdin as NodeJS.ReadStream).setRawMode(true)
+
+        const forward = (chunk: Buffer) => {
+          bridge.writeRaw(chunk.toString())
+        }
+        // Pause readline so it doesn't steal input during execution
+        // (node's readline auto-buffers; pause() is how we disable it).
+        // We listen for raw bytes instead and forward them.
+        const rawInputAvailable = process.stdin.isTTY === true
+        if (rawInputAvailable)
+          process.stdin.on('data', forward)
+
+        try {
+          // Wait for bash to finish the line — onLineDone resolves this.
+          await new Promise<void>((resolve) => {
+            pendingResolve = resolve
+            bridge.writeLine(line)
+          })
+        }
+        finally {
+          if (rawInputAvailable) {
+            process.stdin.off('data', forward)
+            if (!wasRaw && process.stdin.isTTY)
+              (process.stdin as NodeJS.ReadStream).setRawMode(false)
+          }
+        }
+
+        if (lastExitCode !== 0) {
+          // Non-zero exit codes are informational only — the next prompt
+          // comes up regardless. Surface them dimly so users notice.
+          consola.debug(`(exit ${lastExitCode})`)
+        }
+      },
+      onExit: () => {
+        shuttingDown = true
+        try {
+          bridge.kill()
+        }
+        catch {}
+      },
+    },
+  )
+
+  // SIGWINCH forwarding so TUI apps re-render at the right dimensions.
+  const onResize = () => {
+    const cols = process.stdout.columns ?? 80
+    const rows = process.stdout.rows ?? 24
+    try {
+      bridge.resize(cols, rows)
+    }
+    catch {}
+  }
+  process.stdout.on('resize', onResize)
+
+  try {
+    await repl.run()
+  }
+  finally {
+    process.stdout.off('resize', onResize)
+  }
+}

--- a/packages/apes/src/shell/repl.ts
+++ b/packages/apes/src/shell/repl.ts
@@ -105,7 +105,7 @@ export class ShellRepl {
     if (!this.quiet)
       this.writeBanner()
 
-    this.rl.prompt()
+    this.safePrompt(PS1)
 
     return new Promise<void>((resolve) => {
       this.rl!.on('line', async (line) => {
@@ -116,8 +116,7 @@ export class ShellRepl {
           const msg = err instanceof Error ? err.message : String(err)
           consola.error(`Shell error: ${msg}`)
           this.resetBuffer()
-          this.rl!.setPrompt(PS1)
-          this.rl!.prompt()
+          this.safePrompt(PS1)
         }
       })
 
@@ -126,8 +125,7 @@ export class ShellRepl {
         if (this.buffer.length > 0)
           this.output.write('\n')
         this.resetBuffer()
-        this.rl!.setPrompt(PS1)
-        this.rl!.prompt()
+        this.safePrompt(PS1)
       })
 
       this.rl!.on('close', async () => {
@@ -166,16 +164,14 @@ export class ShellRepl {
     const status = checkMultiLineStatus(this.buffer)
 
     if (status.kind === 'continue') {
-      this.rl!.setPrompt(PS2)
-      this.rl!.prompt()
+      this.safePrompt(PS2)
       return
     }
 
     if (status.kind === 'error') {
       this.output.write(`${status.message}\n`)
       this.resetBuffer()
-      this.rl!.setPrompt(PS1)
-      this.rl!.prompt()
+      this.safePrompt(PS1)
       return
     }
 
@@ -185,8 +181,7 @@ export class ShellRepl {
 
     // If the buffer was pure whitespace, skip the callback and re-prompt.
     if (completeLine.trim().length === 0) {
-      this.rl!.setPrompt(PS1)
-      this.rl!.prompt()
+      this.safePrompt(PS1)
       return
     }
 
@@ -194,30 +189,32 @@ export class ShellRepl {
 
     // Back to prompt mode. Owners of onLine can await and drive their own
     // output before we show the next prompt.
-    this.rl!.setPrompt(PS1)
-    this.rl!.prompt()
+    this.safePrompt(PS1)
+  }
+
+  /**
+   * Draw a prompt, but only if the readline interface is still alive.
+   * The onLine callback may have triggered `stop()` (e.g., bash exited),
+   * in which case setPrompt/prompt would throw ERR_USE_AFTER_CLOSE.
+   */
+  private safePrompt(prompt: string): void {
+    if (this.stopped || !this.rl)
+      return
+    try {
+      this.rl.setPrompt(prompt)
+      this.rl.prompt()
+    }
+    catch (err) {
+      // Swallow ERR_USE_AFTER_CLOSE which races with shutdown.
+      const code = (err as NodeJS.ErrnoException)?.code
+      if (code !== 'ERR_USE_AFTER_CLOSE')
+        throw err
+    }
   }
 
   private resetBuffer(): void {
     this.buffer = ''
   }
-}
-
-/**
- * Convenience entry point used by the CLI dispatcher. Spins up a REPL that
- * logs every accepted line (M2 stub). Later milestones replace the `onLine`
- * handler with the real grant dispatch + pty write path.
- */
-export async function runInteractiveShellM2Stub(): Promise<void> {
-  const repl = new ShellRepl({
-    onLine: (line) => {
-      consola.info(`[M2 stub] would execute: ${line}`)
-    },
-    onExit: () => {
-      consola.info('Goodbye.')
-    },
-  })
-  await repl.run()
 }
 
 export { HISTORY_FILE }

--- a/packages/apes/test/shell-orchestrator.test.ts
+++ b/packages/apes/test/shell-orchestrator.test.ts
@@ -1,0 +1,187 @@
+import { PassThrough } from 'node:stream'
+import { afterEach, describe, expect, it } from 'vitest'
+import { PtyBridge } from '../src/shell/pty-bridge.js'
+import { ShellRepl } from '../src/shell/repl.js'
+
+/**
+ * Mini orchestrator that mirrors what `runInteractiveShell` does in the
+ * real CLI entry point, but uses in-memory PassThrough streams for input
+ * and output so tests can drive it deterministically. The real entry point
+ * also wires raw-mode TTY forwarding and SIGWINCH, which we skip here
+ * because there's no real TTY in tests.
+ *
+ * Each test gets its own bash pty so state can't leak between tests.
+ */
+function buildHarness() {
+  const input = new PassThrough()
+  const capturedOutput: string[] = []
+
+  const output = new PassThrough()
+  output.on('data', chunk => capturedOutput.push(chunk.toString()))
+
+  let pendingResolve: ((exitCode: number) => void) | null = null
+
+  const bridge = new PtyBridge({
+    onOutput: (chunk) => {
+      output.write(chunk)
+    },
+    onLineDone: (frame) => {
+      const pending = pendingResolve
+      pendingResolve = null
+      if (pending)
+        pending(frame.exitCode)
+    },
+    onExit: () => {},
+  })
+
+  const repl = new ShellRepl(
+    {
+      onLine: async (line) => {
+        await new Promise<number>((resolve) => {
+          pendingResolve = resolve
+          bridge.writeLine(line)
+        })
+      },
+      onExit: () => {
+        try {
+          bridge.kill()
+        }
+        catch {}
+      },
+    },
+    {
+      input,
+      output,
+      quiet: true,
+    },
+  )
+
+  return {
+    repl,
+    bridge,
+    input,
+    output,
+    capturedOutput,
+    bridgeReady: () => bridge.waitForReady(),
+  }
+}
+
+async function waitUntil(condition: () => boolean, timeoutMs = 5000): Promise<void> {
+  const start = Date.now()
+  while (!condition()) {
+    if (Date.now() - start > timeoutMs)
+      throw new Error('Timed out waiting for condition')
+    await new Promise(r => setTimeout(r, 10))
+  }
+}
+
+describe('shell orchestrator (REPL + PtyBridge integration)', () => {
+  const harnesses: Array<ReturnType<typeof buildHarness>> = []
+
+  afterEach(() => {
+    for (const h of harnesses) {
+      try {
+        h.bridge.kill()
+      }
+      catch {}
+      try {
+        h.repl.stop()
+      }
+      catch {}
+    }
+    harnesses.length = 0
+  })
+
+  it('executes a single command against bash and shows its output', async () => {
+    const h = buildHarness()
+    harnesses.push(h)
+
+    await h.bridgeReady()
+    const runPromise = h.repl.run()
+
+    h.input.write('echo hello-from-shell\n')
+    await waitUntil(() => h.capturedOutput.join('').includes('hello-from-shell'))
+
+    h.input.end()
+    await runPromise
+  })
+
+  it('persists shell state across sequential commands', async () => {
+    const h = buildHarness()
+    harnesses.push(h)
+
+    await h.bridgeReady()
+    const runPromise = h.repl.run()
+
+    h.input.write('cd /tmp\n')
+    // Wait for the cd to complete (first prompt after the line)
+    await new Promise(r => setTimeout(r, 200))
+
+    h.input.write('pwd\n')
+    await waitUntil(() => h.capturedOutput.join('').includes('/tmp'))
+
+    h.input.end()
+    await runPromise
+  })
+
+  it('persists environment variables across lines', async () => {
+    const h = buildHarness()
+    harnesses.push(h)
+
+    await h.bridgeReady()
+    const runPromise = h.repl.run()
+
+    h.input.write('export APES_ORCHESTRATOR_TEST=yes\n')
+    await new Promise(r => setTimeout(r, 200))
+
+    h.input.write('echo "value:$APES_ORCHESTRATOR_TEST"\n')
+    await waitUntil(() => h.capturedOutput.join('').includes('value:yes'))
+
+    h.input.end()
+    await runPromise
+  })
+
+  it('handles multi-line for-loop via accumulation', async () => {
+    const h = buildHarness()
+    harnesses.push(h)
+
+    await h.bridgeReady()
+    const runPromise = h.repl.run()
+
+    h.input.write('for i in a b c\n')
+    await new Promise(r => setTimeout(r, 50))
+    h.input.write('do\n')
+    await new Promise(r => setTimeout(r, 50))
+    h.input.write('  echo item:$i\n')
+    await new Promise(r => setTimeout(r, 50))
+    h.input.write('done\n')
+
+    await waitUntil(() => {
+      const out = h.capturedOutput.join('')
+      return out.includes('item:a') && out.includes('item:b') && out.includes('item:c')
+    })
+
+    h.input.end()
+    await runPromise
+  })
+
+  it('never leaks the prompt marker into visible output', async () => {
+    const h = buildHarness()
+    harnesses.push(h)
+
+    await h.bridgeReady()
+    const runPromise = h.repl.run()
+
+    h.input.write('echo first\n')
+    await new Promise(r => setTimeout(r, 200))
+    h.input.write('echo second\n')
+    await waitUntil(() => h.capturedOutput.join('').includes('second'))
+
+    const all = h.capturedOutput.join('')
+    expect(all).not.toContain('__APES_')
+    expect(all).not.toContain('__END__')
+
+    h.input.end()
+    await runPromise
+  })
+})


### PR DESCRIPTION
Part of #62. Builds on M1 (#63, merged) and M2 (#65, merged).

## Summary
Third milestone of the interactive \`ape-shell\` REPL. Glues the M2 \`ShellRepl\` to the M1 \`PtyBridge\` so every accepted line actually executes against a real bash process with full state persistence.

- **\`runInteractiveShell\`** orchestrator in \`src/shell/orchestrator.ts\` sets up the pty bridge, waits for the initial marker, constructs the REPL with an \`onLine\` handler that writes to the pty and awaits the next marker (via a stashed resolver fired from \`onLineDone\`).
- **Raw-mode stdin** during command execution so TUI apps like \`vim\`, \`less\`, \`top\` receive raw keystrokes via a direct forwarder.
- **SIGWINCH** forwarding via \`process.stdout.on('resize')\` so TUI apps re-render on terminal resize.
- **\`safePrompt\`** helper in \`ShellRepl\` guards \`setPrompt\`/\`prompt\` against \`ERR_USE_AFTER_CLOSE\` when readline is closed concurrently (e.g. bash exits and triggers \`stop()\`).
- **\`cli.ts\`** now dispatches the \`interactive\` action to \`runInteractiveShell\` instead of the M2 stub.

## Integration tests

\`test/shell-orchestrator.test.ts\` exercises a real bash child through the full REPL → pty wiring, one bash per test:

1. single command → output
2. \`cd /tmp\` then \`pwd\` → state persists
3. \`export FOO=yes\` then \`echo \$FOO\` → state persists
4. multi-line \`for\` loop → accumulation works, all iterations execute
5. marker never leaks into visible output

## Test plan
- [x] \`pnpm turbo run lint typecheck --filter=@openape/apes\` clean
- [x] \`pnpm --filter @openape/apes test\` — 341/341 (336 from M2 + 5 new orchestrator tests)

## No grant flow yet
Every line executes unconditionally. M4 inserts the grant dispatch between \`REPL.onLine\` and \`bridge.writeLine\`.