### PR TITLE
fix(nuxt-auth-idp): read frame-ancestors from process.env at build time

### DIFF
--- a/modules/nuxt-auth-idp/src/module.ts
+++ b/modules/nuxt-auth-idp/src/module.ts
@@ -120,7 +120,10 @@ export default defineNuxtModule<ModuleOptions>({
     addImportsDir(resolve('./runtime/composables'))
 
     // Security headers
-    const frameAncestors = options.allowedFrameAncestors.trim()
+    // routeRules are build-time config, so we read the env var directly
+    // (Nuxt's NUXT_OPENAPE_IDP_* → runtimeConfig mapping only applies at
+    // request time, which is too late for static route headers).
+    const frameAncestors = (process.env.NUXT_OPENAPE_IDP_ALLOWED_FRAME_ANCESTORS || options.allowedFrameAncestors).trim()
     const securityHeaders: Record<string, string> = {
       'X-Content-Type-Options': 'nosniff',
       'Referrer-Policy': 'strict-origin-when-cross-origin',


### PR DESCRIPTION
routeRules are static build config — the env var must be read via `process.env` in the module setup, not through Nuxt's runtime config mapping which only resolves at request time.

Follow-up to #110.