### PR TITLE
fix(nuxt-auth-idp): increase challenge TTL from 60s to 5 minutes

### DIFF
--- a/apps/openape-free-idp/app/pages/login.vue
+++ b/apps/openape-free-idp/app/pages/login.vue
@@ -54,8 +54,8 @@ async function requestChallenge() {
     challenge.value = res.challenge
     signCommand.value = `echo -n "${res.challenge}" | ssh-keygen -Y sign -f ~/.ssh/id_ed25519 -n openape`
 
-    // Start 60s countdown
-    countdown.value = 60
+    // Start 5min countdown (matches server-side challenge TTL)
+    countdown.value = 300
     if (countdownTimer) clearInterval(countdownTimer)
     countdownTimer = setInterval(() => {
       countdown.value--

--- a/modules/nuxt-auth-idp/src/runtime/server/utils/grant-challenge-store.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/utils/grant-challenge-store.ts
@@ -21,7 +21,7 @@ export function createGrantChallengeStore(): ChallengeStore {
       await storage.setItem<StoredChallenge>(`challenges:${challenge}`, {
         challenge,
         agentId,
-        expiresAt: Date.now() + 60_000,
+        expiresAt: Date.now() + 300_000,
       })
       return challenge
     },


### PR DESCRIPTION
60s is too tight for a manual ssh-keygen sign flow. 5 minutes is plenty.