### PR TITLE
fix(apes): allow apes run --as to self-dispatch from ape-shell

### DIFF
--- a/.changeset/run-as-self-dispatch.md
+++ b/.changeset/run-as-self-dispatch.md
@@ -1,0 +1,14 @@
+---
+'@openape/apes': patch
+---
+
+Allow `apes run --as <user>` to self-dispatch from inside ape-shell.
+
+When an agent inside ape-shell runs `apes run --as root -- <cmd>`, the
+inner `apes` process has its own escapes-audience grant flow. Previously,
+the ape-shell grant layer treated all `apes run` invocations as gated
+and fell through to a generic session-grant that never reached escapes.
+Now `apes run --as` is recognized as a self-dispatch, so the inner
+process handles the escapes grant flow directly.
+
+`apes run` without `--as` remains gated as before.

--- a/packages/apes/src/shell/apes-self-dispatch.ts
+++ b/packages/apes/src/shell/apes-self-dispatch.ts
@@ -51,7 +51,16 @@ export function isApesSelfDispatch(parsed: ParsedShellCommand | null | undefined
   const subCommand = parsed.argv[0]
   if (!subCommand)
     return false
-  return !APES_GATED_SUBCOMMANDS.has(subCommand)
+  if (!APES_GATED_SUBCOMMANDS.has(subCommand))
+    return true
+  // `apes run --as <user>` has its own internal escapes-audience grant
+  // flow (runAdapterMode delegates to runAudienceMode('escapes', ...)).
+  // Double-gating it through the ape-shell session-grant layer would
+  // fall through to a generic session grant that never reaches escapes.
+  // Let it self-dispatch so the inner apes process handles elevation.
+  if (subCommand === 'run' && parsed.argv.includes('--as'))
+    return true
+  return false
 }
 
 /**

--- a/packages/apes/test/commands-run-async.test.ts
+++ b/packages/apes/test/commands-run-async.test.ts
@@ -718,6 +718,32 @@ describe('commands/run async default', () => {
       expect(out).toContain('gated-grant')
     })
 
+    it('`ape-shell -c "apes run --as root -- brew services restart ollama"` self-dispatches (has its own escapes grant flow)', async () => {
+      const shapes = await import('../src/shapes/index.js')
+      vi.mocked(shapes.parseShellCommand).mockReturnValue({
+        executable: 'apes',
+        argv: ['run', '--as', 'root', '--', 'brew', 'services', 'restart', 'ollama'],
+        isCompound: false,
+        raw: 'apes run --as root -- brew services restart ollama',
+      } as any)
+
+      const { apiFetch } = await import('../src/http.js')
+
+      await driveShellMode('apes run --as root -- brew services restart ollama')
+
+      // Must self-dispatch — no adapter or session-grant path
+      expect(shapes.loadOrInstallAdapter).not.toHaveBeenCalled()
+      expect(apiFetch).not.toHaveBeenCalled()
+
+      // Must exec the inner command directly
+      const { execFileSync } = await import('node:child_process')
+      expect(execFileSync).toHaveBeenCalledWith(
+        'bash',
+        ['-c', 'apes run --as root -- brew services restart ollama'],
+        expect.objectContaining({ stdio: 'inherit' }),
+      )
+    })
+
     it('`ape-shell -c "apes fetch https://example.com"` STAYS gated', async () => {
       const shapes = await import('../src/shapes/index.js')
       vi.mocked(shapes.parseShellCommand).mockReturnValue({

--- a/packages/apes/test/shell-grant-dispatch.test.ts
+++ b/packages/apes/test/shell-grant-dispatch.test.ts
@@ -106,6 +106,44 @@ describe('requestGrantForShellLine', () => {
     expect(result).toEqual({ kind: 'approved', grantId: 'fallthrough-grant', mode: 'session' })
   })
 
+  it('`apes run --as root -- brew services restart ollama` self-dispatches (escapes flow)', async () => {
+    const { parseShellCommand, loadOrInstallAdapter } = await import('../src/shapes/index.js')
+    vi.mocked(parseShellCommand).mockReturnValue({
+      executable: 'apes',
+      argv: ['run', '--as', 'root', '--', 'brew', 'services', 'restart', 'ollama'],
+      isCompound: false,
+      raw: 'apes run --as root -- brew services restart ollama',
+    })
+
+    const { requestGrantForShellLine } = await import('../src/shell/grant-dispatch.js')
+    const result = await requestGrantForShellLine('apes run --as root -- brew services restart ollama', { targetHost: 'host.test' })
+
+    expect(result).toEqual({ kind: 'approved', grantId: 'shell-internal', mode: 'self' })
+    expect(loadOrInstallAdapter).not.toHaveBeenCalled()
+  })
+
+  it('`apes run -- echo hi` without --as STAYS gated', async () => {
+    const { parseShellCommand, loadOrInstallAdapter } = await import('../src/shapes/index.js')
+    const { apiFetch } = await import('../src/http.js')
+    vi.mocked(parseShellCommand).mockReturnValue({
+      executable: 'apes',
+      argv: ['run', '--', 'echo', 'hi'],
+      isCompound: false,
+      raw: 'apes run -- echo hi',
+    })
+    vi.mocked(loadOrInstallAdapter).mockResolvedValue(null)
+    vi.mocked(apiFetch)
+      .mockResolvedValueOnce({ data: [] } as any)
+      .mockResolvedValueOnce({ id: 'gated-run', status: 'pending' } as any)
+      .mockResolvedValueOnce({ status: 'approved' } as any)
+
+    const { requestGrantForShellLine } = await import('../src/shell/grant-dispatch.js')
+    const result = await requestGrantForShellLine('apes run -- echo hi', { targetHost: 'host.test' })
+
+    // Must NOT self-dispatch — no --as flag
+    expect(result).toEqual({ kind: 'approved', grantId: 'gated-run', mode: 'session' })
+  })
+
   it('reuses an existing adapter grant when findExistingGrant returns one', async () => {
     const { parseShellCommand, loadOrInstallAdapter, resolveCommand, findExistingGrant, fetchGrantToken, verifyAndConsume, createShapesGrant } = await import('../src/shapes/index.js')
     vi.mocked(parseShellCommand).mockReturnValue({ executable: 'ls', argv: ['-la'], isCompound: false, raw: 'ls -la' })


### PR DESCRIPTION
## Summary

When an agent inside ape-shell runs `apes run --as root -- brew services restart ollama`, the inner `apes` process has its own escapes-audience grant flow. Previously the shell grant layer treated ALL `apes run` as gated and fell through to a generic session-grant that never reached escapes — the agent saw endless session-grant approvals instead of an escapes grant.

`isApesSelfDispatch` now exempts `apes run --as <user>` from the blocklist. The inner apes process handles the escapes grant flow directly. `apes run` without `--as` remains gated.

## Test plan

- [x] 505 tests passing (+3 new)
- [x] Typecheck green
- [ ] CI green
- [ ] Live: agent runs `apes run --as root -- brew services restart ollama` from ape-shell → escapes grant created, not session grant

🤖 Generated with [Claude Code](https://claude.com/claude-code)