### PR TITLE
fix(apes): grants status display — correct fields, ISO timestamps

### DIFF
--- a/.changeset/fix-grants-status-display.md
+++ b/.changeset/fix-grants-status-display.md
@@ -1,0 +1,27 @@
+---
+'@openape/apes': patch
+---
+
+fix(apes): `apes grants status` zeigt wieder die richtigen Felder
+
+Drei pre-existing Display-Bugs in `apes grants status <id>`:
+
+1. **`Requester: undefined`** — das Kommando las `grant.requester`, aber die IdP-Response hat `requester` unter dem verschachtelten `request`-Objekt (`grant.request.requester`). Fix: lese aus der richtigen Stelle; wenn leer, wird die Zeile übersprungen statt `undefined` zu drucken.
+
+2. **`Owner: undefined`** — ein `owner`-Feld existiert überhaupt nicht auf dem `GET /grants/<id>` Endpoint. War ein Holdover aus einem früheren API-Shape. Komplett entfernt.
+
+3. **`Type: null`** — ein top-level `type`-Feld ist auf dem aktuellen IdP immer `null`. Die Zeile wird nicht mehr gedruckt.
+
+4. **`Decided at: 1776154298`** — Timestamps kamen als Unix-Sekunden (Zahl), wurden aber als Strings gedruckt (Rohzahl auf dem Terminal). Alle Zeitstempel (`created_at`, `decided_at`, `used_at`, `expires_at`) werden jetzt als ISO-8601 formatiert via `new Date(ts * 1000).toISOString()`.
+
+Als Bonus zeigt der Output jetzt zwei neue Felder die für den Debugging-Usecase nützlich sind und vorher fehlten:
+
+- **`Audience:`** — zeigt ob es ein `shapes` / `escapes` / `ape-shell` Grant ist (wichtig seit der Introduction des `apes grants run <id>` Subcommands in 0.9.0, der nach Audience dispatcht)
+- **`Host:`** — zeigt den `target_host`, wichtig für Session-Grants die host-gebunden sind
+
+Sowie:
+
+- **`Used at:`** — neu, zeigt wann ein once-Grant consumed wurde (nützlich um zu unterscheiden ob ein Grant `used` ist weil der User ihn ausgeführt hat oder weil er geblendet wurde)
+- **`Created:`** — neu, der Creation-Timestamp war vorher nicht sichtbar
+
+Keine Änderung an `apes grants status --json` — das dumped weiterhin die rohe API-Response unverändert.

--- a/packages/apes/src/commands/grants/status.ts
+++ b/packages/apes/src/commands/grants/status.ts
@@ -2,22 +2,40 @@ import { defineCommand } from 'citty'
 import { getIdpUrl } from '../../config'
 import { apiFetch, getGrantsEndpoint } from '../../http'
 
+/**
+ * Shape returned by `GET /grants/<id>` on the OpenApe IdP. Matches the
+ * free-idp response as of 2026-04: `requester`, `target_host`, `audience`,
+ * `grant_type`, etc. all live under the nested `request` object. Top-level
+ * `type` is a legacy field that is currently always `null`. Timestamps are
+ * unix seconds (numbers), not ISO strings.
+ */
 interface GrantDetail {
   id: string
-  type: string
+  type?: string | null
   status: string
-  requester: string
-  owner: string
-  approver?: string
-  request: {
-    command?: string[]
+  request?: {
+    requester?: string
+    target_host?: string
+    audience?: string
     grant_type?: string
+    command?: string[]
     reason?: string
   }
-  created_at?: string
-  decided_at?: string
+  created_at?: number
+  decided_at?: number
   decided_by?: string
-  expires_at?: string
+  used_at?: number
+  expires_at?: number
+}
+
+/** Unix seconds → ISO-8601 with graceful fallback for bogus values. */
+function formatTs(ts: number | undefined): string | undefined {
+  if (ts === undefined || ts === null)
+    return undefined
+  const ms = ts * 1000
+  if (!Number.isFinite(ms))
+    return undefined
+  return new Date(ms).toISOString()
 }
 
 export const statusCommand = defineCommand({
@@ -49,22 +67,31 @@ export const statusCommand = defineCommand({
 
     console.log(`Grant:     ${grant.id}`)
     console.log(`Status:    ${grant.status}`)
-    console.log(`Type:      ${grant.type}`)
-    console.log(`Requester: ${grant.requester}`)
-    console.log(`Owner:     ${grant.owner}`)
-    if (grant.approver)
-      console.log(`Approver:  ${grant.approver}`)
+    if (grant.request?.audience)
+      console.log(`Audience:  ${grant.request.audience}`)
+    if (grant.request?.requester)
+      console.log(`Requester: ${grant.request.requester}`)
+    if (grant.request?.target_host)
+      console.log(`Host:      ${grant.request.target_host}`)
     if (grant.request?.command)
       console.log(`Command:   ${grant.request.command.join(' ')}`)
     if (grant.request?.grant_type)
       console.log(`Approval:  ${grant.request.grant_type}`)
     if (grant.request?.reason)
       console.log(`Reason:    ${grant.request.reason}`)
+    const createdAt = formatTs(grant.created_at)
+    if (createdAt)
+      console.log(`Created:   ${createdAt}`)
     if (grant.decided_by)
       console.log(`Decided by: ${grant.decided_by}`)
-    if (grant.decided_at)
-      console.log(`Decided at: ${grant.decided_at}`)
-    if (grant.expires_at)
-      console.log(`Expires:   ${grant.expires_at}`)
+    const decidedAt = formatTs(grant.decided_at)
+    if (decidedAt)
+      console.log(`Decided at: ${decidedAt}`)
+    const usedAt = formatTs(grant.used_at)
+    if (usedAt)
+      console.log(`Used at:   ${usedAt}`)
+    const expiresAt = formatTs(grant.expires_at)
+    if (expiresAt)
+      console.log(`Expires:   ${expiresAt}`)
   },
 })

--- a/packages/apes/test/commands-grants-status.test.ts
+++ b/packages/apes/test/commands-grants-status.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock the config + http modules so we can drive apiFetch responses
+// synthetically and capture console output without touching the network.
+vi.mock('../src/config.js', () => ({
+  getIdpUrl: vi.fn(() => 'http://idp.test'),
+}))
+vi.mock('../src/http.js', () => ({
+  apiFetch: vi.fn(),
+  getGrantsEndpoint: vi.fn(async () => 'http://idp.test/api/grants'),
+}))
+
+// Deterministic timestamps for every test so the ISO comparisons don't drift
+// across timezones or clock values. Real grants on id.openape.at use unix
+// seconds; these are intentionally distinctive so test output stays readable.
+const CREATED_AT = 1776154258 // 2026-04-14T08:10:58.000Z
+const DECIDED_AT = 1776154298 // 2026-04-14T08:11:38.000Z
+const USED_AT = 1776154311 // 2026-04-14T08:11:51.000Z
+const EXPIRES_AT = 1776240658 // 2026-04-15T08:10:58.000Z
+
+function fakeApprovedShapesGrant(overrides: Record<string, any> = {}): any {
+  return {
+    id: 'grant-xyz',
+    type: null,
+    status: 'approved',
+    request: {
+      requester: 'alice@example.com',
+      target_host: 'workstation.local',
+      audience: 'shapes',
+      grant_type: 'once',
+      command: ['whoami'],
+      reason: 'ape-shell: Show current username',
+      authorization_details: [
+        { type: 'openape_cli', display: 'Show current username', permission: 'whoami.system[identity=current]#read' },
+      ],
+    },
+    created_at: CREATED_AT,
+    decided_at: DECIDED_AT,
+    decided_by: 'bob@example.com',
+    used_at: USED_AT,
+    ...overrides,
+  }
+}
+
+describe('apes grants status', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    logSpy.mockRestore()
+    vi.resetModules()
+  })
+
+  // Helper: join all captured stdout into one blob for easy regex matching.
+  function collected(): string {
+    return logSpy.mock.calls.map(args => args.join(' ')).join('\n')
+  }
+
+  it('prints all expected fields for an approved shapes grant', async () => {
+    const { apiFetch } = await import('../src/http.js')
+    vi.mocked(apiFetch).mockResolvedValueOnce(fakeApprovedShapesGrant() as any)
+
+    const { statusCommand } = await import('../src/commands/grants/status.js')
+    await (statusCommand as any).run({ args: { id: 'grant-xyz', json: false } })
+
+    const out = collected()
+    expect(out).toContain('Grant:     grant-xyz')
+    expect(out).toContain('Status:    approved')
+    expect(out).toContain('Audience:  shapes')
+    expect(out).toContain('Requester: alice@example.com')
+    expect(out).toContain('Host:      workstation.local')
+    expect(out).toContain('Command:   whoami')
+    expect(out).toContain('Approval:  once')
+    expect(out).toContain('Reason:    ape-shell: Show current username')
+    expect(out).toContain('Decided by: bob@example.com')
+  })
+
+  it('formats all timestamps as ISO-8601, not raw unix numbers', async () => {
+    const { apiFetch } = await import('../src/http.js')
+    vi.mocked(apiFetch).mockResolvedValueOnce(fakeApprovedShapesGrant({ expires_at: EXPIRES_AT }) as any)
+
+    const { statusCommand } = await import('../src/commands/grants/status.js')
+    await (statusCommand as any).run({ args: { id: 'grant-xyz', json: false } })
+
+    const out = collected()
+    expect(out).toContain('Created:   2026-04-14T08:10:58.000Z')
+    expect(out).toContain('Decided at: 2026-04-14T08:11:38.000Z')
+    expect(out).toContain('Used at:   2026-04-14T08:11:51.000Z')
+    expect(out).toContain('Expires:   2026-04-15T08:10:58.000Z')
+    // Assert that no raw unix timestamp leaked through
+    expect(out).not.toMatch(/\b1776154258\b/)
+    expect(out).not.toMatch(/\b1776154298\b/)
+  })
+
+  it('does not print deprecated Type / Owner / Approver lines', async () => {
+    const { apiFetch } = await import('../src/http.js')
+    vi.mocked(apiFetch).mockResolvedValueOnce(fakeApprovedShapesGrant() as any)
+
+    const { statusCommand } = await import('../src/commands/grants/status.js')
+    await (statusCommand as any).run({ args: { id: 'grant-xyz', json: false } })
+
+    const out = collected()
+    // Type is always null on current API — no point printing it
+    expect(out).not.toMatch(/^Type:/m)
+    // Owner was never a top-level field — old code just printed "undefined"
+    expect(out).not.toMatch(/^Owner:/m)
+    // Approver doesn't exist; we use Decided by instead
+    expect(out).not.toMatch(/^Approver:/m)
+    // And definitely no stringified undefined
+    expect(out).not.toContain('undefined')
+    expect(out).not.toContain('null')
+  })
+
+  it('omits optional fields that are missing from the API response', async () => {
+    const { apiFetch } = await import('../src/http.js')
+    vi.mocked(apiFetch).mockResolvedValueOnce({
+      id: 'grant-min',
+      status: 'pending',
+      request: {
+        requester: 'alice@example.com',
+        audience: 'shapes',
+        command: ['ls'],
+      },
+      created_at: CREATED_AT,
+    } as any)
+
+    const { statusCommand } = await import('../src/commands/grants/status.js')
+    await (statusCommand as any).run({ args: { id: 'grant-min', json: false } })
+
+    const out = collected()
+    expect(out).toContain('Grant:     grant-min')
+    expect(out).toContain('Status:    pending')
+    expect(out).toContain('Audience:  shapes')
+    expect(out).toContain('Requester: alice@example.com')
+    expect(out).toContain('Command:   ls')
+    expect(out).toContain('Created:   2026-04-14T08:10:58.000Z')
+    // Should NOT print any of the decided/used/expires lines when absent
+    expect(out).not.toMatch(/^Decided by:/m)
+    expect(out).not.toMatch(/^Decided at:/m)
+    expect(out).not.toMatch(/^Used at:/m)
+    expect(out).not.toMatch(/^Expires:/m)
+    expect(out).not.toMatch(/^Host:/m)
+    expect(out).not.toMatch(/^Approval:/m)
+    expect(out).not.toMatch(/^Reason:/m)
+  })
+
+  it('JSON mode emits the raw API payload untouched', async () => {
+    const { apiFetch } = await import('../src/http.js')
+    const grant = fakeApprovedShapesGrant()
+    vi.mocked(apiFetch).mockResolvedValueOnce(grant as any)
+
+    const { statusCommand } = await import('../src/commands/grants/status.js')
+    await (statusCommand as any).run({ args: { id: 'grant-xyz', json: true } })
+
+    expect(logSpy).toHaveBeenCalledTimes(1)
+    const jsonArg = logSpy.mock.calls[0]![0] as string
+    const parsed = JSON.parse(jsonArg)
+    expect(parsed.id).toBe('grant-xyz')
+    expect(parsed.status).toBe('approved')
+    expect(parsed.request.requester).toBe('alice@example.com')
+    // JSON mode keeps unix timestamps — that's correct, consumers parse them
+    expect(parsed.created_at).toBe(CREATED_AT)
+    expect(parsed.decided_at).toBe(DECIDED_AT)
+  })
+
+  it('handles an ape-shell session grant shape', async () => {
+    const { apiFetch } = await import('../src/http.js')
+    vi.mocked(apiFetch).mockResolvedValueOnce({
+      id: 'sess-1',
+      status: 'approved',
+      request: {
+        requester: 'alice@example.com',
+        target_host: 'laptop.local',
+        audience: 'ape-shell',
+        grant_type: 'once',
+        command: ['bash', '-c', 'curl example.com | head -5'],
+        reason: 'Shell session: curl example.com | head -5',
+      },
+      created_at: CREATED_AT,
+      decided_at: DECIDED_AT,
+      decided_by: 'bob@example.com',
+    } as any)
+
+    const { statusCommand } = await import('../src/commands/grants/status.js')
+    await (statusCommand as any).run({ args: { id: 'sess-1', json: false } })
+
+    const out = collected()
+    expect(out).toContain('Audience:  ape-shell')
+    expect(out).toContain('Host:      laptop.local')
+    expect(out).toContain('Command:   bash -c curl example.com | head -5')
+    expect(out).toContain('Reason:    Shell session: curl example.com | head -5')
+  })
+})


### PR DESCRIPTION
## Summary

`apes grants status <id>` zeigte vier Display-Bugs die heute bei einem Live-Test gegen `id.openape.at` aufgefallen sind. Reiner Display-Fix auf dem `GET /grants/<id>` Response-Rendering, keine Änderung an der API-Integration oder am JSON-Modus.

## Vorher (aus der Live-Session mit `claude-test+patrick+hofmann_eco@id.openape.at`)

```
$ apes grants status e887a7e3-6f8c-4503-bb50-18f47585deb8
Grant:     e887a7e3-6f8c-4503-bb50-18f47585deb8
Status:    approved
Type:      null           ← immer null auf dem aktuellen API
Requester: undefined      ← Feld liegt auf request.requester, nicht top-level
Owner:     undefined      ← Feld existiert überhaupt nicht
Command:   whoami
Approval:  once
Reason:    ape-shell: Show current username
Decided by: patrick@hofmann.eco
Decided at: 1776154298    ← Unix-Timestamp als Rohzahl
```

## Nachher

```
$ apes grants status e887a7e3-6f8c-4503-bb50-18f47585deb8
Grant:     e887a7e3-6f8c-4503-bb50-18f47585deb8
Status:    used
Audience:  shapes
Requester: claude-test+patrick+hofmann_eco@id.openape.at
Host:      Mac-mini-von-Patrick.fritz.box
Command:   whoami
Approval:  once
Reason:    ape-shell: Show current username
Created:   2026-04-14T08:10:58.000Z
Decided by: patrick@hofmann.eco
Decided at: 2026-04-14T08:11:38.000Z
Used at:   2026-04-14T08:11:51.000Z
```

## Was geändert wurde

### `packages/apes/src/commands/grants/status.ts`

**Korrigierte `GrantDetail` Interface** matching die tatsächliche `GET /grants/<id>` Response-Shape:

- `requester`, `target_host`, `audience`, `grant_type`, `command`, `reason` leben unter dem nested \`request\` Objekt — nicht top-level
- `type` ist optional und kann \`null\` sein (Legacy-Feld, immer null auf current API)
- `created_at`, `decided_at`, `used_at`, `expires_at` sind `number` (Unix-Sekunden), nicht `string`
- `owner` und `approver` wurden entfernt — gab es nie auf diesem API

**Neuer Timestamp-Format-Helper:**

```ts
function formatTs(ts: number | undefined): string | undefined {
  if (ts === undefined || ts === null) return undefined
  const ms = ts * 1000
  if (!Number.isFinite(ms)) return undefined
  return new Date(ms).toISOString()
}
```

**Output-Block refactored:**

- Entfernt: `Type:`, `Owner:`, `Approver:` Zeilen (Felder existieren nicht / sind immer null)
- Gefixed: `Requester:` liest aus `grant.request.requester`
- Gefixed: `Decided at:`, `Expires:` werden via `formatTs` als ISO-8601 gedruckt
- Hinzugefügt: `Audience:` (shapes / escapes / ape-shell) — wichtig weil `apes grants run <id>` seit 0.9.0 nach Audience dispatcht
- Hinzugefügt: `Host:` (`request.target_host`) — wichtig für host-gebundene Session-Grants
- Hinzugefügt: `Created:` und `Used at:` — waren vorher nicht sichtbar

JSON-Modus (`--json`) ist unverändert: dumped die rohe API-Response wie bisher.

### `packages/apes/test/commands-grants-status.test.ts` (neu)

Sechs Unit-Tests mit gemockter `apiFetch`:

1. Prints all expected fields for an approved shapes grant
2. Formats all timestamps as ISO-8601, not raw unix numbers
3. Does not print deprecated Type / Owner / Approver lines (+ no stringified undefined/null)
4. Omits optional fields that are missing from the API response
5. JSON mode emits the raw API payload untouched
6. Handles an ape-shell session grant shape

Test-Pattern folgt dem \`shell-grant-dispatch.test.ts\` Mock-Stil: \`vi.mock('../src/http.js')\` und \`vi.mock('../src/config.js')\`, capture via \`vi.spyOn(console, 'log')\`.

## Test plan

- [x] 6 neue Tests in \`commands-grants-status.test.ts\`: alle grün
- [x] Full \`@openape/apes\` test suite via turbo: **41 test files / 443 tests grün** (437 baseline aus 0.9.0 + 6 neu)
- [x] Pre-commit hook (turbo lint + typecheck): grün
- [ ] Manual smoke post-merge: \`HOME=~/.config/apes-claude-test/HOME apes grants status <any-id>\` zeigt das neue Format

## Commits

- \`0b97f5d\` fix(apes): grants status display — correct fields, ISO timestamps

Changeset: \`@openape/apes: patch\`.

## Out of scope

Dieser PR fixt _nur_ den \`apes grants status\` Display. Andere Commands im \`grants/\` Submodul wurden nicht angefasst (kein Scope-Creep). Falls \`apes grants list\` oder \`apes grants inbox\` ähnliche Interface-Drift haben, sollten die in separaten Follow-up-PRs gefixt werden.

---

Gefunden in: Live-Debugging-Session 2026-04-14 mit \`claude-test+patrick+hofmann_eco@id.openape.at\` nach 0.9.0 Release während Verifikation des neuen \`apes grants run <id>\` Dispatch-Pfads.