### PR TITLE
fix(nuxt-auth-idp): register SSH key session endpoints

### DIFF
--- a/modules/nuxt-auth-idp/src/module.ts
+++ b/modules/nuxt-auth-idp/src/module.ts
@@ -213,6 +213,9 @@ export default defineNuxtModule<ModuleOptions>({
       addServerHandler({ route: '/api/logout', method: 'post', handler: resolve('./runtime/server/api/logout.post') })
       addServerHandler({ route: '/api/session/login', method: 'post', handler: resolve('./runtime/server/api/session/login.post') })
       addServerHandler({ route: '/api/session/logout', method: 'post', handler: resolve('./runtime/server/api/session/logout.post') })
+      addServerHandler({ route: '/api/session/ssh-keys', handler: resolve('./runtime/server/api/session/ssh-keys.get') })
+      addServerHandler({ route: '/api/session/ssh-keys', method: 'post', handler: resolve('./runtime/server/api/session/ssh-keys.post') })
+      addServerHandler({ route: '/api/session/ssh-keys/:keyId', method: 'delete', handler: resolve('./runtime/server/api/session/ssh-keys/[keyId].delete') })
       addServerHandler({ route: '/api/me', handler: resolve('./runtime/server/api/me.get') })
 
       // WebAuthn Registration


### PR DESCRIPTION
The SSH key endpoints were added as files but not registered via addServerHandler. Follow-up to #115.