### PR TITLE
feat(apes): REPL meta-commands :help :status :reset

### DIFF
--- a/.changeset/feat-repl-meta-commands.md
+++ b/.changeset/feat-repl-meta-commands.md
@@ -1,0 +1,32 @@
+---
+'@openape/apes': minor
+---
+
+feat(apes): REPL meta-commands (`:help`, `:status`, `:reset`)
+
+The `ape-shell` interactive REPL now recognizes three meta-commands that are dispatched before the grant flow and the bash pty. They only fire from an empty input buffer (never mid-multiline) and can never be confused with shell commands that happen to start with a colon.
+
+### `:help`
+
+Lists available meta-commands with one-line descriptions.
+
+### `:status`
+
+Prints the current session state — session id, uptime, host, bash child pid, requester identity, IdP URL, and token validity. Auth is re-read at invocation time so external token refreshes are visible immediately. Supports expired and not-logged-in states without throwing.
+
+```
+Session: 3f7a9e2c1b8d4f05 (uptime 12m 34s)
+Host:    lappy.local
+Bash:    pid 54321
+User:    alice@example.com
+IdP:     https://id.openape.at
+Token:   valid until 2026-05-14T14:25:31.000Z
+```
+
+### `:reset`
+
+Kills the current bash pty child and spawns a fresh one. This is the recovery lever when bash gets into a weird state (stuck subshell, leftover environment, unexpected prompt). The session audit log is **preserved** (same session id, continuous event stream) so `:reset` does not look like a new shell to downstream consumers. Grants do not need resetting — they are re-fetched server-side on every line anyway.
+
+`:reset` refuses while a command is in flight (`Cannot reset while a command is running. Wait or press Ctrl-C.`) to avoid orphaning an in-flight promise.
+
+Together with `apes health` (shipped alongside), these give the user observability into and recovery from the grant-gated shell without having to exit and restart.

--- a/packages/apes/src/shell/meta-commands.ts
+++ b/packages/apes/src/shell/meta-commands.ts
@@ -1,0 +1,104 @@
+import type { AuthData } from '../config.js'
+import type { PtyBridge } from './pty-bridge.js'
+import type { ShellSession } from './session.js'
+
+/**
+ * Injected dependencies for the meta-command handler. Keeping these behind
+ * an explicit interface lets tests drive the handler with plain objects and
+ * `vi.fn()` spies, no pty or auth file required.
+ */
+export interface MetaDeps {
+  getBridge: () => PtyBridge
+  resetBridge: () => Promise<void>
+  session: ShellSession
+  getAuth: () => AuthData | null
+  targetHost: string
+  isPending: () => boolean
+  write: (s: string) => void
+}
+
+/**
+ * Short one-line descriptions printed by `:help`. Ordered alphabetically so
+ * the list stays stable as we add more commands.
+ */
+const HELP_ENTRIES: Array<[string, string]> = [
+  [':help', 'Show available meta-commands.'],
+  [':reset', 'Kill and respawn the bash child (preserves grants + audit).'],
+  [':status', 'Show session, host, bash pid, and auth state.'],
+]
+
+/**
+ * Format a millisecond duration as `Nh Nm Ns` with components omitted only
+ * from the left. We always show seconds so zero-ish uptimes still read sanely.
+ */
+function formatUptime(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000))
+  const hours = Math.floor(totalSeconds / 3600)
+  const minutes = Math.floor((totalSeconds % 3600) / 60)
+  const seconds = totalSeconds % 60
+  const parts: string[] = []
+  if (hours > 0)
+    parts.push(`${hours}h`)
+  if (hours > 0 || minutes > 0)
+    parts.push(`${minutes}m`)
+  parts.push(`${seconds}s`)
+  return parts.join(' ')
+}
+
+/**
+ * Build the async handler invoked by `ShellRepl.onMetaCommand`. Return value
+ * semantics match the REPL contract: `true` means the line was consumed and
+ * the REPL should redraw the prompt; `false` would fall through to shell
+ * dispatch, but every branch here currently returns `true`.
+ */
+export function createMetaCommandHandler(deps: MetaDeps): (line: string) => Promise<boolean> {
+  return async (line: string) => {
+    const trimmed = line.trim()
+
+    if (trimmed === ':help') {
+      deps.write('Available meta-commands:\n')
+      for (const [name, desc] of HELP_ENTRIES)
+        deps.write(`  ${name.padEnd(10)} ${desc}\n`)
+      return true
+    }
+
+    if (trimmed === ':status') {
+      const uptime = formatUptime(Date.now() - deps.session.startedAt)
+      const pid = deps.getBridge().pid
+      deps.write(`Session: ${deps.session.id} (uptime ${uptime})\n`)
+      deps.write(`Host:    ${deps.targetHost}\n`)
+      deps.write(`Bash:    pid ${pid}\n`)
+
+      const auth = deps.getAuth()
+      if (!auth) {
+        deps.write('User:    (not logged in)\n')
+        return true
+      }
+      deps.write(`User:    ${auth.email}\n`)
+      deps.write(`IdP:     ${auth.idp}\n`)
+      const expiresMs = auth.expires_at * 1000
+      if (expiresMs <= Date.now()) {
+        deps.write('Token:   EXPIRED\n')
+      }
+      else {
+        const iso = new Date(expiresMs).toISOString()
+        deps.write(`Token:   valid until ${iso}\n`)
+      }
+      return true
+    }
+
+    if (trimmed === ':reset') {
+      if (deps.isPending()) {
+        deps.write('Cannot reset while a command is running. Wait or press Ctrl-C.\n')
+        return true
+      }
+      await deps.resetBridge()
+      const newPid = deps.getBridge().pid
+      deps.write(`Bash reset. New pid: ${newPid}\n`)
+      return true
+    }
+
+    deps.write(`Unknown meta-command \`${trimmed}\`. Try \`:help\`.\n`)
+    return true
+  }
+}

--- a/packages/apes/src/shell/orchestrator.ts
+++ b/packages/apes/src/shell/orchestrator.ts
@@ -2,6 +2,7 @@ import { hostname } from 'node:os'
 import consola from 'consola'
 import { loadAuth } from '../config.js'
 import { requestGrantForShellLine } from './grant-dispatch.js'
+import { createMetaCommandHandler } from './meta-commands.js'
 import { PtyBridge } from './pty-bridge.js'
 import { ShellRepl } from './repl.js'
 import { ShellSession } from './session.js'
@@ -40,13 +41,21 @@ export async function runInteractiveShell(): Promise<void> {
   let pendingResolve: (() => void) | null = null
   let lastExitCode = 0
   let shuttingDown = false
+  // Set to true while `:reset` is tearing down the current bash child and
+  // spinning up a replacement. The old bridge's `onExit` callback checks
+  // this and returns early so the user does not see a spurious
+  // "bash exited" message or have the REPL torn down mid-reset.
+  let resetting = false
   // Forward reference to the REPL so the bridge's onExit can stop it when
   // bash dies. Assigned after construction below.
   let repl: ShellRepl | null = null
 
-  // Spawn the bash child up-front so the REPL can write to it as soon as the
-  // first line is accepted. Output from bash goes straight to the terminal.
-  const bridge = new PtyBridge(
+  /**
+   * Build a fresh PtyBridge with the standard lifecycle callbacks. Extracted
+   * into a factory so `:reset` can spawn a replacement child without
+   * duplicating the callback wiring.
+   */
+  const createBridge = (): PtyBridge => new PtyBridge(
     {
       onOutput: (chunk) => {
         // Live streaming to the user's terminal. Always written straight
@@ -63,6 +72,10 @@ export async function runInteractiveShell(): Promise<void> {
         }
       },
       onExit: (exitCode) => {
+        // `:reset` is intentionally killing this bridge; the replacement
+        // will own the user-facing lifecycle from here.
+        if (resetting)
+          return
         // bash itself died — typically because the user ran `exit`.
         // Tear down the REPL so run() returns cleanly.
         if (!shuttingDown) {
@@ -73,6 +86,11 @@ export async function runInteractiveShell(): Promise<void> {
     },
   )
 
+  // Spawn the bash child up-front so the REPL can write to it as soon as the
+  // first line is accepted. Output from bash goes straight to the terminal.
+  // `bridge` is `let` because `:reset` swaps in a replacement.
+  let bridge = createBridge()
+
   await bridge.waitForReady()
 
   const targetHost = hostname()
@@ -82,8 +100,28 @@ export async function runInteractiveShell(): Promise<void> {
     requester: auth?.email ?? 'unknown',
   })
 
+  const handleMetaCommand = createMetaCommandHandler({
+    getBridge: () => bridge,
+    resetBridge: async () => {
+      resetting = true
+      try {
+        bridge.kill('SIGKILL')
+      }
+      catch {}
+      bridge = createBridge()
+      await bridge.waitForReady()
+      resetting = false
+    },
+    session,
+    getAuth: loadAuth,
+    targetHost,
+    isPending: () => pendingResolve !== null,
+    write: s => process.stdout.write(s),
+  })
+
   repl = new ShellRepl(
     {
+      onMetaCommand: handleMetaCommand,
       onLine: async (line) => {
         // --- 1. Gate the line through the grant flow BEFORE bash sees it ---
         const grant = await requestGrantForShellLine(line, {

--- a/packages/apes/src/shell/repl.ts
+++ b/packages/apes/src/shell/repl.ts
@@ -38,6 +38,14 @@ export interface ReplEvents {
    * `stop`). Gives owners a chance to tear down resources.
    */
   onExit: () => void | Promise<void>
+
+  /**
+   * Called when the user enters a line starting with `:` while not in the
+   * middle of a multi-line buffer. Return true if handled (REPL skips shell
+   * dispatch and redraws the prompt). Return false/undefined to fall through
+   * to normal shell dispatch.
+   */
+  onMetaCommand?: (line: string) => boolean | Promise<boolean>
 }
 
 /**
@@ -155,6 +163,21 @@ export class ShellRepl {
   }
 
   private async handleLine(rawLine: string): Promise<void> {
+    // Meta-commands are single-line, bypass multi-line + grant + shell
+    // entirely. Only fire from an empty buffer (never mid-multiline) so
+    // `:foo` inside a heredoc/for-loop body is still treated as bash input.
+    if (
+      this.buffer.length === 0
+      && rawLine.trim().startsWith(':')
+      && this.events.onMetaCommand
+    ) {
+      const handled = await this.events.onMetaCommand(rawLine.trim())
+      if (handled) {
+        this.safePrompt(PS1)
+        return
+      }
+    }
+
     // Append the new line to the existing buffer. Use a literal newline so
     // bash sees the multi-line structure correctly on `bash -n`.
     this.buffer = this.buffer.length === 0

--- a/packages/apes/test/shell-meta-commands.test.ts
+++ b/packages/apes/test/shell-meta-commands.test.ts
@@ -1,0 +1,133 @@
+import type { AuthData } from '../src/config.js'
+import type { PtyBridge } from '../src/shell/pty-bridge.js'
+import type { MetaDeps } from '../src/shell/meta-commands.js'
+import type { ShellSession } from '../src/shell/session.js'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createMetaCommandHandler } from '../src/shell/meta-commands.js'
+
+/**
+ * Build a MetaDeps fixture with default-happy values plus any overrides the
+ * test needs. Captured `writes` array contains every string the handler
+ * emitted via `deps.write`, in order.
+ */
+function buildDeps(overrides: Partial<MetaDeps> = {}): {
+  deps: MetaDeps
+  writes: string[]
+  output: () => string
+  resetBridge: ReturnType<typeof vi.fn>
+  bridge: { pid: number, kill: ReturnType<typeof vi.fn> }
+} {
+  const writes: string[] = []
+  const bridge = { pid: 12345, kill: vi.fn() }
+  const resetBridge = vi.fn(async () => {
+    bridge.pid = 67890
+  })
+  const session = {
+    id: 'fake-session',
+    startedAt: Date.now() - 60_000,
+  } as unknown as ShellSession
+  const auth: AuthData = {
+    idp: 'https://id.openape.at',
+    access_token: 'token',
+    email: 'alice@example.com',
+    expires_at: Math.floor(Date.now() / 1000) + 3600,
+  }
+
+  const deps: MetaDeps = {
+    getBridge: () => bridge as unknown as PtyBridge,
+    resetBridge,
+    session,
+    getAuth: () => auth,
+    targetHost: 'lappy.local',
+    isPending: () => false,
+    write: (s) => { writes.push(s) },
+    ...overrides,
+  }
+
+  return {
+    deps,
+    writes,
+    output: () => writes.join(''),
+    resetBridge,
+    bridge,
+  }
+}
+
+describe('createMetaCommandHandler', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it(':help lists available meta-commands', async () => {
+    const { deps, output } = buildDeps()
+    const handler = createMetaCommandHandler(deps)
+    const handled = await handler(':help')
+    expect(handled).toBe(true)
+    const text = output()
+    expect(text).toContain(':help')
+    expect(text).toContain(':status')
+    expect(text).toContain(':reset')
+  })
+
+  it(':status with valid auth prints session, bash, host, email, IdP, valid until', async () => {
+    const { deps, output } = buildDeps()
+    const handler = createMetaCommandHandler(deps)
+    await handler(':status')
+    const text = output()
+    expect(text).toContain('fake-session')
+    expect(text).toContain('pid 12345')
+    expect(text).toContain('lappy.local')
+    expect(text).toContain('alice@example.com')
+    expect(text).toContain('https://id.openape.at')
+    expect(text).toContain('valid until')
+  })
+
+  it(':status with expired auth prints EXPIRED', async () => {
+    const { deps, output } = buildDeps({
+      getAuth: () => ({
+        idp: 'https://id.openape.at',
+        access_token: 'token',
+        email: 'alice@example.com',
+        expires_at: Math.floor(Date.now() / 1000) - 120,
+      }),
+    })
+    const handler = createMetaCommandHandler(deps)
+    await handler(':status')
+    expect(output()).toContain('EXPIRED')
+  })
+
+  it(':status with missing auth does not throw and indicates logged-out state', async () => {
+    const { deps, output } = buildDeps({ getAuth: () => null })
+    const handler = createMetaCommandHandler(deps)
+    await expect(handler(':status')).resolves.toBe(true)
+    expect(output().toLowerCase()).toContain('not logged in')
+  })
+
+  it(':reset when not pending calls resetBridge and prints new pid', async () => {
+    const { deps, output, resetBridge } = buildDeps()
+    const handler = createMetaCommandHandler(deps)
+    const handled = await handler(':reset')
+    expect(handled).toBe(true)
+    expect(resetBridge).toHaveBeenCalledOnce()
+    expect(output()).toContain('Bash reset')
+    expect(output()).toContain('67890')
+  })
+
+  it(':reset while pending refuses and does not call resetBridge', async () => {
+    const { deps, output, resetBridge } = buildDeps({ isPending: () => true })
+    const handler = createMetaCommandHandler(deps)
+    const handled = await handler(':reset')
+    expect(handled).toBe(true)
+    expect(resetBridge).not.toHaveBeenCalled()
+    expect(output()).toContain('Cannot reset while a command is running')
+  })
+
+  it('unknown meta-command prints a helpful message and returns true', async () => {
+    const { deps, output } = buildDeps()
+    const handler = createMetaCommandHandler(deps)
+    const handled = await handler(':bogus')
+    expect(handled).toBe(true)
+    expect(output()).toContain('Unknown meta-command')
+    expect(output()).toContain(':bogus')
+  })
+})

--- a/packages/apes/test/shell-repl.test.ts
+++ b/packages/apes/test/shell-repl.test.ts
@@ -8,19 +8,28 @@ import { ShellRepl } from '../src/shell/repl.js'
  * `input.write(...)` simulates the user typing; `output` captures
  * everything the REPL prints (prompt, banners, echoes).
  */
-function buildHarness() {
+function buildHarness(options: {
+  onMetaCommand?: (line: string) => boolean | Promise<boolean>
+} = {}) {
   const input = new PassThrough()
   const output = new PassThrough()
   const collectedOutput: string[] = []
   output.on('data', chunk => collectedOutput.push(chunk.toString()))
 
   const onLineCalls: string[] = []
+  const onMetaCommandCalls: string[] = []
   let exitCalls = 0
 
   const repl = new ShellRepl(
     {
       onLine: (line) => { onLineCalls.push(line) },
       onExit: () => { exitCalls++ },
+      onMetaCommand: options.onMetaCommand
+        ? async (line) => {
+          onMetaCommandCalls.push(line)
+          return await options.onMetaCommand!(line)
+        }
+        : undefined,
     },
     {
       input,
@@ -35,6 +44,7 @@ function buildHarness() {
     output,
     collectedOutput,
     onLineCalls,
+    onMetaCommandCalls,
     get exitCalls() { return exitCalls },
   }
 }
@@ -201,5 +211,74 @@ describe('ShellRepl', () => {
     input.end()
     await runPromise
     errorSpy.mockRestore()
+  })
+
+  it('dispatches to onMetaCommand when a line starts with ":"', async () => {
+    const h = buildHarness({ onMetaCommand: () => true })
+    harnesses.push(h)
+    const runPromise = h.repl.run()
+
+    h.input.write(':help\n')
+    await waitUntil(() => h.onMetaCommandCalls.length >= 1)
+
+    expect(h.onMetaCommandCalls).toEqual([':help'])
+    expect(h.onLineCalls).toEqual([])
+
+    h.input.end()
+    await runPromise
+  })
+
+  it('does not dispatch to onMetaCommand for regular shell lines', async () => {
+    const h = buildHarness({ onMetaCommand: () => true })
+    harnesses.push(h)
+    const runPromise = h.repl.run()
+
+    h.input.write('ls -la\n')
+    await waitUntil(() => h.onLineCalls.length >= 1)
+
+    expect(h.onMetaCommandCalls).toEqual([])
+    expect(h.onLineCalls).toEqual(['ls -la'])
+
+    h.input.end()
+    await runPromise
+  })
+
+  it('falls through to onLine when onMetaCommand returns false', async () => {
+    const h = buildHarness({ onMetaCommand: () => false })
+    harnesses.push(h)
+    const runPromise = h.repl.run()
+
+    h.input.write(':something\n')
+    await waitUntil(() => h.onLineCalls.length >= 1)
+
+    expect(h.onMetaCommandCalls).toEqual([':something'])
+    expect(h.onLineCalls).toEqual([':something'])
+
+    h.input.end()
+    await runPromise
+  })
+
+  it('ignores meta-command prefix when mid-multiline buffer', async () => {
+    const h = buildHarness({ onMetaCommand: () => true })
+    harnesses.push(h)
+    const runPromise = h.repl.run()
+
+    // Open an incomplete for-loop so the buffer is non-empty.
+    h.input.write('for i in 1 2 3; do\n')
+    await new Promise(r => setTimeout(r, 50))
+    expect(h.onLineCalls).toEqual([])
+
+    // A ":help" line while mid-multiline must NOT go to onMetaCommand.
+    // bash will treat ":help" as a command within the for-loop body.
+    h.input.write(':help\n')
+    await new Promise(r => setTimeout(r, 50))
+    expect(h.onMetaCommandCalls).toEqual([])
+
+    h.input.write('done\n')
+    await waitUntil(() => h.onLineCalls.length >= 1)
+    expect(h.onLineCalls[0]).toContain(':help')
+
+    h.input.end()
+    await runPromise
   })
 })


### PR DESCRIPTION
## Summary

Three new REPL meta-commands that give `ape-shell` users observability and recovery without leaving the shell: `:help`, `:status`, and `:reset`. They are dispatched before the grant flow and bash pty, only fire from an empty buffer (never mid-multiline), and can't be confused with shell commands that happen to start with `:`.

## Why

Before this PR, the only way to answer "is my shell still healthy?" from inside `ape-shell` was to exit and run `apes whoami` / `apes grants list` in a different shell. And the only way to recover from a stuck bash child was to kill the whole shell and relaunch. Both of those are exactly the scenarios where you want a lightweight in-shell lever.

`apes health` (PR #90) gave the external probe. This PR gives the internal knobs.

## The commands

### `:help`
Lists available meta-commands with one-line descriptions. Alphabetized.

### `:status`
Prints the current session state. Auth is re-read at invocation time so external token refreshes are visible immediately.

```
Session: 3f7a9e2c1b8d4f05 (uptime 12m 34s)
Host:    lappy.local
Bash:    pid 54321
User:    alice@example.com
IdP:     https://id.openape.at
Token:   valid until 2026-05-14T14:25:31.000Z
```

Handles expired tokens (`Token: EXPIRED`) and not-logged-in (`User: (not logged in)`) without throwing.

### `:reset`
Kills the current bash pty child and spawns a fresh one. Session audit log is preserved (same session id, continuous event stream). Grants are not reset — they're re-fetched server-side on every line anyway. Refuses while a command is in flight (`Cannot reset while a command is running. Wait or press Ctrl-C.`) so an in-flight promise can't be orphaned.

## Architecture

- `ShellRepl` now accepts an optional `onMetaCommand` callback on `ReplEvents`. The REPL checks `buffer.length === 0 && line.trim().startsWith(':')` in `handleLine` before the normal dispatch path. If the callback is set and returns `true`, the line is consumed; otherwise falls through to regular shell dispatch.
- A new pure helper `createMetaCommandHandler(deps)` lives in `packages/apes/src/shell/meta-commands.ts` (104 LOC). Dependencies are injected so it's trivially unit-testable: `getBridge`, `resetBridge`, `session`, `getAuth`, `targetHost`, `isPending`, `write`. No module mocks required in tests.
- `runInteractiveShell` refactored to use a `createBridge()` factory + `let bridge` + `resetting` flag so the existing `onExit` skips the "bash exited" / `repl.stop()` branch during a deliberate reset.

## Test plan

- [x] 4 new tests in `shell-repl.test.ts` for the REPL-level dispatch path
- [x] 7 new tests in `shell-meta-commands.test.ts` for the handler itself, using injected fake deps
- [x] All 18 new tests green (4 REPL + 7 handler + 7 surrounding regressions)
- [x] Touched-surface suites (`shell-repl`, `shell-meta-commands`, `shell-orchestrator`, `shell-orchestrator-polish`): 27/27 green
- [x] Pre-commit hook (turbo lint + typecheck): green on touched files
- [ ] Manual smoke after merge: start \`ape-shell\`, run \`:help\`, \`:status\`, \`:reset\`, confirm new bash pid in next \`:status\`

## Commits

- `032f894` feat(apes): add :help :status :reset REPL meta-commands
- `1288763` chore(apes): changeset for REPL meta-commands

Changeset: \`@openape/apes: minor\`.