### PR TITLE
feat(apes): M5 audit logging for interactive shell sessions

### DIFF
--- a/.changeset/apes-shell-session-audit.md
+++ b/.changeset/apes-shell-session-audit.md
@@ -1,0 +1,14 @@
+---
+'@openape/apes': minor
+---
+
+feat(apes): audit logging for interactive shell sessions (M5 of ape-shell interactive mode)
+
+Every interactive `ape-shell` session is now recorded in `~/.config/apes/audit.jsonl` with the following event types:
+
+- `shell-session-start` — session id (16 random hex chars), host, requester email
+- `shell-session-line` — per line: seq number, literal line, grant id, grant mode (adapter/session), status (executing/denied)
+- `shell-session-line-done` — per completed line: seq number, exit code
+- `shell-session-end` — duration, total line count
+
+Denied lines are logged too, which gives you an auditable record of every attempted command in a session — whether it was executed or rejected by the grant flow.

--- a/packages/apes/src/shell/orchestrator.ts
+++ b/packages/apes/src/shell/orchestrator.ts
@@ -1,8 +1,10 @@
 import { hostname } from 'node:os'
 import consola from 'consola'
+import { loadAuth } from '../config.js'
 import { requestGrantForShellLine } from './grant-dispatch.js'
 import { PtyBridge } from './pty-bridge.js'
 import { ShellRepl } from './repl.js'
+import { ShellSession } from './session.js'
 
 /**
  * Orchestrates the interactive ape-shell session by wiring the user-facing
@@ -66,6 +68,11 @@ export async function runInteractiveShell(): Promise<void> {
   await bridge.waitForReady()
 
   const targetHost = hostname()
+  const auth = loadAuth()
+  const session = new ShellSession({
+    host: targetHost,
+    requester: auth?.email ?? 'unknown',
+  })
 
   repl = new ShellRepl(
     {
@@ -77,9 +84,16 @@ export async function runInteractiveShell(): Promise<void> {
         })
 
         if (grant.kind === 'denied') {
+          session.logLineDenied({ line, reason: grant.reason })
           consola.error(grant.reason)
           return
         }
+
+        const seq = session.logLineGranted({
+          line,
+          grantId: grant.grantId,
+          grantMode: grant.mode,
+        })
 
         // --- 2. Raw-mode stdin passthrough while bash runs the line ---
         const wasRaw = process.stdin.isTTY && (process.stdin as NodeJS.ReadStream).isRaw
@@ -107,12 +121,15 @@ export async function runInteractiveShell(): Promise<void> {
           }
         }
 
+        session.logLineDone({ seq, exitCode: lastExitCode })
+
         if (lastExitCode !== 0) {
           consola.debug(`(exit ${lastExitCode})`)
         }
       },
       onExit: () => {
         shuttingDown = true
+        session.close()
         try {
           bridge.kill()
         }

--- a/packages/apes/src/shell/session.ts
+++ b/packages/apes/src/shell/session.ts
@@ -1,0 +1,81 @@
+import { randomBytes } from 'node:crypto'
+import { appendAuditLog } from '../shapes/index.js'
+
+/**
+ * A single interactive ape-shell session. Tracks a stable session id plus a
+ * monotonic sequence number so individual lines can be correlated back to
+ * their session in the audit log.
+ */
+export class ShellSession {
+  readonly id: string
+  readonly startedAt: number
+  private lineSeq = 0
+
+  constructor(options: { host: string, requester: string }) {
+    this.id = randomBytes(8).toString('hex')
+    this.startedAt = Date.now()
+    appendAuditLog({
+      action: 'shell-session-start',
+      session_id: this.id,
+      host: options.host,
+      requester: options.requester,
+    })
+  }
+
+  /**
+   * Record a granted line that was approved for execution. Called after the
+   * grant flow returns approval but before (or right after) bash runs the
+   * command. Stores the grant id so the line can be traced back to the
+   * specific grant that authorized it.
+   */
+  logLineGranted(params: {
+    line: string
+    grantId: string
+    grantMode: 'adapter' | 'session'
+  }): number {
+    const seq = ++this.lineSeq
+    appendAuditLog({
+      action: 'shell-session-line',
+      session_id: this.id,
+      seq,
+      line: params.line,
+      grant_id: params.grantId,
+      grant_mode: params.grantMode,
+      status: 'executing',
+    })
+    return seq
+  }
+
+  /** Record the final exit code of a previously-granted line. */
+  logLineDone(params: { seq: number, exitCode: number }): void {
+    appendAuditLog({
+      action: 'shell-session-line-done',
+      session_id: this.id,
+      seq: params.seq,
+      exit_code: params.exitCode,
+    })
+  }
+
+  /** Record that a line was denied by the grant flow and never reached bash. */
+  logLineDenied(params: { line: string, reason: string }): void {
+    const seq = ++this.lineSeq
+    appendAuditLog({
+      action: 'shell-session-line',
+      session_id: this.id,
+      seq,
+      line: params.line,
+      status: 'denied',
+      reason: params.reason,
+    })
+  }
+
+  /** Record session termination. Fires on clean Ctrl-D or bash death. */
+  close(): void {
+    appendAuditLog({
+      action: 'shell-session-end',
+      session_id: this.id,
+      duration_ms: Date.now() - this.startedAt,
+      lines: this.lineSeq,
+    })
+  }
+}

--- a/packages/apes/test/shell-session.test.ts
+++ b/packages/apes/test/shell-session.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../src/shapes/index.js', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../src/shapes/index.js')>()
+  return {
+    ...original,
+    appendAuditLog: vi.fn(),
+  }
+})
+
+describe('ShellSession', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+  })
+
+  it('logs a shell-session-start entry on construction', async () => {
+    const { appendAuditLog } = await import('../src/shapes/index.js')
+    const { ShellSession } = await import('../src/shell/session.js')
+
+    const session = new ShellSession({ host: 'host.test', requester: 'alice@example.com' })
+
+    expect(appendAuditLog).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'shell-session-start',
+      session_id: session.id,
+      host: 'host.test',
+      requester: 'alice@example.com',
+    }))
+    expect(session.id).toMatch(/^[0-9a-f]{16}$/)
+  })
+
+  it('logs granted lines with sequence numbers and grant id', async () => {
+    const { appendAuditLog } = await import('../src/shapes/index.js')
+    const { ShellSession } = await import('../src/shell/session.js')
+
+    const session = new ShellSession({ host: 'h', requester: 'r' })
+    vi.mocked(appendAuditLog).mockClear()
+
+    const seq1 = session.logLineGranted({ line: 'ls', grantId: 'g1', grantMode: 'adapter' })
+    const seq2 = session.logLineGranted({ line: 'pwd', grantId: 'g2', grantMode: 'adapter' })
+
+    expect(seq1).toBe(1)
+    expect(seq2).toBe(2)
+    expect(appendAuditLog).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      action: 'shell-session-line',
+      session_id: session.id,
+      seq: 1,
+      line: 'ls',
+      grant_id: 'g1',
+      grant_mode: 'adapter',
+      status: 'executing',
+    }))
+    expect(appendAuditLog).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      seq: 2,
+      line: 'pwd',
+      grant_id: 'g2',
+    }))
+  })
+
+  it('logs denied lines with reason and still consumes a seq number', async () => {
+    const { appendAuditLog } = await import('../src/shapes/index.js')
+    const { ShellSession } = await import('../src/shell/session.js')
+
+    const session = new ShellSession({ host: 'h', requester: 'r' })
+    vi.mocked(appendAuditLog).mockClear()
+
+    session.logLineDenied({ line: 'rm -rf /', reason: 'Grant denied' })
+
+    expect(appendAuditLog).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'shell-session-line',
+      status: 'denied',
+      line: 'rm -rf /',
+      reason: 'Grant denied',
+      seq: 1,
+    }))
+  })
+
+  it('logs line completion with exit code', async () => {
+    const { appendAuditLog } = await import('../src/shapes/index.js')
+    const { ShellSession } = await import('../src/shell/session.js')
+
+    const session = new ShellSession({ host: 'h', requester: 'r' })
+    const seq = session.logLineGranted({ line: 'false', grantId: 'g1', grantMode: 'adapter' })
+    vi.mocked(appendAuditLog).mockClear()
+
+    session.logLineDone({ seq, exitCode: 1 })
+
+    expect(appendAuditLog).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'shell-session-line-done',
+      session_id: session.id,
+      seq: 1,
+      exit_code: 1,
+    }))
+  })
+
+  it('logs session-end with duration and line count', async () => {
+    const { appendAuditLog } = await import('../src/shapes/index.js')
+    const { ShellSession } = await import('../src/shell/session.js')
+
+    const session = new ShellSession({ host: 'h', requester: 'r' })
+    session.logLineGranted({ line: 'a', grantId: 'g1', grantMode: 'adapter' })
+    session.logLineGranted({ line: 'b', grantId: 'g2', grantMode: 'session' })
+    vi.mocked(appendAuditLog).mockClear()
+
+    session.close()
+
+    expect(appendAuditLog).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'shell-session-end',
+      session_id: session.id,
+      lines: 2,
+      duration_ms: expect.any(Number),
+    }))
+  })
+})


### PR DESCRIPTION
Part of #62. Builds on M1–M4 (all merged).

## Summary
Every interactive \`ape-shell\` session is now recorded in \`~/.config/apes/audit.jsonl\` via the existing \`appendAuditLog\` helper. Four event types:

- \`shell-session-start\` — session id (16 random hex chars), host, requester email
- \`shell-session-line\` — per line: seq, literal line, grant_id, grant_mode (adapter/session), status (executing/denied)
- \`shell-session-line-done\` — per completed line: seq, exit_code
- \`shell-session-end\` — duration_ms, total lines

Denied lines are logged too, so the audit trail records every attempted command regardless of approval.

## Files
- **new** \`packages/apes/src/shell/session.ts\` — \`ShellSession\` class wrapping audit emission with typed methods
- **modified** \`packages/apes/src/shell/orchestrator.ts\` — constructs the session, logs granted/denied/done/close events
- **new** \`packages/apes/test/shell-session.test.ts\` — 5 unit tests with mocked \`appendAuditLog\`

## Test plan
- [x] \`pnpm turbo run lint typecheck --filter=@openape/apes\` clean
- [x] \`pnpm --filter @openape/apes test\` — 353/353 pass (348 from M4 + 5 new)

## Still ahead
- M6 login-shell install + \`\$SHELL\` compatibility integration
- M7 E2E tests + polish