### PR TITLE
feat(nuxt-auth-idp): SSH key challenge-response login

### DIFF
--- a/apps/openape-free-idp/app/pages/login.vue
+++ b/apps/openape-free-idp/app/pages/login.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue'
-import { useKeyLogin } from '@openape/vue-components'
+import { onUnmounted, ref } from 'vue'
 
 useSeoMeta({ title: 'Login' })
 
@@ -9,10 +8,18 @@ const loginHint = (route.query.login_hint as string) || ''
 
 const email = ref(loginHint)
 const keyMode = ref(false)
-const privateKeyPem = ref('')
+
+// Challenge-response state
+const challenge = ref('')
+const signCommand = ref('')
+const signature = ref('')
+const challengeLoading = ref(false)
+const verifyLoading = ref(false)
+const challengeError = ref('')
+const countdown = ref(0)
+let countdownTimer: ReturnType<typeof setInterval> | null = null
 
 const { login, error: webauthnError, loading } = useWebAuthn()
-const { loginWithKey, loading: keyLoading, error: keyError } = useKeyLogin()
 const { fetchUser } = useIdpAuth()
 
 async function handlePasskeyLogin() {
@@ -29,9 +36,63 @@ async function handlePasskeyLogin() {
   }
 }
 
-async function handleKeyLogin() {
-  const ok = await loginWithKey(email.value, privateKeyPem.value)
-  if (ok) {
+async function requestChallenge() {
+  challengeError.value = ''
+  challenge.value = ''
+  signature.value = ''
+  if (!email.value) {
+    challengeError.value = 'Email is required'
+    return
+  }
+
+  challengeLoading.value = true
+  try {
+    const res = await $fetch<{ challenge: string }>('/api/auth/challenge', {
+      method: 'POST',
+      body: { id: email.value },
+    })
+    challenge.value = res.challenge
+    signCommand.value = `echo -n "${res.challenge}" | ssh-keygen -Y sign -f ~/.ssh/id_ed25519 -n openape`
+
+    // Start 60s countdown
+    countdown.value = 60
+    if (countdownTimer) clearInterval(countdownTimer)
+    countdownTimer = setInterval(() => {
+      countdown.value--
+      if (countdown.value <= 0) {
+        clearInterval(countdownTimer!)
+        countdownTimer = null
+        challenge.value = ''
+        challengeError.value = 'Challenge expired. Request a new one.'
+      }
+    }, 1000)
+  }
+  catch (err: unknown) {
+    const msg = (err as { data?: { title?: string } })?.data?.title
+    challengeError.value = msg || 'Failed to get challenge. Check your email.'
+  }
+  finally {
+    challengeLoading.value = false
+  }
+}
+
+async function submitSignature() {
+  challengeError.value = ''
+  if (!signature.value.trim()) {
+    challengeError.value = 'Paste the signature output'
+    return
+  }
+
+  verifyLoading.value = true
+  try {
+    await $fetch('/api/session/login', {
+      method: 'POST',
+      body: {
+        id: email.value,
+        challenge: challenge.value,
+        signature: signature.value.trim(),
+      },
+    })
     await fetchUser()
     const returnTo = route.query.returnTo as string
     if (returnTo) {
@@ -41,16 +102,33 @@ async function handleKeyLogin() {
       await navigateTo('/')
     }
   }
-}
-
-function handleFileSelect(event: Event) {
-  const file = (event.target as HTMLInputElement).files?.[0]
-  if (file) {
-    const reader = new FileReader()
-    reader.onload = () => { privateKeyPem.value = reader.result as string }
-    reader.readAsText(file)
+  catch (err: unknown) {
+    const msg = (err as { data?: { title?: string } })?.data?.title
+    challengeError.value = msg || 'Authentication failed. Check your signature.'
+  }
+  finally {
+    verifyLoading.value = false
   }
 }
+
+function resetChallenge() {
+  challenge.value = ''
+  signature.value = ''
+  challengeError.value = ''
+  countdown.value = 0
+  if (countdownTimer) {
+    clearInterval(countdownTimer)
+    countdownTimer = null
+  }
+}
+
+function copyCommand() {
+  navigator.clipboard.writeText(signCommand.value)
+}
+
+onUnmounted(() => {
+  if (countdownTimer) clearInterval(countdownTimer)
+})
 </script>
 
 <template>
@@ -92,53 +170,92 @@ function handleFileSelect(event: Event) {
         </UButton>
       </form>
 
-      <!-- Key mode (pro mode) -->
-      <form v-else class="w-full space-y-4" @submit.prevent="handleKeyLogin">
-        <UInput
-          v-model="email"
-          type="email"
-          placeholder="you@example.com"
-          icon="i-lucide-mail"
-          size="xl"
-          class="w-full"
-        />
+      <!-- SSH Key challenge-response mode -->
+      <div v-else class="w-full space-y-4">
+        <!-- Step 1: Email + Get Challenge -->
+        <div v-if="!challenge" class="space-y-4">
+          <UInput
+            v-model="email"
+            type="email"
+            placeholder="you@example.com"
+            icon="i-lucide-mail"
+            size="xl"
+            class="w-full"
+            @keydown.enter="requestChallenge"
+          />
 
-        <UTextarea
-          v-model="privateKeyPem"
-          placeholder="Paste your ed25519 private key..."
-          :rows="4"
-          class="w-full font-mono text-xs"
-        />
+          <UButton
+            color="primary"
+            size="xl"
+            block
+            :loading="challengeLoading"
+            :disabled="!email || challengeLoading"
+            icon="i-lucide-key-round"
+            @click="requestChallenge"
+          >
+            Get Challenge
+          </UButton>
+        </div>
 
-        <input
-          type="file"
-          accept=".pem,.key,id_ed25519"
-          class="text-sm text-gray-400"
-          @change="handleFileSelect"
-        >
+        <!-- Step 2: Sign + Submit -->
+        <div v-else class="space-y-4 text-left">
+          <div class="text-sm text-gray-400">
+            Sign this challenge with your private key <span class="text-gray-500">({{ countdown }}s)</span>
+          </div>
 
-        <UButton
-          type="submit"
-          color="primary"
-          size="xl"
-          block
-          :loading="keyLoading"
-          :disabled="!email || !privateKeyPem || keyLoading"
-          icon="i-lucide-key-round"
-        >
-          Sign in with Key
-        </UButton>
-      </form>
+          <div class="relative">
+            <pre class="bg-gray-900 border border-gray-700 rounded-lg p-3 text-xs text-green-400 font-mono whitespace-pre-wrap break-all overflow-x-auto">{{ signCommand }}</pre>
+            <button
+              class="absolute top-2 right-2 text-gray-500 hover:text-white transition-colors"
+              title="Copy to clipboard"
+              @click="copyCommand"
+            >
+              <UIcon name="i-lucide-copy" class="w-4 h-4" />
+            </button>
+          </div>
 
-      <p v-if="webauthnError || keyError" class="mt-3 text-sm text-red-400 text-center">
-        {{ webauthnError || keyError }}
+          <div class="text-xs text-gray-500">
+            Your key never leaves your machine.
+          </div>
+
+          <UTextarea
+            v-model="signature"
+            placeholder="Paste the signature output here..."
+            :rows="5"
+            class="w-full font-mono text-xs"
+          />
+
+          <div class="flex gap-2">
+            <UButton
+              color="primary"
+              size="xl"
+              class="flex-1"
+              :loading="verifyLoading"
+              :disabled="!signature.trim() || verifyLoading"
+              icon="i-lucide-log-in"
+              @click="submitSignature"
+            >
+              Sign In
+            </UButton>
+            <UButton
+              variant="ghost"
+              size="xl"
+              icon="i-lucide-rotate-ccw"
+              @click="resetChallenge"
+            />
+          </div>
+        </div>
+      </div>
+
+      <p v-if="webauthnError || challengeError" class="mt-3 text-sm text-red-400 text-center">
+        {{ webauthnError || challengeError }}
       </p>
 
       <button
         class="mt-4 text-sm text-gray-500 hover:text-gray-300 transition-colors"
-        @click="keyMode = !keyMode"
+        @click="keyMode = !keyMode; resetChallenge()"
       >
-        {{ keyMode ? 'Sign in with Passkey instead' : 'Sign in with private key instead' }}
+        {{ keyMode ? 'Sign in with Passkey instead' : 'Sign in with SSH Key instead' }}
       </button>
 
       <div class="mt-6 text-sm text-gray-500">

--- a/modules/nuxt-auth-idp/src/runtime/server/api/session/login.post.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/api/session/login.post.ts
@@ -2,6 +2,7 @@ import { defineEventHandler, readBody } from 'h3'
 import { useIdpStores } from '../../utils/stores'
 import { useGrantStores } from '../../utils/grant-stores'
 import { verifyEd25519Signature } from '../../utils/ed25519'
+import { verifySSHSignature } from '../../utils/sshsig'
 import { getAppSession } from '../../utils/session'
 import { createProblemError } from '../../utils/problem'
 
@@ -50,8 +51,17 @@ export default defineEventHandler(async (event) => {
     throw createProblemError({ status: 401, title: 'Invalid, expired, or already used challenge' })
   }
 
-  const signatureBuffer = Buffer.from(body.signature, 'base64')
-  const isValid = verifyEd25519Signature(sshKey.publicKey, body.challenge, signatureBuffer)
+  const signatureStr = body.signature.trim()
+  let isValid: boolean
+  if (signatureStr.startsWith('-----BEGIN SSH SIGNATURE-----')) {
+    // SSHSIG format from `ssh-keygen -Y sign -n openape`
+    isValid = verifySSHSignature(sshKey.publicKey, body.challenge, signatureStr, 'openape')
+  }
+  else {
+    // Raw base64 Ed25519 signature (from apes login / Web Crypto / openssl)
+    const signatureBuffer = Buffer.from(signatureStr, 'base64')
+    isValid = verifyEd25519Signature(sshKey.publicKey, body.challenge, signatureBuffer)
+  }
   if (!isValid) {
     throw createProblemError({ status: 401, title: 'Invalid signature', type: 'https://ddisa.org/errors/invalid_token' })
   }

--- a/modules/nuxt-auth-idp/src/runtime/server/utils/sshsig.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/utils/sshsig.ts
@@ -1,0 +1,127 @@
+import { createHash, createPublicKey, verify } from 'node:crypto'
+
+const SSHSIG_MAGIC = 'SSHSIG'
+const ED25519_SPKI_PREFIX = Buffer.from('302a300506032b6570032100', 'hex')
+
+// SSH wire format helpers: each value is prefixed with a uint32 big-endian length.
+function readString(buf: Buffer, offset: number): { value: Buffer, next: number } {
+  const len = buf.readUInt32BE(offset)
+  const value = buf.subarray(offset + 4, offset + 4 + len)
+  return { value, next: offset + 4 + len }
+}
+
+function wireString(s: string): Buffer {
+  const data = Buffer.from(s)
+  const len = Buffer.alloc(4)
+  len.writeUInt32BE(data.length)
+  return Buffer.concat([len, data])
+}
+
+function wireBuffer(buf: Buffer): Buffer {
+  const len = Buffer.alloc(4)
+  len.writeUInt32BE(buf.length)
+  return Buffer.concat([len, buf])
+}
+
+/**
+ * Verify an SSH signature produced by `ssh-keygen -Y sign`.
+ *
+ * The SSHSIG format wraps the Ed25519 signature with metadata (namespace,
+ * hash algorithm) and signs a structured message rather than the raw data:
+ *
+ *   signed_data = "SSHSIG"
+ *               + wire(namespace)
+ *               + wire(reserved = "")
+ *               + wire(hash_algorithm)
+ *               + wire(hash(message))
+ *
+ * This function parses the PEM envelope, extracts the raw 64-byte Ed25519
+ * signature, reconstructs the signed_data, and verifies using the known
+ * SSH public key.  Uses only Node.js native crypto — no external deps.
+ */
+export function verifySSHSignature(
+  sshPublicKey: string,
+  message: string,
+  signaturePem: string,
+  expectedNamespace: string,
+): boolean {
+  // 1. Strip PEM armor and decode
+  const b64 = signaturePem
+    .replace(/-----BEGIN SSH SIGNATURE-----/, '')
+    .replace(/-----END SSH SIGNATURE-----/, '')
+    .replace(/\s/g, '')
+  const blob = Buffer.from(b64, 'base64')
+
+  let offset = 0
+
+  // 2. Validate magic
+  const magic = blob.subarray(offset, offset + 6).toString()
+  if (magic !== SSHSIG_MAGIC) return false
+  offset += 6
+
+  // 3. Version (uint32, must be 1)
+  const version = blob.readUInt32BE(offset)
+  if (version !== 1) return false
+  offset += 4
+
+  // 4. Skip public key blob (we use the known key, not the embedded one)
+  const pubKeyBlob = readString(blob, offset)
+  offset = pubKeyBlob.next
+
+  // 5. Namespace — must match expected
+  const namespace = readString(blob, offset)
+  offset = namespace.next
+  if (namespace.value.toString() !== expectedNamespace) return false
+
+  // 6. Reserved (should be empty)
+  const reserved = readString(blob, offset)
+  offset = reserved.next
+
+  // 7. Hash algorithm
+  const hashAlgo = readString(blob, offset)
+  offset = hashAlgo.next
+  const hashAlgoStr = hashAlgo.value.toString()
+
+  // 8. Signature blob — contains: algo type string + raw signature
+  const sigBlob = readString(blob, offset)
+  const sigBlobBuf = sigBlob.value
+
+  let sigOffset = 0
+  const sigAlgo = readString(sigBlobBuf, sigOffset)
+  sigOffset = sigAlgo.next
+  if (sigAlgo.value.toString() !== 'ssh-ed25519') return false
+
+  const rawSig = readString(sigBlobBuf, sigOffset)
+  if (rawSig.value.length !== 64) return false
+
+  // 9. Reconstruct the signed message
+  const messageHash = createHash(hashAlgoStr.replace('-', ''))
+    .update(Buffer.from(message))
+    .digest()
+
+  const signedData = Buffer.concat([
+    Buffer.from(SSHSIG_MAGIC),
+    wireString(expectedNamespace),
+    wireString(''), // reserved
+    wireString(hashAlgoStr),
+    wireBuffer(messageHash),
+  ])
+
+  // 10. Parse public key and verify
+  const parts = sshPublicKey.trim().split(/\s+/)
+  if (parts[0] !== 'ssh-ed25519' || !parts[1]) return false
+
+  const wireFormat = Buffer.from(parts[1], 'base64')
+  let wOffset = 0
+  const typeLen = wireFormat.readUInt32BE(wOffset)
+  wOffset += 4 + typeLen
+  const keyLen = wireFormat.readUInt32BE(wOffset)
+  wOffset += 4
+  const rawKey = wireFormat.subarray(wOffset, wOffset + keyLen)
+  if (rawKey.length !== 32) return false
+
+  const spkiDer = Buffer.concat([ED25519_SPKI_PREFIX, rawKey])
+  const pubKey = createPublicKey({ key: spkiDer, format: 'der', type: 'spki' })
+
+  return verify(null, signedData, pubKey, rawSig.value)
+}


### PR DESCRIPTION
## Summary

Replaces the "paste your private key" login flow with a secure challenge-response approach. The private key never leaves the user's machine.

**Flow:**
1. User enters email → clicks "Get Challenge"
2. IdP shows the challenge hex string + a ready-to-copy `ssh-keygen -Y sign` command
3. User runs the command locally, pastes the SSH signature PEM output
4. Server verifies and sets the browser session

**New: `sshsig.ts`** — parses the SSHSIG format produced by `ssh-keygen -Y sign`, reconstructs the signed preamble (magic + namespace + SHA-512 hash), and verifies with native Node.js Ed25519 crypto. Zero external dependencies.

**`session/login.post.ts`** — auto-detects signature format:
- `-----BEGIN SSH SIGNATURE-----` → SSHSIG path (ssh-keygen)
- Raw base64 → existing Ed25519 path (apes login / Web Crypto)

Both paths remain functional — `apes login` is unaffected.

## Test plan

- [ ] ssh-keygen: challenge → sign → paste PEM → logged in
- [ ] Passkey login still works (regression)
- [ ] Invalid signature → clear error
- [ ] Wrong namespace (`-n wrong`) → error
- [ ] Challenge expires after 60s → countdown + error
- [ ] `apes login` unaffected (raw base64 path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)