### PR TITLE
fix(nuxt-auth-idp): sameSite=none for session cookie when embedded in iframe

### DIFF
--- a/modules/nuxt-auth-idp/src/runtime/server/utils/session.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/utils/session.ts
@@ -7,6 +7,10 @@ export async function getAppSession(event: H3Event) {
   const idpConfig = config.openapeIdp as Record<string, unknown>
   const slug = event.context?.openapeTenantSlug as string | undefined
   const sessionName = slug ? `openape-idp-${slug}` : 'openape-idp'
+  // When the IdP is embedded in an iframe (allowedFrameAncestors is set),
+  // cookies must use sameSite: 'none' or the browser will reject them in
+  // the cross-origin context. 'none' requires secure: true (already set).
+  const embeddable = !!(process.env.NUXT_OPENAPE_IDP_ALLOWED_FRAME_ANCESTORS || idpConfig.allowedFrameAncestors)
   return await useSession(event, {
     name: sessionName,
     password: idpConfig.sessionSecret as string,
@@ -14,7 +18,7 @@ export async function getAppSession(event: H3Event) {
     cookie: {
       secure: true,
       httpOnly: true,
-      sameSite: 'lax',
+      sameSite: embeddable ? 'none' : 'lax',
     },
   })
 }


### PR DESCRIPTION
Browsers reject sameSite=lax cookies in cross-origin iframes. When allowedFrameAncestors is configured, switch to sameSite=none (secure=true already set). Default stays lax.