### PR TITLE
fix(apes): ship scripts/ dir so global install works

### DIFF
--- a/.changeset/apes-ship-postinstall.md
+++ b/.changeset/apes-ship-postinstall.md
@@ -1,0 +1,8 @@
+---
+'@openape/apes': patch
+---
+
+Ship `scripts/` directory in the published npm package so the `postinstall`
+script `scripts/fix-node-pty-perms.mjs` actually exists after `npm install -g`.
+Previously the `files` field only included `dist` and `README.md`, which made
+global install fail with `Cannot find module fix-node-pty-perms.mjs`.

--- a/packages/apes/package.json
+++ b/packages/apes/package.json
@@ -20,6 +20,7 @@
   },
   "files": [
     "dist",
+    "scripts",
     "README.md"
   ],
   "scripts": {


### PR DESCRIPTION
## Summary

Pre-existing packaging bug: `postinstall` references `scripts/fix-node-pty-perms.mjs`, but `files` in package.json only ships `dist` + `README.md`. Result: `npm install -g @openape/apes` fails with `Cannot find module fix-node-pty-perms.mjs` on a fresh machine — which blocked installation of the recently-published v0.7.1 (auto-refresh feature).

## Fix

Add `scripts` to the `files` field so the postinstall hook has the file it expects to run.

## Test plan
- [x] lint + typecheck green
- [ ] After release: `npm install -g @openape/apes@latest` succeeds and `apes --version` prints the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)