### PR TITLE
fix(apes): suppress pty input echo in interactive shell

### DIFF
--- a/.changeset/apes-shell-stty-echo.md
+++ b/.changeset/apes-shell-stty-echo.md
@@ -1,0 +1,25 @@
+---
+'@openape/apes': patch
+---
+
+fix(apes): suppress pty input echo in interactive ape-shell REPL
+
+The persistent bash child runs inside a pty whose default line discipline
+echoes input back in canonical mode. Combined with the ape-shell readline
+frontend (which already renders `apes$ <line>`), this caused every command
+to appear twice in the user's terminal:
+
+```
+apes$ whoami            ← readline echo (frontend)
+ℹ Requesting grant for: …
+whoami                  ← pty line-discipline echo (redundant)
+openclaw                ← actual output
+apes$
+```
+
+Fix: prepend `stty -echo 2>/dev/null` to `PROMPT_COMMAND` so the pty's
+input echo is disabled before every prompt, matching the single-echo
+behavior of a regular interactive shell. Runs after every prompt so it
+also re-applies if a user command toggles echo. Interactive TUI apps
+(vim, less, top) set their own termios when they start and are
+unaffected.

--- a/packages/apes/src/shell/pty-bridge.ts
+++ b/packages/apes/src/shell/pty-bridge.ts
@@ -75,6 +75,15 @@ export class PtyBridge {
     // runs and they get their aliases/functions. Trade-off: if the user
     // overrides PS1 in their rcfile, our marker detection breaks. We protect
     // against that by re-exporting PS1 via PROMPT_COMMAND on every prompt.
+    //
+    // PROMPT_COMMAND also runs `stty -echo` so the pty line discipline stops
+    // echoing user input back to us. Without this, every line the frontend
+    // writes to the pty gets echoed into the output stream — causing the
+    // command to appear twice in the user's terminal (once from readline,
+    // once from the pty echo). The frontend already owns its own display of
+    // what the user typed; the pty echo is redundant and surprising.
+    // Interactive TUI apps (vim/less/top) set their own termios when they
+    // start, so they are unaffected.
     this.term = pty.spawn('bash', ['--login', '-i'], {
       name: 'xterm-256color',
       cols,
@@ -82,8 +91,10 @@ export class PtyBridge {
       cwd: options.cwd ?? process.cwd(),
       env: {
         ...process.env,
-        // Force our marker PS1 on every prompt — survives .bashrc overrides.
-        PROMPT_COMMAND: `PS1='__APES_${this.marker}__:$?:__END__'`,
+        // Force our marker PS1 on every prompt and keep pty echo off —
+        // both survive .bashrc overrides because PROMPT_COMMAND runs
+        // before each prompt.
+        PROMPT_COMMAND: `stty -echo 2>/dev/null; PS1='__APES_${this.marker}__:$?:__END__'`,
         // Also set it initially so the very first prompt carries the marker.
         PS1: `__APES_${this.marker}__:$?:__END__`,
         PS2: '> ',

--- a/packages/apes/test/shell-pty-bridge.test.ts
+++ b/packages/apes/test/shell-pty-bridge.test.ts
@@ -75,11 +75,31 @@ describe('PtyBridge', () => {
 
     expect(h.completedLines).toHaveLength(1)
     expect(h.completedLines[0]!.exitCode).toBe(0)
-    // Output should contain the expected line. PTY echoes the input too, so
-    // the output contains both the typed line and its result.
     expect(h.completedLines[0]!.output).toContain('hello-from-bash')
     // Marker must never appear in the output we hand to the consumer
     expect(h.completedLines[0]!.output).not.toContain('__APES_')
+  })
+
+  it('does not echo the written line back into the output stream', async () => {
+    // The pty line discipline echoes input by default (canonical mode), so
+    // without `stty -echo` the bash pty would reflect every line the
+    // frontend writes. Real shells only echo once (their own readline),
+    // ours already handles display in the REPL frontend, so the pty echo
+    // is redundant and surprising. Verify PROMPT_COMMAND turns it off.
+    const h = createHarness()
+    harnesses.push(h)
+
+    await h.bridge.waitForReady()
+    // Use a command whose input and output differ so we can tell them
+    // apart. `whoami` prints one word, the input is another literal word.
+    h.bridge.writeLine('APES_ECHO_PROBE_INPUT=1 printf "result\\n"')
+    await waitUntil(() => h.completedLines.length >= 1)
+
+    const out = h.completedLines[0]!.output
+    // The command's actual output must be present.
+    expect(out).toContain('result')
+    // The literal input we wrote must NOT appear (no pty echo).
+    expect(out).not.toContain('APES_ECHO_PROBE_INPUT')
   })
 
   it('persists shell state across lines (cd then pwd)', async () => {


### PR DESCRIPTION
## Bug
Every command typed in the interactive \`ape-shell\` appeared twice in the terminal:

\`\`\`
apes$ whoami              ← readline echo (frontend)
ℹ Requesting grant for: …
whoami                    ← pty line-discipline echo (redundant)
openclaw                  ← actual output
apes$
\`\`\`

As the reporter put it: *"ist eigentlich shell-unüblich"* — real interactive shells only echo once because they own the line discipline themselves. We have two layers: the frontend's readline AND the bash pty's default canonical-mode echo. The second layer is redundant noise.

## Fix
Prepend \`stty -echo 2>/dev/null\` to \`PROMPT_COMMAND\` in \`pty-bridge.ts\` so the pty's input echo is turned off before every prompt. Self-heals if a user command flips echo state. Interactive TUI apps (vim, less, top) set their own termios when they start, so they are unaffected.

\`2>/dev/null\` guards against systems where \`stty\` isn't available.

## Test
New dedicated test in \`shell-pty-bridge.test.ts\`:

\`\`\`ts
h.bridge.writeLine('APES_ECHO_PROBE_INPUT=1 printf "result\\n"')
// ...
expect(out).toContain('result')              // real output present
expect(out).not.toContain('APES_ECHO_PROBE_INPUT')  // input not echoed back
\`\`\`

## Test plan
- [x] \`pnpm turbo run lint typecheck --filter=@openape/apes\` clean
- [x] \`pnpm --filter @openape/apes test\` — 365/365 pass
- [ ] Live: \`su - openclaw\` → \`apes$ whoami\` should show single-echo output