### PR TITLE
fix(apes): M7 interactive shell lifecycle polish — completes #62

### DIFF
--- a/.changeset/apes-shell-polish.md
+++ b/.changeset/apes-shell-polish.md
@@ -1,0 +1,14 @@
+---
+'@openape/apes': patch
+---
+
+fix(apes): E2E polish for interactive shell lifecycle (M7 of ape-shell interactive mode)
+
+Final polish of the interactive `ape-shell` REPL:
+
+- **Clean shutdown on SIGTERM / SIGHUP** — `gracefulShutdown` handler kills the bash child, closes the audit session, restores the terminal out of raw mode, and stops the REPL in one idempotent sweep. Previously a kill signal could leave the terminal in raw mode.
+- **Emergency TTY restore** — `process.on('exit', …)` handler restores stdin's raw mode flag even if a crash or unhandled exception short-circuits the normal cleanup.
+- **Clean teardown on success** — all signal handlers and the resize listener are unregistered in the `finally` block of `runInteractiveShell`, preventing listener leaks if the function is called more than once in a process.
+- **Marker-collision robustness** — added polish tests that verify a command echoing fake-marker-looking text (`echo '__APES_fake_marker__:0:__END__'`) does not confuse the prompt detector, non-zero exit codes propagate correctly, 5 back-to-back commands preserve ordering, and ~3KB of output streams through without losing data.
+
+Completes #62 — interactive ape-shell REPL is now feature-complete for v1.

--- a/packages/apes/src/shell/orchestrator.ts
+++ b/packages/apes/src/shell/orchestrator.ts
@@ -13,16 +13,24 @@ import { ShellSession } from './session.js'
  *
  * Flow per user-entered line:
  *   1. ShellRepl emits onLine with the completed (possibly multi-line) buffer
- *   2. We switch the REPL into "output mode" (pauses readline, turns on raw
- *      stdin forwarding so TUI apps like vim receive raw keystrokes)
- *   3. The line is written to the bash pty
+ *   2. Line goes through the grant flow. If denied: session logs the denial,
+ *      we surface the reason, and return without touching bash.
+ *   3. On approval we enter "output mode" (raw stdin passthrough so TUI apps
+ *      like vim/less/top receive raw keystrokes) and write the line to bash.
  *   4. bash output streams back to stdout live via PtyBridge.onOutput
- *   5. When the marker-bearing PS1 reappears we fire a resolve() that lets
- *      the REPL's onLine promise settle → readline takes back the terminal
- *      and shows the next prompt
+ *   5. When the marker-bearing PS1 reappears we resolve the pending promise,
+ *      readline takes back the terminal, and the next prompt is drawn.
  *
- * M3 does NOT yet integrate the grant flow — every line is executed
- * unconditionally. M4 inserts grant-dispatch before the pty.write call.
+ * The orchestrator also owns the lifecycle niceties:
+ *   - SIGWINCH is forwarded to the pty so TUI apps re-render at the right size
+ *   - SIGTERM / SIGHUP trigger a clean shutdown (kill bash, restore TTY mode,
+ *     close the audit session)
+ *   - An emergency process.on('exit') handler restores the terminal out of
+ *     raw mode in case a crash left it there
+ *
+ * Every line is recorded in the audit log via the ShellSession — granted,
+ * denied, and done events with seq numbers correlating each event to its
+ * parent line within the session.
  */
 export async function runInteractiveShell(): Promise<void> {
   /**
@@ -149,10 +157,50 @@ export async function runInteractiveShell(): Promise<void> {
   }
   process.stdout.on('resize', onResize)
 
+  // Emergency TTY restore — if a crash leaves stdin in raw mode, subsequent
+  // terminal input becomes unusable until the user manually runs `reset`.
+  // This handler fires on clean exit and on uncaught exceptions.
+  const restoreTty = () => {
+    if (process.stdin.isTTY && (process.stdin as NodeJS.ReadStream).isRaw) {
+      try {
+        (process.stdin as NodeJS.ReadStream).setRawMode(false)
+      }
+      catch {}
+    }
+  }
+  process.on('exit', restoreTty)
+
+  // Clean shutdown on termination signals. kill() is idempotent in node-pty,
+  // and session.close() swallows audit-log errors internally, so this is safe
+  // to call even if already shutting down.
+  const gracefulShutdown = () => {
+    if (shuttingDown)
+      return
+    shuttingDown = true
+    restoreTty()
+    try {
+      session.close()
+    }
+    catch {}
+    try {
+      bridge.kill()
+    }
+    catch {}
+    try {
+      repl?.stop()
+    }
+    catch {}
+  }
+  process.on('SIGTERM', gracefulShutdown)
+  process.on('SIGHUP', gracefulShutdown)
+
   try {
     await repl.run()
   }
   finally {
     process.stdout.off('resize', onResize)
+    process.off('exit', restoreTty)
+    process.off('SIGTERM', gracefulShutdown)
+    process.off('SIGHUP', gracefulShutdown)
   }
 }

--- a/packages/apes/test/shell-orchestrator-polish.test.ts
+++ b/packages/apes/test/shell-orchestrator-polish.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { PtyBridge } from '../src/shell/pty-bridge.js'
+
+/**
+ * M7 polish tests that exercise edge cases of the bash ↔ bridge wiring:
+ *
+ * - Commands whose output contains text that looks like a marker (should
+ *   not confuse the detector — 16 hex bytes make collisions effectively
+ *   impossible, but we verify the regex is narrow enough)
+ * - Non-zero exit codes propagate correctly
+ * - Rapid back-to-back commands don't lose ordering
+ * - Large output (a few KB) streams through correctly
+ */
+describe('PtyBridge polish', () => {
+  const bridges: PtyBridge[] = []
+
+  afterEach(() => {
+    for (const b of bridges) {
+      try {
+        b.kill()
+      }
+      catch {}
+    }
+    bridges.length = 0
+  })
+
+  async function makeBridge(): Promise<{
+    bridge: PtyBridge
+    output: string[]
+    completed: Array<{ output: string, exitCode: number }>
+  }> {
+    const output: string[] = []
+    const completed: Array<{ output: string, exitCode: number }> = []
+    const bridge = new PtyBridge({
+      onOutput: chunk => output.push(chunk),
+      onLineDone: frame => completed.push({ output: frame.output, exitCode: frame.exitCode }),
+      onExit: () => {},
+    })
+    bridges.push(bridge)
+    await bridge.waitForReady()
+    return { bridge, output, completed }
+  }
+
+  async function waitUntil(cond: () => boolean, ms = 5000) {
+    const start = Date.now()
+    while (!cond()) {
+      if (Date.now() - start > ms)
+        throw new Error('Timed out waiting for condition')
+      await new Promise(r => setTimeout(r, 10))
+    }
+  }
+
+  it('does not confuse a command that echoes __APES_ text in its output', async () => {
+    const { bridge, completed } = await makeBridge()
+
+    // Echo literal "__APES_" — the bridge's marker includes 32 random hex
+    // chars so this must not match the regex.
+    bridge.writeLine(`echo '__APES_fake_marker__:0:__END__'`)
+    await waitUntil(() => completed.length >= 1)
+
+    expect(completed[0]!.output).toContain('__APES_fake_marker__')
+    expect(completed[0]!.exitCode).toBe(0)
+  })
+
+  it('propagates non-zero exit codes correctly', async () => {
+    const { bridge, completed } = await makeBridge()
+
+    bridge.writeLine('exit-code-test() { return 42; }; exit-code-test')
+    await waitUntil(() => completed.length >= 1)
+
+    expect(completed[0]!.exitCode).toBe(42)
+  })
+
+  it('preserves ordering when many commands run back-to-back', async () => {
+    const { bridge, completed } = await makeBridge()
+
+    for (let i = 0; i < 5; i++) {
+      bridge.writeLine(`echo "line-${i}"`)
+    }
+    await waitUntil(() => completed.length >= 5)
+
+    expect(completed).toHaveLength(5)
+    for (let i = 0; i < 5; i++) {
+      expect(completed[i]!.output).toContain(`line-${i}`)
+    }
+  })
+
+  it('handles multi-kb output without losing data', async () => {
+    const { bridge, completed } = await makeBridge()
+
+    // Generate a predictable ~3KB of output via bash
+    bridge.writeLine('for i in $(seq 1 100); do echo "payload-line-$i-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"; done')
+    await waitUntil(() => completed.length >= 1)
+
+    const out = completed[0]!.output
+    expect(out).toContain('payload-line-1-')
+    expect(out).toContain('payload-line-50-')
+    expect(out).toContain('payload-line-100-')
+    expect(completed[0]!.exitCode).toBe(0)
+  })
+})


### PR DESCRIPTION
Part of #62 (final milestone). Builds on M1–M6 (all merged).

## Summary
Final polish pass for the interactive \`ape-shell\` REPL. Tightens the lifecycle edges so a running session survives crash and signal paths cleanly and never leaves the user's terminal in raw mode.

- **SIGTERM / SIGHUP → graceful shutdown** — idempotent handler that kills bash, closes the audit session, restores raw mode, and stops the REPL in one sweep.
- **Emergency TTY restore** — \`process.on('exit', …)\` handler restores stdin raw mode flag even if a crash short-circuits cleanup. Prevents the classic "terminal is stuck, type \`reset\`" outcome.
- **Clean teardown** — all handlers (SIGTERM, SIGHUP, resize, exit) are unregistered in the \`finally\` block of \`runInteractiveShell\` to prevent listener leaks on repeat calls.
- **Marker-collision robustness tests** — new polish test suite against a real bash child:
  1. echoing \`'__APES_fake_marker__:0:__END__'\` does not confuse the prompt detector (the real marker uses 16 random hex bytes, but we verify the regex is narrow enough)
  2. non-zero exit codes propagate correctly
  3. 5 back-to-back commands preserve ordering
  4. ~3KB of output streams through without data loss

## Files
- **modified** \`packages/apes/src/shell/orchestrator.ts\` — signal handlers, emergency TTY restore, updated JSDoc
- **new** \`packages/apes/test/shell-orchestrator-polish.test.ts\` — 4 polish tests

## Test plan
- [x] \`pnpm turbo run lint typecheck --filter=@openape/apes\` clean
- [x] \`pnpm --filter @openape/apes test\` — 360/360 pass (356 from M6 + 4 new polish)

## Completes #62
After this lands, the interactive ape-shell REPL is feature-complete for v1:
- M1 PtyBridge (persistent bash, marker-based prompt detection)
- M2 REPL loop (readline, multi-line detection)
- M3 orchestrator (REPL ↔ PtyBridge wiring, raw-mode TUI passthrough)
- M4 grant flow integration
- M5 audit logging
- M6 login-shell install + \`\$SHELL\` non-regression
- M7 lifecycle polish ← this PR