### PR TITLE
feat(apes): configurable notification when grant approval is pending

### DIFF
--- a/.changeset/apes-grant-pending-notification.md
+++ b/.changeset/apes-grant-pending-notification.md
@@ -1,0 +1,26 @@
+---
+'@openape/apes': minor
+---
+
+feat(apes): configurable notification command when grant approval is pending
+
+When `ape-shell` (or `apes run --shell`) enters the grant approval wait loop, it now optionally runs a user-configured notification command so the user knows they need to approve. This is especially important when an AI agent (e.g., openclaw) spawns `ape-shell -c "<cmd>"` and the user is only reachable via Telegram, a TUI, or another out-of-band channel — previously the agent just silently blocked.
+
+**Only fires when actually waiting.** Reused timed/always grants that don't require new approval do NOT trigger a notification.
+
+Configuration via `~/.config/apes/config.toml`:
+
+```toml
+[notifications]
+pending_command = "curl -sS 'https://api.telegram.org/bot$TOKEN/sendMessage' -d chat_id=$CHAT -d text='⏸ {command}\n{approve_url}'"
+```
+
+Or per-invocation via env var (takes precedence):
+
+```bash
+APES_NOTIFY_PENDING_COMMAND="osascript -e 'display notification \"{command}\" with title \"apes\"'" ape-shell -c "ls"
+```
+
+Template variables: `{grant_id}`, `{command}`, `{approve_url}`, `{audience}`, `{host}`. All values are shell-escaped via `shell-quote` to prevent injection.
+
+The notification subprocess runs fire-and-forget (detached, unref'd, 10-second kill timeout) so it never blocks the grant flow.

--- a/packages/apes/src/commands/run.ts
+++ b/packages/apes/src/commands/run.ts
@@ -20,6 +20,7 @@ import consola from 'consola'
 import { getIdpUrl, loadAuth } from '../config'
 import { apiFetch, getGrantsEndpoint } from '../http'
 import { CliError, CliExit } from '../errors'
+import { notifyGrantPending } from '../notifications'
 
 export const runCommand = defineCommand({
   meta: {
@@ -150,6 +151,14 @@ async function runShellMode(
   consola.info(`Grant requested: ${grant.id}`)
   consola.info('Waiting for approval...')
 
+  notifyGrantPending({
+    grantId: grant.id,
+    approveUrl: `${idp}/grant-approval?grant_id=${grant.id}`,
+    command: command.join(' ').slice(0, 200),
+    audience: 'ape-shell',
+    host: targetHost,
+  })
+
   const maxWait = 300_000
   const interval = 3_000
   const start = Date.now()
@@ -239,6 +248,14 @@ async function tryAdapterModeFromShell(
     consola.info('')
     consola.info(`  Similar grant(s) found (${n}). Your approver can extend an existing grant to cover this request.`)
   }
+
+  notifyGrantPending({
+    grantId: grant.id,
+    approveUrl: `${idp}/grant-approval?grant_id=${grant.id}`,
+    command: resolved.detail?.display || parsed?.raw || 'unknown',
+    audience: resolved.adapter?.cli?.audience ?? 'shapes',
+    host: (args.host as string) || hostname(),
+  })
 
   const status = await waitForGrantStatus(idp, grant.id)
   if (status !== 'approved')

--- a/packages/apes/src/config.ts
+++ b/packages/apes/src/config.ts
@@ -19,6 +19,9 @@ export interface ApesConfig {
     key?: string
     email?: string
   }
+  notifications?: {
+    pending_command?: string
+  }
 }
 
 const CONFIG_DIR = join(homedir(), '.config', 'apes')
@@ -99,6 +102,10 @@ function parseTOML(content: string): ApesConfig {
         config.agent = config.agent || {}
         ;(config.agent as Record<string, string>)[key!] = value!
       }
+      else if (section === 'notifications') {
+        config.notifications = config.notifications || {}
+        ;(config.notifications as Record<string, string>)[key!] = value!
+      }
     }
   }
 
@@ -121,6 +128,15 @@ export function saveConfig(config: ApesConfig): void {
   if (config.agent) {
     lines.push('[agent]')
     for (const [key, value] of Object.entries(config.agent)) {
+      if (value)
+        lines.push(`${key} = "${value}"`)
+    }
+    lines.push('')
+  }
+
+  if (config.notifications) {
+    lines.push('[notifications]')
+    for (const [key, value] of Object.entries(config.notifications)) {
       if (value)
         lines.push(`${key} = "${value}"`)
     }

--- a/packages/apes/src/notifications.ts
+++ b/packages/apes/src/notifications.ts
@@ -1,0 +1,103 @@
+import { spawn } from 'node:child_process'
+import consola from 'consola'
+import { quote } from 'shell-quote'
+import { loadConfig } from './config'
+
+export interface PendingGrantInfo {
+  grantId: string
+  approveUrl: string
+  command: string
+  audience: string
+  host: string
+}
+
+/**
+ * Resolve the notification command for pending grants. Checks (in order):
+ *   1. `APES_NOTIFY_PENDING_COMMAND` env var (highest priority — lets
+ *      parent programs like openclaw override per invocation)
+ *   2. `[notifications] pending_command` in ~/.config/apes/config.toml
+ *
+ * Returns undefined if no notification command is configured.
+ */
+function resolvePendingCommand(): string | undefined {
+  if (process.env.APES_NOTIFY_PENDING_COMMAND)
+    return process.env.APES_NOTIFY_PENDING_COMMAND
+
+  const config = loadConfig()
+  return config.notifications?.pending_command
+}
+
+/**
+ * Escape a value for safe embedding inside a single-quoted shell string.
+ * We use `shell-quote` to produce a safe literal, then strip the outer
+ * quoting because the template substitution embeds the value inside the
+ * user's command template which is itself passed to `sh -c`.
+ */
+function shellEscape(value: string): string {
+  // quote() wraps in single quotes and escapes internal single quotes
+  // e.g. "it's" → "'it'\\''s'"
+  // We return the raw escaped form so it's safe inside sh -c.
+  return quote([value])
+}
+
+/**
+ * Substitute template variables in the notification command.
+ * All values are shell-escaped to prevent injection.
+ */
+function renderTemplate(template: string, info: PendingGrantInfo): string {
+  return template
+    .replace(/\{grant_id\}/g, shellEscape(info.grantId))
+    .replace(/\{approve_url\}/g, shellEscape(info.approveUrl))
+    .replace(/\{command\}/g, shellEscape(info.command))
+    .replace(/\{audience\}/g, shellEscape(info.audience))
+    .replace(/\{host\}/g, shellEscape(info.host))
+}
+
+/**
+ * Send a notification that a grant is awaiting human approval.
+ *
+ * This is **fire-and-forget**: the notification subprocess runs detached
+ * and unref'd so it cannot block the grant flow. A 10-second timeout
+ * kills it if it hangs (e.g. network issue reaching Telegram API).
+ *
+ * Only fires when a notification command is configured. Silently returns
+ * if not — the grant flow must never depend on notifications.
+ *
+ * Only call this when the grant **actually requires waiting** (new grant
+ * with pending status). Do NOT call when:
+ * - An existing timed/always grant was reused (no human action needed)
+ * - The grant was instantly approved (no waiting phase)
+ */
+export function notifyGrantPending(info: PendingGrantInfo): void {
+  const template = resolvePendingCommand()
+  if (!template)
+    return
+
+  const rendered = renderTemplate(template, info)
+
+  try {
+    const child = spawn('sh', ['-c', rendered], {
+      detached: true,
+      stdio: 'ignore',
+      env: { ...process.env },
+    })
+
+    // Don't let the notification process keep the parent alive
+    child.unref()
+
+    // Kill after 10 seconds if it hasn't exited
+    const timeout = setTimeout(() => {
+      try {
+        child.kill('SIGKILL')
+      }
+      catch {}
+    }, 10_000)
+    timeout.unref()
+
+    child.on('exit', () => clearTimeout(timeout))
+  }
+  catch (err) {
+    // Never let notification failure break the grant flow
+    consola.debug('Notification command failed:', err)
+  }
+}

--- a/packages/apes/src/shell/grant-dispatch.ts
+++ b/packages/apes/src/shell/grant-dispatch.ts
@@ -2,6 +2,7 @@ import { basename } from 'node:path'
 import consola from 'consola'
 import { loadAuth } from '../config.js'
 import { apiFetch, getGrantsEndpoint } from '../http.js'
+import { notifyGrantPending } from '../notifications.js'
 import {
   createShapesGrant,
   fetchGrantToken,
@@ -96,6 +97,14 @@ export async function requestGrantForShellLine(
         })
         consola.info(`Approve at: ${idp}/grant-approval?grant_id=${grant.id}`)
 
+        notifyGrantPending({
+          grantId: grant.id,
+          approveUrl: `${idp}/grant-approval?grant_id=${grant.id}`,
+          command: resolved.detail?.display ?? line,
+          audience: resolved.adapter?.cli?.audience ?? 'shapes',
+          host: options.targetHost,
+        })
+
         const status = await waitForGrantStatus(idp, grant.id)
         if (status !== 'approved') {
           return { kind: 'denied', reason: `Grant ${status}` }
@@ -149,6 +158,14 @@ export async function requestGrantForShellLine(
       },
     })
     consola.info(`Approve at: ${idp}/grant-approval?grant_id=${grant.id}`)
+
+    notifyGrantPending({
+      grantId: grant.id,
+      approveUrl: `${idp}/grant-approval?grant_id=${grant.id}`,
+      command: line.slice(0, 200),
+      audience: 'ape-shell',
+      host: options.targetHost,
+    })
 
     const maxWait = 300_000
     const interval = 3_000

--- a/packages/apes/test/notifications.test.ts
+++ b/packages/apes/test/notifications.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { notifyGrantPending } from '../src/notifications'
+import type { PendingGrantInfo } from '../src/notifications'
+
+// Mock child_process.spawn so we can assert what was spawned without
+// actually running shell commands.
+vi.mock('node:child_process', () => ({
+  spawn: vi.fn(() => {
+    const child = {
+      unref: vi.fn(),
+      kill: vi.fn(),
+      on: vi.fn(),
+    }
+    return child
+  }),
+}))
+
+// Mock config so we can control the notification command per test.
+vi.mock('../src/config', () => ({
+  loadConfig: vi.fn(() => ({})),
+}))
+
+const sampleInfo: PendingGrantInfo = {
+  grantId: 'grant-abc-123',
+  approveUrl: 'https://id.openape.at/grant-approval?grant_id=grant-abc-123',
+  command: 'ls -la /tmp',
+  audience: 'shapes',
+  host: 'test-host',
+}
+
+describe('notifyGrantPending', () => {
+  const savedEnv = process.env.APES_NOTIFY_PENDING_COMMAND
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    delete process.env.APES_NOTIFY_PENDING_COMMAND
+  })
+
+  afterEach(() => {
+    if (savedEnv === undefined) delete process.env.APES_NOTIFY_PENDING_COMMAND
+    else process.env.APES_NOTIFY_PENDING_COMMAND = savedEnv
+  })
+
+  it('does nothing when no notification command is configured', async () => {
+    const { spawn } = await import('node:child_process')
+    notifyGrantPending(sampleInfo)
+    expect(spawn).not.toHaveBeenCalled()
+  })
+
+  it('spawns the configured command from env var with template substitution', async () => {
+    process.env.APES_NOTIFY_PENDING_COMMAND = 'echo {grant_id} {command} {approve_url}'
+    const { spawn } = await import('node:child_process')
+
+    notifyGrantPending(sampleInfo)
+
+    expect(spawn).toHaveBeenCalledOnce()
+    const [shell, args] = vi.mocked(spawn).mock.calls[0]!
+    expect(shell).toBe('sh')
+    expect(args![0]).toBe('-c')
+    // The rendered command should contain the escaped grant id and command
+    const rendered = args![1] as string
+    expect(rendered).toContain('grant-abc-123')
+    expect(rendered).toContain('ls')
+    expect(rendered).toContain('openape.at')
+  })
+
+  it('reads the command from config.toml when env var is not set', async () => {
+    const { loadConfig } = await import('../src/config')
+    vi.mocked(loadConfig).mockReturnValue({
+      notifications: { pending_command: 'notify-send {command}' },
+    })
+    const { spawn } = await import('node:child_process')
+
+    notifyGrantPending(sampleInfo)
+
+    expect(spawn).toHaveBeenCalledOnce()
+    const rendered = vi.mocked(spawn).mock.calls[0]![1]![1] as string
+    expect(rendered).toContain('notify-send')
+  })
+
+  it('prefers env var over config.toml', async () => {
+    process.env.APES_NOTIFY_PENDING_COMMAND = 'env-command {grant_id}'
+    const { loadConfig } = await import('../src/config')
+    vi.mocked(loadConfig).mockReturnValue({
+      notifications: { pending_command: 'config-command {grant_id}' },
+    })
+    const { spawn } = await import('node:child_process')
+
+    notifyGrantPending(sampleInfo)
+
+    const rendered = vi.mocked(spawn).mock.calls[0]![1]![1] as string
+    expect(rendered).toContain('env-command')
+    expect(rendered).not.toContain('config-command')
+  })
+
+  it('shell-escapes template values to prevent injection', async () => {
+    process.env.APES_NOTIFY_PENDING_COMMAND = 'echo {command}'
+    const { spawn } = await import('node:child_process')
+
+    notifyGrantPending({
+      ...sampleInfo,
+      command: 'rm -rf / && echo pwned',
+    })
+
+    const rendered = vi.mocked(spawn).mock.calls[0]![1]![1] as string
+    // shell-quote wraps dangerous strings in single quotes so && is not
+    // interpreted as a shell operator. The rendered command should contain
+    // the quoted form, not the raw unquoted form.
+    expect(rendered).toContain('\'')
+    // The raw unquoted form that would execute as two shell commands must
+    // not appear — it must be inside quoting.
+    expect(rendered).toMatch(/echo '/)
+  })
+
+  it('spawns detached and unrefed (fire-and-forget)', async () => {
+    process.env.APES_NOTIFY_PENDING_COMMAND = 'echo test'
+    const { spawn } = await import('node:child_process')
+
+    notifyGrantPending(sampleInfo)
+
+    const spawnOpts = vi.mocked(spawn).mock.calls[0]![2] as Record<string, unknown>
+    expect(spawnOpts.detached).toBe(true)
+    expect(spawnOpts.stdio).toBe('ignore')
+
+    const child = vi.mocked(spawn).mock.results[0]!.value
+    expect(child.unref).toHaveBeenCalled()
+  })
+})

--- a/packages/apes/test/shell-grant-dispatch.test.ts
+++ b/packages/apes/test/shell-grant-dispatch.test.ts
@@ -23,6 +23,9 @@ vi.mock('../src/shapes/index.js', () => ({
   verifyAndConsume: vi.fn(),
   waitForGrantStatus: vi.fn(),
 }))
+vi.mock('../src/notifications.js', () => ({
+  notifyGrantPending: vi.fn(),
+}))
 
 const fakeAuth = { email: 'alice@example.com', idp: 'http://idp.test' }
 


### PR DESCRIPTION
Closes #83

## Problem
When openclaw (or any parent) spawns \`ape-shell -c "<cmd>"\` and a grant requires human approval, the parent blocks silently. The user (e.g., on Telegram or TUI) has no idea an approval is pending — the agent just appears "stuck".

## Solution
A user-configured shell command runs **fire-and-forget** when \`ape-shell\` enters the grant-approval wait loop. Only fires when **actually waiting** — reused timed/always grants don't trigger it.

### Config
\`\`\`toml
# ~/.config/apes/config.toml
[notifications]
pending_command = "curl -sS 'https://api.telegram.org/bot\$TOKEN/sendMessage' -d chat_id=\$CHAT -d text='⏸ {command} {approve_url}'"
\`\`\`

Or per-invocation via env var (takes precedence):
\`\`\`bash
APES_NOTIFY_PENDING_COMMAND="osascript -e 'display notification \"{command}\"'" ape-shell -c "ls"
\`\`\`

Template variables: \`{grant_id}\`, \`{command}\`, \`{approve_url}\`, \`{audience}\`, \`{host}\`. All shell-escaped via \`shell-quote\`.

### Zero change to openclaw
openclaw spawns \`ape-shell\` as usual — the notification is sent directly from ape-shell, not relayed through the parent.

## Files
- **new** \`packages/apes/src/notifications.ts\` — \`notifyGrantPending()\` helper (async spawn, detached, 10s kill timeout)
- **modified** \`packages/apes/src/config.ts\` — \`[notifications]\` section in \`ApesConfig\` + TOML parser
- **modified** \`packages/apes/src/commands/run.ts\` — notification at both grant-wait points (session + adapter)
- **modified** \`packages/apes/src/shell/grant-dispatch.ts\` — notification at both REPL grant-wait points
- **new** \`packages/apes/test/notifications.test.ts\` — 6 unit tests
- **modified** \`packages/apes/test/shell-grant-dispatch.test.ts\` — mock for notifications

## Test plan
- [x] \`pnpm turbo run lint typecheck --filter=@openape/apes\` clean
- [x] \`pnpm --filter @openape/apes test\` — 388/388 pass