### PR TITLE
fix(apes): grant-shell UX — visible cache/approval + apes subcommand routing

### DIFF
--- a/.changeset/fix-grant-shell-ux.md
+++ b/.changeset/fix-grant-shell-ux.md
@@ -1,0 +1,15 @@
+---
+'@openape/apes': patch
+---
+
+fix(apes): grant-shell UX — visible cache/approval state and `apes` subcommand routing from the REPL
+
+Three related fixes that make the ape-shell grant flow observable and self-consistent.
+
+1. **`apes <subcommand>` inside the interactive REPL no longer errors with "unsupported invocation".** Root cause was that the `ape-shell` wrapper script exports `APES_SHELL_WRAPPER=1` into its node process env so `rewriteApeShellArgs` can detect wrapper invocation — but that env var was then leaked, unfiltered, into the bash pty child spawned by `PtyBridge`. Any `apes` subcommand the user typed inside that bash re-read the var from its inherited env, self-detected as ape-shell mode, and rejected its argv. `PtyBridge` now strips `APES_SHELL_WRAPPER` from the env it passes to `pty.spawn`.
+
+2. **Grant cache hits now emit a visible reuse line**, so the user can tell that a command was allowed because a pre-approved grant was reused rather than because the gating layer was bypassed. Both the adapter-grant path (which already logged a reuse line) and the session-grant path (which was silent) now print `Reusing ...`. Both lines can be suppressed by exporting `APES_QUIET_GRANT_REUSE=1` for power users who want a clean stream.
+
+3. **Pending grants now emit an approval acknowledgment line** when the wait loop resolves as approved. Previously the wait loop returned silently — the user only saw the command's output and could not distinguish a live approval round-trip from an instant cache hit. Both the adapter wait path (using `waitForGrantStatus`) and the session-grant inline polling loop now print `Grant <id> approved — continuing` before returning.
+
+Together these make it possible to watch the grant state from inside the interactive shell without leaving it: cache hits are visible, approval round-trips are visible, and `apes grants list` / `apes whoami` work again from the REPL prompt.

--- a/packages/apes/src/shell/grant-dispatch.ts
+++ b/packages/apes/src/shell/grant-dispatch.ts
@@ -110,6 +110,7 @@ export async function requestGrantForShellLine(
         if (status !== 'approved') {
           return { kind: 'denied', reason: `Grant ${status}` }
         }
+        consola.info(`Grant ${grant.id} approved — continuing`)
 
         const token = await fetchGrantToken(idp, grant.id)
         await verifyAndConsume(token, resolved)
@@ -176,8 +177,10 @@ export async function requestGrantForShellLine(
 
     while (Date.now() - start < maxWait) {
       const status = await apiFetch<{ status: string }>(`${grantsUrl}/${grant.id}`)
-      if (status.status === 'approved')
+      if (status.status === 'approved') {
+        consola.info(`Grant ${grant.id} approved — continuing`)
         return { kind: 'approved', grantId: grant.id, mode: 'session' }
+      }
       if (status.status === 'denied' || status.status === 'revoked')
         return { kind: 'denied', reason: `Grant ${status.status}` }
       await new Promise(r => setTimeout(r, interval))

--- a/packages/apes/src/shell/grant-dispatch.ts
+++ b/packages/apes/src/shell/grant-dispatch.ts
@@ -78,7 +78,8 @@ export async function requestGrantForShellLine(
         try {
           const existingGrantId = await findExistingGrant(resolved, idp)
           if (existingGrantId) {
-            consola.info(`Reusing grant ${existingGrantId} for: ${resolved.detail.display}`)
+            if (process.env.APES_QUIET_GRANT_REUSE !== '1')
+              consola.info(`Reusing grant ${existingGrantId} for: ${resolved.detail.display}`)
             const token = await fetchGrantToken(idp, existingGrantId)
             await verifyAndConsume(token, resolved)
             return { kind: 'approved', grantId: existingGrantId, mode: 'adapter' }
@@ -136,6 +137,8 @@ export async function requestGrantForShellLine(
       && g.request.grant_type !== 'once',
     )
     if (sessionGrant) {
+      if (process.env.APES_QUIET_GRANT_REUSE !== '1')
+        consola.info(`Reusing ape-shell session grant ${sessionGrant.id} on ${options.targetHost}`)
       return { kind: 'approved', grantId: sessionGrant.id, mode: 'session' }
     }
   }

--- a/packages/apes/src/shell/pty-bridge.ts
+++ b/packages/apes/src/shell/pty-bridge.ts
@@ -84,13 +84,19 @@ export class PtyBridge {
     // what the user typed; the pty echo is redundant and surprising.
     // Interactive TUI apps (vim/less/top) set their own termios when they
     // start, so they are unaffected.
+    // Strip APES_SHELL_WRAPPER so nested `apes` invocations inside the pty
+    // don't self-detect as ape-shell mode and reject their argv. The wrapper
+    // script sets this marker on the parent ape-shell process; leaking it
+    // into bash would cause `apes <subcommand>` at the REPL prompt to print
+    // "unsupported invocation" instead of running.
+    const { APES_SHELL_WRAPPER: _wrapperMarker, ...inheritedEnv } = process.env
     this.term = pty.spawn('bash', ['--login', '-i'], {
       name: 'xterm-256color',
       cols,
       rows,
       cwd: options.cwd ?? process.cwd(),
       env: {
-        ...process.env,
+        ...inheritedEnv,
         // Force our marker PS1 on every prompt and keep pty echo off —
         // both survive .bashrc overrides because PROMPT_COMMAND runs
         // before each prompt.

--- a/packages/apes/test/shell-grant-dispatch.test.ts
+++ b/packages/apes/test/shell-grant-dispatch.test.ts
@@ -1,3 +1,4 @@
+import consola from 'consola'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // We mock every dependency of the grant-dispatch module so tests run
@@ -30,13 +31,18 @@ vi.mock('../src/notifications.js', () => ({
 const fakeAuth = { email: 'alice@example.com', idp: 'http://idp.test' }
 
 describe('requestGrantForShellLine', () => {
+  let infoSpy: ReturnType<typeof vi.spyOn>
+
   beforeEach(async () => {
     vi.clearAllMocks()
     const { loadAuth } = await import('../src/config.js')
     vi.mocked(loadAuth).mockReturnValue(fakeAuth as any)
+    infoSpy = vi.spyOn(consola, 'info').mockImplementation(() => {})
   })
 
   afterEach(() => {
+    infoSpy.mockRestore()
+    delete process.env.APES_QUIET_GRANT_REUSE
     vi.resetModules()
   })
 
@@ -161,5 +167,108 @@ describe('requestGrantForShellLine', () => {
     const result = await requestGrantForShellLine('obscure-tool --foo', { targetHost: 'host.test' })
 
     expect(result).toEqual({ kind: 'approved', grantId: 'fallback-grant', mode: 'session' })
+  })
+
+  it('logs a reuse line when a session grant cache hit occurs', async () => {
+    const { parseShellCommand } = await import('../src/shapes/index.js')
+    const { apiFetch } = await import('../src/http.js')
+    vi.mocked(parseShellCommand).mockReturnValue({ executable: 'ls', argv: ['|'], isCompound: true, raw: 'ls | grep foo' })
+
+    vi.mocked(apiFetch).mockResolvedValueOnce({
+      data: [
+        {
+          id: 'existing-session',
+          status: 'approved',
+          request: { audience: 'ape-shell', target_host: 'host.test', grant_type: 'timed' },
+        },
+      ],
+    } as any)
+
+    const { requestGrantForShellLine } = await import('../src/shell/grant-dispatch.js')
+    await requestGrantForShellLine('ls | grep foo', { targetHost: 'host.test' })
+
+    const reuseCall = infoSpy.mock.calls.find(call =>
+      typeof call[0] === 'string' && call[0].includes('Reusing') && call[0].includes('existing-session'),
+    )
+    expect(reuseCall).toBeDefined()
+  })
+
+  it('suppresses session grant reuse line when APES_QUIET_GRANT_REUSE=1', async () => {
+    process.env.APES_QUIET_GRANT_REUSE = '1'
+    try {
+      const { parseShellCommand } = await import('../src/shapes/index.js')
+      const { apiFetch } = await import('../src/http.js')
+      vi.mocked(parseShellCommand).mockReturnValue({ executable: 'ls', argv: ['|'], isCompound: true, raw: 'ls | grep foo' })
+
+      vi.mocked(apiFetch).mockResolvedValueOnce({
+        data: [
+          {
+            id: 'existing-session',
+            status: 'approved',
+            request: { audience: 'ape-shell', target_host: 'host.test', grant_type: 'timed' },
+          },
+        ],
+      } as any)
+
+      const { requestGrantForShellLine } = await import('../src/shell/grant-dispatch.js')
+      await requestGrantForShellLine('ls | grep foo', { targetHost: 'host.test' })
+
+      const reuseCall = infoSpy.mock.calls.find(call =>
+        typeof call[0] === 'string' && call[0].includes('Reusing'),
+      )
+      expect(reuseCall).toBeUndefined()
+    }
+    finally {
+      delete process.env.APES_QUIET_GRANT_REUSE
+    }
+  })
+
+  it('suppresses adapter grant reuse line when APES_QUIET_GRANT_REUSE=1', async () => {
+    process.env.APES_QUIET_GRANT_REUSE = '1'
+    try {
+      const { parseShellCommand, loadOrInstallAdapter, resolveCommand, findExistingGrant, fetchGrantToken, verifyAndConsume } = await import('../src/shapes/index.js')
+      vi.mocked(parseShellCommand).mockReturnValue({ executable: 'ls', argv: ['-la'], isCompound: false, raw: 'ls -la' })
+      vi.mocked(loadOrInstallAdapter).mockResolvedValue({ adapter: { cli: { id: 'ls', executable: 'ls', audience: 'shapes' }, operations: [] }, source: '/tmp/ls.toml', digest: 'sha' } as any)
+      vi.mocked(resolveCommand).mockResolvedValue({ detail: { display: 'ls -la' } } as any)
+      vi.mocked(findExistingGrant).mockResolvedValue('reused-grant-id')
+      vi.mocked(fetchGrantToken).mockResolvedValue('token123')
+      vi.mocked(verifyAndConsume).mockResolvedValue(undefined)
+
+      const { requestGrantForShellLine } = await import('../src/shell/grant-dispatch.js')
+      await requestGrantForShellLine('ls -la', { targetHost: 'host.test' })
+
+      const reuseCall = infoSpy.mock.calls.find(call =>
+        typeof call[0] === 'string' && call[0].includes('Reusing'),
+      )
+      expect(reuseCall).toBeUndefined()
+    }
+    finally {
+      delete process.env.APES_QUIET_GRANT_REUSE
+    }
+  })
+
+  it('still logs fresh session grant request line when APES_QUIET_GRANT_REUSE=1', async () => {
+    process.env.APES_QUIET_GRANT_REUSE = '1'
+    try {
+      const { parseShellCommand } = await import('../src/shapes/index.js')
+      const { apiFetch } = await import('../src/http.js')
+      vi.mocked(parseShellCommand).mockReturnValue({ executable: 'ls', argv: ['|'], isCompound: true, raw: 'ls | grep foo' })
+
+      vi.mocked(apiFetch)
+        .mockResolvedValueOnce({ data: [] } as any) // no existing grant
+        .mockResolvedValueOnce({ id: 'new-session', status: 'pending' } as any) // create
+        .mockResolvedValueOnce({ status: 'approved' } as any) // poll
+
+      const { requestGrantForShellLine } = await import('../src/shell/grant-dispatch.js')
+      await requestGrantForShellLine('ls | grep foo', { targetHost: 'host.test' })
+
+      const requestCall = infoSpy.mock.calls.find(call =>
+        typeof call[0] === 'string' && call[0].includes('Requesting ape-shell session grant'),
+      )
+      expect(requestCall).toBeDefined()
+    }
+    finally {
+      delete process.env.APES_QUIET_GRANT_REUSE
+    }
   })
 })

--- a/packages/apes/test/shell-grant-dispatch.test.ts
+++ b/packages/apes/test/shell-grant-dispatch.test.ts
@@ -247,6 +247,97 @@ describe('requestGrantForShellLine', () => {
     }
   })
 
+  it('logs an approval ack line after session grant poll resolves approved', async () => {
+    const { parseShellCommand } = await import('../src/shapes/index.js')
+    const { apiFetch } = await import('../src/http.js')
+    vi.mocked(parseShellCommand).mockReturnValue({ executable: 'ls', argv: ['|'], isCompound: true, raw: 'ls | grep foo' })
+
+    vi.mocked(apiFetch)
+      .mockResolvedValueOnce({ data: [] } as any) // list grants
+      .mockResolvedValueOnce({ id: 'session-grant-id', status: 'pending' } as any) // create
+      .mockResolvedValueOnce({ status: 'approved' } as any) // poll
+
+    const { requestGrantForShellLine } = await import('../src/shell/grant-dispatch.js')
+    await requestGrantForShellLine('ls | grep foo', { targetHost: 'host.test' })
+
+    const requestingCall = infoSpy.mock.calls.find(call =>
+      typeof call[0] === 'string' && call[0].includes('Requesting ape-shell session grant'),
+    )
+    expect(requestingCall).toBeDefined()
+
+    const approvalCall = infoSpy.mock.calls.find(call =>
+      typeof call[0] === 'string' && /Grant .* approved/.test(call[0]),
+    )
+    expect(approvalCall).toBeDefined()
+  })
+
+  it('logs an approval ack line after adapter grant waitForGrantStatus resolves approved', async () => {
+    const { parseShellCommand, loadOrInstallAdapter, resolveCommand, findExistingGrant, createShapesGrant, waitForGrantStatus, fetchGrantToken, verifyAndConsume } = await import('../src/shapes/index.js')
+    vi.mocked(parseShellCommand).mockReturnValue({ executable: 'curl', argv: ['https://example.com'], isCompound: false, raw: 'curl https://example.com' })
+    vi.mocked(loadOrInstallAdapter).mockResolvedValue({ adapter: { cli: { id: 'curl', executable: 'curl', audience: 'shapes' }, operations: [] }, source: '/tmp/curl.toml', digest: 'sha' } as any)
+    vi.mocked(resolveCommand).mockResolvedValue({ detail: { display: 'curl https://example.com' } } as any)
+    vi.mocked(findExistingGrant).mockResolvedValue(null)
+    vi.mocked(createShapesGrant).mockResolvedValue({ id: 'new-grant-id', status: 'pending' } as any)
+    vi.mocked(waitForGrantStatus).mockResolvedValue('approved')
+    vi.mocked(fetchGrantToken).mockResolvedValue('token456')
+    vi.mocked(verifyAndConsume).mockResolvedValue(undefined)
+
+    const { requestGrantForShellLine } = await import('../src/shell/grant-dispatch.js')
+    await requestGrantForShellLine('curl https://example.com', { targetHost: 'host.test' })
+
+    const approvalCall = infoSpy.mock.calls.find(call =>
+      typeof call[0] === 'string' && /Grant .* approved/.test(call[0]),
+    )
+    expect(approvalCall).toBeDefined()
+  })
+
+  it('does not log an approval ack line when adapter grant is denied', async () => {
+    const { parseShellCommand, loadOrInstallAdapter, resolveCommand, findExistingGrant, createShapesGrant, waitForGrantStatus } = await import('../src/shapes/index.js')
+    vi.mocked(parseShellCommand).mockReturnValue({ executable: 'rm', argv: ['-rf', '/'], isCompound: false, raw: 'rm -rf /' })
+    vi.mocked(loadOrInstallAdapter).mockResolvedValue({ adapter: { cli: { id: 'rm', executable: 'rm', audience: 'shapes' }, operations: [] }, source: '/tmp/rm.toml', digest: 'sha' } as any)
+    vi.mocked(resolveCommand).mockResolvedValue({ detail: { display: 'rm -rf /' } } as any)
+    vi.mocked(findExistingGrant).mockResolvedValue(null)
+    vi.mocked(createShapesGrant).mockResolvedValue({ id: 'scary-grant-id', status: 'pending' } as any)
+    vi.mocked(waitForGrantStatus).mockResolvedValue('denied')
+
+    const { requestGrantForShellLine } = await import('../src/shell/grant-dispatch.js')
+    await requestGrantForShellLine('rm -rf /', { targetHost: 'host.test' })
+
+    const approvalCall = infoSpy.mock.calls.find(call =>
+      typeof call[0] === 'string' && call[0].includes('approved — continuing'),
+    )
+    expect(approvalCall).toBeUndefined()
+  })
+
+  it('does not log an approval ack line on session grant cache hit', async () => {
+    const { parseShellCommand } = await import('../src/shapes/index.js')
+    const { apiFetch } = await import('../src/http.js')
+    vi.mocked(parseShellCommand).mockReturnValue({ executable: 'ls', argv: ['|'], isCompound: true, raw: 'ls | grep foo' })
+
+    vi.mocked(apiFetch).mockResolvedValueOnce({
+      data: [
+        {
+          id: 'existing-session',
+          status: 'approved',
+          request: { audience: 'ape-shell', target_host: 'host.test', grant_type: 'timed' },
+        },
+      ],
+    } as any)
+
+    const { requestGrantForShellLine } = await import('../src/shell/grant-dispatch.js')
+    await requestGrantForShellLine('ls | grep foo', { targetHost: 'host.test' })
+
+    const reuseCall = infoSpy.mock.calls.find(call =>
+      typeof call[0] === 'string' && /Reusing/.test(call[0]),
+    )
+    expect(reuseCall).toBeDefined()
+
+    const approvalCall = infoSpy.mock.calls.find(call =>
+      typeof call[0] === 'string' && call[0].includes('approved — continuing'),
+    )
+    expect(approvalCall).toBeUndefined()
+  })
+
   it('still logs fresh session grant request line when APES_QUIET_GRANT_REUSE=1', async () => {
     process.env.APES_QUIET_GRANT_REUSE = '1'
     try {

--- a/packages/apes/test/shell-pty-bridge.test.ts
+++ b/packages/apes/test/shell-pty-bridge.test.ts
@@ -157,4 +157,28 @@ describe('PtyBridge', () => {
 
     expect(h.exitInfo).not.toBeNull()
   })
+
+  it('does not leak APES_SHELL_WRAPPER into the bash child env', async () => {
+    const saved = process.env.APES_SHELL_WRAPPER
+    process.env.APES_SHELL_WRAPPER = '1'
+    try {
+      const h = createHarness()
+      harnesses.push(h)
+      await h.bridge.waitForReady()
+      // Print the var; bash emits an empty value if unset. Use `$VAR` (not
+      // `${VAR}`) so the JS lint rule no-template-curly-in-string isn't
+      // triggered by the bash-side parameter expansion.
+      h.bridge.writeLine('printf "WRAPPER=[%s]\\n" "$APES_SHELL_WRAPPER"')
+      await waitUntil(() => h.completedLines.length >= 1)
+      const out = h.completedLines[0]!.output
+      expect(out).toContain('WRAPPER=[]')
+      expect(out).not.toContain('WRAPPER=[1]')
+    }
+    finally {
+      if (saved === undefined)
+        delete process.env.APES_SHELL_WRAPPER
+      else
+        process.env.APES_SHELL_WRAPPER = saved
+    }
+  })
 })


### PR DESCRIPTION
## Summary

Three narrow fixes that make the ape-shell grant flow observable and self-consistent from inside the interactive REPL.

### 1. `apes <subcommand>` from inside the REPL no longer errors with "unsupported invocation"

Root cause: `scripts/ape-shell-wrapper.sh` exports `APES_SHELL_WRAPPER=1` so `rewriteApeShellArgs` can detect wrapper invocation (required since the wrapper execs `cli.js` so basename detection on `argv[1]` alone is insufficient). But that env var was then leaked, unfiltered, into the bash pty child via `PtyBridge`'s `...process.env` spread. Any nested `apes <subcommand>` the user typed inside that bash re-read the var from its inherited env, self-detected as ape-shell mode, ran through `rewriteApeShellArgs`, saw an unrecognized argv shape, and hit the `unsupported invocation` branch in `cli.ts`.

Fix: strip `APES_SHELL_WRAPPER` from the env object passed to `pty.spawn` in `packages/apes/src/shell/pty-bridge.ts`. One destructure, one comment explaining why.

### 2. Grant cache hits now emit a visible reuse line

Previously the adapter-grant path logged `Reusing grant …` but the session-grant cache-hit path returned silently. Both paths now log uniformly. Both lines honor `APES_QUIET_GRANT_REUSE=1` for power users who want a clean stream. Fresh grant requests are never suppressed.

### 3. Pending grants now emit an approval acknowledgment

The adapter wait path (`waitForGrantStatus`) and the session-grant inline polling loop both used to return silently when status flipped to `approved`. The user only saw command output and could not tell a live approval round-trip apart from an instant cache hit. Both paths now emit `Grant <id> approved — continuing` before returning. Denial/timeout paths remain unchanged (those already surface via orchestrator error logging). Cache-hit reuse paths do not emit this line (they have their own `Reusing` line).

Together these let you watch grant state from inside `ape-shell` without leaving it: cache hits are visible, approval round-trips are visible, and `apes grants list` / `apes whoami` work again from the REPL prompt.

## Test plan

- [x] New test `does not leak APES_SHELL_WRAPPER into the bash child env` in `shell-pty-bridge.test.ts` (TDD-verified: failed pre-fix, passes post-fix)
- [x] 4 new tests in `shell-grant-dispatch.test.ts` for session-grant reuse line + `APES_QUIET_GRANT_REUSE` gating on both paths + fresh-request regression guard
- [x] 4 new tests in `shell-grant-dispatch.test.ts` for approval ack line on adapter and session paths + denial no-ack + cache-hit no-ack
- [x] Full `@openape/apes` suite: 36 files, 401/401 tests green
- [x] Pre-commit hook (turbo lint + typecheck): green
- [ ] Manual REPL smoke after merge: `apes whoami` from inside ape-shell, cache-hit reuse line visible, approval ack visible

## Commits

- `caeee08` fix(apes): strip APES_SHELL_WRAPPER from bash pty env
- `4c41a33` fix(apes): log session-grant cache hits and honor APES_QUIET_GRANT_REUSE
- `a32cd40` fix(apes): log grant approval in wait loops
- `b82a36d` chore(apes): changeset for grant-shell UX fixes

Changeset: `@openape/apes: patch`.