### PR TITLE
feat(apes): transparent session auto-refresh — no hourly re-login

### DIFF
--- a/.changeset/apes-session-auto-refresh.md
+++ b/.changeset/apes-session-auto-refresh.md
@@ -1,0 +1,27 @@
+---
+'@openape/apes': patch
+---
+
+Transparent session auto-refresh — no more hourly `apes login`.
+
+- `apes login --key <path>` now persists the resolved absolute key path and agent email
+  to `~/.config/apes/config.toml` so every subsequent `apes` / `ape-shell` invocation
+  can auto-refresh its access token via Ed25519 challenge-response, without the user
+  needing to edit the config file manually. Auto-refresh is enabled as a one-time setup,
+  not a recurring ritual.
+- New OAuth2 refresh_token flow in `apiFetch()` for PKCE/browser-login users: when the
+  access token is expired and a `refresh_token` is stored in `auth.json`, the client
+  now calls `/token` with `grant_type=refresh_token` and rotates both the access token
+  and the refresh token. Concurrent refreshes are serialized via a POSIX file lock
+  (`~/.config/apes/auth.json.lock`) with stale-lock eviction, so parallel `ape-shell`
+  invocations don't race each other into a rotating-family revoke.
+- Refresh priority: Ed25519 agent key > OAuth refresh_token > "Run `apes login` first".
+  Agent-key first because each challenge is independent server-side and therefore
+  concurrency-safe.
+- `apes logout` now also wipes the `[agent]` section from `config.toml`, keeping
+  `[defaults]` so the IdP URL survives.
+- Server-side 400/401 responses to `/token` clear the stored `refresh_token` so a
+  revoked family doesn't trigger an infinite retry loop.
+- 13 new unit + integration tests cover the refresh priority chain, family-revoke
+  handling, file-lock serialization, stale-lock eviction, config.toml merge, and
+  logout wipe.

--- a/packages/apes/src/auth-lock.ts
+++ b/packages/apes/src/auth-lock.ts
@@ -1,0 +1,56 @@
+import type { FileHandle } from 'node:fs/promises'
+import { open, rm, stat } from 'node:fs/promises'
+import { join } from 'node:path'
+import { CONFIG_DIR } from './config'
+
+const LOCK_FILE = join(CONFIG_DIR, 'auth.json.lock')
+
+export interface AuthLock {
+  handle: FileHandle
+}
+
+/**
+ * Best-effort exclusive file lock to serialize concurrent token refreshes
+ * between parallel apes / ape-shell invocations. Uses O_CREAT|O_EXCL which
+ * is atomic on POSIX. Returns null on timeout so the caller can fall back
+ * to "just re-read auth.json" (the assumption being that another process
+ * successfully refreshed in the meantime).
+ *
+ * A stale lock older than 30s is considered abandoned (from a crashed
+ * process) and is removed so the next acquire can proceed.
+ */
+export async function acquireAuthLock(
+  opts: { timeoutMs?: number } = {},
+): Promise<AuthLock | null> {
+  const deadline = Date.now() + (opts.timeoutMs ?? 5000)
+  while (Date.now() < deadline) {
+    try {
+      const handle = await open(LOCK_FILE, 'wx')
+      return { handle }
+    }
+    catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'EEXIST')
+        throw err
+      // Stale lock? If the file is older than 30s, remove it and retry.
+      try {
+        const s = await stat(LOCK_FILE)
+        if (Date.now() - s.mtimeMs > 30_000)
+          await rm(LOCK_FILE, { force: true })
+      }
+      catch {
+        // File gone between stat and rm — next iteration will retry the open.
+      }
+      await new Promise(r => setTimeout(r, 100))
+    }
+  }
+  return null
+}
+
+export async function releaseAuthLock(lock: AuthLock): Promise<void> {
+  try {
+    await lock.handle.close()
+  }
+  finally {
+    await rm(LOCK_FILE, { force: true })
+  }
+}

--- a/packages/apes/src/commands/auth/login.ts
+++ b/packages/apes/src/commands/auth/login.ts
@@ -1,10 +1,12 @@
 import { Buffer } from 'node:buffer'
 import { execFile } from 'node:child_process'
 import { createServer } from 'node:http'
+import { homedir } from 'node:os'
+import { resolve as resolvePath } from 'node:path'
 import { defineCommand } from 'citty'
 import { generateCodeChallenge, generateCodeVerifier } from '@openape/core'
 import consola from 'consola'
-import { saveAuth } from '../../config'
+import { loadConfig, saveAuth, saveConfig } from '../../config'
 import { getAgentAuthenticateEndpoint, getAgentChallengeEndpoint } from '../../http'
 import { CliError } from '../../errors'
 import { resolveLoginInputs } from './resolve-login'
@@ -246,5 +248,20 @@ async function loginWithKey(idp: string, keyPath: string, agentEmail: string) {
     expires_at: Math.floor(Date.now() / 1000) + (expires_in || 3600),
   })
 
+  // Persist the resolved key path + email to config.toml so future apes/ape-shell
+  // invocations can auto-refresh via Ed25519 challenge-response without a new
+  // `apes login`. Merge with existing config so [defaults] is preserved.
+  const absoluteKeyPath = resolvePath(keyPath.replace(/^~/, homedir()))
+  const existingConfig = loadConfig()
+  saveConfig({
+    ...existingConfig,
+    agent: {
+      ...existingConfig.agent,
+      key: absoluteKeyPath,
+      email: agentEmail,
+    },
+  })
+
   consola.success(`Logged in as ${agentEmail}`)
+  consola.info(`Auto-refresh enabled (key path saved to ~/.config/apes/config.toml)`)
 }

--- a/packages/apes/src/config.ts
+++ b/packages/apes/src/config.ts
@@ -51,6 +51,15 @@ export function clearAuth(): void {
   if (existsSync(AUTH_FILE)) {
     writeFileSync(AUTH_FILE, '', { mode: 0o600 })
   }
+  // Also wipe the [agent] section from config.toml so logout disables
+  // auto-refresh. Preserves [defaults] so the IdP URL stays configured.
+  if (existsSync(CONFIG_FILE)) {
+    const existing = loadConfig()
+    if (existing.agent) {
+      const { agent: _removed, ...rest } = existing
+      saveConfig(rest)
+    }
+  }
 }
 
 export function loadConfig(): ApesConfig {

--- a/packages/apes/src/http.ts
+++ b/packages/apes/src/http.ts
@@ -120,6 +120,86 @@ async function refreshAgentToken(): Promise<string | null> {
   }
 }
 
+/**
+ * Refresh an OAuth2 access token using a stored refresh_token. Used for
+ * PKCE/browser login sessions where no Ed25519 agent key is configured.
+ *
+ * Serialized via a file lock so concurrent apes/ape-shell invocations don't
+ * both consume the same rotating refresh token (which would revoke the
+ * entire family server-side).
+ */
+async function refreshOAuthToken(): Promise<string | null> {
+  const auth = loadAuth()
+  if (!auth?.refresh_token)
+    return null
+
+  const { acquireAuthLock, releaseAuthLock } = await import('./auth-lock.js')
+  const lock = await acquireAuthLock({ timeoutMs: 5000 })
+  if (!lock) {
+    // Another process is refreshing. It should have updated auth.json by now;
+    // re-read and return whatever fresh token is there (may still be null).
+    return getAuthToken()
+  }
+
+  try {
+    // Re-read auth.json inside the lock — another holder may already have
+    // refreshed while we were waiting, in which case we reuse the new token.
+    const latest = loadAuth()
+    if (latest?.expires_at && Date.now() / 1000 < latest.expires_at - 30)
+      return latest.access_token
+
+    const activeRefreshToken = latest?.refresh_token ?? auth.refresh_token
+    if (!activeRefreshToken)
+      return null
+
+    const disco = await discoverEndpoints(auth.idp)
+    const tokenEndpoint = (disco.token_endpoint as string) || `${auth.idp}/token`
+
+    const body = new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: activeRefreshToken,
+    })
+
+    const resp = await fetch(tokenEndpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+    })
+
+    if (!resp.ok) {
+      // Family may have been revoked server-side — clear refresh_token to
+      // prevent an infinite retry loop on every subsequent apes invocation.
+      if (resp.status === 400 || resp.status === 401) {
+        const base = latest ?? auth
+        saveAuth({ ...base, refresh_token: undefined })
+      }
+      return null
+    }
+
+    const tokens = await resp.json() as {
+      access_token: string
+      refresh_token?: string
+      expires_in?: number
+    }
+
+    const base = latest ?? auth
+    saveAuth({
+      ...base,
+      access_token: tokens.access_token,
+      refresh_token: tokens.refresh_token ?? base.refresh_token,
+      expires_at: Math.floor(Date.now() / 1000) + (tokens.expires_in || 300),
+    })
+
+    if (debug)
+      consola.debug('Token refreshed via OAuth refresh_token')
+
+    return tokens.access_token
+  }
+  finally {
+    await releaseAuthLock(lock)
+  }
+}
+
 export async function apiFetch<T = unknown>(
   path: string,
   options: {
@@ -131,9 +211,13 @@ export async function apiFetch<T = unknown>(
 ): Promise<T> {
   let token = options.token || getAuthToken()
 
-  // Auto-refresh expired agent tokens
+  // Auto-refresh: priority (1) ed25519 agent key, (2) OAuth refresh_token.
+  // Agent-key first because it is concurrency-safe — every challenge is
+  // independent server-side, so parallel ape-shell spawns don't race.
   if (!token) {
     token = await refreshAgentToken()
+    if (!token)
+      token = await refreshOAuthToken()
   }
 
   if (!token) {

--- a/packages/apes/test/additional.test.ts
+++ b/packages/apes/test/additional.test.ts
@@ -294,11 +294,17 @@ describe('additional coverage tests', () => {
 
   describe('grants delegate (with mock endpoint)', () => {
     let savedAgentAuth: string
+    let savedAgentConfig: string
 
     beforeAll(async () => {
-      // Save agent auth, then login as human user (delegations require act: 'human')
+      // Save agent auth + config.toml, then login as human user (delegations
+      // require act: 'human'). loginCommand now also persists the agent.key
+      // path to config.toml, so we must save/restore both to avoid clobbering
+      // the agent-auto-refresh state that later tests depend on.
       const authFile = join(testHome, '.config', 'apes', 'auth.json')
+      const configFile = join(testHome, '.config', 'apes', 'config.toml')
       savedAgentAuth = readFileSync(authFile, 'utf-8')
+      savedAgentConfig = readFileSync(configFile, 'utf-8')
 
       const { loginCommand } = await import('../src/commands/auth/login')
       await loginCommand.run!({ args: {
@@ -309,9 +315,11 @@ describe('additional coverage tests', () => {
     })
 
     afterAll(() => {
-      // Restore agent auth
+      // Restore agent auth + config.toml
       const authFile = join(testHome, '.config', 'apes', 'auth.json')
+      const configFile = join(testHome, '.config', 'apes', 'config.toml')
       writeFileSync(authFile, savedAgentAuth, { mode: 0o600 })
+      writeFileSync(configFile, savedAgentConfig, { mode: 0o600 })
     })
 
     it('creates a delegation', async () => {
@@ -412,7 +420,12 @@ describe('additional coverage tests', () => {
     it('clearAuth clears auth data', async () => {
       const { clearAuth, loadAuth } = await import('../src/config')
       const authFile = join(testHome, '.config', 'apes', 'auth.json')
-      const saved = readFileSync(authFile, 'utf-8')
+      const configFile = join(testHome, '.config', 'apes', 'config.toml')
+      const savedAuth = readFileSync(authFile, 'utf-8')
+      // clearAuth() also wipes the [agent] section in config.toml, so save
+      // both and restore both so later tests still have their agent refresh
+      // config available.
+      const savedConfig = existsSync(configFile) ? readFileSync(configFile, 'utf-8') : null
 
       try {
         clearAuth()
@@ -420,7 +433,9 @@ describe('additional coverage tests', () => {
         expect(auth).toBeNull()
       }
       finally {
-        writeFileSync(authFile, saved, { mode: 0o600 })
+        writeFileSync(authFile, savedAuth, { mode: 0o600 })
+        if (savedConfig !== null)
+          writeFileSync(configFile, savedConfig, { mode: 0o600 })
       }
     })
 

--- a/packages/apes/test/auth-lock.test.ts
+++ b/packages/apes/test/auth-lock.test.ts
@@ -1,0 +1,90 @@
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { stat, utimes } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Isolate HOME so CONFIG_DIR + LOCK_FILE resolve inside tmpdir
+const testHome = join(tmpdir(), `apes-lock-${process.pid}-${Date.now()}`)
+
+vi.mock('node:os', async (importOriginal) => {
+  const original = await importOriginal<typeof import('node:os')>()
+  return { ...original, homedir: () => testHome }
+})
+
+describe('auth-lock', () => {
+  beforeEach(() => {
+    rmSync(testHome, { recursive: true, force: true })
+    mkdirSync(join(testHome, '.config', 'apes'), { recursive: true })
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    rmSync(testHome, { recursive: true, force: true })
+  })
+
+  it('acquires and releases a lock', async () => {
+    const { acquireAuthLock, releaseAuthLock } = await import('../src/auth-lock')
+
+    const lock = await acquireAuthLock()
+    expect(lock).not.toBeNull()
+    expect(existsSync(join(testHome, '.config', 'apes', 'auth.json.lock'))).toBe(true)
+
+    await releaseAuthLock(lock!)
+    expect(existsSync(join(testHome, '.config', 'apes', 'auth.json.lock'))).toBe(false)
+  })
+
+  it('serializes two concurrent acquires — second one waits for the first', async () => {
+    const { acquireAuthLock, releaseAuthLock } = await import('../src/auth-lock')
+
+    const first = await acquireAuthLock({ timeoutMs: 1000 })
+    expect(first).not.toBeNull()
+
+    // Start the second acquire in the background; it must NOT succeed until we release.
+    let firstReleased = false
+    let secondResolvedEarly = false
+    const secondPromise = acquireAuthLock({ timeoutMs: 3000 }).then((l) => {
+      secondResolvedEarly = !firstReleased
+      return l
+    })
+
+    await new Promise(r => setTimeout(r, 300))
+    expect(secondResolvedEarly).toBe(false)
+
+    firstReleased = true
+    await releaseAuthLock(first!)
+
+    const second = await secondPromise
+    expect(second).not.toBeNull()
+    await releaseAuthLock(second!)
+  })
+
+  it('returns null on acquire timeout while another holder keeps the lock', async () => {
+    const { acquireAuthLock, releaseAuthLock } = await import('../src/auth-lock')
+
+    const first = await acquireAuthLock()
+    expect(first).not.toBeNull()
+
+    const second = await acquireAuthLock({ timeoutMs: 500 })
+    expect(second).toBeNull()
+
+    await releaseAuthLock(first!)
+  })
+
+  it('evicts a stale lock older than 30 seconds', async () => {
+    const { acquireAuthLock, releaseAuthLock } = await import('../src/auth-lock')
+
+    // Create a stale lock file manually
+    const lockPath = join(testHome, '.config', 'apes', 'auth.json.lock')
+    writeFileSync(lockPath, '', { mode: 0o600 })
+    // Backdate it 60 seconds
+    const past = new Date(Date.now() - 60_000)
+    await utimes(lockPath, past, past)
+    const statBefore = await stat(lockPath)
+    expect(Date.now() - statBefore.mtimeMs).toBeGreaterThan(30_000)
+
+    const fresh = await acquireAuthLock({ timeoutMs: 2000 })
+    expect(fresh).not.toBeNull()
+    await releaseAuthLock(fresh!)
+  })
+})

--- a/packages/apes/test/auth-refresh.test.ts
+++ b/packages/apes/test/auth-refresh.test.ts
@@ -1,0 +1,240 @@
+import { generateKeyPairSync } from 'node:crypto'
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// Isolate HOME so config.ts reads/writes a fresh dir per test.
+// ---------------------------------------------------------------------------
+
+const testHome = join(tmpdir(), `apes-refresh-${process.pid}-${Date.now()}`)
+
+vi.mock('node:os', async (importOriginal) => {
+  const original = await importOriginal<typeof import('node:os')>()
+  return { ...original, homedir: () => testHome }
+})
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const IDP = 'http://idp.test'
+const EMAIL = 'agent@example.com'
+
+function seedExpiredAuth(opts: { refreshToken?: string } = {}) {
+  mkdirSync(join(testHome, '.config', 'apes'), { recursive: true })
+  writeFileSync(
+    join(testHome, '.config', 'apes', 'auth.json'),
+    JSON.stringify({
+      idp: IDP,
+      access_token: 'expired-token',
+      ...(opts.refreshToken ? { refresh_token: opts.refreshToken } : {}),
+      email: EMAIL,
+      expires_at: 1, // always expired
+    }),
+    { mode: 0o600 },
+  )
+}
+
+function seedConfig(toml: string) {
+  mkdirSync(join(testHome, '.config', 'apes'), { recursive: true })
+  writeFileSync(join(testHome, '.config', 'apes', 'config.toml'), toml, { mode: 0o600 })
+}
+
+function readAuth(): any {
+  return JSON.parse(readFileSync(join(testHome, '.config', 'apes', 'auth.json'), 'utf-8'))
+}
+
+/**
+ * Install a fetch mock that drives the various IdP endpoints. Returns a log
+ * of every fetch call so tests can assert which endpoints were hit.
+ */
+function installFetchMock(handler: (url: string, init?: RequestInit) => Response | Promise<Response>) {
+  const calls: { url: string, init?: RequestInit }[] = []
+  const spy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url: string | URL | Request, init?: RequestInit) => {
+    const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url
+    calls.push({ url: urlStr, init })
+    return handler(urlStr, init)
+  })
+  return { calls, spy }
+}
+
+function jsonResponse(body: unknown, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: { 'Content-Type': 'application/json', ...(init.headers || {}) },
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('apiFetch auto-refresh', () => {
+  beforeEach(() => {
+    rmSync(testHome, { recursive: true, force: true })
+    mkdirSync(testHome, { recursive: true })
+    // Discovery cache is module-level — nuke ESM module cache so each test
+    // gets a fresh cache and fresh fetch mock.
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('falls back to "run apes login" when neither refresh path is available', async () => {
+    seedExpiredAuth() // no refresh_token
+    // No config.toml → no agent.key
+
+    const { calls } = installFetchMock(async (url) => {
+      // Discovery may still be called; return empty
+      if (url.includes('/.well-known/')) return jsonResponse({})
+      return new Response('', { status: 404 })
+    })
+
+    const { apiFetch } = await import('../src/http')
+    await expect(apiFetch('/api/grants')).rejects.toThrow('Not authenticated')
+    // Should NOT have called /token since no refresh_token is set
+    expect(calls.some(c => c.url.endsWith('/token'))).toBe(false)
+  })
+
+  it('uses OAuth refresh_token flow when refresh_token is set and no agent key configured', async () => {
+    seedExpiredAuth({ refreshToken: 'rt-original' })
+
+    installFetchMock(async (url, init) => {
+      if (url.includes('/.well-known/openid-configuration')) {
+        return jsonResponse({
+          issuer: IDP,
+          token_endpoint: `${IDP}/token`,
+        })
+      }
+      if (url === `${IDP}/token`) {
+        const body = init?.body as string
+        expect(body).toContain('grant_type=refresh_token')
+        expect(body).toContain('refresh_token=rt-original')
+        return jsonResponse({
+          access_token: 'new-access-token',
+          refresh_token: 'rt-rotated',
+          expires_in: 300,
+        })
+      }
+      if (url.includes('/api/grants')) {
+        expect(init?.headers).toMatchObject({
+          Authorization: 'Bearer new-access-token',
+        })
+        return jsonResponse({ data: [] })
+      }
+      return new Response('', { status: 404 })
+    })
+
+    const { apiFetch } = await import('../src/http')
+    const result = await apiFetch<{ data: unknown[] }>('/api/grants')
+    expect(result).toEqual({ data: [] })
+
+    // Rotated refresh_token + new access_token must be persisted to auth.json
+    const auth = readAuth()
+    expect(auth.access_token).toBe('new-access-token')
+    expect(auth.refresh_token).toBe('rt-rotated')
+    expect(auth.expires_at).toBeGreaterThan(Date.now() / 1000)
+  })
+
+  it('keeps the old refresh_token when server does not return a rotated one', async () => {
+    seedExpiredAuth({ refreshToken: 'rt-stable' })
+
+    installFetchMock(async (url) => {
+      if (url.includes('/.well-known/'))
+        return jsonResponse({ token_endpoint: `${IDP}/token` })
+      if (url === `${IDP}/token`) {
+        return jsonResponse({
+          access_token: 'new-access-token',
+          expires_in: 300,
+          // No refresh_token in response (non-rotating mode)
+        })
+      }
+      if (url.includes('/api/grants'))
+        return jsonResponse({ data: [] })
+      return new Response('', { status: 404 })
+    })
+
+    const { apiFetch } = await import('../src/http')
+    await apiFetch('/api/grants')
+
+    const auth = readAuth()
+    expect(auth.refresh_token).toBe('rt-stable')
+  })
+
+  it('clears refresh_token on 401 from /token to prevent an infinite refresh loop', async () => {
+    seedExpiredAuth({ refreshToken: 'rt-revoked' })
+
+    installFetchMock(async (url) => {
+      if (url.includes('/.well-known/'))
+        return jsonResponse({ token_endpoint: `${IDP}/token` })
+      if (url === `${IDP}/token`)
+        return jsonResponse({ error: 'invalid_grant' }, { status: 401 })
+      return new Response('', { status: 404 })
+    })
+
+    const { apiFetch } = await import('../src/http')
+    await expect(apiFetch('/api/grants')).rejects.toThrow('Not authenticated')
+
+    const auth = readAuth()
+    expect(auth.refresh_token).toBeUndefined()
+    // Other fields should be preserved so the user can still see their email etc.
+    expect(auth.email).toBe(EMAIL)
+  })
+
+  it('clears refresh_token on 400 from /token (invalid_grant)', async () => {
+    seedExpiredAuth({ refreshToken: 'rt-bad' })
+
+    installFetchMock(async (url) => {
+      if (url.includes('/.well-known/'))
+        return jsonResponse({ token_endpoint: `${IDP}/token` })
+      if (url === `${IDP}/token`)
+        return jsonResponse({ error: 'invalid_grant' }, { status: 400 })
+      return new Response('', { status: 404 })
+    })
+
+    const { apiFetch } = await import('../src/http')
+    await expect(apiFetch('/api/grants')).rejects.toThrow()
+
+    expect(readAuth().refresh_token).toBeUndefined()
+  })
+
+  it('prefers ed25519 agent-key refresh over OAuth refresh_token when both are configured', async () => {
+    // Set up an agent key that "exists" on disk and a refresh_token in auth.json.
+    const keyPath = join(testHome, 'test_key.pem')
+    // Generate a real key so loadEd25519PrivateKey() can parse it
+    const { privateKey } = generateKeyPairSync('ed25519')
+    writeFileSync(keyPath, privateKey.export({ type: 'pkcs8', format: 'pem' }) as string, { mode: 0o600 })
+    seedConfig(`[agent]\nkey = "${keyPath}"\n`)
+    seedExpiredAuth({ refreshToken: 'rt-unused' })
+
+    const { calls } = installFetchMock(async (url) => {
+      if (url.includes('/.well-known/'))
+        return jsonResponse({ token_endpoint: `${IDP}/token` })
+      if (url.endsWith('/api/agent/challenge'))
+        return jsonResponse({ challenge: 'Y2hhbGxlbmdlMTIz' }) // base64
+      if (url.endsWith('/api/agent/authenticate')) {
+        return jsonResponse({
+          token: 'agent-refreshed-token',
+          expires_in: 3600,
+        })
+      }
+      if (url.includes('/api/grants'))
+        return jsonResponse({ data: [] })
+      return new Response('', { status: 404 })
+    })
+
+    const { apiFetch } = await import('../src/http')
+    await apiFetch('/api/grants')
+
+    // Agent challenge + authenticate hit, /token must NOT have been called
+    expect(calls.some(c => c.url.endsWith('/api/agent/challenge'))).toBe(true)
+    expect(calls.some(c => c.url.endsWith('/api/agent/authenticate'))).toBe(true)
+    expect(calls.some(c => c.url === `${IDP}/token`)).toBe(false)
+
+    expect(readAuth().access_token).toBe('agent-refreshed-token')
+  })
+})

--- a/packages/apes/test/inprocess.test.ts
+++ b/packages/apes/test/inprocess.test.ts
@@ -265,6 +265,42 @@ describe('apes CLI in-process tests', () => {
     expect(auth.expires_at).toBeGreaterThan(Date.now() / 1000)
   })
 
+  // ---------- 1b. Login persists agent key path to config.toml ----------
+  it('login: persists absolute key path and email to config.toml for auto-refresh', async () => {
+    const { loginCommand } = await import('../src/commands/auth/login')
+
+    const configFile = join(testHome, '.config', 'apes', 'config.toml')
+    // Pre-seed an existing [defaults] section so we verify the merge.
+    // Use `approval` (not `idp`) to avoid poisoning later "no IdP configured" tests.
+    writeFileSync(configFile, '[defaults]\napproval = "once"\n', { mode: 0o600 })
+
+    await loginCommand.run!({ args: {
+      idp: idpBase,
+      key: join(testHome, 'test_key'),
+      email: AGENT_EMAIL,
+    } } as any)
+
+    expect(existsSync(configFile)).toBe(true)
+    const tomlContent = readFileSync(configFile, 'utf-8')
+
+    // [agent] section must exist with an ABSOLUTE key path + the email
+    expect(tomlContent).toContain('[agent]')
+    const expectedKeyPath = join(testHome, 'test_key')
+    expect(tomlContent).toContain(`key = "${expectedKeyPath}"`)
+    expect(tomlContent).toContain(`email = "${AGENT_EMAIL}"`)
+
+    // Existing [defaults] must be preserved (merge, not replace)
+    expect(tomlContent).toContain('[defaults]')
+    expect(tomlContent).toContain('approval = "once"')
+
+    // And the loaded config should reflect both
+    const { loadConfig } = await import('../src/config')
+    const loaded = loadConfig()
+    expect(loaded.agent?.key).toBe(expectedKeyPath)
+    expect(loaded.agent?.email).toBe(AGENT_EMAIL)
+    expect(loaded.defaults?.approval).toBe('once')
+  })
+
   // ---------- 2. Whoami ----------
   it('whoami: shows current identity after login', async () => {
     const { whoamiCommand } = await import('../src/commands/auth/whoami')
@@ -428,5 +464,24 @@ describe('apes CLI in-process tests', () => {
     expect(() =>
       workflowsCommand.run!({ args: { id: 'nonexistent', json: false } } as any),
     ).toThrow(CliError)
+  })
+
+  // NOTE: This test MUST remain the last test in this describe block because
+  // it wipes the auth.json and [agent] section, leaving no valid login state.
+  it('logout: wipes [agent] section from config.toml but keeps [defaults]', async () => {
+    const { logoutCommand } = await import('../src/commands/auth/logout')
+
+    const configFile = join(testHome, '.config', 'apes', 'config.toml')
+    // Sanity: after earlier tests, [agent] section should already be present.
+    const beforeLogout = readFileSync(configFile, 'utf-8')
+    expect(beforeLogout).toContain('[agent]')
+
+    logoutCommand.run!({ args: {} } as any)
+
+    const afterLogout = readFileSync(configFile, 'utf-8')
+    expect(afterLogout).not.toContain('[agent]')
+    expect(afterLogout).not.toMatch(/^key = /m)
+    // [defaults] that was pre-seeded in test 1b must survive.
+    expect(afterLogout).toContain('[defaults]')
   })
 })


### PR DESCRIPTION
## Summary

- Fixes the "every hour I need to run `apes login` again" problem. Two separate gaps, one for agent-key login, one for PKCE/browser login.
- `apes login --key <path>` now persists the resolved absolute key path and agent email to `~/.config/apes/config.toml`. The existing `refreshAgentToken()` ed25519 challenge-response logic reads this path, so every subsequent `apes`/`ape-shell` spawn transparently re-authenticates when the access token expires. It's a one-time setup, not a recurring ritual.
- New `refreshOAuthToken()` implements the OAuth2 refresh_token grant for PKCE/browser users. The refresh token was always persisted to auth.json, the client just never called it. Serialized via a POSIX file lock (`auth.json.lock`) with 30s stale eviction to prevent rotating-family revokes during parallel `ape-shell` invocations.
- `apiFetch()` priority chain: **ed25519 agent-key → OAuth refresh_token → fail with "Run apes login".** Agent-key first because each challenge is server-side independent → concurrency-safe with no file lock needed.
- `apes logout` now wipes `[agent]` from config.toml in addition to clearing auth.json, so sign-out actually disables auto-refresh. `[defaults]` is preserved.
- 400/401 from `/token` clears the stored refresh_token to prevent infinite retry loops on a revoked family.

## Verification

- `pnpm turbo run lint typecheck test` → **62/62 tasks green**, **376 apes tests pass** (13 new)
- New test files:
  - `test/auth-refresh.test.ts` — 6 tests: fallback when nothing is available, OAuth refresh happy path, non-rotating server, 400/401 revoke handling, agent-key preferred over refresh_token
  - `test/auth-lock.test.ts` — 4 tests: acquire/release, concurrent serialization, timeout fallback, stale-lock eviction
- Updated existing tests:
  - `test/inprocess.test.ts` — new tests for `loginWithKey` config.toml persistence + merge + logout-wipe
  - `test/additional.test.ts` — existing `clearAuth` and `grants delegate` tests updated to save/restore config.toml since clearAuth now also touches it

## Security

- Only the **path** to the ed25519 key lands in config.toml — never the key itself.
- Rotating refresh token family integrity is preserved: the file lock prevents two concurrent spawns from both consuming the same refresh_token (which would revoke the entire family on the second request).
- On 400/401 from `/token` the refresh_token is cleared locally so the client doesn't loop forever.
- `apes logout` now wipes `[agent]` so an explicit sign-out disables every refresh path.
- Feature is additive: when neither refresh path is available, behavior is byte-for-byte identical to today ("Run `apes login` first").

## Test plan
- [x] `pnpm turbo run lint typecheck test` — 62/62 tasks green
- [x] `@openape/apes` unit + integration tests — 376 tests, 13 new
- [x] `openape-free-idp` shapes E2E — still green
- [ ] Manual E2E against `https://id.openape.at`: re-login once, expire `auth.json`, run `apes grants list` → should auto-refresh silently

🤖 Generated with [Claude Code](https://claude.com/claude-code)