### PR TITLE
feat(apes): align with escapes — APES_IDP, apes-cli, sudo guardrail

### DIFF
--- a/.changeset/escapes-alignment.md
+++ b/.changeset/escapes-alignment.md
@@ -1,0 +1,18 @@
+---
+'@openape/apes': minor
+---
+
+Align apes with the escapes naming and MIT-relicensed escapes repo:
+
+- `APES_IDP` is now the canonical env var for the IdP URL. `GRAPES_IDP`
+  remains as a deprecated alias — it still works, but emits a warning.
+  When both are set, `APES_IDP` wins.
+- OAuth `CLIENT_ID` used in the PKCE login flow is renamed from
+  `grapes-cli` to `apes-cli`. `openape-free-idp` accepts any client id,
+  so this is transparent there. Third-party IdPs with strict client
+  allowlists need to register `apes-cli` (a transitional phase
+  accepting both is recommended).
+- `ape-shell` now rejects bare `sudo <cmd>` lines with a clear hint
+  pointing at `apes run --as root -- <cmd>`, which routes through the
+  escapes setuid binary and requires a fresh grant per invocation.
+  Compound lines still fall through to the generic session-grant path.

--- a/packages/apes/src/commands/auth/login.ts
+++ b/packages/apes/src/commands/auth/login.ts
@@ -12,7 +12,12 @@ import { CliError } from '../../errors'
 import { resolveLoginInputs } from './resolve-login'
 
 const CALLBACK_PORT = 9876
-const CLIENT_ID = 'grapes-cli'
+// OAuth client ID registered with IdPs. Historically `grapes-cli`;
+// renamed to `apes-cli` as part of the apes/escapes naming alignment.
+// IdP operators must register this client id (free-idp already does;
+// third-party IdPs need a coordinated rollout with a transitional
+// period accepting both).
+const CLIENT_ID = 'apes-cli'
 
 export const loginCommand = defineCommand({
   meta: {

--- a/packages/apes/src/commands/auth/resolve-login.ts
+++ b/packages/apes/src/commands/auth/resolve-login.ts
@@ -75,6 +75,14 @@ export async function resolveLoginInputs(
   }
 
   // 3. IdP
+  // APES_IDP is the canonical env var. GRAPES_IDP is a deprecated alias
+  // kept for users with older shell profiles; APES_IDP wins on conflict.
+  if (process.env.APES_IDP && process.env.GRAPES_IDP) {
+    consola.warn(
+      'Both APES_IDP and GRAPES_IDP are set — using APES_IDP. '
+      + 'GRAPES_IDP is deprecated and will be removed in a future release.',
+    )
+  }
   let idp: string | undefined
   if (flags.idp) {
     idp = flags.idp
@@ -84,6 +92,10 @@ export async function resolveLoginInputs(
   }
   else if (process.env.GRAPES_IDP) {
     idp = process.env.GRAPES_IDP
+    consola.warn(
+      'GRAPES_IDP is deprecated, use APES_IDP instead. '
+      + 'GRAPES_IDP support will be removed in a future release.',
+    )
   }
   else if (config.defaults?.idp) {
     idp = config.defaults.idp

--- a/packages/apes/src/shell/grant-dispatch.ts
+++ b/packages/apes/src/shell/grant-dispatch.ts
@@ -87,6 +87,25 @@ export async function requestGrantForShellLine(
     return { kind: 'approved', grantId: 'shell-internal', mode: 'self' }
   }
 
+  // --- 0b. sudo reject ---
+  // `sudo` is not available inside ape-shell: the wrapper user is not in
+  // /etc/sudoers by design. Agents and humans should use the explicit
+  // `apes run --as root -- <cmd>` flow which routes through escapes and
+  // requires a fresh grant per invocation. We detect the literal `sudo`
+  // token at the line start (after trim) and return a denied result with
+  // a clear migration hint instead of silently handing the line to bash
+  // where it would fail with a less helpful error.
+  if (parsed && !parsed.isCompound && basename(parsed.executable) === 'sudo') {
+    const rest = parsed.argv.join(' ').trim()
+    const hint = rest.length > 0
+      ? `apes run --as root -- ${rest}`
+      : 'apes run --as root -- <cmd>'
+    return {
+      kind: 'denied',
+      reason: `sudo is not available in ape-shell. Use \`${hint}\` for privileged commands.`,
+    }
+  }
+
   // --- 1. Adapter path ---
   if (parsed && !parsed.isCompound) {
     try {

--- a/packages/apes/test/resolve-login.test.ts
+++ b/packages/apes/test/resolve-login.test.ts
@@ -1,6 +1,7 @@
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import consola from 'consola'
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Isolate HOME so config.ts and resolveLoginInputs see an empty world by default.
@@ -167,11 +168,30 @@ describe('resolveLoginInputs', () => {
 
   it('GRAPES_IDP is honored as a fallback alias for APES_IDP', async () => {
     process.env.GRAPES_IDP = 'https://grapes-idp.example.test'
+    const warnSpy = vi.spyOn(consola, 'warn').mockImplementation(() => {})
 
     const { resolveLoginInputs } = await import('../src/commands/auth/resolve-login')
     const result = await resolveLoginInputs({})
 
     expect(result.idp).toBe('https://grapes-idp.example.test')
+    // Deprecation hint must fire when the fallback is actually used.
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0]?.[0]).toMatch(/GRAPES_IDP is deprecated/)
+    warnSpy.mockRestore()
+  })
+
+  it('APES_IDP wins over GRAPES_IDP and emits a duplicate warning', async () => {
+    process.env.APES_IDP = 'https://apes-idp.example.test'
+    process.env.GRAPES_IDP = 'https://grapes-idp.example.test'
+    const warnSpy = vi.spyOn(consola, 'warn').mockImplementation(() => {})
+
+    const { resolveLoginInputs } = await import('../src/commands/auth/resolve-login')
+    const result = await resolveLoginInputs({})
+
+    expect(result.idp).toBe('https://apes-idp.example.test')
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0]?.[0]).toMatch(/Both APES_IDP and GRAPES_IDP/)
+    warnSpy.mockRestore()
   })
 })
 

--- a/packages/apes/test/shell-grant-dispatch.test.ts
+++ b/packages/apes/test/shell-grant-dispatch.test.ts
@@ -56,6 +56,56 @@ describe('requestGrantForShellLine', () => {
     expect(result).toEqual({ kind: 'denied', reason: expect.stringContaining('Not logged in') })
   })
 
+  it('rejects `sudo <cmd>` with a hint to use `apes run --as root -- <cmd>`', async () => {
+    const { parseShellCommand, loadOrInstallAdapter } = await import('../src/shapes/index.js')
+    vi.mocked(parseShellCommand).mockReturnValue({ executable: 'sudo', argv: ['apt', 'install', 'ffmpeg'], isCompound: false, raw: 'sudo apt install ffmpeg' })
+
+    const { requestGrantForShellLine } = await import('../src/shell/grant-dispatch.js')
+    const result = await requestGrantForShellLine('sudo apt install ffmpeg', { targetHost: 'host.test' })
+
+    expect(result).toEqual({
+      kind: 'denied',
+      reason: expect.stringContaining('apes run --as root -- apt install ffmpeg'),
+    })
+    // Must short-circuit before any adapter work.
+    expect(loadOrInstallAdapter).not.toHaveBeenCalled()
+  })
+
+  it('rejects bare `sudo` with a generic hint', async () => {
+    const { parseShellCommand } = await import('../src/shapes/index.js')
+    vi.mocked(parseShellCommand).mockReturnValue({ executable: 'sudo', argv: [], isCompound: false, raw: 'sudo' })
+
+    const { requestGrantForShellLine } = await import('../src/shell/grant-dispatch.js')
+    const result = await requestGrantForShellLine('sudo', { targetHost: 'host.test' })
+
+    expect(result).toEqual({
+      kind: 'denied',
+      reason: expect.stringContaining('apes run --as root -- <cmd>'),
+    })
+  })
+
+  it('does not short-circuit `sudo` when the leading token is not sudo', async () => {
+    // We only short-circuit the simple leading-`sudo` case which is the
+    // agent footgun we care about. Compound lines and lines where sudo
+    // appears later fall through to the generic session-grant path so
+    // the REPL can still negotiate a grant and bash surfaces the real
+    // error. Set up a minimal session-grant mock chain and assert the
+    // result is approved via the session path, not denied with our sudo
+    // message.
+    const { parseShellCommand } = await import('../src/shapes/index.js')
+    const { apiFetch } = await import('../src/http.js')
+    vi.mocked(parseShellCommand).mockReturnValue({ executable: 'echo', argv: ['foo', '|', 'sudo', 'tee'], isCompound: true, raw: 'echo foo | sudo tee /etc/x' })
+    vi.mocked(apiFetch)
+      .mockResolvedValueOnce({ data: [] } as any)
+      .mockResolvedValueOnce({ id: 'fallthrough-grant', status: 'pending' } as any)
+      .mockResolvedValueOnce({ status: 'approved' } as any)
+
+    const { requestGrantForShellLine } = await import('../src/shell/grant-dispatch.js')
+    const result = await requestGrantForShellLine('echo foo | sudo tee /etc/x', { targetHost: 'host.test' })
+
+    expect(result).toEqual({ kind: 'approved', grantId: 'fallthrough-grant', mode: 'session' })
+  })
+
   it('reuses an existing adapter grant when findExistingGrant returns one', async () => {
     const { parseShellCommand, loadOrInstallAdapter, resolveCommand, findExistingGrant, fetchGrantToken, verifyAndConsume, createShapesGrant } = await import('../src/shapes/index.js')
     vi.mocked(parseShellCommand).mockReturnValue({ executable: 'ls', argv: ['-la'], isCompound: false, raw: 'ls -la' })


### PR DESCRIPTION
## Summary

Three small, independent user-facing changes plus a changeset to align \`@openape/apes\` with the \`escapes\` naming and the MIT-relicensed \`escapes\` repo. Each decision was discussed and approved as part of the escapes-alignment plan.

**D1 — \`APES_IDP\` env var + \`GRAPES_IDP\` deprecation warning (\`d9b69b9\`)**

\`GRAPES_IDP\` is a historical artifact from the grapes-era CLI. It stays as a runtime fallback in \`resolveLoginInputs\` so users with older shell profiles keep working, but \`APES_IDP\` is now canonical and wins on conflict. A \`consola.warn\` fires when \`GRAPES_IDP\` is actually used, and another fires when both are set.

**D2 — OAuth \`CLIENT_ID\` \`grapes-cli\` → \`apes-cli\` (\`2722671\`)**

The PKCE login flow registered its browser client as \`grapes-cli\` for historical reasons. \`openape-free-idp\` accepts any client id (it only stores it in the refresh token family schema; no hard whitelist), so this is transparent there. Third-party IdPs with strict client allowlists will need to register \`apes-cli\`; a transitional phase accepting both is recommended.

**D3 — ape-shell rejects bare \`sudo <cmd>\` with an escapes hint (\`3047d03\`)**

Inside an ape-shell session, sudo is a dead end: the wrapper user is not in \`/etc/sudoers\` by design. Agents that habitually prefix commands with sudo hit a bash error with no guidance. \`grant-dispatch\` now detects a parsed, non-compound line whose leading executable is sudo and returns a denied result:

> \`sudo is not available in ape-shell. Use \\\`apes run --as root -- apt install ffmpeg\\\` for privileged commands.\`

Compound lines (\`echo x | sudo tee ...\`) fall through to the generic session-grant path — we only short-circuit the leading-sudo case which is the agent footgun.

## Changes

| Commit | File | Change |
|---|---|---|
| \`d9b69b9\` | \`packages/apes/src/commands/auth/resolve-login.ts\` | APES_IDP parallel + warnings |
| \`d9b69b9\` | \`packages/apes/test/resolve-login.test.ts\` | +2 tests (deprecation, duplicate) |
| \`2722671\` | \`packages/apes/src/commands/auth/login.ts\` | CLIENT_ID = 'apes-cli' + comment |
| \`3047d03\` | \`packages/apes/src/shell/grant-dispatch.ts\` | sudo short-circuit in requestGrantForShellLine |
| \`3047d03\` | \`packages/apes/test/shell-grant-dispatch.test.ts\` | +3 tests (sudo-with-args, bare sudo, compound fallthrough) |
| \`62c07a6\` | \`.changeset/escapes-alignment.md\` | minor bump |

## Companion PR

README/SKILL.md alignment + MIT relicense for the \`escapes\` Rust binary: openape-ai/escapes#6.

## Test plan

- [x] \`pnpm turbo run test --filter '@openape/apes'\` — 499 passed (41 files, +4 new)
- [x] \`pnpm turbo run typecheck --filter '@openape/apes'\` — green
- [x] Pre-commit hook (lint + typecheck) — green on all four commits
- [ ] CI green
- [ ] Manual smoke: \`APES_IDP=... apes login\` takes precedence over \`GRAPES_IDP\`
- [ ] Manual smoke: \`sudo whoami\` inside an ape-shell session prints the guardrail and does not hit bash

🤖 Generated with [Claude Code](https://claude.com/claude-code)