### PR TITLE
fix(apes): resolve symlink chain in ape-shell-wrapper.sh

### DIFF
--- a/.changeset/apes-shell-wrapper-symlink.md
+++ b/.changeset/apes-shell-wrapper-symlink.md
@@ -1,0 +1,9 @@
+---
+'@openape/apes': patch
+---
+
+fix(apes): resolve symlink chain in ape-shell-wrapper.sh before computing cli.js path
+
+The wrapper used `$(dirname "${BASH_SOURCE[0]}")/../dist/cli.js` to locate the CLI, which fails when the wrapper is installed as a symlink (the typical `/usr/local/bin/ape-shell` → wrapper install pattern). `BASH_SOURCE[0]` points at the symlink path, so the relative walk lands at `/usr/local/dist/cli.js` instead of the real `packages/apes/dist/cli.js`.
+
+Fix: walk the symlink chain with a portable bash loop (macOS's `readlink` has no `-f` flag) before computing the relative path. `APES_SHELL_CLI_JS` override is still honored and short-circuits this resolution.

--- a/packages/apes/scripts/ape-shell-wrapper.sh
+++ b/packages/apes/scripts/ape-shell-wrapper.sh
@@ -60,8 +60,24 @@ fi
 # relative path (assumes the wrapper lives in packages/apes/scripts). Can be
 # overridden via APES_SHELL_CLI_JS for production installs where the paths
 # might differ.
+#
+# Symlink resolution: when the wrapper is installed as a symlink (e.g.
+# /usr/local/bin/ape-shell → /path/to/packages/apes/scripts/ape-shell-wrapper.sh)
+# BASH_SOURCE[0] points at the symlink, not the real file. We must walk the
+# symlink chain before computing the relative `../dist/cli.js` path, otherwise
+# it ends up as `/usr/local/bin/../dist/cli.js` = `/usr/local/dist/cli.js`
+# which doesn't exist. macOS's readlink lacks `-f`, so use the portable
+# loop idiom.
 if [ -z "${APES_SHELL_CLI_JS:-}" ]; then
-  _wrapper_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  _source="${BASH_SOURCE[0]}"
+  while [ -L "$_source" ]; do
+    _target="$(readlink "$_source")"
+    case "$_target" in
+      /*) _source="$_target" ;;
+      *) _source="$(cd -P "$(dirname "$_source")" >/dev/null && pwd)/$_target" ;;
+    esac
+  done
+  _wrapper_dir="$(cd -P "$(dirname "$_source")" >/dev/null && pwd)"
   _cli_js="$_wrapper_dir/../dist/cli.js"
 else
   _cli_js="$APES_SHELL_CLI_JS"


### PR DESCRIPTION
## Bug
The wrapper script computed \`cli.js\` location via:

\`\`\`bash
_wrapper_dir="$(cd "$(dirname "\${BASH_SOURCE[0]}")" && pwd)"
_cli_js="\$_wrapper_dir/../dist/cli.js"
\`\`\`

But when installed as a symlink (\`/usr/local/bin/ape-shell\` → \`/path/to/wrapper.sh\`), \`BASH_SOURCE[0]\` is the **symlink path**, not the real file. So the relative walk lands at \`/usr/local/dist/cli.js\`:

\`\`\`
ape-shell: cli.js not found at /usr/local/bin/../dist/cli.js.
\`\`\`

Reproduced live via \`su - openclaw\` after setting the symlink.

## Fix
Walk the symlink chain before computing the relative path. macOS's \`readlink\` has no \`-f\` flag so use the portable while-loop idiom. \`APES_SHELL_CLI_JS\` override still short-circuits.

## Test plan
- [x] Live symlink: \`/usr/local/bin/ape-shell --version\` → prints version
- [x] Minimal PATH: \`env -i PATH=/bin:/usr/bin /usr/local/bin/ape-shell --version\` → prints version