### PR TITLE
fix(apes): extend apes self-dispatch shortcut to one-shot ape-shell -c path

### DIFF
--- a/.changeset/fix-one-shot-self-dispatch.md
+++ b/.changeset/fix-one-shot-self-dispatch.md
@@ -1,0 +1,103 @@
+---
+'@openape/apes': patch
+---
+
+fix(apes): extend apes self-dispatch shortcut to `ape-shell -c` one-shot path + strip `APES_SHELL_WRAPPER` in `execShellCommand`
+
+Behebt einen Rekursions-Loop den openclaw's Polling-Flow exposed: `ape-shell -c "apes grants status <id> --json"` kreiert jetzt keinen eigenen Grant mehr. Der 0.9.2 self-dispatch shortcut (der `apes <subcmd>` aus der interaktiven REPL exempted) wird auf den one-shot Pfad erweitert, und als defense-in-depth wird `APES_SHELL_WRAPPER` in `execShellCommand` aus der bash-Env gestrippt.
+
+## Das Problem
+
+Unter 0.9.2 kriegen Subcommands wie `apes grants run <id>` den self-dispatch shortcut im REPL (`shell/grant-dispatch.ts`) — sie bypassen den Grant-Flow weil sie als trusted shell-internal gelten. Aber der gleiche Check lebt **nicht** im one-shot Pfad (`commands/run.ts runShellMode`), den `ape-shell -c "<cmd>"` trifft nachdem `rewriteApeShellArgs` es zu `apes run --shell -- bash -c <cmd>` umschreibt.
+
+Für openclaw's Polling-Flow heißt das konkret:
+
+1. Openclaw spawnt `ape-shell -c "apes grants status <date-grant-id> --json"` als Child-Prozess
+2. Wird rewritten zu `apes run --shell -- bash -c "apes grants status <date-grant-id> --json"`
+3. `runShellMode` ruft `tryAdapterModeFromShell` — versucht den apes-Adapter zu laden
+4. Entweder wird ein shapes-Grant für die spezifische `apes grants status` Operation kreiert, oder der adapter-resolve failed und es fällt durch zum Session-Grant path mit command `['bash', '-c', 'apes grants status ...']`
+5. Openclaw sieht einen NEUEN Pending-Grant, wartet auf Approval
+6. User approved den → wait loop wacht auf → `execShellCommand(['bash', '-c', 'apes grants status ...'])`
+7. Bash spawnt `apes grants status ...` als Child, der aber `APES_SHELL_WRAPPER=1` aus dem inherited env sieht → `rewriteApeShellArgs` detected wrapper-mode → argv matched keine Regel → `action: 'error'` → "ape-shell: unsupported invocation" → exit 1
+8. Oder: openclaw pollt weiter und jedes Poll-Call kreiert einen neuen Grant. Turtles all the way down.
+
+Ergebnis: ein hängender Agent der mit jedem Poll-Call einen neuen Pending-Grant produziert und nie terminiert.
+
+## Der Fix
+
+### 1. Shared Module `packages/apes/src/shell/apes-self-dispatch.ts` (neu)
+
+Extrahiert `APES_GATED_SUBCOMMANDS` (nur `run`, `fetch`, `mcp`) und den `isApesSelfDispatch(parsed)` Helper als single source of truth. Beide Dispatch-Pfade importieren jetzt denselben Check.
+
+### 2. `shell/grant-dispatch.ts`
+
+Ersetzt die inline-deklarierte Blocklist und den Check durch den Import + Helper-Call. Verhalten unverändert für die interaktive REPL — 27/27 bestehende `shell-grant-dispatch.test.ts` Tests bleiben grün.
+
+### 3. `commands/run.ts runShellMode`
+
+Neuer early-return BEVOR `tryAdapterModeFromShell`:
+
+```ts
+const innerLine = extractShellCommandString(command)
+if (innerLine) {
+  const parsedInner = parseShellCommand(innerLine)
+  if (isApesSelfDispatch(parsedInner)) {
+    execShellCommand(command)
+    return
+  }
+}
+```
+
+Wenn `ape-shell -c "apes grants status <id>"` reinkommt, entpackt der Check den bash-c-wrapper, parst die innere Zeile, erkennt dass es ein trusted `apes` self-call ist, und ruft `execShellCommand` direkt — kein Grant, keine Wait-Loop, kein Info-Block.
+
+Das löst den Rekursions-Loop vollständig. Openclaw's Poll-Calls laufen jetzt durch als direct-exec ohne irgendeine Server-interaction.
+
+### 4. `commands/run.ts execShellCommand` + `runAudienceMode` execFileSync
+
+Beide `execFileSync` Call-Sites in `commands/run.ts` strippen jetzt `APES_SHELL_WRAPPER` aus dem env den sie an bash bzw. escapes weitergeben:
+
+```ts
+const { APES_SHELL_WRAPPER: _wrapperMarker, ...inheritedEnv } = process.env
+execFileSync(command[0]!, command.slice(1), {
+  stdio: 'inherit',
+  env: inheritedEnv,
+})
+```
+
+Das spiegelt den Fix aus `pty-bridge.ts` (0.8.0 Finding 4) auf dem one-shot Pfad. Ohne diesen Strip würde ein nested `apes grants status` im bash-child die "unsupported invocation" Error kriegen, weil es seinen Parent's `APES_SHELL_WRAPPER=1` inheritet und sich selbst als ape-shell-mode detected.
+
+Defense in depth: selbst wenn jemand in Zukunft einen weiteren Call-Path einbaut der durch `execShellCommand` geht, bleibt der env-Strip als automatischer Schutz.
+
+## Warum shared Module statt lokale Duplikation
+
+Code-Duplication wäre auch 10 Zeilen pro Seite gewesen — klein, aber mit einem echten Risiko: wenn jemand später `APES_GATED_SUBCOMMANDS` in einem der beiden Files editiert und vergisst den anderen zu updaten, läuft ein inkonsistentes Gating-Modell. Der shared Module macht die Regel explizit single-source-of-truth, und der bestehende Tripwire-Test in `shell-grant-dispatch.test.ts` (der behavioral die exakte gating-set überprüft) greift weiterhin.
+
+## Test-Manifest
+
+**11 neue Tests** in `packages/apes/test/commands-run-async.test.ts` in zwei neuen describe-Blöcken:
+
+### `runShellMode apes self-dispatch shortcut` (9 Tests)
+
+1. `apes grants status <id>` bypasses grant flow, execs directly
+2. `apes grants run <id>` bypasses (the bootstrap case)
+3. `apes whoami` bypasses
+4. `apes adapter install curl` bypasses
+5. `apes run -- echo hi` STAYS gated (run is in blocklist)
+6. `apes fetch https://example.com` STAYS gated
+7. `apes mcp server` STAYS gated
+8. `apes whoami | grep alice` (compound) does NOT self-dispatch
+9. `curl example.com` (non-apes) does NOT self-dispatch
+
+### `execShellCommand APES_SHELL_WRAPPER env strip` (2 Tests)
+
+10. Strips `APES_SHELL_WRAPPER` from the bash child env when self-dispatching
+11. Strips `APES_SHELL_WRAPPER` from the escapes pipe in `runAudienceMode --wait` mode
+
+**Regression:**
+- `shell-grant-dispatch.test.ts`: **27/27 green** (0.9.2 baseline preserved via shared module)
+- `commands-run-async.test.ts`: **32/32 green** (21 baseline + 11 new)
+- Full `@openape/apes` suite via turbo: **41 files / 477 green** (466 baseline from 0.9.3 + 11 new)
+
+## Lineage
+
+`0.7.2 → 0.8.0 → 0.9.0 → 0.9.1 → 0.9.2 → 0.9.3 → 0.9.4`

--- a/packages/apes/src/commands/run.ts
+++ b/packages/apes/src/commands/run.ts
@@ -21,6 +21,7 @@ import { getIdpUrl, loadAuth, loadConfig } from '../config'
 import { apiFetch, getGrantsEndpoint } from '../http'
 import { CliError, CliExit } from '../errors'
 import { notifyGrantPending } from '../notifications'
+import { isApesSelfDispatch } from '../shell/apes-self-dispatch'
 
 /**
  * Returns true when the caller asked for the legacy blocking path via
@@ -230,6 +231,24 @@ async function runShellMode(
   if (!idp)
     throw new CliError('No IdP URL configured. Run `apes login` first or pass --idp.')
 
+  // --- 0. apes self-dispatch shortcut (pre-adapter) ---
+  // If `ape-shell -c "apes <subcmd>"` was rewritten into this shell-mode
+  // invocation, the inner command is a trusted apes self-call and should
+  // bypass the grant flow entirely. Same trust-root reasoning as the
+  // interactive REPL path in `shell/grant-dispatch.ts` — see
+  // `shell/apes-self-dispatch.ts` for the full rationale. Without this,
+  // polling flows like openclaw's `ape-shell -c "apes grants status <id>"`
+  // cascade infinitely: every poll creates a new pending grant, every
+  // grant needs approval, turtles all the way down.
+  const innerLine = extractShellCommandString(command)
+  if (innerLine) {
+    const parsedInner = parseShellCommand(innerLine)
+    if (isApesSelfDispatch(parsedInner)) {
+      execShellCommand(command)
+      return
+    }
+  }
+
   // Try to handle this command via the shapes adapter system first.
   // This gives us structured grants with resource chains (e.g. "rm file:/tmp/foo.txt")
   // instead of opaque "bash -c …" grants.
@@ -401,12 +420,26 @@ async function tryAdapterModeFromShell(
   return true
 }
 
-/** Execute a shell command as [shell, '-c', command_string] via execFileSync */
+/**
+ * Execute a shell command as [shell, '-c', command_string] via execFileSync.
+ *
+ * Strips `APES_SHELL_WRAPPER` from the env so any nested `apes` process
+ * spawned by the bash child runs in normal citty-dispatch mode instead
+ * of self-detecting as ape-shell and rejecting its argv. This mirrors
+ * the pty-bridge.ts fix from 0.8.0 (Finding 4) for the one-shot path —
+ * openclaw's polling flow `ape-shell -c "apes grants status <id>"` would
+ * hit this leak on the nested `apes` call inside bash, manifesting as
+ * "ape-shell: unsupported invocation" and breaking the async-grant loop.
+ */
 function execShellCommand(command: string[]): void {
   if (command.length === 0)
     throw new CliError('No command to execute')
   try {
-    execFileSync(command[0]!, command.slice(1), { stdio: 'inherit' })
+    const { APES_SHELL_WRAPPER: _wrapperMarker, ...inheritedEnv } = process.env
+    execFileSync(command[0]!, command.slice(1), {
+      stdio: 'inherit',
+      env: inheritedEnv,
+    })
   }
   catch (err: unknown) {
     const exitCode = (err as { status?: number }).status || 1
@@ -564,8 +597,13 @@ async function runAudienceMode(
   if (audience === 'escapes') {
     consola.info(`Executing: ${command.join(' ')}`)
     try {
+      // Strip APES_SHELL_WRAPPER so nested `apes` invocations inside
+      // the escapes pipe don't self-detect as ape-shell mode. Same
+      // rationale as execShellCommand above.
+      const { APES_SHELL_WRAPPER: _wrapperMarker, ...inheritedEnv } = process.env
       execFileSync((args['escapes-path'] as string) || 'escapes', ['--grant', authz_jwt, '--', ...command], {
         stdio: 'inherit',
+        env: inheritedEnv,
       })
     }
     catch (err: unknown) {

--- a/packages/apes/src/shell/apes-self-dispatch.ts
+++ b/packages/apes/src/shell/apes-self-dispatch.ts
@@ -1,0 +1,55 @@
+import { basename } from 'node:path'
+import type { ParsedShellCommand } from '../shapes/shell-parser.js'
+
+/**
+ * Subset of `apes` subcommands that remain grant-gated even when invoked
+ * as self-dispatches from inside an ape-shell context. These are the
+ * three categories where the shell-grant layer adds real security value
+ * that isn't duplicated by server-side auth gates or local-file-only
+ * semantics:
+ *
+ *   - `run`   — spawns arbitrary executables, the core of the grant system
+ *   - `fetch` — forwards the bearer token to a user-specified URL
+ *   - `mcp`   — binds a network port and serves a persistent API
+ *
+ * Every other `apes <subcmd>` either reads state, mutates the user's own
+ * local config, or talks to the IdP through endpoints that are already
+ * scoped by the auth token — gating them in the shell is redundant
+ * friction, and under 0.9.0's async-default grant flow it actively
+ * breaks `apes grants run <id>` via recursion (the polling call itself
+ * creates a new grant, cascading indefinitely).
+ *
+ * This is the single source of truth shared by both dispatch paths:
+ *   - Interactive REPL: `shell/grant-dispatch.ts` → `requestGrantForShellLine`
+ *   - One-shot `ape-shell -c`: `commands/run.ts` → `runShellMode` (which
+ *     receives the bash-c-wrapped command after `rewriteApeShellArgs`
+ *     rewrites `ape-shell -c "<cmd>"` into `apes run --shell -- bash -c <cmd>`)
+ *
+ * Keep this list in sync with the blocklist snapshot test in
+ * `shell-grant-dispatch.test.ts` — the tripwire that forces a review
+ * decision whenever a new top-level apes subcommand is added.
+ */
+export const APES_GATED_SUBCOMMANDS = new Set(['run', 'fetch', 'mcp'])
+
+/**
+ * Returns true if the parsed shell command is an `apes <subcmd>`
+ * invocation that should bypass the grant flow entirely. Non-apes
+ * binaries, compound lines (pipes, &&, etc.), and subcommands in
+ * `APES_GATED_SUBCOMMANDS` all return false so they stay on the normal
+ * grant path.
+ *
+ * The caller (either `requestGrantForShellLine` for the REPL path or
+ * `runShellMode` for the one-shot path) is responsible for parsing the
+ * input string and passing the resulting ParsedShellCommand here.
+ */
+export function isApesSelfDispatch(parsed: ParsedShellCommand | null | undefined): boolean {
+  if (!parsed || parsed.isCompound)
+    return false
+  const invokedName = basename(parsed.executable)
+  if (invokedName !== 'apes' && invokedName !== 'apes.js')
+    return false
+  const subCommand = parsed.argv[0]
+  if (!subCommand)
+    return false
+  return !APES_GATED_SUBCOMMANDS.has(subCommand)
+}

--- a/packages/apes/src/shell/grant-dispatch.ts
+++ b/packages/apes/src/shell/grant-dispatch.ts
@@ -13,6 +13,7 @@ import {
   verifyAndConsume,
   waitForGrantStatus,
 } from '../shapes/index.js'
+import { isApesSelfDispatch } from './apes-self-dispatch.js'
 
 /**
  * Result of attempting to obtain a grant for a shell line. On success the
@@ -28,28 +29,10 @@ export type GrantLineResult =
   | { kind: 'approved', grantId: string, mode: 'adapter' | 'session' | 'self' }
   | { kind: 'denied', reason: string }
 
-/**
- * Subset of `apes` subcommands that the REPL still routes through the
- * normal grant flow, even after the self-dispatch shortcut below. These
- * are the three categories where the shell-grant layer adds real security
- * value that isn't duplicated by server-side auth gates or local-only
- * config-file semantics:
- *
- *   - `run`   — spawns arbitrary executables, the core of the grant system
- *   - `fetch` — forwards the bearer token to a user-specified URL
- *   - `mcp`   — binds a network port and serves a persistent API
- *
- * Every other `apes <subcmd>` either reads state, mutates the user's own
- * local config, or talks to the IdP through endpoints that are already
- * scoped by the auth token — so gating them in the shell is redundant
- * friction, and breaks `apes grants run <id>` recursively once 0.9.0's
- * async-default grant flow is in play.
- *
- * Keep this list in sync with the blocklist snapshot test in
- * `shell-grant-dispatch.test.ts` — that test is the tripwire that forces
- * a review decision whenever a new top-level apes subcommand is added.
- */
-const APES_GATED_SUBCOMMANDS = new Set(['run', 'fetch', 'mcp'])
+// The APES_GATED_SUBCOMMANDS blocklist + `isApesSelfDispatch` helper
+// live in `./apes-self-dispatch.ts` so the same rule is shared with the
+// one-shot `ape-shell -c` path in `commands/run.ts runShellMode`. See
+// that module for the full rationale.
 
 /**
  * Options the orchestrator passes to `requestGrantForShellLine`. They
@@ -98,24 +81,10 @@ export async function requestGrantForShellLine(
   // --- 0. apes self-dispatch shortcut ---
   // `apes <subcmd>` invocations from inside the ape-shell REPL are the
   // shell's own control surface — not a new user-authored action that
-  // needs approval. The REPL is already authenticated as an apes agent;
-  // its subcommands either talk to IdP endpoints that are scoped by the
-  // same auth token (grants, admin, register-user, ...), mutate local
-  // config files in the user's own $HOME (login, logout, config,
-  // adapter, enroll, init), or are strictly read-only (whoami, health,
-  // explain, dns-check, workflows). Gating them in the shell is
-  // redundant friction and, more importantly, makes `apes grants run
-  // <id>` recursively unusable under the 0.9.0 async-default grant
-  // flow. Only the three genuinely-dangerous subcommands in
-  // APES_GATED_SUBCOMMANDS (run/fetch/mcp) stay on the grant path.
-  if (parsed && !parsed.isCompound) {
-    const invokedName = basename(parsed.executable)
-    if (invokedName === 'apes' || invokedName === 'apes.js') {
-      const subCommand = parsed.argv[0]
-      if (subCommand && !APES_GATED_SUBCOMMANDS.has(subCommand)) {
-        return { kind: 'approved', grantId: 'shell-internal', mode: 'self' }
-      }
-    }
+  // needs approval. See `apes-self-dispatch.ts` for the full rationale.
+  // Only `run`, `fetch`, `mcp` remain on the grant path.
+  if (isApesSelfDispatch(parsed)) {
+    return { kind: 'approved', grantId: 'shell-internal', mode: 'self' }
   }
 
   // --- 1. Adapter path ---

--- a/packages/apes/test/commands-run-async.test.ts
+++ b/packages/apes/test/commands-run-async.test.ts
@@ -512,4 +512,297 @@ describe('commands/run async default', () => {
       expect(out).toContain('up to 5 minutes')
     })
   })
+
+  // ------------------------------------------------------------------------
+  // one-shot `ape-shell -c "apes <subcmd>"` self-dispatch shortcut.
+  //
+  // The 0.9.2 exemption lived only in shell/grant-dispatch.ts (interactive
+  // REPL). This suite verifies that runShellMode in commands/run.ts — the
+  // code path for `ape-shell -c "<cmd>"` after `rewriteApeShellArgs` has
+  // rewritten it to `apes run --shell -- bash -c "<cmd>"` — also short-
+  // circuits apes self-invocations without creating a grant.
+  //
+  // Regression guard for the openclaw polling cascade: without this fix,
+  // `ape-shell -c "apes grants status <id> --json"` creates a new grant
+  // itself, and every poll of the resulting pending grant creates yet
+  // another grant, cascading indefinitely.
+  // ------------------------------------------------------------------------
+  describe('runShellMode apes self-dispatch shortcut', () => {
+    async function driveShellMode(inner: string) {
+      const shapes = await import('../src/shapes/index.js')
+      // extractShellCommandString pulls out the inner bash -c payload.
+      // The default mock returns command.at(-1), which is exactly the
+      // inner string when command = ['bash', '-c', inner].
+      vi.mocked(shapes.extractShellCommandString).mockReturnValue(inner)
+
+      const { runCommand } = await import('../src/commands/run.js')
+      await runCommand.run!({
+        rawArgs: ['run', '--shell', '--', 'bash', '-c', inner],
+        args: { shell: true, wait: false, approval: 'once' } as any,
+      } as any)
+    }
+
+    it('`ape-shell -c "apes grants status <id>"` bypasses grant flow, execs directly', async () => {
+      const shapes = await import('../src/shapes/index.js')
+      vi.mocked(shapes.parseShellCommand).mockReturnValue({
+        executable: 'apes',
+        argv: ['grants', 'status', 'abc-123', '--json'],
+        isCompound: false,
+        raw: 'apes grants status abc-123 --json',
+      } as any)
+
+      const { apiFetch } = await import('../src/http.js')
+
+      await driveShellMode('apes grants status abc-123 --json')
+
+      // Must NOT hit the adapter flow
+      expect(shapes.loadOrInstallAdapter).not.toHaveBeenCalled()
+      expect(shapes.createShapesGrant).not.toHaveBeenCalled()
+      // Must NOT hit the session-grant API calls
+      expect(apiFetch).not.toHaveBeenCalled()
+      // Must NOT print the async info block
+      expect(successSpy.mock.calls.map(c => c.join(' ')).join('\n')).not.toContain('created (pending approval)')
+
+      // Must directly exec bash -c <line>
+      const { execFileSync } = await import('node:child_process')
+      expect(execFileSync).toHaveBeenCalledWith(
+        'bash',
+        ['-c', 'apes grants status abc-123 --json'],
+        expect.objectContaining({ stdio: 'inherit' }),
+      )
+    })
+
+    it('`ape-shell -c "apes grants run <id>"` bypasses grant flow (the bootstrap case)', async () => {
+      const shapes = await import('../src/shapes/index.js')
+      vi.mocked(shapes.parseShellCommand).mockReturnValue({
+        executable: 'apes',
+        argv: ['grants', 'run', 'xyz-grant-id'],
+        isCompound: false,
+        raw: 'apes grants run xyz-grant-id',
+      } as any)
+
+      const { apiFetch } = await import('../src/http.js')
+
+      await driveShellMode('apes grants run xyz-grant-id')
+
+      expect(shapes.loadOrInstallAdapter).not.toHaveBeenCalled()
+      expect(apiFetch).not.toHaveBeenCalled()
+
+      const { execFileSync } = await import('node:child_process')
+      expect(execFileSync).toHaveBeenCalledWith(
+        'bash',
+        ['-c', 'apes grants run xyz-grant-id'],
+        expect.objectContaining({ stdio: 'inherit' }),
+      )
+    })
+
+    it('`ape-shell -c "apes whoami"` bypasses grant flow', async () => {
+      const shapes = await import('../src/shapes/index.js')
+      vi.mocked(shapes.parseShellCommand).mockReturnValue({
+        executable: 'apes',
+        argv: ['whoami'],
+        isCompound: false,
+        raw: 'apes whoami',
+      } as any)
+
+      const { apiFetch } = await import('../src/http.js')
+
+      await driveShellMode('apes whoami')
+
+      expect(shapes.loadOrInstallAdapter).not.toHaveBeenCalled()
+      expect(apiFetch).not.toHaveBeenCalled()
+    })
+
+    it('`ape-shell -c "apes adapter install curl"` bypasses grant flow', async () => {
+      const shapes = await import('../src/shapes/index.js')
+      vi.mocked(shapes.parseShellCommand).mockReturnValue({
+        executable: 'apes',
+        argv: ['adapter', 'install', 'curl'],
+        isCompound: false,
+        raw: 'apes adapter install curl',
+      } as any)
+
+      const { apiFetch } = await import('../src/http.js')
+
+      await driveShellMode('apes adapter install curl')
+
+      expect(shapes.loadOrInstallAdapter).not.toHaveBeenCalled()
+      expect(apiFetch).not.toHaveBeenCalled()
+    })
+
+    it('`ape-shell -c "apes run -- echo hi"` STAYS gated (run is in blocklist)', async () => {
+      const shapes = await import('../src/shapes/index.js')
+      // The parseShellCommand for `apes run -- echo hi` returns executable=apes,
+      // argv starting with 'run'. `run` is in APES_GATED_SUBCOMMANDS → falls
+      // through to the normal flow.
+      vi.mocked(shapes.parseShellCommand).mockReturnValue({
+        executable: 'apes',
+        argv: ['run', '--', 'echo', 'hi'],
+        isCompound: false,
+        raw: 'apes run -- echo hi',
+      } as any)
+      // No adapter for `apes` registered → adapter path returns false
+      vi.mocked(shapes.loadOrInstallAdapter).mockResolvedValue(null)
+
+      const { apiFetch } = await import('../src/http.js')
+      vi.mocked(apiFetch)
+        .mockResolvedValueOnce({ data: [] } as any) // session grant lookup
+        .mockResolvedValueOnce({ id: 'gated-grant', status: 'pending' } as any) // create
+
+      await driveShellMode('apes run -- echo hi')
+
+      // Should NOT have short-circuited — adapter path was attempted
+      expect(shapes.loadOrInstallAdapter).toHaveBeenCalled()
+      // Session-grant path was taken, pending info printed
+      expect(apiFetch).toHaveBeenCalled()
+      const out = successSpy.mock.calls.map(c => c.join(' ')).join('\n')
+      expect(out).toContain('gated-grant')
+    })
+
+    it('`ape-shell -c "apes fetch https://example.com"` STAYS gated', async () => {
+      const shapes = await import('../src/shapes/index.js')
+      vi.mocked(shapes.parseShellCommand).mockReturnValue({
+        executable: 'apes',
+        argv: ['fetch', 'https://example.com'],
+        isCompound: false,
+        raw: 'apes fetch https://example.com',
+      } as any)
+      vi.mocked(shapes.loadOrInstallAdapter).mockResolvedValue(null)
+
+      const { apiFetch } = await import('../src/http.js')
+      vi.mocked(apiFetch)
+        .mockResolvedValueOnce({ data: [] } as any)
+        .mockResolvedValueOnce({ id: 'gated-fetch', status: 'pending' } as any)
+
+      await driveShellMode('apes fetch https://example.com')
+
+      expect(apiFetch).toHaveBeenCalled()
+    })
+
+    it('`ape-shell -c "apes mcp server"` STAYS gated', async () => {
+      const shapes = await import('../src/shapes/index.js')
+      vi.mocked(shapes.parseShellCommand).mockReturnValue({
+        executable: 'apes',
+        argv: ['mcp', 'server'],
+        isCompound: false,
+        raw: 'apes mcp server',
+      } as any)
+      vi.mocked(shapes.loadOrInstallAdapter).mockResolvedValue(null)
+
+      const { apiFetch } = await import('../src/http.js')
+      vi.mocked(apiFetch)
+        .mockResolvedValueOnce({ data: [] } as any)
+        .mockResolvedValueOnce({ id: 'gated-mcp', status: 'pending' } as any)
+
+      await driveShellMode('apes mcp server')
+
+      expect(apiFetch).toHaveBeenCalled()
+    })
+
+    it('`ape-shell -c "apes whoami | grep alice"` (compound) does NOT self-dispatch', async () => {
+      const shapes = await import('../src/shapes/index.js')
+      vi.mocked(shapes.parseShellCommand).mockReturnValue({
+        executable: 'apes',
+        argv: ['whoami', '|', 'grep', 'alice'],
+        isCompound: true, // the key signal
+        raw: 'apes whoami | grep alice',
+      } as any)
+      vi.mocked(shapes.loadOrInstallAdapter).mockResolvedValue(null)
+
+      const { apiFetch } = await import('../src/http.js')
+      vi.mocked(apiFetch)
+        .mockResolvedValueOnce({ data: [] } as any)
+        .mockResolvedValueOnce({ id: 'compound-grant', status: 'pending' } as any)
+
+      await driveShellMode('apes whoami | grep alice')
+
+      // Compound short-circuits the self-dispatch, falls through to
+      // the normal session-grant path
+      expect(apiFetch).toHaveBeenCalled()
+    })
+
+    it('`ape-shell -c "curl example.com"` (non-apes) does NOT self-dispatch', async () => {
+      const shapes = await import('../src/shapes/index.js')
+      vi.mocked(shapes.parseShellCommand).mockReturnValue({
+        executable: 'curl',
+        argv: ['example.com'],
+        isCompound: false,
+        raw: 'curl example.com',
+      } as any)
+      vi.mocked(shapes.loadOrInstallAdapter).mockResolvedValue({} as any)
+      vi.mocked(shapes.resolveCommand).mockResolvedValue(makeResolved('curl example.com'))
+      vi.mocked(shapes.findExistingGrant).mockResolvedValue(null)
+      vi.mocked(shapes.createShapesGrant).mockResolvedValue({ id: 'curl-grant' } as any)
+
+      await driveShellMode('curl example.com')
+
+      // Adapter flow was attempted (not short-circuited)
+      expect(shapes.loadOrInstallAdapter).toHaveBeenCalled()
+      expect(shapes.createShapesGrant).toHaveBeenCalled()
+    })
+  })
+
+  // ------------------------------------------------------------------------
+  // execShellCommand env strip — mirrors the Finding 4 fix from pty-bridge.ts
+  // for the one-shot `ape-shell -c` path. Without this, nested `apes` in the
+  // bash child inherits APES_SHELL_WRAPPER=1 and hits "unsupported invocation".
+  // ------------------------------------------------------------------------
+  describe('execShellCommand APES_SHELL_WRAPPER env strip', () => {
+    afterEach(() => {
+      delete process.env.APES_SHELL_WRAPPER
+    })
+
+    it('strips APES_SHELL_WRAPPER from the bash child env when self-dispatching', async () => {
+      process.env.APES_SHELL_WRAPPER = '1'
+      const shapes = await import('../src/shapes/index.js')
+      vi.mocked(shapes.parseShellCommand).mockReturnValue({
+        executable: 'apes',
+        argv: ['whoami'],
+        isCompound: false,
+        raw: 'apes whoami',
+      } as any)
+      vi.mocked(shapes.extractShellCommandString).mockReturnValue('apes whoami')
+
+      const { runCommand } = await import('../src/commands/run.js')
+      await runCommand.run!({
+        rawArgs: ['run', '--shell', '--', 'bash', '-c', 'apes whoami'],
+        args: { shell: true, wait: false, approval: 'once' } as any,
+      } as any)
+
+      const { execFileSync } = await import('node:child_process')
+      expect(execFileSync).toHaveBeenCalled()
+      const callArgs = vi.mocked(execFileSync).mock.calls[0]!
+      const opts = callArgs[2] as { env?: Record<string, string | undefined> }
+      expect(opts.env).toBeDefined()
+      expect(opts.env!.APES_SHELL_WRAPPER).toBeUndefined()
+      // Other env vars still there
+      expect(opts.env!.PATH).toBeDefined()
+    })
+
+    it('strips APES_SHELL_WRAPPER from escapes pipe in runAudienceMode --wait mode', async () => {
+      process.env.APES_SHELL_WRAPPER = '1'
+      const { apiFetch } = await import('../src/http.js')
+      vi.mocked(apiFetch)
+        .mockResolvedValueOnce({ id: 'escapes-grant', status: 'pending' } as any)
+        .mockResolvedValueOnce({ status: 'approved' } as any)
+        .mockResolvedValueOnce({ authz_jwt: 'jwt-tok' } as any)
+
+      const { runCommand } = await import('../src/commands/run.js')
+      await runCommand.run!({
+        rawArgs: ['run', 'escapes', 'mount-nfs', '--wait'],
+        args: { shell: false, wait: true, approval: 'once', 'escapes-path': 'escapes' } as any,
+      } as any)
+
+      const { execFileSync } = await import('node:child_process')
+      expect(execFileSync).toHaveBeenCalledWith(
+        'escapes',
+        ['--grant', 'jwt-tok', '--', 'mount-nfs'],
+        expect.objectContaining({ stdio: 'inherit' }),
+      )
+      const callArgs = vi.mocked(execFileSync).mock.calls[0]!
+      const opts = callArgs[2] as { env?: Record<string, string | undefined> }
+      expect(opts.env).toBeDefined()
+      expect(opts.env!.APES_SHELL_WRAPPER).toBeUndefined()
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Behebt den Rekursions-Loop den openclaw's Polling-Flow beim Live-Test nach 0.9.3 exposed: `ape-shell -c "apes grants status <id>"` (der one-shot Pfad) kreiert jetzt keinen eigenen Grant mehr. Der 0.9.2 self-dispatch shortcut (interaktive REPL) wird auf den one-shot Pfad erweitert, und als defense-in-depth wird `APES_SHELL_WRAPPER` in `execShellCommand` + `runAudienceMode` aus der bash-Env gestrippt.

## Observed bug

Openclaw hat `date` als user-task ausgeführt, der async-Info-Block erschien, openclaw fing an zu pollen via `ape-shell -c "apes grants status <id> --json"`. Statt das Polling-Call als shell-internal dispatch zu behandeln (wie es im REPL seit 0.9.2 passiert), kreierte es einen zweiten pending Grant (`bash -c apes grants status ...`). User approvte beide, der Agent blieb trotzdem stocken weil der nested `apes` Call im bash child `APES_SHELL_WRAPPER=1` inheritete und mit "unsupported invocation" fehlschlug.

Patrick: *"danach bleibt er stocken wenn ich beides approved habe - ich denke dass apes wohl wieder durch die grants läuft obwohl es eigentlich immer ausgeführt werden soll - apes ist erlaubt haben wir gesagt"* — exactly right.

## Zwei Leaks in einem Fix

### Leak #1: self-dispatch shortcut nur im REPL, nicht im one-shot Pfad

0.9.2 hat `APES_GATED_SUBCOMMANDS = new Set(['run', 'fetch', 'mcp'])` + `isApesSelfDispatch` in `shell/grant-dispatch.ts` eingeführt. Der Helper wird aber ausschließlich von `requestGrantForShellLine` (interaktive REPL via `shell/orchestrator.ts`) aufgerufen. Wenn openclaw `ape-shell -c "apes grants status <id>"` spawnt, geht das durch `rewriteApeShellArgs` → `apes run --shell -- bash -c "apes grants status <id>"` → `runCommand.run` → `runShellMode` in `commands/run.ts`. Das ist ein komplett anderer Code-Pfad. Kein self-dispatch check dort.

### Leak #2: `execShellCommand` inherited `APES_SHELL_WRAPPER` an bash

`execShellCommand` rief `execFileSync('bash', ['-c', ...], { stdio: 'inherit' })` ohne explicit env-option. Die bash child process inherited den parent env samt `APES_SHELL_WRAPPER=1` (das der ape-shell-wrapper.sh setzt). Wenn die bash-Zeile dann `apes` als nested child spawnt, sieht der nested apes den env var und wird von `rewriteApeShellArgs` fälschlicherweise als ape-shell-mode detected, was die argv-shape rejected und "unsupported invocation" wirft.

Das ist dieselbe Klasse von Bug wie Finding 4 aus 0.8.0 (env-leak in `pty-bridge.ts`), nur auf dem one-shot Pfad statt der REPL pty.

## Der Fix

**1. Neuer shared Module `packages/apes/src/shell/apes-self-dispatch.ts`** — extrahiert `APES_GATED_SUBCOMMANDS` + `isApesSelfDispatch(parsed)` als single source of truth. Beide Dispatch-Pfade importieren das.

**2. `shell/grant-dispatch.ts`** — ersetzt die inline Blocklist und den Check durch den Import + Helper-Call. Verhalten unverändert für die interaktive REPL. Die bestehenden 27 Tests bleiben grün.

**3. `commands/run.ts runShellMode`** — neuer early-return BEVOR `tryAdapterModeFromShell`:

\`\`\`ts
const innerLine = extractShellCommandString(command)
if (innerLine) {
  const parsedInner = parseShellCommand(innerLine)
  if (isApesSelfDispatch(parsedInner)) {
    execShellCommand(command)
    return
  }
}
\`\`\`

Entpackt den `bash -c` wrapper, parst die innere Zeile, checkt ob es ein trusted `apes <safe-subcmd>` ist, und ruft `execShellCommand` direkt. Kein Grant, kein Wait-Loop, kein Info-Block.

**4. `execShellCommand` + `runAudienceMode` escapes-pipe env strip** — beide `execFileSync` Call-Sites strippen jetzt `APES_SHELL_WRAPPER`:

\`\`\`ts
const { APES_SHELL_WRAPPER: _wrapperMarker, ...inheritedEnv } = process.env
execFileSync(command[0]!, command.slice(1), {
  stdio: 'inherit',
  env: inheritedEnv,
})
\`\`\`

## Test plan

- [x] 11 new tests in \`packages/apes/test/commands-run-async.test.ts\`:
  - 9 self-dispatch tests: grants status / grants run / whoami / adapter install bypassen; run / fetch / mcp bleiben gated; compound and non-apes don't short-circuit
  - 2 env strip tests: \`execShellCommand\` und \`runAudienceMode\` escapes pipe strippen \`APES_SHELL_WRAPPER\`
- [x] \`shell-grant-dispatch.test.ts\`: **27/27 green** (0.9.2 baseline preserved via shared module)
- [x] \`commands-run-async.test.ts\`: **32/32 green** (21 baseline + 11 new)
- [x] Full \`@openape/apes\` suite via turbo: **41 files / 477 green** (466 from 0.9.3 + 11 new)
- [x] Pre-commit hook (turbo lint + typecheck): green
- [ ] Manual smoke post-merge: openclaw polling flow terminates cleanly without grant cascades

## Commits

- \`610393a\` fix(apes): extend self-dispatch shortcut to one-shot path + env strip

Changeset: \`@openape/apes: patch\` → \`0.9.3 → 0.9.4\`.

---

User feedback from live debug: *"ich denke dass apes wohl wieder durch die grants läuft obwohl es eigentlich immer ausgeführt werden soll - apes ist erlaubt haben wir gesagt"*. Diagnosis was exactly right — the 0.9.2 exemption was only in half of the code-paths.