### PR TITLE
docs: full content refresh against current code

### DIFF
--- a/apps/docs/content/1.getting-started/1.index.md
+++ b/apps/docs/content/1.getting-started/1.index.md
@@ -12,6 +12,7 @@ Pick your path — each takes about 3 minutes:
 - **[Add login to my app →](/getting-started/quickstart-sp)** — Nuxt module, Free IdP, zero config
 - **[Run my own Identity Provider →](/getting-started/quickstart-idp)** — Own domain, own users
 - **[Enroll an AI agent →](/getting-started/quickstart-agent)** — Ed25519 key, grant-based permissions
+- **[Use the Free IdP →](/getting-started/free-idp)** — No server, no DNS, get started instantly
 
 ---
 

--- a/apps/docs/content/1.getting-started/5.installation.md
+++ b/apps/docs/content/1.getting-started/5.installation.md
@@ -20,19 +20,19 @@ The fastest way is a Nuxt app with the `@openape/nuxt-auth-idp` module:
 ```bash
 npx nuxi init my-idp
 cd my-idp
-pnpm add @openape/nuxt-auth-idp @openape/nuxt-grants
+pnpm add @openape/nuxt-auth-idp
 ```
 
 Configure `nuxt.config.ts`:
 
 ```ts
 export default defineNuxtConfig({
-  modules: ['@openape/nuxt-auth-idp', '@openape/nuxt-grants'],
+  modules: ['@openape/nuxt-auth-idp'],
   openapeIdp: {
     rpName: 'My Identity Provider',
     rpID: 'id.example.com',
     rpOrigin: 'https://id.example.com',
-    storageDriver: 's3', // or '' for local filesystem
+    // Storage is configured via Nitro storage mounts
   },
 })
 ```
@@ -88,23 +88,22 @@ All configuration can be set via `NUXT_OPENAPE_*` environment variables:
 
 | Variable | Description | Default |
 |---|---|---|
-| `NUXT_OPENAPE_RP_ID` | Relying Party ID (domain) | `localhost` |
-| `NUXT_OPENAPE_RP_ORIGIN` | Relying Party origin (URL) | `http://localhost:3000` |
-| `NUXT_OPENAPE_RP_NAME` | Display name | `OpenApe Identity` |
-| `NUXT_OPENAPE_STORAGE_DRIVER` | Storage driver (`s3` or empty for FS) | `` |
-| `NUXT_OPENAPE_ADMIN_EMAILS` | Comma-separated admin emails | |
-| `NUXT_OPENAPE_MANAGEMENT_TOKEN` | Bearer token for admin API | |
-| `NUXT_OPENAPE_SESSION_SECRET` | Session encryption secret (32+ chars) | |
-| `NUXT_OPENAPE_ISSUER` | JWT issuer URL | |
-| `NUXT_OPENAPE_S3_*` | S3 credentials (ACCESS_KEY, SECRET_KEY, BUCKET, ENDPOINT, REGION) | |
+| `NUXT_OPENAPE_IDP_RP_ID` | Relying Party ID (domain) | `localhost` |
+| `NUXT_OPENAPE_IDP_RP_ORIGIN` | Relying Party origin (URL) | `http://localhost:3000` |
+| `NUXT_OPENAPE_IDP_RP_NAME` | Display name | `OpenApe Identity` |
+| `NUXT_OPENAPE_IDP_ADMIN_EMAILS` | Comma-separated admin emails | |
+| `NUXT_OPENAPE_IDP_MANAGEMENT_TOKEN` | Bearer token for admin API | |
+| `NUXT_OPENAPE_IDP_SESSION_SECRET` | Session encryption secret (32+ chars) | |
+| `NUXT_OPENAPE_IDP_ISSUER` | JWT issuer URL | |
 
 ### SP
 
 | Variable | Description | Default |
 |---|---|---|
-| `NUXT_OPENAPE_CLIENT_ID` | Service Provider ID | |
-| `NUXT_OPENAPE_URL` | IdP URL for discovery | |
+| `NUXT_OPENAPE_SP_CLIENT_ID` | Service Provider ID | |
+| `NUXT_OPENAPE_SP_OPENAPE_URL` | IdP URL for discovery | |
 | `NUXT_OPENAPE_SP_SESSION_SECRET` | Session encryption secret (32+ chars) | |
+| `NUXT_OPENAPE_SP_FALLBACK_IDP_URL` | Fallback IdP URL | `https://id.openape.at` |
 
 ## Create Your First User
 

--- a/apps/docs/content/1.getting-started/9.free-idp.md
+++ b/apps/docs/content/1.getting-started/9.free-idp.md
@@ -1,0 +1,89 @@
+---
+title: Free IdP
+description: Use the hosted OpenApe Identity Provider — no server, no DNS, no setup.
+---
+
+# Free IdP
+
+The Free IdP at [id.openape.at](https://id.openape.at) is a hosted OpenApe Identity Provider. Use it to get started without running your own infrastructure.
+
+## When to Use
+
+| Scenario | Use Free IdP | Use Self-Hosted |
+|---|---|---|
+| Development & testing | ✅ | |
+| Personal projects | ✅ | |
+| Prototyping agent workflows | ✅ | |
+| Production with own domain | | ✅ |
+| Custom user management | | ✅ |
+| Enterprise compliance | | ✅ |
+
+## Get Started
+
+### 1. Create an Account
+
+Open [id.openape.at/register](https://id.openape.at) and register with a passkey. You'll need a registration link from an existing admin, or use the public registration if enabled.
+
+### 2. Enroll an Agent
+
+After logging in, go to the agent enrollment page or use the CLI:
+
+```bash
+npx @openape/apes enroll --idp https://id.openape.at
+```
+
+The wizard guides you through generating an Ed25519 key and registering it at the Free IdP.
+
+### 3. Use in Your App
+
+Point your Service Provider at the Free IdP:
+
+```ts
+export default defineNuxtConfig({
+  modules: ['@openape/nuxt-auth-sp'],
+  openapeSp: {
+    fallbackIdpUrl: 'https://id.openape.at',
+  },
+})
+```
+
+In development, the SP module uses `id.openape.at` as fallback by default — no configuration needed.
+
+### 4. Request a Grant
+
+```bash
+npx @openape/apes run -- git status
+```
+
+The grant request appears at the Free IdP. Log in to approve it.
+
+## What the Free IdP Provides
+
+- WebAuthn passkey authentication
+- Agent enrollment and management
+- Grant approval workflow
+- Delegation support
+- No cost, no sign-up fees
+
+## What It Doesn't Provide
+
+- Custom domain (your users authenticate at `id.openape.at`, not `id.yourdomain.com`)
+- Admin API access (no management token)
+- Custom storage backends
+- SLA or uptime guarantees
+
+## Moving to Self-Hosted
+
+When you outgrow the Free IdP:
+
+1. [Set up your own IdP](/getting-started/quickstart-idp) — 3 minutes with the starter
+2. [Configure DNS](/getting-started/installation) — add a `_ddisa.` TXT record
+3. Migrate users — re-enroll passkeys at your new IdP (passkeys are origin-bound and cannot be transferred)
+
+Your Service Providers don't need any code changes — DDISA DNS discovery automatically finds the new IdP.
+
+## See Also
+
+- [Quick Start: SP](/getting-started/quickstart-sp) — add login to your app (uses Free IdP by default)
+- [Quick Start: Agent](/getting-started/quickstart-agent) — enroll an agent
+- [Quick Start: IdP](/getting-started/quickstart-idp) — run your own IdP

--- a/apps/docs/content/2.ecosystem/1.index.md
+++ b/apps/docs/content/2.ecosystem/1.index.md
@@ -12,10 +12,11 @@ OpenApe isn't a monolith — it's a set of small, focused packages you compose a
 ```
 ┌─────────────────────────────────────────────┐
 │            Framework Modules                │
-│  nuxt-auth-idp  nuxt-auth-sp  nuxt-grants  │
+│       nuxt-auth-idp       nuxt-auth-sp      │
 ├─────────────────────────────────────────────┤
 │            Protocol Packages                │
-│         @openape/auth    @openape/grants    │
+│    @openape/auth  @openape/grants           │
+│    @openape/proxy @openape/apes             │
 ├─────────────────────────────────────────────┤
 │              Foundation                     │
 │              @openape/core                  │
@@ -27,23 +28,26 @@ OpenApe isn't a monolith — it's a set of small, focused packages you compose a
 | Package | Description | Framework |
 |---|---|---|
 | `@openape/core` | DNS discovery, crypto, PKCE, JWT utilities | None |
-| `@openape/auth` | OIDC login protocol — IdP and SP sides | None |
-| `@openape/grants` | Grant lifecycle, AuthZ-JWT issuance | None |
-| `@openape/nuxt-auth-idp` | Drop-in Nuxt module: run your own IdP | Nuxt |
-| `@openape/nuxt-auth-sp` | Drop-in Nuxt module: login via OpenApe | Nuxt |
-| `@openape/nuxt-grants` | Drop-in Nuxt module: grant management | Nuxt |
-| `openape-escapes` (`escapes`) | Rust binary for privilege elevation | OS-level |
+| [`@openape/auth`](/ecosystem/auth) | OIDC login protocol — IdP and SP sides | None |
+| [`@openape/grants`](/ecosystem/grants) | Grant lifecycle, AuthZ-JWT issuance | None |
+| [`@openape/apes`](/getting-started/cli) | CLI + ape-shell: authentication, grants, grant-secured execution | None |
+| `@openape/proxy` | HTTP forward proxy with grant-based access control | None |
+| `@openape/browser` | Headless browser automation with grant enforcement | None |
+| [`@openape/nuxt-auth-idp`](/ecosystem/nuxt-auth-idp) | Drop-in Nuxt module: run your own IdP (includes grants) | Nuxt |
+| [`@openape/nuxt-auth-sp`](/ecosystem/nuxt-auth-sp) | Drop-in Nuxt module: login via OpenApe | Nuxt |
+| [`escapes`](/ecosystem/escapes) | Rust binary for privilege elevation | OS-level |
 
 ## Combinations
 
 | Use Case | Packages |
 |---|---|
 | App with OpenApe login | `nuxt-auth-sp` |
-| Run your own IdP | `nuxt-auth-idp` |
-| Agent permissions | `nuxt-grants` |
-| Full IdP + Grants | `nuxt-auth-idp` + `nuxt-grants` |
-| SP with grant requests | `nuxt-auth-sp` + `nuxt-grants` |
+| Run your own IdP (with grants) | `nuxt-auth-idp` |
+| Full IdP + SP | `nuxt-auth-idp` + `nuxt-auth-sp` |
+| CLI agent management | `@openape/apes` |
 | Non-Nuxt integration | `@openape/auth` + `@openape/grants` |
+| Agent HTTP traffic control | `@openape/proxy` |
+| Browser automation with grants | `@openape/browser` |
 | Local privilege elevation | `openape-escapes` (`escapes`) |
 
 ## Design Principles

--- a/apps/docs/content/2.ecosystem/2.auth.md
+++ b/apps/docs/content/2.ecosystem/2.auth.md
@@ -37,11 +37,20 @@ Drop-in Nuxt module. Add it, configure it, you're an IdP.
 
 **Auto-registered routes:**
 - `/login`, `/register`, `/account` — Passkey-based UI (overridable)
-- `/admin` — User and agent management
-- `/authorize`, `/token` — OAuth endpoints
-- `/.well-known/jwks.json` — Public key discovery
+- `/admin` — User, agent, session & grant administration
+- `/authorize`, `/token`, `/revoke`, `/userinfo` — OAuth/OIDC endpoints
+- `/.well-known/jwks.json`, `/.well-known/openid-configuration` — Public key & metadata discovery
 - `/api/webauthn/*` — Registration and login flows
-- `/api/admin/*` — User, agent, and registration URL management
+- `/api/admin/users/*` — User management (CRUD, credentials, SSH keys)
+- `/api/admin/agents/*` — Agent management (CRUD)
+- `/api/admin/sessions/*` — Session management
+- `/api/admin/registration-urls/*` — Invitation link management
+- `/api/grants/*` — Grant lifecycle (create, approve, deny, revoke, consume, verify, batch)
+- `/api/delegations/*` — Delegation management
+- `/api/agent/*` — Agent auth (challenge, authenticate, enroll)
+- `/api/auth/*` — Unified auth endpoints (agents + humans with SSH keys)
+- `/api/federation/*` — Federated login providers
+- `/enroll`, `/grants`, `/grant-approval` — Grant management pages (when enabled)
 
 **Configuration via `openapeIdp` in `nuxt.config.ts`:**
 
@@ -65,7 +74,9 @@ Drop-in Nuxt module. Stateless. Zero server storage.
 - `/api/callback` — handle OAuth callback
 - `/api/logout` — destroy session
 - `/api/me` — current user info
-- `/.well-known/sp-manifest.json` — SP metadata
+- `/.well-known/oauth-client-metadata` — OAuth client metadata
+- `/.well-known/auth.md` — Machine-readable auth documentation for agents
+- `/.well-known/openape.json` — SP manifest (service info, scopes, policies)
 
 **Composable:** `useOpenApeAuth()` for client-side auth state.
 

--- a/apps/docs/content/2.ecosystem/3.grants.md
+++ b/apps/docs/content/2.ecosystem/3.grants.md
@@ -62,10 +62,19 @@ Grant management is integrated into `@openape/nuxt-auth-idp`. Enable grant pages
 - `/api/grants/:id/deny` — deny a grant
 - `/api/grants/:id/revoke` — revoke an active grant
 - `/api/grants/:id/token` — issue AuthZ-JWT for approved grant
+- `/api/grants/:id/consume` — consume a once-grant
+- `/api/grants/batch` — batch grant creation
 - `/api/grants/verify` — verify an AuthZ-JWT
+- `/api/delegations` — list and create delegations
+- `/api/delegations/:id` — revoke a delegation
+- `/api/delegations/:id/validate` — validate a delegation
 - `/api/agent/enroll` — register a new agent
 - `/api/agent/challenge` — request auth challenge
 - `/api/agent/authenticate` — authenticate with signed challenge
+
+::callout{type="info"}
+The `/api/agent/*` endpoints are backward-compatible aliases. The unified endpoints at `/api/auth/*` (challenge, authenticate, enroll) work for both agents and humans with SSH keys.
+::
 
 **Pages** (overridable, enabled via `grants.enablePages: true`):
 - `/grants` — grant dashboard

--- a/apps/docs/content/2.ecosystem/4.nuxt-auth-sp.md
+++ b/apps/docs/content/2.ecosystem/4.nuxt-auth-sp.md
@@ -179,7 +179,9 @@ The module auto-registers these server routes:
 | `/api/callback` | GET | Handle OAuth callback from IdP |
 | `/api/logout` | POST | Destroy session |
 | `/api/me` | GET | Return current user claims |
-| `/.well-known/sp-manifest.json` | GET | SP metadata for IdP discovery |
+| `/.well-known/oauth-client-metadata` | GET | OAuth client metadata (RFC 7591) |
+| `/.well-known/auth.md` | GET | Machine-readable auth documentation for AI agents |
+| `/.well-known/openape.json` | GET | SP manifest with service info, scopes, and policies |
 
 ## Configuration
 
@@ -198,6 +200,34 @@ export default defineNuxtConfig({
 })
 ```
 
+### Manifest Configuration
+
+The SP module serves a machine-readable manifest at `/.well-known/openape.json`. Configure it via the `manifest` key:
+
+```ts
+openapeSp: {
+  manifest: {
+    service: {
+      name: 'My App',
+      description: 'A grant-aware service',
+      url: 'https://myapp.example.com',
+      privacy_policy: 'https://myapp.example.com/privacy',
+    },
+    scopes: {
+      'deploy': {
+        name: 'Deploy',
+        description: 'Deploy application updates',
+        risk: 'high',
+      },
+    },
+    policies: {
+      agent_access: 'grant-required',
+      delegation: 'allowed',
+    },
+  },
+}
+```
+
 All options can be set via environment variables:
 
 | Variable | Config Key |
@@ -207,6 +237,7 @@ All options can be set via environment variables:
 | `NUXT_OPENAPE_SP_SESSION_SECRET` | `sessionSecret` |
 | `NUXT_OPENAPE_SP_OPENAPE_URL` | `openapeUrl` |
 | `NUXT_OPENAPE_SP_FALLBACK_IDP_URL` | `fallbackIdpUrl` |
+| `NUXT_OPENAPE_SP_ROUTES` | `routes` |
 
 ## Production Deployment
 

--- a/apps/docs/content/2.ecosystem/6.nuxt-auth-idp.md
+++ b/apps/docs/content/2.ecosystem/6.nuxt-auth-idp.md
@@ -1,0 +1,231 @@
+---
+title: nuxt-auth-idp
+description: Run your own OpenApe Identity Provider as a Nuxt module.
+---
+
+# @openape/nuxt-auth-idp
+
+Drop-in Nuxt module that turns any Nuxt app into a DDISA Identity Provider. Includes WebAuthn authentication, OAuth/OIDC endpoints, grant management, agent enrollment, and admin UI.
+
+## Quick Start
+
+### 1. Install
+
+```bash
+pnpm add @openape/nuxt-auth-idp
+```
+
+### 2. Add to `nuxt.config.ts`
+
+```ts
+export default defineNuxtConfig({
+  modules: ['@openape/nuxt-auth-idp'],
+  openapeIdp: {
+    rpName: 'My Identity Provider',
+    rpID: 'id.example.com',
+    rpOrigin: 'https://id.example.com',
+  },
+})
+```
+
+### 3. Start
+
+```bash
+npm run dev
+```
+
+Open [http://localhost:3000/admin](http://localhost:3000/admin) to create registration URLs, enroll users, and manage agents.
+
+## What's Included
+
+The module auto-registers everything an IdP needs:
+
+### Pages (overridable)
+
+| Page | Purpose |
+|------|---------|
+| `/login` | WebAuthn passkey login |
+| `/register?token=...` | Passkey registration via invitation link |
+| `/account` | Device & credential management |
+| `/admin` | User, agent, session & grant administration |
+| `/enroll` | Agent enrollment form |
+| `/grants` | Grant dashboard |
+| `/grant-approval` | Approve/deny grant requests |
+
+Disable module pages with `pages: false` to provide your own UI.
+
+### API Routes
+
+**Authentication:**
+- `/api/webauthn/*` — Passkey registration and login flows
+- `/api/session/*` — Session management (login, logout)
+- `/api/me` — Current user info
+- `/api/auth/*` — Unified auth endpoints (agents + humans with SSH keys)
+- `/api/agent/*` — Agent-specific auth (backward-compatible aliases)
+
+**OAuth/OIDC:**
+- `/authorize` — Authorization endpoint
+- `/token` — Token exchange
+- `/revoke` — Token revocation
+- `/userinfo` — User info endpoint
+- `/.well-known/jwks.json` — Public key discovery
+- `/.well-known/openid-configuration` — OIDC metadata
+
+**Grants:**
+- `/api/grants` — List and create grant requests
+- `/api/grants/:id` — Get, approve, deny, revoke, consume grants
+- `/api/grants/:id/token` — Issue AuthZ-JWT for approved grant
+- `/api/grants/verify` — Verify an AuthZ-JWT
+- `/api/grants/batch` — Batch grant creation
+
+**Delegations:**
+- `/api/delegations` — List and create delegations
+- `/api/delegations/:id` — Delete a delegation
+- `/api/delegations/:id/validate` — Validate a delegation
+
+**Administration:**
+- `/api/admin/users/*` — User CRUD, credentials, SSH keys
+- `/api/admin/agents/*` — Agent CRUD
+- `/api/admin/sessions/*` — Session management
+- `/api/admin/registration-urls/*` — Invitation link management
+
+**Federation:**
+- `/api/federation/providers` — List configured federation providers
+- `/auth/federated/:providerId` — Federated login redirect
+- `/auth/federated/:providerId/callback` — Federated login callback
+
+## Configuration
+
+### Core Options
+
+| Option | Type | Default | Env Var |
+|---|---|---|---|
+| `rpName` | `string` | `''` | `NUXT_OPENAPE_IDP_RP_NAME` |
+| `rpID` | `string` | `''` | `NUXT_OPENAPE_IDP_RP_ID` |
+| `rpOrigin` | `string` | `''` | `NUXT_OPENAPE_IDP_RP_ORIGIN` |
+| `issuer` | `string` | `''` | `NUXT_OPENAPE_IDP_ISSUER` |
+| `managementToken` | `string` | `''` | `NUXT_OPENAPE_IDP_MANAGEMENT_TOKEN` |
+| `adminEmails` | `string` | `''` | `NUXT_OPENAPE_IDP_ADMIN_EMAILS` |
+
+::callout{type="warning"}
+The `managementToken` is the most critical security credential. It must never be accessible to agents. See the [Threat Model](/security/threat-model) for details.
+::
+
+### Session Options
+
+| Option | Type | Default | Env Var |
+|---|---|---|---|
+| `sessionSecret` | `string` | `'change-me-...'` | `NUXT_OPENAPE_IDP_SESSION_SECRET` |
+| `sessionMaxAge` | `number` | `604800` (7 days) | `NUXT_OPENAPE_IDP_SESSION_MAX_AGE` |
+
+### WebAuthn Options
+
+| Option | Type | Default |
+|---|---|---|
+| `requireUserVerification` | `boolean` | `false` |
+| `residentKey` | `'preferred' \| 'required' \| 'discouraged'` | `'preferred'` |
+| `attestationType` | `'none' \| 'indirect' \| 'direct' \| 'enterprise'` | `'none'` |
+
+### Storage
+
+The module uses Nitro's built-in storage layer. Configure the storage driver in `nitro.storage`:
+
+```ts
+export default defineNuxtConfig({
+  modules: ['@openape/nuxt-auth-idp'],
+  openapeIdp: {
+    storageKey: 'openape-idp',       // default
+    grants: {
+      storageKey: 'openape-grants',  // default
+    },
+  },
+  nitro: {
+    storage: {
+      'openape-idp': {
+        driver: 's3',
+        bucket: 'my-bucket',
+        region: 'eu-central-1',
+      },
+      'openape-grants': {
+        driver: 's3',
+        bucket: 'my-bucket',
+        region: 'eu-central-1',
+      },
+    },
+  },
+})
+```
+
+For development, storage defaults to in-memory. For production, configure a persistent driver (S3, filesystem, or any [Nitro storage driver](https://nitro.build/guide/storage)).
+
+::callout{type="info"}
+The [Free IdP](https://id.openape.at) uses Drizzle ORM with LibSQL instead of Nitro storage. This is an app-level choice — the module itself works with any Nitro storage driver.
+::
+
+### Route Control
+
+Selectively disable route groups:
+
+```ts
+openapeIdp: {
+  routes: {
+    auth: true,    // WebAuthn + session endpoints
+    oauth: true,   // authorize, token, well-known
+    grants: true,  // Grant lifecycle + delegations
+    admin: true,   // Admin API
+    agent: true,   // Agent auth endpoints
+  },
+}
+```
+
+Set `routes: false` to disable all auto-registered server routes.
+
+### Grant Pages
+
+```ts
+openapeIdp: {
+  grants: {
+    enablePages: true,   // default: register /grants, /grant-approval, /enroll
+    storageKey: 'openape-grants',
+  },
+}
+```
+
+### Federation
+
+Configure external identity providers (Google, GitHub, etc.):
+
+```ts
+openapeIdp: {
+  federationProviders: JSON.stringify([
+    { id: 'google', clientId: '...', clientSecret: '...' },
+  ]),
+}
+```
+
+Or via environment variable: `NUXT_OPENAPE_IDP_FEDERATION_PROVIDERS`.
+
+## Production Deployment
+
+Required environment variables:
+
+```bash
+NUXT_OPENAPE_IDP_RP_NAME="My IdP"
+NUXT_OPENAPE_IDP_RP_ID=id.example.com
+NUXT_OPENAPE_IDP_RP_ORIGIN=https://id.example.com
+NUXT_OPENAPE_IDP_SESSION_SECRET=$(openssl rand -hex 32)
+NUXT_OPENAPE_IDP_MANAGEMENT_TOKEN=$(openssl rand -hex 32)
+NUXT_OPENAPE_IDP_ADMIN_EMAILS=admin@example.com
+```
+
+Add the DDISA DNS record:
+
+```
+_ddisa.example.com TXT "v=ddisa1; idp=https://id.example.com; mode=strict"
+```
+
+## See Also
+
+- [Quick Start: IdP](/getting-started/quickstart-idp) — scaffold an IdP in 3 minutes
+- [nuxt-auth-sp](/ecosystem/nuxt-auth-sp) — the Service Provider counterpart
+- [Threat Model](/security/threat-model) — security analysis and credential handling

--- a/apps/docs/content/index.md
+++ b/apps/docs/content/index.md
@@ -15,8 +15,14 @@ AI agents are getting powerful. They send emails, move money, deploy code. OpenA
   ::card{title="OpenApe Grants" icon="i-heroicons-shield-check" to="/ecosystem/grants"}
   Human-in-the-loop permission system. Agents request, humans approve — once, time-limited, or standing.
   ::
+  ::card{title="apes CLI & ape-shell" icon="i-heroicons-command-line" to="/getting-started/cli"}
+  Authentication, grant management, and grant-secured command execution. `ape-shell` validates every command through the grant system.
+  ::
   ::card{title="Ecosystem" icon="i-heroicons-cube" to="/ecosystem"}
-  Small, focused packages you compose as needed. Core, Auth, Grants, Nuxt modules, and `escapes` CLI.
+  Small, focused packages you compose as needed. Core, Auth, Grants, Nuxt modules, proxy, browser, and `escapes`.
+  ::
+  ::card{title="Free IdP" icon="i-heroicons-cloud" to="/getting-started/free-idp"}
+  Get started without infrastructure. Hosted IdP at id.openape.at — free, zero-setup.
   ::
   ::card{title="Compliance" icon="i-heroicons-document-check" to="/security/compliance"}
   NIS2 and NIST CSF 2.0 compliant by design. Passkeys-only, phishing-proof, no bolt-on MFA.


### PR DESCRIPTION
## Summary

- Fix env var prefixes throughout docs (`NUXT_OPENAPE_*` → `NUXT_OPENAPE_IDP_*` / `NUXT_OPENAPE_SP_*`)
- Remove all references to deprecated `@openape/nuxt-grants` (consolidated into `nuxt-auth-idp`)
- Add missing packages to ecosystem: `@openape/apes`, `@openape/proxy`, `@openape/browser`
- Correct SP well-known routes (`sp-manifest.json` → `oauth-client-metadata`, `auth.md`, `openape.json`)
- Add missing IdP API endpoints (admin sessions, registration URLs, delegations, federation, batch grants)
- Add unified `/api/auth/*` endpoint callout alongside legacy `/api/agent/*` aliases
- New page: `2.ecosystem/6.nuxt-auth-idp.md` — full IdP module reference (config, routes, storage, federation)
- New page: `1.getting-started/9.free-idp.md` — getting-started path for hosted Free IdP
- Homepage: add cards for ape-shell CLI and Free IdP
- Ecosystem index: add doc links, fix architecture diagram

## Follow-up (separate issues)
- Archive standalone `openape-ai/docs` repo (superseded by monorepo docs)
- Update `openape-ai/.github` profile README (PR prepared locally)

## Test plan
- [x] `pnpm turbo run build --filter=docs` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [ ] Visual review of new pages in dev server

Closes #81