### PR TITLE
feat(nuxt-auth-idp): self-service SSH key management on account page

### DIFF
--- a/modules/nuxt-auth-idp/src/runtime/pages/account.vue
+++ b/modules/nuxt-auth-idp/src/runtime/pages/account.vue
@@ -11,13 +11,21 @@ const credentialsLoading = ref(false)
 const error = ref('')
 const success = ref('')
 const newDeviceName = ref('')
+
+// SSH Keys
+const sshKeys = ref([])
+const sshKeysLoading = ref(false)
+const newSshKey = ref('')
+const newSshKeyName = ref('')
+const sshKeyAdding = ref(false)
+
 onMounted(async () => {
   await fetchUser()
   if (!user.value) {
     await navigateTo('/login')
     return
   }
-  await loadCredentials()
+  await Promise.all([loadCredentials(), loadSshKeys()])
 })
 async function loadCredentials() {
   credentialsLoading.value = true
@@ -64,6 +72,57 @@ function deviceLabel(c) {
   if (c.name) return c.name
   if (c.deviceType === 'multiDevice') return 'Synced Passkey'
   return 'Device-bound Passkey'
+}
+
+async function loadSshKeys() {
+  sshKeysLoading.value = true
+  try {
+    sshKeys.value = await $fetch('/api/session/ssh-keys')
+  }
+  catch {
+    sshKeys.value = []
+  }
+  finally {
+    sshKeysLoading.value = false
+  }
+}
+async function handleAddSshKey() {
+  error.value = ''
+  success.value = ''
+  sshKeyAdding.value = true
+  try {
+    await $fetch('/api/session/ssh-keys', {
+      method: 'POST',
+      body: { publicKey: newSshKey.value, name: newSshKeyName.value || undefined },
+    })
+    success.value = 'SSH key added. You can now use "Sign in with SSH Key" on the login page.'
+    newSshKey.value = ''
+    newSshKeyName.value = ''
+    await loadSshKeys()
+  }
+  catch (err) {
+    const e = err
+    error.value = e.data?.title ?? 'Failed to add SSH key'
+  }
+  finally {
+    sshKeyAdding.value = false
+  }
+}
+async function handleDeleteSshKey(keyId) {
+  if (!confirm('Remove this SSH key?'))
+    return
+  error.value = ''
+  try {
+    await $fetch(`/api/session/ssh-keys/${encodeURIComponent(keyId)}`, { method: 'DELETE' })
+    await loadSshKeys()
+  }
+  catch (err) {
+    const e = err
+    error.value = e.data?.title ?? 'Failed to remove SSH key'
+  }
+}
+function fingerprint(keyId) {
+  return `SHA256:${keyId.substring(0, 16)}...`
 }
 </script>
 
@@ -166,6 +225,95 @@ function deviceLabel(c) {
                     color="error"
                     :disabled="credentials.length <= 1"
                     @click="handleDeleteCredential(c.credentialId)"
+                  >
+                    Remove
+                  </UButton>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </UCard>
+
+        <UCard class="mt-6 mb-6">
+          <template #header>
+            <h2 class="text-lg font-semibold">
+              Add SSH Key
+            </h2>
+            <p class="text-sm text-muted mt-1">
+              Register your public key to use "Sign in with SSH Key" on the login page.
+            </p>
+          </template>
+
+          <div class="space-y-3">
+            <UFormField label="Name (optional)">
+              <UInput v-model="newSshKeyName" placeholder="e.g. Work Laptop" />
+            </UFormField>
+            <UFormField label="Public Key">
+              <UTextarea
+                v-model="newSshKey"
+                placeholder="ssh-ed25519 AAAA... (paste contents of ~/.ssh/id_ed25519.pub)"
+                :rows="2"
+                class="font-mono text-xs"
+              />
+            </UFormField>
+            <UButton
+              color="primary"
+              :loading="sshKeyAdding"
+              :disabled="!newSshKey.trim() || sshKeyAdding"
+              @click="handleAddSshKey"
+            >
+              Add SSH Key
+            </UButton>
+          </div>
+        </UCard>
+
+        <UCard :ui="{ body: 'p-0' }">
+          <template #header>
+            <h2 class="text-lg font-semibold">
+              SSH Keys
+            </h2>
+          </template>
+
+          <div v-if="sshKeysLoading" class="p-6 text-center text-muted">
+            Loading...
+          </div>
+          <div v-else-if="sshKeys.length === 0" class="p-6 text-center text-muted">
+            No SSH keys registered.
+          </div>
+          <table v-else class="w-full">
+            <thead class="border-b border-(--ui-border)">
+              <tr>
+                <th class="text-left px-4 py-3 text-xs font-medium text-muted uppercase">
+                  Name
+                </th>
+                <th class="text-left px-4 py-3 text-xs font-medium text-muted uppercase">
+                  Fingerprint
+                </th>
+                <th class="text-left px-4 py-3 text-xs font-medium text-muted uppercase">
+                  Added
+                </th>
+                <th class="text-right px-4 py-3 text-xs font-medium text-muted uppercase">
+                  Actions
+                </th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-(--ui-border)">
+              <tr v-for="k in sshKeys" :key="k.keyId" class="odd:bg-(--ui-bg-elevated)/40 even:bg-(--ui-bg) hover:bg-(--ui-bg-elevated)">
+                <td class="px-4 py-3 text-sm">
+                  {{ k.name }}
+                </td>
+                <td class="px-4 py-3 text-xs font-mono text-muted">
+                  {{ fingerprint(k.keyId) }}
+                </td>
+                <td class="px-4 py-3 text-xs text-muted">
+                  {{ formatDate(k.createdAt) }}
+                </td>
+                <td class="px-4 py-3 text-right">
+                  <UButton
+                    variant="ghost"
+                    size="xs"
+                    color="error"
+                    @click="handleDeleteSshKey(k.keyId)"
                   >
                     Remove
                   </UButton>

--- a/modules/nuxt-auth-idp/src/runtime/server/api/session/ssh-keys.get.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/api/session/ssh-keys.get.ts
@@ -1,0 +1,15 @@
+import { defineEventHandler } from 'h3'
+import { getAppSession } from '../../utils/session'
+import { useIdpStores } from '../../utils/stores'
+import { createProblemError } from '../../utils/problem'
+
+export default defineEventHandler(async (event) => {
+  const session = await getAppSession(event)
+  const email = session.data.userId as string | undefined
+  if (!email) {
+    throw createProblemError({ status: 401, title: 'Not authenticated' })
+  }
+
+  const { sshKeyStore } = useIdpStores()
+  return await sshKeyStore.findByUser(email)
+})

--- a/modules/nuxt-auth-idp/src/runtime/server/api/session/ssh-keys.post.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/api/session/ssh-keys.post.ts
@@ -1,0 +1,54 @@
+import { createHash } from 'node:crypto'
+import { defineEventHandler, readBody } from 'h3'
+import { getAppSession } from '../../utils/session'
+import { useIdpStores } from '../../utils/stores'
+import { sshEd25519ToKeyObject } from '../../utils/ed25519'
+import { createProblemError } from '../../utils/problem'
+
+export default defineEventHandler(async (event) => {
+  const session = await getAppSession(event)
+  const email = session.data.userId as string | undefined
+  if (!email) {
+    throw createProblemError({ status: 401, title: 'Not authenticated' })
+  }
+
+  const body = await readBody<{ publicKey: string, name?: string }>(event)
+  if (!body.publicKey || typeof body.publicKey !== 'string') {
+    throw createProblemError({ status: 400, title: 'Missing required field: publicKey' })
+  }
+
+  const trimmedKey = body.publicKey.trim()
+
+  // Validate ssh-ed25519 format
+  try {
+    sshEd25519ToKeyObject(trimmedKey)
+  }
+  catch {
+    throw createProblemError({ status: 400, title: 'Invalid SSH key. Must be ssh-ed25519 format (paste the contents of ~/.ssh/id_ed25519.pub).' })
+  }
+
+  const parts = trimmedKey.split(/\s+/)
+  const comment = parts.length >= 3 ? parts.slice(2).join(' ') : undefined
+  const name = body.name || comment || 'SSH Key'
+
+  const keyData = parts[1]!
+  const keyId = createHash('sha256').update(Buffer.from(keyData, 'base64')).digest('hex')
+
+  const { sshKeyStore } = useIdpStores()
+
+  const existing = await sshKeyStore.findByPublicKey(trimmedKey)
+  if (existing) {
+    throw createProblemError({ status: 409, title: 'This SSH key is already registered' })
+  }
+
+  const sshKey = {
+    keyId,
+    userEmail: email,
+    publicKey: trimmedKey,
+    name,
+    createdAt: Math.floor(Date.now() / 1000),
+  }
+
+  await sshKeyStore.save(sshKey)
+  return sshKey
+})

--- a/modules/nuxt-auth-idp/src/runtime/server/api/session/ssh-keys/[keyId].delete.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/api/session/ssh-keys/[keyId].delete.ts
@@ -1,0 +1,26 @@
+import { defineEventHandler, getRouterParam } from 'h3'
+import { getAppSession } from '../../../utils/session'
+import { useIdpStores } from '../../../utils/stores'
+import { createProblemError } from '../../../utils/problem'
+
+export default defineEventHandler(async (event) => {
+  const session = await getAppSession(event)
+  const email = session.data.userId as string | undefined
+  if (!email) {
+    throw createProblemError({ status: 401, title: 'Not authenticated' })
+  }
+
+  const keyId = decodeURIComponent(getRouterParam(event, 'keyId') || '')
+  if (!keyId) {
+    throw createProblemError({ status: 400, title: 'Key ID is required' })
+  }
+
+  const { sshKeyStore } = useIdpStores()
+  const key = await sshKeyStore.findById(keyId)
+  if (!key || key.userEmail !== email) {
+    throw createProblemError({ status: 404, title: 'SSH key not found' })
+  }
+
+  await sshKeyStore.delete(keyId)
+  return { ok: true }
+})


### PR DESCRIPTION
## Summary

Follow-up to #114 (SSH key challenge-response login). Users can now register their SSH public keys themselves from the account page — no admin API needed.

**New endpoints** (session-authenticated):
- `GET /api/session/ssh-keys` — list my keys
- `POST /api/session/ssh-keys` — add key (paste `~/.ssh/id_ed25519.pub`)
- `DELETE /api/session/ssh-keys/:keyId` — remove key (ownership verified)

**Account page** gains "Add SSH Key" form + "SSH Keys" table.

**Full flow now:**
1. Login with Passkey → Account → Add SSH Key (paste public key)
2. Next login: "Sign in with SSH Key" → Challenge → `ssh-keygen -Y sign` → done

🤖 Generated with [Claude Code](https://claude.com/claude-code)