### PR TITLE
feat(apes)!: async-default exit code → EX_TEMPFAIL (75)

### DIFF
--- a/.changeset/feat-async-exit-code.md
+++ b/.changeset/feat-async-exit-code.md
@@ -1,0 +1,143 @@
+---
+'@openape/apes': minor
+---
+
+**BREAKING**: `apes run` / `ape-shell -c` async-default exit code changes from `0` to `75` (`EX_TEMPFAIL`)
+
+When the async-default path creates a pending grant (i.e. no `--wait` or `APE_WAIT=1`), the process now exits with code **75** instead of 0. This is [`EX_TEMPFAIL` from `sysexits.h`](https://man.openbsd.org/sysexits.3) — semantically "temporary failure, try again later" — and is the same exit code `sendmail` and other mail-delivery tools have used for decades to signal "defer and retry" to their schedulers.
+
+## Warum
+
+In 0.9.3 haben wir eine explizite Agent-Protokoll-Nachricht ("For agents: poll every 10s, wait up to 5 min, ...") in den async-Info-Block eingebaut um LLM-Agenten zu erklären was sie tun sollen. Beim Live-Test nach 0.9.4 stellte sich heraus dass openclaw's Agent die Nachricht **buchstäblich vor den Augen hatte und ignoriert hat**:
+
+> *"Das war direkt an mich als Agent adressiert — ich hätte es einfach befolgen müssen. Ich hab's schlicht ignoriert."*
+
+Untersuchung von openclaw's exec-runtime (`bash-tools.exec.ts`, `bash-tools.exec-runtime.ts`, `bash-process-registry.ts`) zeigte den strukturellen Grund: der Agent-Wrapper mapped **non-zero exit code → `failed` tool-result status**, und die "failed"-annotation ist ein viel stärkerer Aufmerksamkeits-Anker für den LLM als reiner Text-in-Stdout. Bei exit 0 sieht der Agent einen "success" tool-result mit einem ✓ Glyph, und trained-in behavior overridet alles was in der Nachricht selbst steht. Bei non-zero exit wird der Output als `failedTextResult` präsentiert, der LLM liest ihn aufmerksamer, und die Agent-Instruktionen werden befolgt.
+
+Das 0.9.3 text-first Design war korrekt aber **unzureichend ohne einen strukturellen Attention-Anker.** Der exit code IST der Anker. Das ist der fehlende zweite Kanal.
+
+## Was sich ändert
+
+**Default:**
+```bash
+$ apes run -- curl https://example.com
+ℹ Requesting grant for: Execute with elevated privileges: curl
+✔ Grant <uuid> created (pending approval)
+  Approve:   ...
+  ...
+
+$ echo $?
+75
+```
+
+Openclaw (und analoge Agent-Wrapper) sehen jetzt einen `failed`-annotierten tool-result mit allen bisherigen Output-Zeilen, inklusive dem expliziten "For agents: poll..." Block. Der Agent liest den Output aufmerksamer und folgt den Instruktionen.
+
+**Unverändert:**
+
+- `--wait` Flag / `APE_WAIT=1` → immer exit 0 on erfolgreichem Exec, wie bisher
+- Cache-Hits (`findExistingGrant` oder session-grant-reuse) → immer exit 0, command läuft sofort durch
+- Die self-dispatch shortcut für `apes <subcmd>` in ape-shell → immer exit 0 (weil direkt execShellCommand, kein pending grant)
+- Die rohen Output-Zeilen (`Approve:`, `Status:`, `Execute:`, agent/human Block) → **identisch**, nur der exit code ist anders
+
+Scripts die die Output-Zeilen via grep/sed extrahieren brechen nicht. Nur scripts die `$?` nach `apes run` checken — und die sollten entweder zu `--wait` wechseln (wenn sie synchrones Verhalten brauchen) oder den neuen exit code handhaben (wenn sie async OK sind).
+
+## Override
+
+Der exit code ist dreistufig konfigurierbar, analog zu den anderen 0.9.3-Knobs (`APES_USER`, `APES_GRANT_POLL_INTERVAL`):
+
+```bash
+# Env var (höchste Priorität)
+APES_ASYNC_EXIT_CODE=0    # restore pre-0.10.0 exit-0 behaviour
+APES_ASYNC_EXIT_CODE=2    # alternative: use shell usage-error convention
+APES_ASYNC_EXIT_CODE=7    # alternative: arbitrary distinctive code
+```
+
+```toml
+# ~/.config/apes/config.toml — fallback when env unset
+[defaults]
+async_exit_code = "0"
+```
+
+Hierarchie: env wins → config fallback → default 75. Bogus values (non-numeric, negative, > 255) fallen zurück auf 75.
+
+Valid range ist POSIX exit code space (0–255).
+
+## Warum 75 und nicht 1, 2, oder -1
+
+- **1** = POSIX "general error". Agenten und CI-Pipelines lesen das als "etwas ist schiefgegangen" ohne Spezifität. Falsches Signal — es ist kein Fehler, es ist ein erwarteter pending state.
+- **2** = lose Konvention für "shell usage error" oder "misuse of shell builtins" (bash, git). Würde als user's fault interpretiert. Auch falsch.
+- **-1** ist in POSIX nicht gültig — shells truncieren zu 255. Nicht portabel.
+- **126 / 127** sind reserviert für "command found but not executable" bzw. "command not found". Nicht passend.
+- **75** (`EX_TEMPFAIL`) hat über Jahrzehnte als Konvention für "defer and retry" in mail-delivery-tools gelebt. Dokumentiert in `sysexits.h` seit BSD-Zeiten, trainiert in LLMs via `man sysexits`, semantisch sehr nah an "pending grant, retry after approval". Best available fit.
+
+Alternative Kandidaten die auch sinnvoll gewesen wären: `73` (`EX_CANTCREAT`), `74` (`EX_IOERR`), `78` (`EX_CONFIG`). Alle schwächer gefittet als 75. Plus 75 hat die Bonus-Geschichte mit sendmail als retry-signal.
+
+## Migration
+
+### Für CI-Scripts die explizit `$?` prüfen
+
+```bash
+# Vorher (implizit success assumption):
+apes run -- curl example.com && echo done
+
+# Option 1: explicit --wait
+apes run --wait -- curl example.com && echo done
+
+# Option 2: APE_WAIT env var
+APE_WAIT=1 apes run -- curl example.com && echo done
+
+# Option 3: expect the new exit code
+apes run -- curl example.com
+if [ $? -eq 75 ]; then echo "grant pending, need approval"; fi
+
+# Option 4: restore legacy behaviour explicitly
+APES_ASYNC_EXIT_CODE=0 apes run -- curl example.com
+```
+
+### Für AI-Agent frameworks
+
+Keine Migration nötig. Der neue exit code ist **exakt der Effekt den wir wollten**: tool-result wird als `failed` präsentiert, LLM liest den Output aufmerksamer, Agent folgt den "For agents:" Instruktionen. Falls ein Framework den exit code allerdings direkt als "task failed, abort the whole workflow" interpretiert (statt als "needs attention, read the output"), dann muss dort ein Custom-Handler hinzugefügt werden der 75 speziell als "pending, not an error" behandelt.
+
+### Für Humans am Terminal
+
+Das `$?` nach einem `apes run` ist jetzt 75. Für die meisten interaktiven Workflows irrelevant — man liest den Output direkt und folgt der "Execute: apes grants run <id>" Zeile manuell. Wer den alten 0-Status zurück will:
+
+```bash
+# .zshrc
+export APES_ASYNC_EXIT_CODE=0
+```
+
+Oder in `~/.config/apes/config.toml`:
+```toml
+[defaults]
+async_exit_code = "0"
+```
+
+## Test plan
+
+- [x] 11 new tests in `packages/apes/test/commands-run-async.test.ts` `async exit code (APES_ASYNC_EXIT_CODE)` describe block:
+  - default 75 (EX_TEMPFAIL)
+  - `APES_ASYNC_EXIT_CODE=0` restores legacy
+  - `=2` custom override
+  - `=255` POSIX maximum
+  - `=256` (out of range) → fallback 75
+  - `=-1` (negative) → fallback 75
+  - `=not-a-number` → fallback 75
+  - empty string → fallback 75
+  - config.toml `defaults.async_exit_code` override when env unset
+  - env wins over config
+  - `--wait` mode unaffected (always exit 0 on successful exec)
+- [x] All existing 32 baseline tests updated to use new `expectCliExit(promise, 75)` helper for async-exit paths; `--wait` tests remain unchanged
+- [x] `shell-grant-dispatch.test.ts`: 27/27 green (0.9.2 REPL behavior untouched)
+- [x] Full `@openape/apes` suite via turbo: **41 files / 488 green** (477 baseline from 0.9.4 + 11 new)
+- [x] Pre-commit hook (turbo lint + typecheck): green
+
+## Files touched
+
+- `packages/apes/src/commands/run.ts` — new `getAsyncExitCode()` helper, `throw new CliExit(getAsyncExitCode())` at all four async-exit sites (`runShellMode` session, `tryAdapterModeFromShell`, `runAdapterMode`, `runAudienceMode`)
+- `packages/apes/src/config.ts` — new `defaults.async_exit_code?: string` field in `ApesConfig` interface
+- `packages/apes/test/commands-run-async.test.ts` — new `expectCliExit` helper + 20 existing tests wrapped + 11 new exit code tests
+
+## Lineage
+
+`0.7.2 → 0.8.0 → 0.9.0 → 0.9.1 → 0.9.2 → 0.9.3 → 0.9.4 → 0.10.0`

--- a/packages/apes/src/commands/run.ts
+++ b/packages/apes/src/commands/run.ts
@@ -92,6 +92,49 @@ function getPollMaxMinutes(): number {
 }
 
 /**
+ * Exit code for the async-default pending-grant path.
+ *
+ * Default is **75** (`EX_TEMPFAIL` from `sysexits.h`, semantically "temporary
+ * failure — try again later"). This is the clearest POSIX-adjacent signal
+ * that the command was accepted but the target action has not yet been
+ * performed and needs a retry. Unlike exit 1 (general error) or exit 2
+ * (usage error), 75 does not collide with common shell conventions, and
+ * it happens to be the same code `sendmail` and other mail delivery agents
+ * have used for decades to signal "defer and retry".
+ *
+ * The non-zero exit has a very practical effect on AI-agent consumers:
+ * openclaw's exec-runtime (and most similar frameworks) maps non-zero
+ * exits to a `failed` / `error` tool-result status, which LLMs attend
+ * to much more carefully than a `success` result with the same text in
+ * stdout. In 0.9.3 we added explicit agent-facing instructions to the
+ * async info block; in practice agents still ignored them because the
+ * wrapping tool-result looked like a success. The non-zero exit is the
+ * structural attention anchor that the text alone couldn't provide.
+ *
+ * Overridable via `APES_ASYNC_EXIT_CODE` env var or `config.toml`
+ * `defaults.async_exit_code`. Set to `0` to restore the legacy exit-0
+ * behaviour (for CI scripts that rely on it, or humans who find the
+ * non-zero exit noisy). Valid range is 0–255 (POSIX exit code space);
+ * bogus values fall back to the default 75.
+ */
+function getAsyncExitCode(): number {
+  const envValue = process.env.APES_ASYNC_EXIT_CODE
+  if (envValue !== undefined && envValue !== '') {
+    const n = Number(envValue)
+    if (Number.isFinite(n) && n >= 0 && n <= 255)
+      return Math.floor(n)
+  }
+  const cfg = loadConfig()
+  const cfgValue = cfg.defaults?.async_exit_code
+  if (cfgValue !== undefined && cfgValue !== '') {
+    const n = Number(cfgValue)
+    if (Number.isFinite(n) && n >= 0 && n <= 255)
+      return Math.floor(n)
+  }
+  return 75 // EX_TEMPFAIL
+}
+
+/**
  * Print the async info block for a freshly created pending grant. Two
  * output modes:
  *
@@ -322,6 +365,7 @@ async function runShellMode(
   }
 
   printPendingGrantInfo(grant, idp)
+  throw new CliExit(getAsyncExitCode())
 }
 
 /**
@@ -417,7 +461,7 @@ async function tryAdapterModeFromShell(
   }
 
   printPendingGrantInfo(grant, idp)
-  return true
+  throw new CliExit(getAsyncExitCode())
 }
 
 /**
@@ -531,6 +575,7 @@ async function runAdapterMode(
   }
 
   printPendingGrantInfo(grant, idp)
+  throw new CliExit(getAsyncExitCode())
 }
 
 async function runAudienceMode(
@@ -564,7 +609,7 @@ async function runAudienceMode(
   })
   if (!shouldWaitForGrant(args)) {
     printPendingGrantInfo(grant, idp)
-    return
+    throw new CliExit(getAsyncExitCode())
   }
 
   consola.success(`Grant requested: ${grant.id}`)

--- a/packages/apes/src/config.ts
+++ b/packages/apes/src/config.ts
@@ -32,6 +32,14 @@ export interface ApesConfig {
      * instructions. Default 5. Env var `APES_GRANT_POLL_MAX_MINUTES` wins.
      */
     grant_poll_max_minutes?: string
+    /**
+     * Exit code emitted by `apes run` / `ape-shell -c` when the async
+     * default path creates a pending grant. Default `75` (`EX_TEMPFAIL`
+     * from sysexits.h — "temporary failure, retry later"). Set to `0`
+     * to restore the pre-0.10.0 exit-0 behaviour. Env var
+     * `APES_ASYNC_EXIT_CODE` wins. Valid range 0–255.
+     */
+    async_exit_code?: string
   }
   agent?: {
     key?: string

--- a/packages/apes/test/commands-run-async.test.ts
+++ b/packages/apes/test/commands-run-async.test.ts
@@ -62,6 +62,32 @@ function makeResolved(display = 'curl https://example.com') {
   } as any
 }
 
+/**
+ * Wait for a promise that should throw `CliExit(expectedCode)`. As of
+ * 0.10.0 every async-default exit path in `runCommand` throws CliExit
+ * with the configured exit code (default 75 = EX_TEMPFAIL) instead of
+ * returning 0. Tests that exercise those paths use this helper to catch
+ * the throw while still running their post-hoc assertions on the spies
+ * (which were populated during the print BEFORE the throw).
+ *
+ * The legacy sync path (--wait / APE_WAIT=1) still returns normally,
+ * so --wait tests continue to `await runCommand.run!(...)` directly.
+ */
+async function expectCliExit(promise: Promise<unknown>, expectedCode: number = 75): Promise<void> {
+  const { CliExit } = await import('../src/errors.js')
+  try {
+    await promise
+  }
+  catch (err) {
+    if (err instanceof CliExit) {
+      expect(err.exitCode).toBe(expectedCode)
+      return
+    }
+    throw err
+  }
+  throw new Error(`Expected CliExit(${expectedCode}) but promise resolved normally`)
+}
+
 describe('commands/run async default', () => {
   let consoleLogSpy: ReturnType<typeof vi.spyOn>
   let infoSpy: ReturnType<typeof vi.spyOn>
@@ -114,10 +140,10 @@ describe('commands/run async default', () => {
       vi.mocked(shapes.createShapesGrant).mockResolvedValue({ id: 'grant-abc' } as any)
 
       const { runCommand } = await import('../src/commands/run.js')
-      await runCommand.run!({
+      await expectCliExit(runCommand.run!({
         rawArgs: ['run', '--shell', '--', 'bash', '-c', 'curl https://example.com'],
         args: { shell: true, wait: false, approval: 'once' } as any,
-      } as any)
+      } as any))
 
       expect(shapes.waitForGrantStatus).not.toHaveBeenCalled()
       expect(shapes.verifyAndExecute).not.toHaveBeenCalled()
@@ -224,10 +250,10 @@ describe('commands/run async default', () => {
       const { execFileSync } = await import('node:child_process')
 
       const { runCommand } = await import('../src/commands/run.js')
-      await runCommand.run!({
+      await expectCliExit(runCommand.run!({
         rawArgs: ['run', '--shell', '--', 'bash', '-c', 'echo a | echo b'],
         args: { shell: true, wait: false, approval: 'once' } as any,
-      } as any)
+      } as any))
 
       expect(execFileSync).not.toHaveBeenCalled()
       assertAsyncInfoBlock('sess-1')
@@ -267,10 +293,10 @@ describe('commands/run async default', () => {
       vi.mocked(shapes.createShapesGrant).mockResolvedValue({ id: 'grant-xyz' } as any)
 
       const { runCommand } = await import('../src/commands/run.js')
-      await runCommand.run!({
+      await expectCliExit(runCommand.run!({
         rawArgs: ['run', '--', 'whoami'],
         args: { shell: false, wait: false, approval: 'once' } as any,
-      } as any)
+      } as any))
 
       expect(shapes.waitForGrantStatus).not.toHaveBeenCalled()
       expect(shapes.verifyAndExecute).not.toHaveBeenCalled()
@@ -309,10 +335,10 @@ describe('commands/run async default', () => {
       const { execFileSync } = await import('node:child_process')
 
       const { runCommand } = await import('../src/commands/run.js')
-      await runCommand.run!({
+      await expectCliExit(runCommand.run!({
         rawArgs: ['run', 'escapes', 'mount-nfs'],
         args: { shell: false, wait: false, approval: 'once', 'escapes-path': 'escapes' } as any,
-      } as any)
+      } as any))
 
       // Only the grant-create call; no poll, no token fetch
       expect(apiFetch).toHaveBeenCalledTimes(1)
@@ -361,15 +387,18 @@ describe('commands/run async default', () => {
     // runAudienceMode async branch — to avoid re-mocking the shapes
     // adapter chain. printPendingGrantInfo is the same helper in every
     // call site, so one driving path is representative.
-    async function driveRun() {
+    async function driveRun(expectedExitCode: number = 75) {
       const { apiFetch } = await import('../src/http.js')
       vi.mocked(apiFetch).mockResolvedValueOnce({ id: 'grant-mode-test', status: 'pending' } as any)
 
       const { runCommand } = await import('../src/commands/run.js')
-      await runCommand.run!({
-        rawArgs: ['run', 'escapes', 'mount-nfs'],
-        args: { shell: false, wait: false, approval: 'once' } as any,
-      } as any)
+      await expectCliExit(
+        runCommand.run!({
+          rawArgs: ['run', 'escapes', 'mount-nfs'],
+          args: { shell: false, wait: false, approval: 'once' } as any,
+        } as any),
+        expectedExitCode,
+      )
     }
 
     function collectedLog(): string {
@@ -528,7 +557,21 @@ describe('commands/run async default', () => {
   // another grant, cascading indefinitely.
   // ------------------------------------------------------------------------
   describe('runShellMode apes self-dispatch shortcut', () => {
-    async function driveShellMode(inner: string) {
+    /**
+     * Drive runShellMode with a given inner command. Two termination paths:
+     *
+     * - `expectedExit === 'none'`: the call returns normally. Used by the
+     *   self-dispatch tests where `execShellCommand` is called directly and
+     *   the helper (a mock) returns normally without throwing.
+     * - `expectedExit === <number>`: the call is expected to throw
+     *   `CliExit(<number>)`. Used by the "stays gated" tests where the
+     *   command falls through to the normal grant flow and exits with the
+     *   async exit code.
+     */
+    async function driveShellMode(
+      inner: string,
+      expectedExit: number | 'none' = 'none',
+    ) {
       const shapes = await import('../src/shapes/index.js')
       // extractShellCommandString pulls out the inner bash -c payload.
       // The default mock returns command.at(-1), which is exactly the
@@ -536,10 +579,15 @@ describe('commands/run async default', () => {
       vi.mocked(shapes.extractShellCommandString).mockReturnValue(inner)
 
       const { runCommand } = await import('../src/commands/run.js')
-      await runCommand.run!({
+      const promise = runCommand.run!({
         rawArgs: ['run', '--shell', '--', 'bash', '-c', inner],
         args: { shell: true, wait: false, approval: 'once' } as any,
       } as any)
+
+      if (expectedExit === 'none')
+        await promise
+      else
+        await expectCliExit(promise, expectedExit)
     }
 
     it('`ape-shell -c "apes grants status <id>"` bypasses grant flow, execs directly', async () => {
@@ -649,7 +697,7 @@ describe('commands/run async default', () => {
         .mockResolvedValueOnce({ data: [] } as any) // session grant lookup
         .mockResolvedValueOnce({ id: 'gated-grant', status: 'pending' } as any) // create
 
-      await driveShellMode('apes run -- echo hi')
+      await driveShellMode('apes run -- echo hi', 75)
 
       // Should NOT have short-circuited — adapter path was attempted
       expect(shapes.loadOrInstallAdapter).toHaveBeenCalled()
@@ -674,7 +722,7 @@ describe('commands/run async default', () => {
         .mockResolvedValueOnce({ data: [] } as any)
         .mockResolvedValueOnce({ id: 'gated-fetch', status: 'pending' } as any)
 
-      await driveShellMode('apes fetch https://example.com')
+      await driveShellMode('apes fetch https://example.com', 75)
 
       expect(apiFetch).toHaveBeenCalled()
     })
@@ -694,7 +742,7 @@ describe('commands/run async default', () => {
         .mockResolvedValueOnce({ data: [] } as any)
         .mockResolvedValueOnce({ id: 'gated-mcp', status: 'pending' } as any)
 
-      await driveShellMode('apes mcp server')
+      await driveShellMode('apes mcp server', 75)
 
       expect(apiFetch).toHaveBeenCalled()
     })
@@ -714,7 +762,7 @@ describe('commands/run async default', () => {
         .mockResolvedValueOnce({ data: [] } as any)
         .mockResolvedValueOnce({ id: 'compound-grant', status: 'pending' } as any)
 
-      await driveShellMode('apes whoami | grep alice')
+      await driveShellMode('apes whoami | grep alice', 75)
 
       // Compound short-circuits the self-dispatch, falls through to
       // the normal session-grant path
@@ -734,7 +782,7 @@ describe('commands/run async default', () => {
       vi.mocked(shapes.findExistingGrant).mockResolvedValue(null)
       vi.mocked(shapes.createShapesGrant).mockResolvedValue({ id: 'curl-grant' } as any)
 
-      await driveShellMode('curl example.com')
+      await driveShellMode('curl example.com', 75)
 
       // Adapter flow was attempted (not short-circuited)
       expect(shapes.loadOrInstallAdapter).toHaveBeenCalled()
@@ -803,6 +851,113 @@ describe('commands/run async default', () => {
       const opts = callArgs[2] as { env?: Record<string, string | undefined> }
       expect(opts.env).toBeDefined()
       expect(opts.env!.APES_SHELL_WRAPPER).toBeUndefined()
+    })
+  })
+
+  // ------------------------------------------------------------------------
+  // Async-default exit code — 0.10.0 changed the default from 0 to 75
+  // (EX_TEMPFAIL from sysexits.h) so AI agent wrappers receive the pending
+  // state as a structural `failed` tool-result status instead of success.
+  //
+  // Override via APES_ASYNC_EXIT_CODE env var or config.toml
+  // `defaults.async_exit_code`. Set to 0 to restore pre-0.10.0 behaviour.
+  // Bogus values (non-numeric, out of 0–255 range) fall back to 75.
+  //
+  // --wait mode is unaffected — the blocking path always returns 0 on
+  // successful exec, regardless of APES_ASYNC_EXIT_CODE.
+  // ------------------------------------------------------------------------
+  describe('async exit code (APES_ASYNC_EXIT_CODE)', () => {
+    async function driveAsyncExit(expectedCode: number) {
+      const { apiFetch } = await import('../src/http.js')
+      vi.mocked(apiFetch).mockResolvedValueOnce({ id: 'exit-test', status: 'pending' } as any)
+
+      const { runCommand } = await import('../src/commands/run.js')
+      await expectCliExit(
+        runCommand.run!({
+          rawArgs: ['run', 'escapes', 'mount-nfs'],
+          args: { shell: false, wait: false, approval: 'once' } as any,
+        } as any),
+        expectedCode,
+      )
+    }
+
+    afterEach(() => {
+      delete process.env.APES_ASYNC_EXIT_CODE
+    })
+
+    it('default: throws CliExit(75) = EX_TEMPFAIL', async () => {
+      await driveAsyncExit(75)
+    })
+
+    it('APES_ASYNC_EXIT_CODE=0 restores legacy exit-0 behaviour', async () => {
+      process.env.APES_ASYNC_EXIT_CODE = '0'
+      await driveAsyncExit(0)
+    })
+
+    it('APES_ASYNC_EXIT_CODE=2 respects a custom numeric override', async () => {
+      process.env.APES_ASYNC_EXIT_CODE = '2'
+      await driveAsyncExit(2)
+    })
+
+    it('APES_ASYNC_EXIT_CODE=255 accepts the maximum POSIX exit code', async () => {
+      process.env.APES_ASYNC_EXIT_CODE = '255'
+      await driveAsyncExit(255)
+    })
+
+    it('APES_ASYNC_EXIT_CODE=256 (out of range) falls back to 75', async () => {
+      process.env.APES_ASYNC_EXIT_CODE = '256'
+      await driveAsyncExit(75)
+    })
+
+    it('APES_ASYNC_EXIT_CODE=-1 (negative) falls back to 75', async () => {
+      process.env.APES_ASYNC_EXIT_CODE = '-1'
+      await driveAsyncExit(75)
+    })
+
+    it('APES_ASYNC_EXIT_CODE=not-a-number (bogus) falls back to 75', async () => {
+      process.env.APES_ASYNC_EXIT_CODE = 'not-a-number'
+      await driveAsyncExit(75)
+    })
+
+    it('APES_ASYNC_EXIT_CODE empty string falls back to 75', async () => {
+      process.env.APES_ASYNC_EXIT_CODE = ''
+      await driveAsyncExit(75)
+    })
+
+    it('config.toml defaults.async_exit_code override respected when env unset', async () => {
+      const { loadConfig } = await import('../src/config.js')
+      vi.mocked(loadConfig).mockReturnValue({ defaults: { async_exit_code: '42' } })
+      await driveAsyncExit(42)
+    })
+
+    it('APES_ASYNC_EXIT_CODE env wins over config.toml async_exit_code', async () => {
+      const { loadConfig } = await import('../src/config.js')
+      vi.mocked(loadConfig).mockReturnValue({ defaults: { async_exit_code: '42' } })
+      process.env.APES_ASYNC_EXIT_CODE = '7'
+      await driveAsyncExit(7)
+    })
+
+    it('--wait mode is unaffected — returns 0 on successful exec even with APES_ASYNC_EXIT_CODE=99', async () => {
+      process.env.APES_ASYNC_EXIT_CODE = '99'
+      const { apiFetch } = await import('../src/http.js')
+      vi.mocked(apiFetch)
+        .mockResolvedValueOnce({ id: 'sync-test', status: 'pending' } as any)
+        .mockResolvedValueOnce({ status: 'approved' } as any)
+        .mockResolvedValueOnce({ authz_jwt: 'jwt-sync' } as any)
+
+      const { execFileSync } = await import('node:child_process')
+      vi.mocked(execFileSync).mockReturnValue(Buffer.from(''))
+
+      const { runCommand } = await import('../src/commands/run.js')
+      // --wait mode: runCommand.run returns normally (no CliExit thrown)
+      // because the blocking path runs execFileSync to completion and the
+      // async exit code is never consulted.
+      await runCommand.run!({
+        rawArgs: ['run', 'escapes', 'mount-nfs', '--wait'],
+        args: { shell: false, wait: true, approval: 'once', 'escapes-path': 'escapes' } as any,
+      } as any)
+
+      expect(execFileSync).toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
## Summary

**BREAKING**: `apes run` / `ape-shell -c` async-default exit code changes from `0` to `75` (`EX_TEMPFAIL` from sysexits.h). Configurable via `APES_ASYNC_EXIT_CODE` env var or `config.toml` `defaults.async_exit_code`. Set to `0` to restore legacy behaviour.

## Why this is necessary

0.9.3 shipped explicit agent-protocol instructions ("For agents: poll every 10s...") inside the async info block. The 0.9.4 live test confirmed that openclaw's agent **literally saw the instructions and ignored them**:

> *"Das war direkt an mich als Agent adressiert — ich hätte es einfach befolgen müssen. Ich hab's schlicht ignoriert."* — openclaw agent

Investigation of openclaw's exec-runtime showed the structural reason: non-zero exit → `failed` tool-result status → LLM reads the output with significantly more attention. Exit 0 with the same text gets ignored as "success, move on".

The non-zero exit code is the **structural attention anchor** that the 0.9.3 text-in-stdout strategy alone couldn't provide. Text-first is necessary but not sufficient.

## What changes

**Default behaviour:**
```bash
$ apes run -- curl https://example.com
ℹ Requesting grant for: Execute with elevated privileges: curl
✔ Grant <uuid> created (pending approval)
  ...
$ echo $?
75
```

**openclaw's wrapper now sees:**
```ts
// bash-tools.exec.ts:75 — openclaw source
if (params.outcome.status === "failed") {
  return failedTextResult(...)  // ← this branch now taken
}
return textResult(...)
```

→ LLM receives `failedTextResult`, reads the output carefully, follows the "For agents:" instructions, polls, exits cleanly when approved.

## What stays the same

- **`--wait` / `APE_WAIT=1`** → always exit 0 on successful exec
- **Cache hits** (findExistingGrant / session-grant-reuse) → always exit 0
- **Self-dispatch shortcut for `apes <subcmd>` in ape-shell** → always exit 0
- **Output text** (Approve/Status/Execute/agent-block) → identical, only exit code changes
- **scripts grepping for output labels** → unaffected

## Why 75 specifically

| Code | Meaning | Fit |
|---|---|---|
| 1 | POSIX general error | ❌ generic, misleading |
| 2 | Shell usage error | ❌ reads as "user's fault" |
| -1 | Not POSIX valid | ❌ shells truncate |
| 126/127 | Command not found/executable | ❌ collision |
| **75** | `EX_TEMPFAIL` ("temporary failure, retry later") | ✅ exactly right |

`EX_TEMPFAIL` from `sysexits.h` has been the mail-delivery "defer and retry" signal for decades (sendmail, postfix, etc.). Semantically near-identical to "pending grant, retry after approval". Documented in `man sysexits`, widely trained in LLM corpora.

## Override hierarchy

\`\`\`bash
# Env var (highest precedence)
export APES_ASYNC_EXIT_CODE=0    # restore pre-0.10.0 behaviour
export APES_ASYNC_EXIT_CODE=2    # custom override
\`\`\`

\`\`\`toml
# ~/.config/apes/config.toml — fallback when env unset
[defaults]
async_exit_code = "0"
\`\`\`

env > config > default 75. Bogus values (non-numeric, negative, >255) fall back gracefully to 75.

## Test plan

- [x] 11 new tests in \`commands-run-async.test.ts\` \`async exit code (APES_ASYNC_EXIT_CODE)\` describe
- [x] All 32 baseline tests updated with new \`expectCliExit\` helper for async-exit paths
- [x] \`--wait\` tests unchanged (return 0 on successful exec)
- [x] \`shell-grant-dispatch.test.ts\`: 27/27 green (0.9.2 REPL behaviour untouched)
- [x] Full \`@openape/apes\` suite via turbo: **41 files / 488 green** (477 baseline from 0.9.4 + 11 new)
- [x] Pre-commit hook (turbo lint + typecheck): green
- [ ] Manual smoke post-merge: openclaw's polling flow terminates cleanly with the "failed" tool-result status triggering the LLM to follow the instructions

## Files touched

- \`packages/apes/src/commands/run.ts\` — \`getAsyncExitCode()\` helper + \`throw new CliExit(getAsyncExitCode())\` at all four async-exit sites
- \`packages/apes/src/config.ts\` — new \`defaults.async_exit_code?: string\` in \`ApesConfig\`
- \`packages/apes/test/commands-run-async.test.ts\` — \`expectCliExit\` helper + 20 wrapped baseline tests + 11 new exit-code tests

## Commit

- \`5ba1188\` feat(apes): async-default exit code -> EX_TEMPFAIL (75), configurable via APES_ASYNC_EXIT_CODE

Changeset: \`@openape/apes: minor\` → \`0.9.4 → 0.10.0\` (minor bump because it's a breaking change in the CLI exit-code contract).

---

User design question that drove this: *"Wäre ein Exit code -1 oder 2 sinnvoller da der command ja nicht durchgelaufen ist?"* — exactly the right instinct. Exit code is the structural attention anchor I missed in 0.9.3.