### PR TITLE
feat(apes): agent-facing polling protocol in async grant output + APES_USER

### DIFF
--- a/.changeset/feat-async-grant-agent-text.md
+++ b/.changeset/feat-async-grant-agent-text.md
@@ -1,0 +1,108 @@
+---
+'@openape/apes': patch
+---
+
+feat(apes): agent-facing polling protocol in `apes run` async output + `APES_USER` mode switch
+
+Schließt einen echten UX-Gap der 0.9.0 async-default Releases: der Info-Block der beim Pending-Grant gedruckt wird, erzählt dem AI-Agent jetzt explicit was er als nächstes tun soll — poll-interval, max-wait, behavior bei approved / denied / timeout. Humans können via `APES_USER=human` auf einen kurzen freundlichen Block umschalten.
+
+## Das Problem
+
+0.9.0's async default machte `apes run` / `ape-shell -c` non-blocking: nach Grant-Creation exit 0 mit Info-Text, User muss später `apes grants run <id>` rufen um tatsächlich auszuführen. Für Humans am Terminal war das klar; für AI-Agents (openclaw, Claude Code, ChatGPT) war's unsichtbar — der Agent sah die erfolgreiche `✔` Glyphe und exit 0 und meldete dem User "done", obwohl nichts passiert war. Es gab keine Instruktion im Output-Text, *was* der Agent mit der Grant-ID machen soll, wie lange er polling soll, oder was bei Denial zu tun ist.
+
+## Was neu ist
+
+### 1. Agent-facing polling protocol
+
+Default-Output (wird gezeigt wenn `APES_USER` nicht auf `human` gesetzt ist):
+
+```
+✔ Grant e887a7e3-... created (pending approval)
+  Approve:   https://id.openape.at/grant-approval?grant_id=e887a7e3-...
+  Status:    apes grants status e887a7e3-... [--json]
+  Execute:   apes grants run e887a7e3-...
+
+  For agents: poll `apes grants status e887a7e3-... --json` every 10s, wait up to 5 minutes.
+  When .status == "approved", run `apes grants run e887a7e3-...` to execute.
+  On "denied" or "revoked", stop and report to the user.
+  On timeout, stop and notify the user that approval has not happened.
+
+  Tip: Approve as "timed" or "always" in the browser to let this
+  grant be reused on subsequent invocations without re-approval.
+```
+
+Der Agent bekommt konkrete imperative Instruktionen — poll, run, stop, report — und weiß wie die drei Terminal-States zu handlen sind (approved / denied|revoked / timeout). Per-agent Skill-Definitionen sind damit optional; jeder Agent in jedem Ökosystem bekommt dasselbe Verhalten ohne zusätzliche Konfiguration.
+
+### 2. `APES_USER=human` für Humans
+
+Humans die regelmäßig mit `apes` arbeiten und den verbose Block nervig finden, setzen einmal `export APES_USER=human` in ihrer `.zshrc` und bekommen:
+
+```
+✔ Grant e887a7e3-... created — awaiting your approval
+  Approve in browser:  https://id.openape.at/grant-approval?grant_id=e887a7e3-...
+  Check status:        apes grants status e887a7e3-...
+  Run after approval:  apes grants run e887a7e3-...
+
+  Tip: Approve as "timed" or "always" in the browser to reuse
+  this grant without re-approval on the next invocation.
+```
+
+Kürzer, freundlicher, kein Agent-Polling-Block.
+
+### 3. Konfigurierbares Poll-Interval + Max-Duration
+
+Die 10-Sekunden / 5-Minuten Defaults sind konfigurierbar via Env-Vars und `config.toml`:
+
+```bash
+# Env vars (höchste Priorität)
+APES_GRANT_POLL_INTERVAL=30        # seconds between polls
+APES_GRANT_POLL_MAX_MINUTES=10     # max total wait
+```
+
+```toml
+# ~/.config/apes/config.toml (lower priority, fallback when env unset)
+[defaults]
+user = "agent"                       # or "human"
+grant_poll_interval_seconds = "30"
+grant_poll_max_minutes = "10"
+```
+
+Env wins über config, config wins über baked-in defaults. Bogus values (non-numeric, negative) fallen gracefully zum Default. Die Zahlen fließen direkt in den Output-Text, damit der Agent immer die tatsächlich aktuelle Policy sieht — nicht eine hardcoded.
+
+### 4. Default ist agent
+
+Die User-Mode Default-Wahl ist `agent`, nicht `human`. Rationale: Agenten sind die Zielgruppe bei der der Output-Text der einzige Kommunikationskanal ist. Humans können den verbose Block ignorieren — schlimmstenfalls lesen sie zwei extra Absätze. Agenten ohne explizite Instruktionen können den async-Flow gar nicht nutzen. Der konservative Default ist "zero-config für agents, one-line rc für humans".
+
+## Konsistenz-Stabilität für Scripts
+
+Die drei Core-Label-Zeilen bleiben in beiden Modes enthalten und finden sich in jedem Output:
+
+- Die URL enthält immer `grant-approval?grant_id=<uuid>`
+- Die Status-Zeile enthält immer `apes grants status <uuid>`
+- Die Execute-Zeile enthält immer `apes grants run <uuid>`
+
+Existing Scripts die diese Strings via grep/sed extrahieren brechen nicht. Der Unterschied ist nur der Prosa-Block drumrum.
+
+## Test-Manifest
+
+11 neue Tests in `packages/apes/test/commands-run-async.test.ts` im neuen `async info block audience mode` describe:
+
+1. Default (kein env, keine config): agent mode mit polling protocol
+2. `APES_USER=human`: short block, kein polling
+3. `APES_USER=agent`: wie default
+4. `APES_USER=invalid`: fällt zurück auf agent
+5. `config.toml defaults.user=human` überridet den agent default
+6. `APES_USER` env wins über `config.toml defaults.user`
+7. `APES_GRANT_POLL_INTERVAL=30` fließt in den agent text
+8. `APES_GRANT_POLL_MAX_MINUTES=10` fließt in den agent text
+9. config fallback für poll interval wenn env unset
+10. env wins über config für numeric knobs
+11. bogus env values (non-numeric, negative) werden ignored, defaults apply
+
+Plus: zusätzlicher Mock für `loadConfig()` im bestehenden `vi.mock('../src/config.js')` Setup, und Reset-auf-leere-config im `beforeEach` damit `mockReturnValue` aus einem Test nicht in den nächsten leakt.
+
+Full `@openape/apes` suite via turbo: 41 files, **466/466 green** (455 baseline aus 0.9.2 + 11 neu).
+
+## Migration
+
+Keine. Ist ein pure-additive Output-Format-Change. Existing scripts die die Core-Label-Strings grep-en brechen nicht. Wer explicit den alten deutschen Text mit "erstellt" / "Ausführen" / "Tipp" parsed, bricht — aber das war 0.9.0 und wir sind nur 4 Patch-Releases später.

--- a/packages/apes/src/commands/run.ts
+++ b/packages/apes/src/commands/run.ts
@@ -17,7 +17,7 @@ import {
   waitForGrantStatus,
 } from '../shapes/index.js'
 import consola from 'consola'
-import { getIdpUrl, loadAuth } from '../config'
+import { getIdpUrl, loadAuth, loadConfig } from '../config'
 import { apiFetch, getGrantsEndpoint } from '../http'
 import { CliError, CliExit } from '../errors'
 import { notifyGrantPending } from '../notifications'
@@ -31,18 +31,115 @@ function shouldWaitForGrant(args: Record<string, unknown>): boolean {
 }
 
 /**
- * Print the async info block for a freshly created pending grant. This is
- * what the user sees when the non-blocking default path is taken: the grant
- * id, the approval URL, the `grants status` and `grants run` commands.
+ * Audience of the `apes run` async info block. Drives whether the output
+ * targets a human reader (short, friendly) or an AI agent (verbose, with
+ * explicit polling protocol).
+ *
+ * Default is `'agent'` — zero-config for agent ecosystems (openclaw, Claude,
+ * etc.), and humans who want brevity just set `APES_USER=human` once in
+ * their shell rc. Env var wins over config.toml; unknown values fall back
+ * to the agent default.
+ */
+type ApesUserMode = 'agent' | 'human'
+
+function getUserMode(): ApesUserMode {
+  const envValue = process.env.APES_USER
+  if (envValue === 'human')
+    return 'human'
+  if (envValue === 'agent')
+    return 'agent'
+  const cfg = loadConfig()
+  if (cfg.defaults?.user === 'human')
+    return 'human'
+  return 'agent'
+}
+
+/** Poll interval (seconds) embedded in the agent-mode instructions. */
+function getPollIntervalSeconds(): number {
+  const envValue = process.env.APES_GRANT_POLL_INTERVAL
+  if (envValue) {
+    const n = Number(envValue)
+    if (Number.isFinite(n) && n > 0)
+      return Math.floor(n)
+  }
+  const cfg = loadConfig()
+  const cfgValue = cfg.defaults?.grant_poll_interval_seconds
+  if (cfgValue) {
+    const n = Number(cfgValue)
+    if (Number.isFinite(n) && n > 0)
+      return Math.floor(n)
+  }
+  return 10
+}
+
+/** Poll max minutes embedded in the agent-mode instructions. */
+function getPollMaxMinutes(): number {
+  const envValue = process.env.APES_GRANT_POLL_MAX_MINUTES
+  if (envValue) {
+    const n = Number(envValue)
+    if (Number.isFinite(n) && n > 0)
+      return Math.floor(n)
+  }
+  const cfg = loadConfig()
+  const cfgValue = cfg.defaults?.grant_poll_max_minutes
+  if (cfgValue) {
+    const n = Number(cfgValue)
+    if (Number.isFinite(n) && n > 0)
+      return Math.floor(n)
+  }
+  return 5
+}
+
+/**
+ * Print the async info block for a freshly created pending grant. Two
+ * output modes:
+ *
+ * - **agent** (default): verbose, with an explicit polling protocol so
+ *   the consuming LLM knows exactly what to do next. Tells the agent to
+ *   poll `apes grants status <id> --json` every N seconds for up to M
+ *   minutes, handle each terminal status, and run `apes grants run <id>`
+ *   once approved. Every agent in every ecosystem sees the same text
+ *   without needing a per-tool skill integration.
+ *
+ * - **human** (opt-in via `APES_USER=human` or `config.toml` defaults.user):
+ *   short, friendly, no polling block. Humans at a terminal know to wait
+ *   for approval and then come back.
+ *
+ * Both modes keep the same core Approve / Status / Execute lines so
+ * external scripts that grep for those labels keep working.
  */
 function printPendingGrantInfo(grant: { id: string }, idp: string): void {
-  consola.success(`Grant ${grant.id} erstellt`)
-  console.log(`  Approve:   ${idp}/grant-approval?grant_id=${grant.id}`)
-  console.log(`  Status:    apes grants status ${grant.id}`)
-  console.log(`  Ausführen: apes grants run ${grant.id}`)
+  const mode = getUserMode()
+  const approveUrl = `${idp}/grant-approval?grant_id=${grant.id}`
+  const statusCmd = `apes grants status ${grant.id}`
+  const executeCmd = `apes grants run ${grant.id}`
+
+  if (mode === 'human') {
+    consola.success(`Grant ${grant.id} created — awaiting your approval`)
+    console.log(`  Approve in browser:  ${approveUrl}`)
+    console.log(`  Check status:        ${statusCmd}`)
+    console.log(`  Run after approval:  ${executeCmd}`)
+    console.log('')
+    console.log('  Tip: Approve as "timed" or "always" in the browser to reuse')
+    console.log('  this grant without re-approval on the next invocation.')
+    return
+  }
+
+  // agent mode (default)
+  const pollSec = getPollIntervalSeconds()
+  const maxMin = getPollMaxMinutes()
+  consola.success(`Grant ${grant.id} created (pending approval)`)
+  console.log(`  Approve:   ${approveUrl}`)
+  console.log(`  Status:    ${statusCmd} [--json]`)
+  console.log(`  Execute:   ${executeCmd}`)
   console.log('')
-  console.log('  Tipp: Im Browser "als timed/always approven" wählen, um das')
-  console.log('  Kommando ohne erneuten Approval wiederzuverwenden.')
+  console.log(`  For agents: poll \`${statusCmd} --json\` every ${pollSec}s, wait up to ${maxMin} minutes.`)
+  console.log(`  When .status == "approved", run \`${executeCmd}\` to execute.`)
+  console.log(`  On "denied" or "revoked", stop and report to the user.`)
+  console.log(`  On timeout, stop and notify the user that approval has not happened.`)
+  console.log('')
+  console.log('  Tip: Approve as "timed" or "always" in the browser to let this')
+  console.log('  grant be reused on subsequent invocations without re-approval.')
 }
 
 export const runCommand = defineCommand({

--- a/packages/apes/src/config.ts
+++ b/packages/apes/src/config.ts
@@ -14,6 +14,24 @@ export interface ApesConfig {
   defaults?: {
     idp?: string
     approval?: string
+    /**
+     * Audience for the `apes run` async info block. `agent` (default)
+     * emits verbose agent-facing instructions with a polling protocol;
+     * `human` emits a short friendly block. Env var `APES_USER` wins.
+     */
+    user?: 'agent' | 'human'
+    /**
+     * Poll interval (seconds) embedded in the agent-mode instructions.
+     * Default 10. Env var `APES_GRANT_POLL_INTERVAL` wins. Stored as a
+     * string in TOML because the hand-rolled parser only handles quoted
+     * values — casting to number happens at read time.
+     */
+    grant_poll_interval_seconds?: string
+    /**
+     * Maximum poll duration (minutes) embedded in the agent-mode
+     * instructions. Default 5. Env var `APES_GRANT_POLL_MAX_MINUTES` wins.
+     */
+    grant_poll_max_minutes?: string
   }
   agent?: {
     key?: string

--- a/packages/apes/test/commands-run-async.test.ts
+++ b/packages/apes/test/commands-run-async.test.ts
@@ -14,6 +14,12 @@ vi.mock('../src/config.js', () => ({
     expires_at: Date.now() / 1000 + 3600,
   })),
   getIdpUrl: vi.fn(() => 'http://idp.test'),
+  // Async info block helpers in run.ts call loadConfig() to resolve
+  // APES_USER / poll interval / poll max minutes from config.toml when
+  // the matching env vars aren't set. Return an empty config by default
+  // so tests get the baked-in defaults; individual tests can override
+  // via `vi.mocked(loadConfig).mockReturnValueOnce(...)`.
+  loadConfig: vi.fn(() => ({})),
 }))
 
 vi.mock('../src/http.js', () => ({
@@ -61,8 +67,14 @@ describe('commands/run async default', () => {
   let infoSpy: ReturnType<typeof vi.spyOn>
   let successSpy: ReturnType<typeof vi.spyOn>
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks()
+    // Reset loadConfig to an empty default so a prior test's
+    // mockReturnValue doesn't leak through the describe block. Individual
+    // tests that need a config override use `vi.mocked(loadConfig)
+    // .mockReturnValue(...)` inside the test body.
+    const { loadConfig } = await import('../src/config.js')
+    vi.mocked(loadConfig).mockReturnValue({})
     consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     infoSpy = vi.spyOn(consola, 'info').mockImplementation(() => {})
     successSpy = vi.spyOn(consola, 'success').mockImplementation(() => {})
@@ -330,6 +342,174 @@ describe('commands/run async default', () => {
         ['--grant', 'jwt-tok', '--', 'mount-nfs'],
         expect.objectContaining({ stdio: 'inherit' }),
       )
+    })
+  })
+
+  // ------------------------------------------------------------------------
+  // Async info block audience: agent (default) vs human
+  //
+  // The output of printPendingGrantInfo switches between two flavours:
+  //   - agent (default): verbose, with an explicit polling protocol
+  //   - human (opt-in via APES_USER=human or config.toml defaults.user)
+  //
+  // APES_USER env var wins over config.toml. Numeric knobs
+  // (APES_GRANT_POLL_INTERVAL, APES_GRANT_POLL_MAX_MINUTES) flow into the
+  // agent-mode text so different environments can tune the polling policy.
+  // ------------------------------------------------------------------------
+  describe('async info block audience mode', () => {
+    // All cases below go through the simplest exit path we have — the
+    // runAudienceMode async branch — to avoid re-mocking the shapes
+    // adapter chain. printPendingGrantInfo is the same helper in every
+    // call site, so one driving path is representative.
+    async function driveRun() {
+      const { apiFetch } = await import('../src/http.js')
+      vi.mocked(apiFetch).mockResolvedValueOnce({ id: 'grant-mode-test', status: 'pending' } as any)
+
+      const { runCommand } = await import('../src/commands/run.js')
+      await runCommand.run!({
+        rawArgs: ['run', 'escapes', 'mount-nfs'],
+        args: { shell: false, wait: false, approval: 'once' } as any,
+      } as any)
+    }
+
+    function collectedLog(): string {
+      return consoleLogSpy.mock.calls.map(c => c.join(' ')).join('\n')
+    }
+
+    function collectedSuccess(): string {
+      return successSpy.mock.calls.map(c => c.join(' ')).join('\n')
+    }
+
+    afterEach(() => {
+      delete process.env.APES_USER
+      delete process.env.APES_GRANT_POLL_INTERVAL
+      delete process.env.APES_GRANT_POLL_MAX_MINUTES
+    })
+
+    it('default (no env, no config): agent mode with polling protocol', async () => {
+      await driveRun()
+
+      const out = collectedLog()
+      const success = collectedSuccess()
+
+      expect(success).toContain('Grant grant-mode-test created (pending approval)')
+      expect(out).toContain('For agents: poll `apes grants status grant-mode-test --json` every 10s')
+      expect(out).toContain('up to 5 minutes')
+      expect(out).toContain('apes grants run grant-mode-test')
+      // Must NOT include the human-mode label wording
+      expect(out).not.toContain('Approve in browser:')
+      expect(out).not.toContain('Run after approval:')
+    })
+
+    it('APES_USER=human: short block, no polling protocol', async () => {
+      process.env.APES_USER = 'human'
+      await driveRun()
+
+      const out = collectedLog()
+      const success = collectedSuccess()
+
+      expect(success).toContain('Grant grant-mode-test created — awaiting your approval')
+      expect(out).toContain('Approve in browser:')
+      expect(out).toContain('Check status:')
+      expect(out).toContain('Run after approval:')
+      // Agent-only blocks must NOT appear in human mode
+      expect(out).not.toContain('For agents:')
+      expect(out).not.toContain('every 10s')
+      expect(out).not.toContain('If .status is')
+    })
+
+    it('APES_USER=agent: same as default', async () => {
+      process.env.APES_USER = 'agent'
+      await driveRun()
+
+      const out = collectedLog()
+      expect(out).toContain('For agents:')
+      expect(out).toContain('every 10s')
+    })
+
+    it('APES_USER=invalid: falls back to agent default', async () => {
+      process.env.APES_USER = 'random-garbage-xxxxxxx'
+      await driveRun()
+
+      const out = collectedLog()
+      expect(out).toContain('For agents:')
+    })
+
+    it('config.toml defaults.user=human overrides the agent default', async () => {
+      const { loadConfig } = await import('../src/config.js')
+      vi.mocked(loadConfig).mockReturnValue({ defaults: { user: 'human' } })
+      await driveRun()
+
+      const out = collectedLog()
+      expect(out).toContain('Approve in browser:')
+      expect(out).not.toContain('For agents:')
+    })
+
+    it('APES_USER env wins over config.toml defaults.user', async () => {
+      const { loadConfig } = await import('../src/config.js')
+      vi.mocked(loadConfig).mockReturnValue({ defaults: { user: 'human' } })
+      process.env.APES_USER = 'agent'
+      await driveRun()
+
+      const out = collectedLog()
+      // Env said agent → agent wins even though config said human
+      expect(out).toContain('For agents:')
+      expect(out).not.toContain('Approve in browser:')
+    })
+
+    it('APES_GRANT_POLL_INTERVAL=30 flows into the agent text', async () => {
+      process.env.APES_GRANT_POLL_INTERVAL = '30'
+      await driveRun()
+
+      const out = collectedLog()
+      expect(out).toContain('every 30s')
+      // Default max still 5 minutes
+      expect(out).toContain('up to 5 minutes')
+    })
+
+    it('APES_GRANT_POLL_MAX_MINUTES=10 flows into the agent text', async () => {
+      process.env.APES_GRANT_POLL_MAX_MINUTES = '10'
+      await driveRun()
+
+      const out = collectedLog()
+      expect(out).toContain('every 10s')
+      expect(out).toContain('up to 10 minutes')
+    })
+
+    it('config fallback for poll interval when env unset', async () => {
+      const { loadConfig } = await import('../src/config.js')
+      vi.mocked(loadConfig).mockReturnValue({
+        defaults: { grant_poll_interval_seconds: '20', grant_poll_max_minutes: '15' },
+      })
+      await driveRun()
+
+      const out = collectedLog()
+      expect(out).toContain('every 20s')
+      expect(out).toContain('up to 15 minutes')
+    })
+
+    it('env wins over config for numeric knobs', async () => {
+      const { loadConfig } = await import('../src/config.js')
+      vi.mocked(loadConfig).mockReturnValue({
+        defaults: { grant_poll_interval_seconds: '20', grant_poll_max_minutes: '15' },
+      })
+      process.env.APES_GRANT_POLL_INTERVAL = '30'
+      process.env.APES_GRANT_POLL_MAX_MINUTES = '10'
+      await driveRun()
+
+      const out = collectedLog()
+      expect(out).toContain('every 30s')
+      expect(out).toContain('up to 10 minutes')
+    })
+
+    it('bogus env values are ignored, defaults apply', async () => {
+      process.env.APES_GRANT_POLL_INTERVAL = 'not-a-number'
+      process.env.APES_GRANT_POLL_MAX_MINUTES = '-5'
+      await driveRun()
+
+      const out = collectedLog()
+      expect(out).toContain('every 10s')
+      expect(out).toContain('up to 5 minutes')
     })
   })
 })


### PR DESCRIPTION
## Summary

Closes a real UX gap the 0.9.0 async-default exposed: when `apes run` exits 0 with a pending grant, the output now explicitly tells the consuming AI agent what to do next — poll `apes grants status <id> --json`, wait for approved, then run `apes grants run <id>`. Configurable polling policy. Humans can opt into a short friendly output via `APES_USER=human`.

## The gap

0.9.0 made `apes run` / `ape-shell -c` non-blocking by default. The output was user-friendly German text with Approve URL + Status + Execute commands. A human read it, approved in the browser, came back, tipped the execute command. Worked.

An AI agent read the same text, saw the ✔ glyph + exit 0, reported "done" to the user, and moved on. The user sat there waiting for their actual command to run. **No instruction in the output text telling the agent to poll or retry.**

## The fix

### Default agent mode — verbose with polling protocol

```
✔ Grant e887a7e3-... created (pending approval)
  Approve:   https://id.openape.at/grant-approval?grant_id=e887a7e3-...
  Status:    apes grants status e887a7e3-... [--json]
  Execute:   apes grants run e887a7e3-...

  For agents: poll \`apes grants status e887a7e3-... --json\` every 10s, wait up to 5 minutes.
  When .status == "approved", run \`apes grants run e887a7e3-...\` to execute.
  On "denied" or "revoked", stop and report to the user.
  On timeout, stop and notify the user that approval has not happened.

  Tip: Approve as "timed" or "always" in the browser to let this
  grant be reused on subsequent invocations without re-approval.
```

Imperative English instructions for maximum LLM compliance. Handles all three terminal states (approved / denied|revoked / timeout).

### Human mode — short, opt-in

`export APES_USER=human` in \`.zshrc\` and the output becomes:

```
✔ Grant e887a7e3-... created — awaiting your approval
  Approve in browser:  https://id.openape.at/grant-approval?grant_id=e887a7e3-...
  Check status:        apes grants status e887a7e3-...
  Run after approval:  apes grants run e887a7e3-...

  Tip: Approve as "timed" or "always" in the browser to reuse
  this grant without re-approval on the next invocation.
```

### Configurable polling policy

Env vars (highest priority):

\`\`\`bash
APES_USER=agent|human                # audience mode
APES_GRANT_POLL_INTERVAL=30          # seconds between polls
APES_GRANT_POLL_MAX_MINUTES=10       # max total wait
\`\`\`

Config fallback in \`~/.config/apes/config.toml\`:

\`\`\`toml
[defaults]
user = "agent"
grant_poll_interval_seconds = "30"
grant_poll_max_minutes = "10"
\`\`\`

Bogus values (non-numeric, negative) are ignored and fall back to defaults.

### Why default = agent

Agents are the audience for whom the output is the only communication channel. Humans can ignore a verbose block — worst case they read two extra paragraphs. Agents without explicit instructions cannot use the async flow at all. Conservative default is "zero-config for agents, one-line rc for humans".

## Script compatibility

Both modes keep the same core label lines:
- \`grant-approval?grant_id=<uuid>\`
- \`apes grants status <uuid>\`
- \`apes grants run <uuid>\`

Existing scripts that grep for these tokens continue to work. Only the surrounding prose block changed.

## Test plan

- [x] 11 new tests in \`commands-run-async.test.ts\` \`async info block audience mode\` describe:
  - default (no env, no config): agent mode with polling protocol
  - \`APES_USER=human\`: short block, no polling
  - \`APES_USER=agent\`: same as default
  - \`APES_USER=invalid\`: falls back to agent
  - \`config.toml defaults.user=human\` overrides the agent default
  - \`APES_USER\` env wins over \`config.toml defaults.user\`
  - \`APES_GRANT_POLL_INTERVAL=30\` flows into agent text
  - \`APES_GRANT_POLL_MAX_MINUTES=10\` flows into agent text
  - config fallback when env unset
  - env wins over config for numeric knobs
  - bogus env values fall back to defaults gracefully
- [x] Full \`@openape/apes\` suite via turbo: 41 files, **466/466 green** (455 baseline from 0.9.2 + 11 new)
- [x] Pre-commit hook (turbo lint + typecheck): green
- [ ] Manual smoke post-merge: \`apes run -- date\` shows agent block, \`APES_USER=human apes run -- date\` shows human block

## Files touched

- \`packages/apes/src/commands/run.ts\` — rewrote \`printPendingGrantInfo\` with two modes, added \`getUserMode\`/\`getPollIntervalSeconds\`/\`getPollMaxMinutes\` helpers
- \`packages/apes/src/config.ts\` — added \`defaults.user\`, \`defaults.grant_poll_interval_seconds\`, \`defaults.grant_poll_max_minutes\` to \`ApesConfig\` interface
- \`packages/apes/test/commands-run-async.test.ts\` — 11 new tests + \`loadConfig\` mock + beforeEach reset

## Commits

- \`559a9ad\` feat(apes): agent-facing polling protocol in async grant output + APES_USER mode

Changeset: \`@openape/apes: patch\` → \`0.9.2 → 0.9.3\`.

---

User feedback that drove this: *"der agent kommt zwar nun sofort zurück und informiert mich dass ich den grant bestätigen soll, aber er weiß nicht dass er selbstständig den grant prüfen soll ob er approved ist — das sollte wahrscheinlich einfach im text stehen"* — exactly right, and text-first beats per-agent skills because every ecosystem gets the same behavior without per-tool integration.