### PR TITLE
feat(apes): apes grants run --wait + simplified agent text

### DIFF
--- a/.changeset/feat-grants-run-wait.md
+++ b/.changeset/feat-grants-run-wait.md
@@ -1,0 +1,164 @@
+---
+'@openape/apes': patch
+---
+
+feat(apes): `apes grants run <id> --wait` + simplified agent text block
+
+Neuer `--wait` flag auf `apes grants run <id>` der CLI-seitig auf Approval wartet, plus refactored agent-mode text block der den neuen Flow empfiehlt. Schließt den letzten Gap aus dem 0.10.0 live-test: openclaw hat exit 75 + text korrekt gelesen, aber sein turn-based Execution-Modell konnte den "poll every 10s" Loop nicht durchhalten weil jede User-Nachricht den polling-turn unterbrochen hat.
+
+## Das Problem
+
+Nach 0.10.0 hat openclaw den async-grant-Flow das erste Mal überhaupt **gelesen und befolgt**. Der strukturelle Attention-Anker (exit code 75 → `failed` tool-result status) hat gewirkt. Aber dann kam der zweite Layer:
+
+openclaw hat 2x gepollt, dann aufgehört. Ehrliche Selbst-Diagnose vom Agent:
+
+> *"Ich habe aufgehört zu pollen weil ich auf deine Nachricht reagiert habe statt stur weiterzupollen. Das war falsch — die Anweisung sagt 5 Minuten warten, egal was. Ich lerne es."*
+
+Der Grund ist architektonisch: **Chat-basierte Agents sind turn-based**. Ein Turn = ein Request/Response. Zwischen Turns gibt es keinen persistenten Background-Worker der Polling weiterlaufen lassen kann. Der 0.9.3/0.10.0 agent-text hat "poll every 10s for 5 minutes" verlangt, aber das setzt einen Persistent-Background-Worker voraus den Chat-Agents nicht haben.
+
+Jede neue User-Nachricht unterbricht den Agent, er reagiert auf die Nachricht statt zu pollen, der pending grant bleibt hängen.
+
+## Der Fix — Polling-Orchestrierung von Agent-Seite auf CLI-Seite verlagern
+
+Patrick's Vorschlag war die richtige strukturelle Antwort: *"Inform User about the open Grant and retry with `apes grants run <id> --wait` until User approved."*
+
+Statt dass der Agent die Polling-Schleife selbst orchestriert, ruft er einmal `apes grants run <id> --wait` und die CLI blockiert intern bis approved/denied/timeout. Das passt zu **jedem** Execution-Modell:
+
+- **Chat-Agents (turn-based)**: ein einzelner Tool-Call der blockt, openclaw's `yieldMs` + `notifyOnExit` Mechanik resumed den Agent wenn das Kommando fertig ist
+- **Persistent-Background-Worker**: ein single call der bis zur Auflösung blockt, keine Loop-State-Machine nötig
+- **Script-Konsumenten**: ein single call, dann `$?` prüfen — der sauberste CI-Workflow
+
+Der Agent muss keinen Polling-Loop selber bauen, keinen Zustand zwischen Turns halten, und muss auch nicht mit "ich wurde durch User-Input unterbrochen" zurechtkommen.
+
+## Die Implementation
+
+### 1. Neuer shared Module `packages/apes/src/grant-poll.ts`
+
+Extrahiert die Poll-Config-Getter (`getPollIntervalSeconds`, `getPollMaxMinutes`) die bisher in `commands/run.ts` lokal definiert waren, plus einen neuen `pollGrantUntilResolved(idp, grantId)` Helper der das Polling macht:
+
+```ts
+export type PollOutcome =
+  | { kind: 'approved' }
+  | { kind: 'terminal', status: 'denied' | 'revoked' | 'used' }
+  | { kind: 'timeout' }
+
+export async function pollGrantUntilResolved(idp: string, grantId: string): Promise<PollOutcome> {
+  const intervalMs = getPollIntervalSeconds() * 1000
+  const maxMs = getPollMaxMinutes() * 60_000
+  const start = Date.now()
+  while (Date.now() - start < maxMs) {
+    const grant = await apiFetch<{ status: string }>(`${grantsEndpoint}/${grantId}`)
+    if (grant.status === 'approved') return { kind: 'approved' }
+    if (grant.status === 'denied' || grant.status === 'revoked' || grant.status === 'used')
+      return { kind: 'terminal', status: grant.status }
+    await new Promise(r => setTimeout(r, intervalMs))
+  }
+  return { kind: 'timeout' }
+}
+```
+
+Single source of truth — beide Code-Pfade (`commands/run.ts` für die initiale Grant-Creation wait loops und `commands/grants/run.ts` für die CLI-side wait in `--wait` Mode) benutzen dieselben Knobs.
+
+### 2. `commands/grants/run.ts` — neuer `--wait` flag
+
+```ts
+args: {
+  id: { type: 'positional', required: true },
+  'escapes-path': { type: 'string', default: 'escapes' },
+  wait: {
+    type: 'boolean',
+    description: 'If the grant is pending, block and poll until approved',
+    default: false,
+  },
+}
+```
+
+Wenn status pending AND `args.wait === true`:
+
+```ts
+if (grant.status === 'pending') {
+  if (!args.wait) {
+    throw new CliError(`Grant ${grant.id} is still pending. Approve at: ...`)
+  }
+  const outcome = await pollGrantUntilResolved(idp, grant.id)
+  if (outcome.kind === 'timeout') throw new CliError(`... timed out after ${maxMin} minutes ...`)
+  if (outcome.kind === 'terminal') throw new CliError(`Grant ... resolved to ${outcome.status}`)
+  // outcome.kind === 'approved' — re-fetch grant for up-to-date shape
+  grant = await apiFetch<GrantDetail>(`${grantsUrl}/${args.id}`)
+  consola.info(`Grant ${grant.id} approved — continuing`)
+}
+```
+
+Wenn pending ohne `--wait`: bestehender Error wie bisher (regression guard).
+
+Nach dem pending-handler fällt der Flow in den bestehenden dispatch-Code durch — shapes grant → verifyAndExecute, escapes audience → escapes pipe, etc. Alle existierenden dispatch paths unverändert.
+
+### 3. `commands/run.ts printPendingGrantInfo` — neuer agent-mode text
+
+Der "For agents:" Block wird komplett umformuliert von "poll every Xs" zu "call `apes grants run <id> --wait`":
+
+```
+For agents:
+  1. Tell the user about the pending grant and the approve URL above.
+  2. Run `apes grants run <id> --wait`. This blocks up to 5 minutes
+     until the user approves (or denies/timeout) and then executes
+     the command in a single step. The CLI handles the polling loop
+     internally — you do not need to poll the status yourself.
+  3. Exit 0 means approved + executed; stdout is the command output.
+     Exit 75 (pending) only appears if you accidentally call this
+     without --wait. Any other non-zero exit means denied, revoked,
+     used, or timeout — report the reason to the user.
+
+Note: exit code 75 (EX_TEMPFAIL) from this command means "pending,
+retry later" — do not abort your workflow, follow the steps above.
+```
+
+Der Text ist jetzt execution-model-agnostisch — sowohl turn-based als auch persistent-background-Konsumenten können den single-call-Ansatz nahtlos ausführen. Plus der explizite Hinweis zu exit code 75 als "not an error" adressiert den edge case wo ein Agent-Framework den exit code als "task failed, abort" missinterpretiert.
+
+Das `APES_GRANT_POLL_INTERVAL` Knob ist jetzt ein **internes CLI-Detail** und wird nicht mehr im agent-text erwähnt — der Agent ruft einfach `--wait`, die CLI entscheidet wie sie pollt. Nur `APES_GRANT_POLL_MAX_MINUTES` bleibt im Text sichtbar weil es den User informiert wie lange er Zeit hat zu approven.
+
+### 4. openclaw's yield-and-resume Mechanik als perfekter Fit
+
+Die Flow-Dynamik für openclaw wird:
+
+1. User: *"Führe `date` aus"*
+2. Agent ruft `ape-shell -c "date"` → exit 75 + grant info
+3. Agent liest "For agents: tell user + run `apes grants run xyz --wait`"
+4. Agent: *"Grant xyz erstellt. Bitte bestätigen: <url>. Ich warte bis approved."*
+5. Agent ruft `apes grants run xyz --wait` via exec tool
+6. openclaw's exec tool spawnt den child, wartet `yieldMs` (default 10s), yieldet zum Agent mit *"Command still running (session S)"*
+7. Agent endet seinen turn (z.B. *"warte noch auf approval, melde mich wenn's durch ist"*)
+8. Background-child pollt weiter mit `pollGrantUntilResolved`
+9. User approved im Browser
+10. Background-child sieht `approved`, fetcht token, führt `date` aus, schreibt Output nach session, exited 0
+11. openclaw's `notifyOnExit` fires → `requestHeartbeatNow({reason: "exec-event"})` → Agent wacht auf
+12. Agent liest session output, meldet `Tue Apr 14 21:11:38 CEST 2026`
+
+Das ist genau das Pattern das die Finding 5 "Silent-Agent-Block" aus dem ursprünglichen 0.8.0 plan addressed. Wenn openclaw's notifyOnExit funktioniert, terminiert der Flow ohne User-Nachstupsen. Wenn es nicht funktioniert, reicht ein User-Message als Re-Trigger (wie im aktuellen Screenshot-Fall).
+
+## Test-Manifest
+
+### Neue Tests in `commands-grants-run.test.ts` (7 Tests)
+
+1. **Regression guard**: ohne `--wait` bleibt pending → error Verhalten
+2. `--wait` + pending → poll → approved → dispatch shapes grant
+3. `--wait` + pending → poll → denied → CliError
+4. `--wait` + pending → poll → revoked → CliError
+5. `--wait` + pending → poll → timeout → CliError mit max minutes
+6. `--wait` + already-approved → dispatch sofort, kein poll
+7. `--wait` + pending → approved → escapes audience pipe
+
+### Updated Tests in `commands-run-async.test.ts`
+
+8 existierende "async info block audience mode" Tests geupdated: die alten `expect(out).toContain('every 10s')` Assertions werden durch Assertions auf die neue Text-Struktur ersetzt (`For agents:`, `apes grants run X --wait`, `exit code 75`, `EX_TEMPFAIL`). Zusätzliche Regression-Guard: `APES_GRANT_POLL_INTERVAL` darf NICHT mehr in den agent-text leaken (da es jetzt internes CLI-Detail ist).
+
+### Regression
+
+- `shell-grant-dispatch.test.ts`: 27/27 green (unberührt)
+- `commands-run-async.test.ts`: 43/43 green
+- `commands-grants-run.test.ts`: 15/15 green (8 baseline + 7 neu)
+- Full `@openape/apes` suite via turbo: **41 files / 495 green** (488 baseline aus 0.10.0 + 7 neu)
+
+## Lineage
+
+`0.7.2 → 0.8.0 → 0.9.0 → 0.9.1 → 0.9.2 → 0.9.3 → 0.9.4 → 0.10.0 → 0.10.1`

--- a/packages/apes/src/commands/grants/run.ts
+++ b/packages/apes/src/commands/grants/run.ts
@@ -3,6 +3,7 @@ import { defineCommand } from 'citty'
 import consola from 'consola'
 import { getIdpUrl } from '../../config'
 import { CliError, CliExit } from '../../errors'
+import { getPollMaxMinutes, pollGrantUntilResolved } from '../../grant-poll'
 import { apiFetch, getGrantsEndpoint } from '../../http'
 import { fetchGrantToken, resolveFromGrant, verifyAndExecute } from '../../shapes/index.js'
 
@@ -38,6 +39,11 @@ export const runGrantCommand = defineCommand({
       description: 'Path to escapes binary (audience=escapes only)',
       default: 'escapes',
     },
+    wait: {
+      type: 'boolean',
+      description: 'If the grant is pending, block and poll until approved (or denied/revoked/used/timeout). Reuses APES_GRANT_POLL_INTERVAL / APES_GRANT_POLL_MAX_MINUTES knobs.',
+      default: false,
+    },
   },
   async run({ args }) {
     const idp = getIdpUrl()
@@ -45,11 +51,40 @@ export const runGrantCommand = defineCommand({
       throw new CliError('No IdP URL configured. Run `apes login` first or pass --idp.')
 
     const grantsUrl = await getGrantsEndpoint(idp)
-    const grant = await apiFetch<GrantDetail>(`${grantsUrl}/${args.id}`)
+    let grant = await apiFetch<GrantDetail>(`${grantsUrl}/${args.id}`)
 
     // --- status gate ---
-    if (grant.status === 'pending')
-      throw new CliError(`Grant ${grant.id} is still pending. Approve at: ${idp}/grant-approval?grant_id=${grant.id}`)
+    // Pending status has two paths: default error, or --wait poll loop.
+    // The CLI-side poll is the "ape-shell -c \"apes grants run <id> --wait\""
+    // pattern that agents use: one tool call, the CLI handles the wait,
+    // and the agent only sees the final state. See `commands/run.ts`
+    // `printPendingGrantInfo` agent-mode text for the usage contract.
+    if (grant.status === 'pending') {
+      if (!args.wait) {
+        throw new CliError(
+          `Grant ${grant.id} is still pending. Approve at: ${idp}/grant-approval?grant_id=${grant.id}`,
+        )
+      }
+      const maxMinutes = getPollMaxMinutes()
+      consola.info(`Waiting for grant ${grant.id} approval (up to ${maxMinutes} minute${maxMinutes === 1 ? '' : 's'})...`)
+      const outcome = await pollGrantUntilResolved(idp, grant.id)
+      if (outcome.kind === 'timeout') {
+        throw new CliError(
+          `Grant ${grant.id} approval timed out after ${maxMinutes} minute${maxMinutes === 1 ? '' : 's'}. `
+          + `Re-run after approval, or extend the timeout via APES_GRANT_POLL_MAX_MINUTES.`,
+        )
+      }
+      if (outcome.kind === 'terminal') {
+        throw new CliError(
+          `Grant ${grant.id} resolved to ${outcome.status}. Request a new one.`,
+        )
+      }
+      // outcome.kind === 'approved' — re-fetch the grant so we have the
+      // up-to-date shape (approver, decided_at, etc.) for downstream code.
+      grant = await apiFetch<GrantDetail>(`${grantsUrl}/${args.id}`)
+      consola.info(`Grant ${grant.id} approved — continuing`)
+    }
+
     if (grant.status === 'denied' || grant.status === 'revoked')
       throw new CliError(`Grant ${grant.id} is ${grant.status}. Request a new one.`)
     if (grant.status === 'used')

--- a/packages/apes/src/commands/run.ts
+++ b/packages/apes/src/commands/run.ts
@@ -18,6 +18,7 @@ import {
 } from '../shapes/index.js'
 import consola from 'consola'
 import { getIdpUrl, loadAuth, loadConfig } from '../config'
+import { getPollMaxMinutes } from '../grant-poll'
 import { apiFetch, getGrantsEndpoint } from '../http'
 import { CliError, CliExit } from '../errors'
 import { notifyGrantPending } from '../notifications'
@@ -55,41 +56,10 @@ function getUserMode(): ApesUserMode {
   return 'agent'
 }
 
-/** Poll interval (seconds) embedded in the agent-mode instructions. */
-function getPollIntervalSeconds(): number {
-  const envValue = process.env.APES_GRANT_POLL_INTERVAL
-  if (envValue) {
-    const n = Number(envValue)
-    if (Number.isFinite(n) && n > 0)
-      return Math.floor(n)
-  }
-  const cfg = loadConfig()
-  const cfgValue = cfg.defaults?.grant_poll_interval_seconds
-  if (cfgValue) {
-    const n = Number(cfgValue)
-    if (Number.isFinite(n) && n > 0)
-      return Math.floor(n)
-  }
-  return 10
-}
-
-/** Poll max minutes embedded in the agent-mode instructions. */
-function getPollMaxMinutes(): number {
-  const envValue = process.env.APES_GRANT_POLL_MAX_MINUTES
-  if (envValue) {
-    const n = Number(envValue)
-    if (Number.isFinite(n) && n > 0)
-      return Math.floor(n)
-  }
-  const cfg = loadConfig()
-  const cfgValue = cfg.defaults?.grant_poll_max_minutes
-  if (cfgValue) {
-    const n = Number(cfgValue)
-    if (Number.isFinite(n) && n > 0)
-      return Math.floor(n)
-  }
-  return 5
-}
+// Poll interval + max-minutes helpers live in `../grant-poll.ts` so they
+// are shared with the CLI-side wait loop in `commands/grants/run.ts --wait`.
+// See that module for the full rationale; in this file we only need the
+// max-minutes value for the agent-facing text block.
 
 /**
  * Exit code for the async-default pending-grant path.
@@ -170,17 +140,25 @@ function printPendingGrantInfo(grant: { id: string }, idp: string): void {
   }
 
   // agent mode (default)
-  const pollSec = getPollIntervalSeconds()
   const maxMin = getPollMaxMinutes()
   consola.success(`Grant ${grant.id} created (pending approval)`)
   console.log(`  Approve:   ${approveUrl}`)
   console.log(`  Status:    ${statusCmd} [--json]`)
-  console.log(`  Execute:   ${executeCmd}`)
+  console.log(`  Execute:   ${executeCmd} --wait`)
   console.log('')
-  console.log(`  For agents: poll \`${statusCmd} --json\` every ${pollSec}s, wait up to ${maxMin} minutes.`)
-  console.log(`  When .status == "approved", run \`${executeCmd}\` to execute.`)
-  console.log(`  On "denied" or "revoked", stop and report to the user.`)
-  console.log(`  On timeout, stop and notify the user that approval has not happened.`)
+  console.log('  For agents:')
+  console.log(`    1. Tell the user about the pending grant and the approve URL above.`)
+  console.log(`    2. Run \`${executeCmd} --wait\`. This blocks up to ${maxMin} minutes`)
+  console.log(`       until the user approves (or denies/timeout) and then executes`)
+  console.log(`       the command in a single step. The CLI handles the polling loop`)
+  console.log(`       internally — you do not need to poll the status yourself.`)
+  console.log(`    3. Exit 0 means approved + executed; stdout is the command output.`)
+  console.log(`       Exit 75 (pending) only appears if you accidentally call this`)
+  console.log(`       without --wait. Any other non-zero exit means denied, revoked,`)
+  console.log(`       used, or timeout — report the reason to the user.`)
+  console.log('')
+  console.log('  Note: exit code 75 (EX_TEMPFAIL) from this command means "pending,')
+  console.log('  retry later" — do not abort your workflow, follow the steps above.')
   console.log('')
   console.log('  Tip: Approve as "timed" or "always" in the browser to let this')
   console.log('  grant be reused on subsequent invocations without re-approval.')

--- a/packages/apes/src/grant-poll.ts
+++ b/packages/apes/src/grant-poll.ts
@@ -1,0 +1,88 @@
+import { loadConfig } from './config.js'
+import { apiFetch, getGrantsEndpoint } from './http.js'
+
+/**
+ * Shared poll-config helpers used by both the one-shot grant-creation
+ * wait loops in `commands/run.ts` and the CLI-side wait loop in
+ * `commands/grants/run.ts --wait`.
+ *
+ * Source-of-truth for the default poll interval (10 s) and max-wait
+ * duration (5 min). Env var wins over config.toml wins over baked-in
+ * default; bogus values fall back gracefully.
+ */
+
+/** Poll interval (seconds). Default 10. */
+export function getPollIntervalSeconds(): number {
+  const envValue = process.env.APES_GRANT_POLL_INTERVAL
+  if (envValue) {
+    const n = Number(envValue)
+    if (Number.isFinite(n) && n > 0)
+      return Math.floor(n)
+  }
+  const cfg = loadConfig()
+  const cfgValue = cfg.defaults?.grant_poll_interval_seconds
+  if (cfgValue) {
+    const n = Number(cfgValue)
+    if (Number.isFinite(n) && n > 0)
+      return Math.floor(n)
+  }
+  return 10
+}
+
+/** Maximum poll duration (minutes). Default 5. */
+export function getPollMaxMinutes(): number {
+  const envValue = process.env.APES_GRANT_POLL_MAX_MINUTES
+  if (envValue) {
+    const n = Number(envValue)
+    if (Number.isFinite(n) && n > 0)
+      return Math.floor(n)
+  }
+  const cfg = loadConfig()
+  const cfgValue = cfg.defaults?.grant_poll_max_minutes
+  if (cfgValue) {
+    const n = Number(cfgValue)
+    if (Number.isFinite(n) && n > 0)
+      return Math.floor(n)
+  }
+  return 5
+}
+
+/** Outcome of a grant polling loop. */
+export type PollOutcome =
+  | { kind: 'approved' }
+  | { kind: 'terminal', status: 'denied' | 'revoked' | 'used' }
+  | { kind: 'timeout' }
+
+/**
+ * Poll a specific grant's status via `GET /grants/<id>` until it reaches
+ * a terminal state or the max-wait budget is exhausted. Uses the shared
+ * `getPollIntervalSeconds` / `getPollMaxMinutes` knobs so users get
+ * consistent behavior across both the grant-creation wait loops and the
+ * CLI-side `grants run --wait` loop.
+ *
+ * The caller is responsible for handling the outcome — this helper only
+ * polls the status endpoint, it does not dispatch or execute the grant.
+ * See `commands/grants/run.ts --wait` for the dispatch path.
+ */
+export async function pollGrantUntilResolved(
+  idp: string,
+  grantId: string,
+): Promise<PollOutcome> {
+  const grantsEndpoint = await getGrantsEndpoint(idp)
+  const intervalSec = getPollIntervalSeconds()
+  const maxMinutes = getPollMaxMinutes()
+  const maxMs = maxMinutes * 60_000
+  const intervalMs = intervalSec * 1000
+  const start = Date.now()
+
+  while (Date.now() - start < maxMs) {
+    const grant = await apiFetch<{ status: string }>(`${grantsEndpoint}/${grantId}`)
+    if (grant.status === 'approved')
+      return { kind: 'approved' }
+    if (grant.status === 'denied' || grant.status === 'revoked' || grant.status === 'used')
+      return { kind: 'terminal', status: grant.status }
+    await new Promise(r => setTimeout(r, intervalMs))
+  }
+
+  return { kind: 'timeout' }
+}

--- a/packages/apes/test/commands-grants-run.test.ts
+++ b/packages/apes/test/commands-grants-run.test.ts
@@ -19,6 +19,15 @@ vi.mock('../src/shapes/index.js', () => ({
   fetchGrantToken: vi.fn(),
   verifyAndExecute: vi.fn(),
 }))
+vi.mock('../src/grant-poll.js', () => ({
+  // Mock the entire grant-poll module so the --wait tests can control
+  // the polling outcome deterministically instead of actually polling
+  // against a fake IdP. The real helper lives in src/grant-poll.ts and
+  // has its own unit tests elsewhere.
+  pollGrantUntilResolved: vi.fn(),
+  getPollIntervalSeconds: vi.fn(() => 10),
+  getPollMaxMinutes: vi.fn(() => 5),
+}))
 vi.mock('node:child_process', () => ({
   execFileSync: vi.fn(),
 }))
@@ -203,5 +212,150 @@ describe('apes grants run <id>', () => {
     } as any)
 
     await expectCliError(invoke('grant-weird'), 'unsupported audience')
+  })
+
+  // --------------------------------------------------------------------
+  // --wait flag — CLI-side polling loop that keeps the subprocess alive
+  // until the grant resolves. This is the pattern 0.10.1 agent-mode text
+  // recommends: one tool call, the CLI handles the wait, the agent only
+  // sees the final state.
+  // --------------------------------------------------------------------
+  describe('--wait flag', () => {
+    function pendingGrant(id: string) {
+      return {
+        id,
+        type: 'cli',
+        status: 'pending',
+        requester: 'alice@example.com',
+        owner: 'alice@example.com',
+        request: {
+          command: ['curl', 'https://example.com'],
+          audience: 'shapes',
+          authorization_details: [{ type: 'openape_cli' }],
+          execution_context: { adapter_digest: 'sha-local' },
+        },
+      }
+    }
+
+    function approvedGrant(id: string) {
+      return { ...pendingGrant(id), status: 'approved' }
+    }
+
+    it('without --wait: pending grant still errors immediately (regression guard)', async () => {
+      const { apiFetch } = await import('../src/http.js')
+      const { pollGrantUntilResolved } = await import('../src/grant-poll.js')
+      vi.mocked(apiFetch).mockResolvedValueOnce(pendingGrant('grant-pending') as any)
+
+      await expectCliError(invoke('grant-pending'), /still pending.*grant-approval/)
+      // pollGrantUntilResolved must NOT have been called without --wait
+      expect(pollGrantUntilResolved).not.toHaveBeenCalled()
+    })
+
+    it('with --wait: pending → poll → approved → dispatch shapes grant', async () => {
+      const { apiFetch } = await import('../src/http.js')
+      const { pollGrantUntilResolved } = await import('../src/grant-poll.js')
+      const { resolveFromGrant, fetchGrantToken, verifyAndExecute } = await import('../src/shapes/index.js')
+
+      // First fetch: pending. Second fetch (after poll): approved.
+      vi.mocked(apiFetch)
+        .mockResolvedValueOnce(pendingGrant('grant-wait-1') as any)
+        .mockResolvedValueOnce(approvedGrant('grant-wait-1') as any)
+
+      vi.mocked(pollGrantUntilResolved).mockResolvedValueOnce({ kind: 'approved' })
+      vi.mocked(resolveFromGrant).mockResolvedValueOnce({ executable: 'curl' } as any)
+      vi.mocked(fetchGrantToken).mockResolvedValueOnce('jwt-tok')
+      vi.mocked(verifyAndExecute).mockResolvedValueOnce(undefined)
+
+      await invoke('grant-wait-1', { wait: true })
+
+      expect(pollGrantUntilResolved).toHaveBeenCalledWith('http://idp.test', 'grant-wait-1')
+      expect(verifyAndExecute).toHaveBeenCalledWith('jwt-tok', { executable: 'curl' })
+    })
+
+    it('with --wait: pending → poll → denied → CliError', async () => {
+      const { apiFetch } = await import('../src/http.js')
+      const { pollGrantUntilResolved } = await import('../src/grant-poll.js')
+      const { verifyAndExecute } = await import('../src/shapes/index.js')
+
+      vi.mocked(apiFetch).mockResolvedValueOnce(pendingGrant('grant-wait-denied') as any)
+      vi.mocked(pollGrantUntilResolved).mockResolvedValueOnce({ kind: 'terminal', status: 'denied' })
+
+      await expectCliError(invoke('grant-wait-denied', { wait: true }), /resolved to denied/)
+      expect(verifyAndExecute).not.toHaveBeenCalled()
+    })
+
+    it('with --wait: pending → poll → revoked → CliError', async () => {
+      const { apiFetch } = await import('../src/http.js')
+      const { pollGrantUntilResolved } = await import('../src/grant-poll.js')
+      const { verifyAndExecute } = await import('../src/shapes/index.js')
+
+      vi.mocked(apiFetch).mockResolvedValueOnce(pendingGrant('grant-wait-revoked') as any)
+      vi.mocked(pollGrantUntilResolved).mockResolvedValueOnce({ kind: 'terminal', status: 'revoked' })
+
+      await expectCliError(invoke('grant-wait-revoked', { wait: true }), /resolved to revoked/)
+      expect(verifyAndExecute).not.toHaveBeenCalled()
+    })
+
+    it('with --wait: pending → poll → timeout → CliError mentioning max minutes', async () => {
+      const { apiFetch } = await import('../src/http.js')
+      const { pollGrantUntilResolved, getPollMaxMinutes } = await import('../src/grant-poll.js')
+      const { verifyAndExecute } = await import('../src/shapes/index.js')
+
+      vi.mocked(apiFetch).mockResolvedValueOnce(pendingGrant('grant-wait-timeout') as any)
+      vi.mocked(pollGrantUntilResolved).mockResolvedValueOnce({ kind: 'timeout' })
+      vi.mocked(getPollMaxMinutes).mockReturnValue(5)
+
+      await expectCliError(invoke('grant-wait-timeout', { wait: true }), /timed out after 5 minutes/)
+      expect(verifyAndExecute).not.toHaveBeenCalled()
+    })
+
+    it('with --wait: already-approved grant dispatches immediately, no poll', async () => {
+      const { apiFetch } = await import('../src/http.js')
+      const { pollGrantUntilResolved } = await import('../src/grant-poll.js')
+      const { resolveFromGrant, fetchGrantToken, verifyAndExecute } = await import('../src/shapes/index.js')
+
+      vi.mocked(apiFetch).mockResolvedValueOnce(approvedGrant('grant-already-approved') as any)
+      vi.mocked(resolveFromGrant).mockResolvedValueOnce({ executable: 'curl' } as any)
+      vi.mocked(fetchGrantToken).mockResolvedValueOnce('jwt-tok')
+      vi.mocked(verifyAndExecute).mockResolvedValueOnce(undefined)
+
+      await invoke('grant-already-approved', { wait: true })
+
+      // --wait is harmless on an already-approved grant: it only triggers
+      // the poll loop on pending status, not on approved.
+      expect(pollGrantUntilResolved).not.toHaveBeenCalled()
+      expect(verifyAndExecute).toHaveBeenCalled()
+    })
+
+    it('with --wait: pending → approved → dispatch escapes audience', async () => {
+      const { apiFetch } = await import('../src/http.js')
+      const { pollGrantUntilResolved } = await import('../src/grant-poll.js')
+
+      const pending = {
+        id: 'grant-esc',
+        type: 'cli',
+        status: 'pending',
+        requester: 'a',
+        owner: 'a',
+        request: { audience: 'escapes', command: ['mount-nfs'], authorization_details: [] },
+      }
+      const approved = { ...pending, status: 'approved' }
+
+      vi.mocked(apiFetch)
+        .mockResolvedValueOnce(pending as any) // initial fetch
+        .mockResolvedValueOnce(approved as any) // re-fetch after poll
+        .mockResolvedValueOnce({ authz_jwt: 'jwt-esc' } as any) // token
+
+      vi.mocked(pollGrantUntilResolved).mockResolvedValueOnce({ kind: 'approved' })
+
+      await invoke('grant-esc', { wait: true })
+
+      const { execFileSync } = await import('node:child_process')
+      expect(execFileSync).toHaveBeenCalledWith(
+        'escapes',
+        ['--grant', 'jwt-esc', '--', 'mount-nfs'],
+        expect.objectContaining({ stdio: 'inherit' }),
+      )
+    })
   })
 })

--- a/packages/apes/test/commands-run-async.test.ts
+++ b/packages/apes/test/commands-run-async.test.ts
@@ -415,22 +415,31 @@ describe('commands/run async default', () => {
       delete process.env.APES_GRANT_POLL_MAX_MINUTES
     })
 
-    it('default (no env, no config): agent mode with polling protocol', async () => {
+    it('default (no env, no config): agent mode with "call --wait" instruction', async () => {
       await driveRun()
 
       const out = collectedLog()
       const success = collectedSuccess()
 
       expect(success).toContain('Grant grant-mode-test created (pending approval)')
-      expect(out).toContain('For agents: poll `apes grants status grant-mode-test --json` every 10s')
+      // Core instruction: call `apes grants run <id> --wait`, CLI handles polling.
+      expect(out).toContain('For agents:')
+      expect(out).toContain('apes grants run grant-mode-test --wait')
       expect(out).toContain('up to 5 minutes')
-      expect(out).toContain('apes grants run grant-mode-test')
+      // Exit 75 explanation is critical so agent frameworks don't abort.
+      expect(out).toContain('exit code 75')
+      expect(out).toContain('EX_TEMPFAIL')
       // Must NOT include the human-mode label wording
       expect(out).not.toContain('Approve in browser:')
       expect(out).not.toContain('Run after approval:')
+      // The old "poll every 10s" instruction must NOT leak through — it
+      // was replaced by the CLI-side --wait pattern and agent frameworks
+      // should not see a mix of both.
+      expect(out).not.toContain('poll `apes grants status')
+      expect(out).not.toContain('every 10s')
     })
 
-    it('APES_USER=human: short block, no polling protocol', async () => {
+    it('APES_USER=human: short block, no agent protocol', async () => {
       process.env.APES_USER = 'human'
       await driveRun()
 
@@ -443,8 +452,8 @@ describe('commands/run async default', () => {
       expect(out).toContain('Run after approval:')
       // Agent-only blocks must NOT appear in human mode
       expect(out).not.toContain('For agents:')
-      expect(out).not.toContain('every 10s')
-      expect(out).not.toContain('If .status is')
+      expect(out).not.toContain('--wait')
+      expect(out).not.toContain('EX_TEMPFAIL')
     })
 
     it('APES_USER=agent: same as default', async () => {
@@ -453,7 +462,7 @@ describe('commands/run async default', () => {
 
       const out = collectedLog()
       expect(out).toContain('For agents:')
-      expect(out).toContain('every 10s')
+      expect(out).toContain('apes grants run grant-mode-test --wait')
     })
 
     it('APES_USER=invalid: falls back to agent default', async () => {
@@ -486,13 +495,19 @@ describe('commands/run async default', () => {
       expect(out).not.toContain('Approve in browser:')
     })
 
-    it('APES_GRANT_POLL_INTERVAL=30 flows into the agent text', async () => {
+    it('APES_GRANT_POLL_INTERVAL no longer leaks into the agent text', async () => {
+      // 0.10.1: the poll interval is now an internal CLI detail — `apes
+      // grants run --wait` polls at APES_GRANT_POLL_INTERVAL internally,
+      // and the agent text no longer mentions it. Regression guard that
+      // setting the env var does NOT produce any "every Xs" string.
       process.env.APES_GRANT_POLL_INTERVAL = '30'
       await driveRun()
 
       const out = collectedLog()
-      expect(out).toContain('every 30s')
-      // Default max still 5 minutes
+      expect(out).not.toContain('every 30s')
+      expect(out).not.toContain('every 10s')
+      // Default max still 5 minutes; the max IS still surfaced because
+      // it informs the user how long they have to approve.
       expect(out).toContain('up to 5 minutes')
     })
 
@@ -501,43 +516,39 @@ describe('commands/run async default', () => {
       await driveRun()
 
       const out = collectedLog()
-      expect(out).toContain('every 10s')
       expect(out).toContain('up to 10 minutes')
+      expect(out).not.toContain('up to 5 minutes')
     })
 
-    it('config fallback for poll interval when env unset', async () => {
+    it('config fallback for grant_poll_max_minutes when env unset', async () => {
       const { loadConfig } = await import('../src/config.js')
       vi.mocked(loadConfig).mockReturnValue({
-        defaults: { grant_poll_interval_seconds: '20', grant_poll_max_minutes: '15' },
+        defaults: { grant_poll_max_minutes: '15' },
       })
       await driveRun()
 
       const out = collectedLog()
-      expect(out).toContain('every 20s')
       expect(out).toContain('up to 15 minutes')
     })
 
-    it('env wins over config for numeric knobs', async () => {
+    it('env wins over config for max minutes', async () => {
       const { loadConfig } = await import('../src/config.js')
       vi.mocked(loadConfig).mockReturnValue({
-        defaults: { grant_poll_interval_seconds: '20', grant_poll_max_minutes: '15' },
+        defaults: { grant_poll_max_minutes: '15' },
       })
-      process.env.APES_GRANT_POLL_INTERVAL = '30'
       process.env.APES_GRANT_POLL_MAX_MINUTES = '10'
       await driveRun()
 
       const out = collectedLog()
-      expect(out).toContain('every 30s')
       expect(out).toContain('up to 10 minutes')
+      expect(out).not.toContain('up to 15 minutes')
     })
 
-    it('bogus env values are ignored, defaults apply', async () => {
-      process.env.APES_GRANT_POLL_INTERVAL = 'not-a-number'
+    it('bogus max-minutes env values are ignored, default 5 applies', async () => {
       process.env.APES_GRANT_POLL_MAX_MINUTES = '-5'
       await driveRun()
 
       const out = collectedLog()
-      expect(out).toContain('every 10s')
       expect(out).toContain('up to 5 minutes')
     })
   })


### PR DESCRIPTION
## Summary

Closes the last architectural gap in the async-grant flow: openclaw's 0.10.0 live test showed that turn-based chat agents cannot hold a polling loop across user messages. Fix: add `--wait` to `apes grants run <id>` so the CLI blocks internally, and rewrite the agent-mode text block to recommend a **single tool call** that lets the CLI handle the polling orchestration.

## The gap 0.10.0 exposed

After 0.10.0 shipped, Patrick observed openclaw finally reading the "For agents:" block (exit code 75 worked as a structural attention anchor) and starting to poll. But openclaw stopped after 2 polls. Agent's self-diagnosis:

> *"Ich habe aufgehört zu pollen weil ich auf deine Nachricht reagiert habe statt stur weiterzupollen. Das war falsch — die Anweisung sagt 5 Minuten warten, egal was."*

The reason is architectural: **chat-based agents are turn-based**. One turn = one request/response. There's no persistent background worker holding polling loops across user messages. The 0.9.3/0.10.0 "poll every 10s for 5 minutes" instruction required something the agent runtime doesn't have.

## Patrick's proposed fix (implemented in this PR)

> *"Inform User about the open Grant and retry with `apes grants run <id> --wait` until User approved"*

Shift the polling orchestration **from the agent to the CLI**. The agent makes ONE tool call (`apes grants run <id> --wait`), the CLI blocks until approved/denied/timeout, the agent only sees the final result. This pattern works for every execution model:

- **Chat agents (turn-based)**: single tool call, openclaw's `yieldMs` + `notifyOnExit` resumes the agent when the child exits
- **Persistent-background agents**: single blocking call, no state machine needed
- **Script consumers**: single call, check `$?` — cleanest CI workflow

## The implementation

### 1. New shared module `packages/apes/src/grant-poll.ts`

Extracts the poll-config helpers (`getPollIntervalSeconds`, `getPollMaxMinutes`) that previously lived in `commands/run.ts`, plus a new `pollGrantUntilResolved(idp, grantId)` helper that returns a typed `PollOutcome`:

\`\`\`ts
export type PollOutcome =
  | { kind: 'approved' }
  | { kind: 'terminal', status: 'denied' | 'revoked' | 'used' }
  | { kind: 'timeout' }
\`\`\`

Single source of truth — both the grant-creation wait loops in \`commands/run.ts\` and the new CLI-side wait in \`commands/grants/run.ts --wait\` use the same knobs.

### 2. \`commands/grants/run.ts\` — new \`--wait\` flag

When status is \`pending\` and \`args.wait\` is true, calls \`pollGrantUntilResolved\`, handles all three terminal outcomes (approved/terminal/timeout), and falls through to the existing dispatch logic on approved. Without \`--wait\`, pending still errors immediately (regression guard preserved).

### 3. \`commands/run.ts printPendingGrantInfo\` — rewritten agent-mode text

\`\`\`
For agents:
  1. Tell the user about the pending grant and the approve URL above.
  2. Run \`apes grants run <id> --wait\`. This blocks up to 5 minutes
     until the user approves (or denies/timeout) and then executes
     the command in a single step. The CLI handles the polling loop
     internally — you do not need to poll the status yourself.
  3. Exit 0 means approved + executed; stdout is the command output.
     Exit 75 (pending) only appears if you accidentally call this
     without --wait. Any other non-zero exit means denied, revoked,
     used, or timeout — report the reason to the user.

Note: exit code 75 (EX_TEMPFAIL) from this command means "pending,
retry later" — do not abort your workflow, follow the steps above.
\`\`\`

Execution-model-agnostic (works for turn-based and persistent agents), plus an explicit "exit 75 is not an error" hint that addresses the edge case where an agent framework interprets non-zero as "task failed, abort workflow".

\`APES_GRANT_POLL_INTERVAL\` is now an internal CLI detail and no longer surfaced in the agent text. Only \`APES_GRANT_POLL_MAX_MINUTES\` stays because it tells the user how long they have to approve.

## How this composes with openclaw's yield-and-resume

1. Agent: \`ape-shell -c "date"\` → exit 75 + grant info
2. Agent reads "For agents: ... run \`apes grants run xyz --wait\`"
3. Agent tells user about pending, spawns \`apes grants run xyz --wait\` via exec tool
4. openclaw spawns child, waits \`yieldMs\` (default 10s), yields to agent with "Command still running"
5. Agent ends turn, user waits
6. Background child polls via \`pollGrantUntilResolved\`, sees approved, runs date, exits 0
7. openclaw's \`notifyOnExit\` fires → \`requestHeartbeatNow({reason: "exec-event"})\` → agent wakes up
8. Agent reads session output, reports to user

This is exactly the pattern Finding 5 ("Silent-Agent-Block") from the original 0.8.0 plan was supposed to enable. If openclaw's notifyOnExit works, the flow terminates without any user nudge.

## Test plan

- [x] 7 new tests in \`commands-grants-run.test.ts\` \`--wait flag\` describe:
  - regression guard: pending without --wait still errors immediately
  - --wait + pending → approved → shapes dispatch
  - --wait + pending → denied
  - --wait + pending → revoked
  - --wait + pending → timeout with max-min mention
  - --wait + already-approved → immediate dispatch, no poll
  - --wait + pending → approved → escapes audience pipe
- [x] 8 existing async info block audience tests updated to new text structure
- [x] \`shell-grant-dispatch.test.ts\`: 27/27 green (unchanged)
- [x] \`commands-run-async.test.ts\`: 43/43 green
- [x] \`commands-grants-run.test.ts\`: 15/15 green (8 baseline + 7 new)
- [x] Full \`@openape/apes\` suite via turbo: **41 files / 495 green** (488 baseline from 0.10.0 + 7 new)
- [x] Pre-commit hook (turbo lint + typecheck): green
- [ ] Manual smoke post-merge: openclaw polls 2x, agent calls \`apes grants run --wait\`, yields, user approves, notifyOnExit fires, agent resumes with the \`date\` output

## Files touched

- \`packages/apes/src/grant-poll.ts\` — **new** shared module
- \`packages/apes/src/commands/run.ts\` — removed local poll-config helpers (moved to grant-poll.ts), rewrote agent-mode text block
- \`packages/apes/src/commands/grants/run.ts\` — new \`--wait\` flag + CLI-side polling
- \`packages/apes/test/commands-run-async.test.ts\` — 8 text assertions rewritten
- \`packages/apes/test/commands-grants-run.test.ts\` — new \`grant-poll\` mock + 7 new \`--wait\` tests

## Commits

- \`8200f95\` feat(apes): apes grants run --wait + simplified agent text block

Changeset: \`@openape/apes: patch\` → \`0.10.0 → 0.10.1\`. Patch because the default behavior of \`apes grants run <id>\` is unchanged — \`--wait\` is strictly additive.