### PR TITLE
fix(apes): login-shell wrapper for environments without node on PATH

### DIFF
--- a/.changeset/apes-shell-login-node-wrapper.md
+++ b/.changeset/apes-shell-login-node-wrapper.md
@@ -1,0 +1,23 @@
+---
+'@openape/apes': patch
+---
+
+fix(apes): login-shell wrapper script for environments without node on PATH
+
+When `ape-shell` is set as a user's login shell via `chsh`, the kernel invokes it **before** any rc file has run. The CLI's `#!/usr/bin/env node` shebang then fails with `env: node: No such file or directory` in environments where node lives in an nvm path that is only added to `PATH` by `.bashrc`/`.zshrc`.
+
+Fixes:
+
+- New `packages/apes/scripts/ape-shell-wrapper.sh` bash wrapper that hoists Homebrew / `/usr/local/bin` / nvm onto `PATH` before exec-ing node with the real `cli.js`. Uses `exec -a "$0"` to preserve the original argv[0] (including the leading dash login/sshd prepend to signal "login shell") so interactive-mode detection still works.
+- `rewriteApeShellArgs` now also accepts an optional `argv0` second parameter and honors `process.env.APES_SHELL_WRAPPER=1` as a detection signal. When either is set, invocation is recognized as ape-shell even though `argv[1]` is now the path to `cli.js` (not literal `ape-shell`).
+- `cli.ts` passes `process.argv0` through so the wrapper path sees login-shell dash detection correctly.
+
+Install:
+
+```bash
+sudo ln -sf /path/to/packages/apes/scripts/ape-shell-wrapper.sh /usr/local/bin/ape-shell
+echo /usr/local/bin/ape-shell | sudo tee -a /etc/shells
+sudo chsh -s /usr/local/bin/ape-shell openclaw
+```
+
+Backward compat: direct invocations with `argv[1]` basename matching `ape-shell` still work exactly as before, so existing symlink setups keep functioning without any env var.

--- a/packages/apes/scripts/ape-shell-wrapper.sh
+++ b/packages/apes/scripts/ape-shell-wrapper.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# -----------------------------------------------------------------------------
+# ape-shell login-shell wrapper
+# -----------------------------------------------------------------------------
+#
+# The `@openape/apes` CLI is a Node.js script with a `#!/usr/bin/env node`
+# shebang. When `ape-shell` is set as a user's login shell via `chsh`, the
+# kernel invokes it BEFORE any rc file has run — so only the system default
+# PATH is visible, which typically does NOT include Homebrew or nvm paths.
+# The shebang then fails with:
+#
+#   env: node: No such file or directory
+#
+# This wrapper is the actual file pointed at by `chsh` and by the
+# `/usr/local/bin/ape-shell` symlink. It:
+#
+#   1. Prepends known node install locations to PATH (Homebrew, nvm)
+#   2. Sets APES_SHELL_WRAPPER=1 so the CLI knows it was invoked via this
+#      wrapper (because argv[0]/argv[1] inspection gets clobbered when we
+#      exec Node through the wrapper)
+#   3. Exec's node with the real dist/cli.js path, preserving the original
+#      argv[0] via `exec -a "$0"` so login-shell detection ("-ape-shell"
+#      prefix) still works inside the CLI
+#
+# To install, point a symlink at this file:
+#
+#   sudo ln -sf /path/to/ape-shell-wrapper.sh /usr/local/bin/ape-shell
+#   sudo chsh -s /usr/local/bin/ape-shell <user>
+#
+# You can override the node binary via APES_SHELL_NODE, and the CLI entry
+# point via APES_SHELL_CLI_JS, for environments where the defaults don't
+# apply.
+# -----------------------------------------------------------------------------
+
+set -e
+
+# Known node install locations searched in order. The first one found wins.
+# Users with exotic setups can override via APES_SHELL_NODE env var.
+_node_candidates=(
+  "${APES_SHELL_NODE:-}"
+  "/opt/homebrew/bin/node"
+  "/usr/local/bin/node"
+  "/usr/bin/node"
+)
+
+_node_bin=""
+for candidate in "${_node_candidates[@]}"; do
+  if [ -n "$candidate" ] && [ -x "$candidate" ]; then
+    _node_bin="$candidate"
+    break
+  fi
+done
+
+if [ -z "$_node_bin" ]; then
+  echo "ape-shell: no node binary found. Install Node.js or set APES_SHELL_NODE." >&2
+  exit 127
+fi
+
+# Locate the CLI JS. Default: sibling of this wrapper script via a known
+# relative path (assumes the wrapper lives in packages/apes/scripts). Can be
+# overridden via APES_SHELL_CLI_JS for production installs where the paths
+# might differ.
+if [ -z "${APES_SHELL_CLI_JS:-}" ]; then
+  _wrapper_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  _cli_js="$_wrapper_dir/../dist/cli.js"
+else
+  _cli_js="$APES_SHELL_CLI_JS"
+fi
+
+if [ ! -f "$_cli_js" ]; then
+  echo "ape-shell: cli.js not found at $_cli_js. Set APES_SHELL_CLI_JS to override." >&2
+  exit 127
+fi
+
+# Prepend common node install dirs to PATH so anything spawned inside the
+# shell (or by the interactive REPL's bash child) can also find node.
+export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+
+# Signal to the CLI that it was invoked via this wrapper, so invocation-mode
+# detection can fall back to this hint when argv-based detection fails (the
+# argv[1] basename check becomes `cli.js` once we exec node directly).
+export APES_SHELL_WRAPPER=1
+
+# exec -a preserves the original argv[0] that login/sshd/su gave us — notably
+# the leading "-" prefix for a login shell. The CLI still sees it via
+# process.argv0, so its login-shell detection keeps working.
+exec -a "$0" "$_node_bin" "$_cli_js" "$@"

--- a/packages/apes/src/ape-shell.ts
+++ b/packages/apes/src/ape-shell.ts
@@ -20,23 +20,46 @@ export type ApeShellAction =
  * keeps the historical rewrite behavior so `SHELL=$(which ape-shell) <prog>`
  * patterns (e.g. `SHELL=ape-shell openclaw tui`) continue to work.
  *
- * Detection rules (first match wins):
- *   • basename != ape-shell → not an ape-shell invocation, returns null.
+ * Detection strategy:
+ *   1. `process.env.APES_SHELL_WRAPPER === '1'` is the strongest signal —
+ *      it means we were invoked via the ape-shell-wrapper.sh shell script,
+ *      which hoists node onto PATH before exec-ing cli.js. In that case
+ *      argv[1] becomes `cli.js` (or some dist/chunk file) and the old
+ *      basename check fails, so we trust the wrapper's declaration.
+ *   2. Otherwise fall back to `argv[1]` basename matching literal
+ *      `ape-shell` / `ape-shell.js` (the direct-symlink invocation path).
+ *
+ * After detection, the rest of the rules decide the action (first match):
  *   • `-c <command>` → rewrite to `apes run --shell -- bash -c <command>`.
  *   • `--version` / `-v` → version action.
  *   • `--help` / `-h` → help action.
- *   • no args, `-i`, `-l`, `--login`, or argv[0] starts with `-`
- *     (login-shell convention from sshd/login) → interactive REPL.
+ *   • no args, `-i`, `-l`, `--login`, or a login-shell convention dash
+ *     prefix (on argv[1] or argv0) → interactive REPL.
  *   • anything else → error action.
  */
-export function rewriteApeShellArgs(argv: string[]): ApeShellAction | null {
+export function rewriteApeShellArgs(argv: string[], argv0?: string): ApeShellAction | null {
   const rawInvokedAs = argv[1] ?? ''
   // sshd/login use a leading dash on argv[0] to signal "login shell".
-  // Strip it for the basename comparison, but remember the flag.
-  const looksLikeLoginShell = rawInvokedAs.startsWith('-')
-  const normalizedInvokedAs = looksLikeLoginShell ? rawInvokedAs.slice(1) : rawInvokedAs
+  // Strip it for the basename comparison, but remember the flag. The dash
+  // may appear on argv[1] (direct invocation) or on the separately-passed
+  // argv0 parameter (wrapper invocation — shell `exec -a "$0"` sets node's
+  // actual argv[0] / `process.argv0` independently from argv[1]).
+  const dashFromArgv1 = rawInvokedAs.startsWith('-')
+  const dashFromArgv0 = typeof argv0 === 'string' && argv0.startsWith('-')
+  const looksLikeLoginShell = dashFromArgv1 || dashFromArgv0
+  const normalizedInvokedAs = dashFromArgv1 ? rawInvokedAs.slice(1) : rawInvokedAs
   const invokedAs = path.basename(normalizedInvokedAs)
-  if (invokedAs !== 'ape-shell' && invokedAs !== 'ape-shell.js')
+
+  // Primary detection: explicit wrapper signal via env var. Takes
+  // precedence because argv-based detection gets clobbered when the
+  // wrapper execs node directly and argv[1] becomes cli.js.
+  const wrapperEnv = typeof process !== 'undefined' && process.env?.APES_SHELL_WRAPPER === '1'
+
+  // Secondary detection: argv[1] basename matches literal `ape-shell` or
+  // `ape-shell.js` — the direct-symlink invocation path.
+  const argvMatch = invokedAs === 'ape-shell' || invokedAs === 'ape-shell.js'
+
+  if (!wrapperEnv && !argvMatch)
     return null
 
   const shellArgs = argv.slice(2)

--- a/packages/apes/src/cli.ts
+++ b/packages/apes/src/cli.ts
@@ -43,7 +43,11 @@ declare const __VERSION__: string
 // ape-shell mode:
 // • `ape-shell -c <command>` rewrites to `apes run --shell -- bash -c <command>` (one-shot)
 // • `ape-shell` (no args), `-i`, `-l`, or invoked as a login shell → interactive REPL
-const shellRewrite = rewriteApeShellArgs(process.argv)
+// Pass `process.argv0` explicitly so the wrapper script path (which uses
+// bash's `exec -a "$0"` to preserve the original argv[0] from login/sshd)
+// still benefits from login-shell detection when the cli.js is invoked
+// indirectly via the ape-shell-wrapper.sh shim.
+const shellRewrite = rewriteApeShellArgs(process.argv, process.argv0)
 if (shellRewrite) {
   if (shellRewrite.action === 'rewrite') {
     process.argv = shellRewrite.argv

--- a/packages/apes/test/ape-shell.test.ts
+++ b/packages/apes/test/ape-shell.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { rewriteApeShellArgs } from '../src/ape-shell'
 
 describe('ape-shell argv rewriting', () => {
@@ -72,5 +72,60 @@ describe('ape-shell argv rewriting', () => {
     // through the existing one-shot rewrite, not the interactive REPL.
     const result = rewriteApeShellArgs(['/usr/bin/node', '/usr/local/bin/ape-shell', '-c', 'echo hello'])
     expect(result?.action).toBe('rewrite')
+  })
+
+  describe('wrapper-script invocation (APES_SHELL_WRAPPER env var)', () => {
+    const savedEnv = process.env.APES_SHELL_WRAPPER
+
+    beforeEach(() => {
+      process.env.APES_SHELL_WRAPPER = '1'
+    })
+
+    afterEach(() => {
+      if (savedEnv === undefined) delete process.env.APES_SHELL_WRAPPER
+      else process.env.APES_SHELL_WRAPPER = savedEnv
+    })
+
+    it('recognizes wrapper invocation with no args as interactive', () => {
+      // Wrapper execs node cli.js with no trailing args — argv[1] becomes
+      // the cli.js path. Without the wrapper env var we would return null
+      // (not recognized as ape-shell). With it, we should enter the REPL.
+      const result = rewriteApeShellArgs([
+        '/opt/homebrew/bin/node',
+        '/Users/someone/openape/packages/apes/dist/cli.js',
+      ])
+      expect(result).toEqual({ action: 'interactive' })
+    })
+
+    it('recognizes wrapper invocation with -c as one-shot rewrite', () => {
+      const result = rewriteApeShellArgs([
+        '/opt/homebrew/bin/node',
+        '/Users/someone/openape/packages/apes/dist/cli.js',
+        '-c',
+        'echo hi',
+      ])
+      expect(result?.action).toBe('rewrite')
+    })
+
+    it('detects login-shell convention via argv0 (wrapper preserves it via exec -a)', () => {
+      // When the wrapper script does `exec -a "$0" node cli.js`, the node
+      // process's argv0 becomes "-ape-shell" (dash-prefixed from login).
+      // argv[1] is cli.js. Detection needs to see the dash via the argv0
+      // parameter.
+      const result = rewriteApeShellArgs(
+        ['/opt/homebrew/bin/node', '/Users/someone/openape/packages/apes/dist/cli.js'],
+        '-ape-shell',
+      )
+      expect(result).toEqual({ action: 'interactive' })
+    })
+
+    it('returns null when wrapper env var is unset and argv does not match', () => {
+      delete process.env.APES_SHELL_WRAPPER
+      const result = rewriteApeShellArgs([
+        '/opt/homebrew/bin/node',
+        '/Users/someone/openape/packages/apes/dist/cli.js',
+      ])
+      expect(result).toBeNull()
+    })
   })
 })


### PR DESCRIPTION
## Problem
When \`ape-shell\` is set as a user's login shell via \`chsh\`, the kernel invokes it **before** any rc file has run. The CLI's \`#!/usr/bin/env node\` shebang then fails with:

\`\`\`
env: node: No such file or directory
\`\`\`

This happens in environments where node lives in an nvm path that is only added to \`PATH\` by \`.bashrc\`/\`.zshrc\`. Reproduced today: \`su - openclaw\` → immediate failure.

## Fix

1. **New bash wrapper** \`packages/apes/scripts/ape-shell-wrapper.sh\` that prepends Homebrew / \`/usr/local/bin\` to PATH before exec-ing node with the real \`cli.js\`. Uses \`exec -a "\$0"\` to preserve the original argv[0] — including the leading dash that login/sshd prepend to signal "login shell" — so interactive-mode detection still fires inside cli.js.

2. **Detection extended in \`rewriteApeShellArgs\`**:
   - New optional second argument \`argv0\` (passed by cli.ts from \`process.argv0\`)
   - Honors \`process.env.APES_SHELL_WRAPPER=1\` as a strong detection signal
   - When either is set, the invocation is recognized as ape-shell even though \`argv[1]\` is now the path to \`cli.js\`, not literal \`ape-shell\`

3. **\`cli.ts\`** passes \`process.argv0\` through so the wrapper path benefits from login-shell dash detection.

## Install
\`\`\`bash
sudo ln -sf /path/to/packages/apes/scripts/ape-shell-wrapper.sh /usr/local/bin/ape-shell
echo /usr/local/bin/ape-shell | sudo tee -a /etc/shells
sudo chsh -s /usr/local/bin/ape-shell openclaw
\`\`\`

## Backward compat
Direct invocations with \`argv[1]\` basename matching \`ape-shell\` / \`ape-shell.js\` still work exactly as before. The env-var + argv0 detection is additive; existing symlink setups are unaffected.

## Test plan
- [x] \`pnpm turbo run lint typecheck --filter=@openape/apes\` clean
- [x] \`pnpm --filter @openape/apes test\` — 364/364 pass (360 from M7 + 4 new wrapper tests)
- [x] Wrapper smoke-tested in a minimal-PATH env: \`env -i PATH=/bin:/usr/bin wrapper.sh\` successfully hoists node onto PATH, exec's cli.js, and enters the REPL.