### PR TITLE
fix(apes): extend sudo guardrail to one-shot ape-shell -c path

### DIFF
--- a/.changeset/sudo-detection-one-shot.md
+++ b/.changeset/sudo-detection-one-shot.md
@@ -1,0 +1,20 @@
+---
+'@openape/apes': patch
+---
+
+Fix the `sudo` guardrail regression in the `ape-shell -c "<cmd>"` one-shot
+path. 0.11.0 added the detection only to the interactive REPL
+(`shell/grant-dispatch.ts`), but agents using openclaw's `bash-tools.exec`
+with `SHELL=ape-shell` take the one-shot path through `runShellMode` in
+`commands/run.ts` — which fell through to the generic session-grant flow
+and surfaced an opaque "sudo: a password is required" error with no
+guidance.
+
+`checkSudoRejection` is now a shared helper in `shell/apes-self-dispatch.ts`
+used by both paths. `ape-shell -c "sudo chown root:wheel /tmp/x"` now
+throws a `CliError` with the same migration hint the REPL produces:
+
+> sudo is not available in ape-shell. Use `apes run --as root -- chown root:wheel /tmp/x` for privileged commands.
+
+Compound lines (e.g. `echo x | sudo tee ...`) still fall through to the
+generic session-grant path in both dispatch paths.

--- a/packages/apes/src/commands/run.ts
+++ b/packages/apes/src/commands/run.ts
@@ -22,7 +22,7 @@ import { getPollMaxMinutes } from '../grant-poll'
 import { apiFetch, getGrantsEndpoint } from '../http'
 import { CliError, CliExit } from '../errors'
 import { notifyGrantPending } from '../notifications'
-import { isApesSelfDispatch } from '../shell/apes-self-dispatch'
+import { checkSudoRejection, isApesSelfDispatch } from '../shell/apes-self-dispatch'
 
 /**
  * Returns true when the caller asked for the legacy blocking path via
@@ -268,6 +268,15 @@ async function runShellMode(
       execShellCommand(command)
       return
     }
+    // --- 0b. sudo reject ---
+    // Parallels the REPL path in `shell/grant-dispatch.ts`. Agents that
+    // habitually prefix commands with `sudo` inside `ape-shell -c "…"`
+    // would otherwise silently fall through to the generic session-grant
+    // path and ultimately hit a bash error with no guidance. Short-circuit
+    // with an explicit migration hint to `apes run --as root -- <cmd>`.
+    const sudoRejection = checkSudoRejection(parsedInner)
+    if (sudoRejection)
+      throw new CliError(sudoRejection.reason)
   }
 
   // Try to handle this command via the shapes adapter system first.

--- a/packages/apes/src/shell/apes-self-dispatch.ts
+++ b/packages/apes/src/shell/apes-self-dispatch.ts
@@ -53,3 +53,41 @@ export function isApesSelfDispatch(parsed: ParsedShellCommand | null | undefined
     return false
   return !APES_GATED_SUBCOMMANDS.has(subCommand)
 }
+
+/**
+ * Result of checking a parsed shell command for a leading `sudo` token.
+ * The `reason` doubles as a ready-to-print error message so the REPL
+ * and one-shot paths emit byte-identical text.
+ */
+export interface SudoRejection {
+  reason: string
+}
+
+/**
+ * Returns a rejection hint if the parsed line is a simple, non-compound
+ * command whose leading executable is `sudo`. `sudo` is not available
+ * inside ape-shell (the wrapper user is not in /etc/sudoers by design),
+ * so agents and humans should use the explicit
+ * `apes run --as root -- <cmd>` flow which routes through the escapes
+ * setuid binary.
+ *
+ * Compound lines (pipes, &&, etc.) return null so the downstream
+ * session-grant path can still negotiate a grant and bash surfaces the
+ * real sudo error. We only short-circuit the leading-sudo case which is
+ * the agent footgun.
+ *
+ * Shared by both dispatch paths:
+ *   - Interactive REPL: `shell/grant-dispatch.ts` → `requestGrantForShellLine`
+ *   - One-shot `ape-shell -c`: `commands/run.ts` → `runShellMode`
+ */
+export function checkSudoRejection(parsed: ParsedShellCommand | null | undefined): SudoRejection | null {
+  if (!parsed || parsed.isCompound) return null
+  if (basename(parsed.executable) !== 'sudo') return null
+  const rest = parsed.argv.join(' ').trim()
+  const hint = rest.length > 0
+    ? `apes run --as root -- ${rest}`
+    : 'apes run --as root -- <cmd>'
+  return {
+    reason: `sudo is not available in ape-shell. Use \`${hint}\` for privileged commands.`,
+  }
+}

--- a/packages/apes/src/shell/grant-dispatch.ts
+++ b/packages/apes/src/shell/grant-dispatch.ts
@@ -13,7 +13,7 @@ import {
   verifyAndConsume,
   waitForGrantStatus,
 } from '../shapes/index.js'
-import { isApesSelfDispatch } from './apes-self-dispatch.js'
+import { checkSudoRejection, isApesSelfDispatch } from './apes-self-dispatch.js'
 
 /**
  * Result of attempting to obtain a grant for a shell line. On success the
@@ -88,22 +88,11 @@ export async function requestGrantForShellLine(
   }
 
   // --- 0b. sudo reject ---
-  // `sudo` is not available inside ape-shell: the wrapper user is not in
-  // /etc/sudoers by design. Agents and humans should use the explicit
-  // `apes run --as root -- <cmd>` flow which routes through escapes and
-  // requires a fresh grant per invocation. We detect the literal `sudo`
-  // token at the line start (after trim) and return a denied result with
-  // a clear migration hint instead of silently handing the line to bash
-  // where it would fail with a less helpful error.
-  if (parsed && !parsed.isCompound && basename(parsed.executable) === 'sudo') {
-    const rest = parsed.argv.join(' ').trim()
-    const hint = rest.length > 0
-      ? `apes run --as root -- ${rest}`
-      : 'apes run --as root -- <cmd>'
-    return {
-      kind: 'denied',
-      reason: `sudo is not available in ape-shell. Use \`${hint}\` for privileged commands.`,
-    }
+  // Shared logic lives in `apes-self-dispatch.ts` so the one-shot path
+  // in `commands/run.ts runShellMode` emits the same message.
+  const sudoRejection = checkSudoRejection(parsed)
+  if (sudoRejection) {
+    return { kind: 'denied', reason: sudoRejection.reason }
   }
 
   // --- 1. Adapter path ---

--- a/packages/apes/test/commands-run-async.test.ts
+++ b/packages/apes/test/commands-run-async.test.ts
@@ -802,6 +802,88 @@ describe('commands/run async default', () => {
   })
 
   // ------------------------------------------------------------------------
+  // one-shot `ape-shell -c "sudo <cmd>"` sudo rejection.
+  //
+  // The REPL path in shell/grant-dispatch.ts already short-circuits leading
+  // sudo with a hint to `apes run --as root -- <cmd>`. The one-shot path
+  // through runShellMode in commands/run.ts — which is what openclaw's
+  // bash-tools.exec hits when it has SHELL=ape-shell — missed the check and
+  // fell through to the generic session-grant flow, producing an opaque
+  // "sudo: a password is required" error with no guidance.
+  //
+  // These tests lock the symmetric behavior in: `apes run --shell --
+  // bash -c "sudo <cmd>"` throws a CliError with the same hint the REPL
+  // produces.
+  // ------------------------------------------------------------------------
+  describe('runShellMode sudo rejection', () => {
+    async function driveShellModeExpectError(inner: string, pattern: RegExp) {
+      const shapes = await import('../src/shapes/index.js')
+      vi.mocked(shapes.extractShellCommandString).mockReturnValue(inner)
+      const { runCommand } = await import('../src/commands/run.js')
+      await expect(runCommand.run!({
+        rawArgs: ['run', '--shell', '--', 'bash', '-c', inner],
+        args: { shell: true, wait: false, approval: 'once' } as any,
+      } as any)).rejects.toThrow(pattern)
+    }
+
+    it('`ape-shell -c "sudo chown root:wheel /tmp/x"` throws with apes run --as root hint', async () => {
+      const shapes = await import('../src/shapes/index.js')
+      vi.mocked(shapes.parseShellCommand).mockReturnValue({
+        executable: 'sudo',
+        argv: ['chown', 'root:wheel', '/tmp/x'],
+        isCompound: false,
+        raw: 'sudo chown root:wheel /tmp/x',
+      } as any)
+
+      await driveShellModeExpectError(
+        'sudo chown root:wheel /tmp/x',
+        /apes run --as root -- chown root:wheel \/tmp\/x/,
+      )
+
+      // Must short-circuit before the adapter or session-grant path.
+      expect(shapes.loadOrInstallAdapter).not.toHaveBeenCalled()
+    })
+
+    it('`ape-shell -c "sudo"` (bare) throws with the generic hint', async () => {
+      const shapes = await import('../src/shapes/index.js')
+      vi.mocked(shapes.parseShellCommand).mockReturnValue({
+        executable: 'sudo',
+        argv: [],
+        isCompound: false,
+        raw: 'sudo',
+      } as any)
+
+      await driveShellModeExpectError('sudo', /apes run --as root -- <cmd>/)
+    })
+
+    it('`ape-shell -c "echo foo | sudo tee /etc/x"` (compound) does NOT short-circuit', async () => {
+      const shapes = await import('../src/shapes/index.js')
+      vi.mocked(shapes.extractShellCommandString).mockReturnValue('echo foo | sudo tee /etc/x')
+      vi.mocked(shapes.parseShellCommand).mockReturnValue({
+        executable: 'echo',
+        argv: ['foo', '|', 'sudo', 'tee', '/etc/x'],
+        isCompound: true,
+        raw: 'echo foo | sudo tee /etc/x',
+      } as any)
+      vi.mocked(shapes.loadOrInstallAdapter).mockResolvedValue(null)
+
+      const { apiFetch } = await import('../src/http.js')
+      vi.mocked(apiFetch)
+        .mockResolvedValueOnce({ data: [] } as any)
+        .mockResolvedValueOnce({ id: 'compound-sudo-grant', status: 'pending' } as any)
+
+      // Compound lines fall through to the normal session-grant path.
+      const { runCommand } = await import('../src/commands/run.js')
+      await expectCliExit(runCommand.run!({
+        rawArgs: ['run', '--shell', '--', 'bash', '-c', 'echo foo | sudo tee /etc/x'],
+        args: { shell: true, wait: false, approval: 'once' } as any,
+      } as any), 75)
+
+      expect(apiFetch).toHaveBeenCalled()
+    })
+  })
+
+  // ------------------------------------------------------------------------
   // execShellCommand env strip — mirrors the Finding 4 fix from pty-bridge.ts
   // for the one-shot `ape-shell -c` path. Without this, nested `apes` in the
   // bash child inherits APES_SHELL_WRAPPER=1 and hits "unsupported invocation".


### PR DESCRIPTION
## Summary

0.11.0 (#106) added the \`sudo\` guardrail to the interactive REPL path (\`shell/grant-dispatch.ts\`) but missed the one-shot path in \`commands/run.ts runShellMode\`. Agents that use openclaw's \`bash-tools.exec\` with \`SHELL=ape-shell\` go through the one-shot path, so the live test \`sudo chown root:wheel /Users/openclaw/chown-test.txt\` silently fell through to the generic session-grant flow instead of printing the migration hint.

\`checkSudoRejection\` is now a shared helper in \`shell/apes-self-dispatch.ts\` (next to \`isApesSelfDispatch\`), consumed by both dispatch paths so the message is byte-identical.

Both paths now emit:
> sudo is not available in ape-shell. Use \`apes run --as root -- chown root:wheel /tmp/x\` for privileged commands.

Compound lines (\`echo foo | sudo tee ...\`) still fall through to the session-grant path in both dispatch paths — we only short-circuit the leading-sudo footgun.

## Files

| File | Change |
|---|---|
| \`packages/apes/src/shell/apes-self-dispatch.ts\` | +\`checkSudoRejection\` + \`SudoRejection\` type |
| \`packages/apes/src/shell/grant-dispatch.ts\` | REPL path consumes shared helper |
| \`packages/apes/src/commands/run.ts\` | \`runShellMode\` consumes shared helper; throws \`CliError\` on match |
| \`packages/apes/test/commands-run-async.test.ts\` | +3 tests (leading-sudo-with-args, bare sudo, compound fallthrough) |
| \`.changeset/sudo-detection-one-shot.md\` | patch bump |

## Test plan

- [x] \`pnpm turbo run test --filter '@openape/apes'\` — 502 passed (41 files, +3 new)
- [x] \`pnpm turbo run typecheck --filter '@openape/apes'\` — green
- [x] Pre-commit hook (lint + typecheck) — green
- [ ] CI green
- [ ] Live verify with openclaw: \`sudo chown ...\` prints the hint through \`bash-tools.exec\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)