### PR TITLE
fix: auto-detect SSH key for multi-key users

### DIFF
--- a/modules/nuxt-auth-idp/src/runtime/server/api/auth/authenticate.post.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/api/auth/authenticate.post.ts
@@ -21,23 +21,20 @@ export default defineEventHandler(async (event) => {
   const { sshKeyStore, userStore, keyStore } = useIdpStores()
   const { challengeStore } = useGrantStores()
 
-  // Find SSH key to verify against
-  let sshKey
+  // Find SSH key(s) to verify against
+  let keys
   if (body.public_key) {
-    sshKey = await sshKeyStore.findByPublicKey(body.public_key)
+    const sshKey = await sshKeyStore.findByPublicKey(body.public_key)
     if (!sshKey || sshKey.userEmail !== body.id) {
       throw createProblemError({ status: 404, title: 'SSH key not found for this user' })
     }
+    keys = [sshKey]
   }
   else {
-    const keys = await sshKeyStore.findByUser(body.id)
+    keys = await sshKeyStore.findByUser(body.id)
     if (keys.length === 0) {
       throw createProblemError({ status: 404, title: 'No user with SSH keys found' })
     }
-    if (keys.length > 1) {
-      throw createProblemError({ status: 400, title: 'Multiple SSH keys registered. Specify public_key to identify which key to use.' })
-    }
-    sshKey = keys[0]!
   }
 
   // Verify user exists
@@ -51,8 +48,15 @@ export default defineEventHandler(async (event) => {
     throw createProblemError({ status: 401, title: 'Invalid, expired, or already used challenge' })
   }
 
+  // Try each registered key until one verifies
   const signatureBuffer = Buffer.from(body.signature, 'base64')
-  const isValid = verifyEd25519Signature(sshKey.publicKey, body.challenge, signatureBuffer)
+  let isValid = false
+  for (const key of keys) {
+    if (verifyEd25519Signature(key.publicKey, body.challenge, signatureBuffer)) {
+      isValid = true
+      break
+    }
+  }
   if (!isValid) {
     throw createProblemError({ status: 401, title: 'Invalid signature', type: 'https://ddisa.org/errors/invalid_token' })
   }

--- a/modules/nuxt-auth-idp/src/runtime/server/api/session/login.post.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/api/session/login.post.ts
@@ -21,23 +21,20 @@ export default defineEventHandler(async (event) => {
   const { sshKeyStore, userStore } = useIdpStores()
   const { challengeStore } = useGrantStores()
 
-  // Find SSH key to verify against
-  let sshKey
+  // Find SSH key(s) to verify against
+  let keys
   if (body.public_key) {
-    sshKey = await sshKeyStore.findByPublicKey(body.public_key)
+    const sshKey = await sshKeyStore.findByPublicKey(body.public_key)
     if (!sshKey || sshKey.userEmail !== body.id) {
       throw createProblemError({ status: 404, title: 'SSH key not found for this user' })
     }
+    keys = [sshKey]
   }
   else {
-    const keys = await sshKeyStore.findByUser(body.id)
+    keys = await sshKeyStore.findByUser(body.id)
     if (keys.length === 0) {
       throw createProblemError({ status: 404, title: 'No user with SSH keys found' })
     }
-    if (keys.length > 1) {
-      throw createProblemError({ status: 400, title: 'Multiple SSH keys registered. Specify public_key to identify which key to use.' })
-    }
-    sshKey = keys[0]!
   }
 
   // Verify user exists
@@ -51,16 +48,19 @@ export default defineEventHandler(async (event) => {
     throw createProblemError({ status: 401, title: 'Invalid, expired, or already used challenge' })
   }
 
+  // Try each registered key until one verifies
   const signatureStr = body.signature.trim()
-  let isValid: boolean
-  if (signatureStr.startsWith('-----BEGIN SSH SIGNATURE-----')) {
-    // SSHSIG format from `ssh-keygen -Y sign -n openape`
-    isValid = verifySSHSignature(sshKey.publicKey, body.challenge, signatureStr, 'openape')
-  }
-  else {
-    // Raw base64 Ed25519 signature (from apes login / Web Crypto / openssl)
-    const signatureBuffer = Buffer.from(signatureStr, 'base64')
-    isValid = verifyEd25519Signature(sshKey.publicKey, body.challenge, signatureBuffer)
+  const isSSHSIG = signatureStr.startsWith('-----BEGIN SSH SIGNATURE-----')
+  let isValid = false
+  for (const key of keys) {
+    if (isSSHSIG) {
+      isValid = verifySSHSignature(key.publicKey, body.challenge, signatureStr, 'openape')
+    }
+    else {
+      const signatureBuffer = Buffer.from(signatureStr, 'base64')
+      isValid = verifyEd25519Signature(key.publicKey, body.challenge, signatureBuffer)
+    }
+    if (isValid) break
   }
   if (!isValid) {
     throw createProblemError({ status: 401, title: 'Invalid signature', type: 'https://ddisa.org/errors/invalid_token' })

--- a/packages/server/src/idp/handlers/auth.ts
+++ b/packages/server/src/idp/handlers/auth.ts
@@ -51,23 +51,20 @@ export function createAuthenticateHandler(stores: IdPStores, config: IdPConfig) 
       throw createProblemError({ status: 403, title: 'User is inactive' })
     }
 
-    // Determine which SSH key to use for verification
-    let sshKey
+    // Determine which SSH key(s) to verify against
+    let keys
     if (body.public_key) {
-      sshKey = await stores.sshKeyStore.findByPublicKey(body.public_key)
+      const sshKey = await stores.sshKeyStore.findByPublicKey(body.public_key)
       if (!sshKey || sshKey.userEmail !== body.id) {
         throw createProblemError({ status: 404, title: 'SSH key not found for this user' })
       }
+      keys = [sshKey]
     }
     else {
-      const keys = await stores.sshKeyStore.findByUser(body.id)
+      keys = await stores.sshKeyStore.findByUser(body.id)
       if (keys.length === 0) {
         throw createProblemError({ status: 404, title: 'No SSH keys found for this user' })
       }
-      if (keys.length > 1) {
-        throw createProblemError({ status: 400, title: 'Multiple SSH keys registered. Specify public_key to identify which key to use.' })
-      }
-      sshKey = keys[0]!
     }
 
     // Consume challenge
@@ -76,9 +73,15 @@ export function createAuthenticateHandler(stores: IdPStores, config: IdPConfig) 
       throw createProblemError({ status: 401, title: 'Invalid, expired, or already used challenge' })
     }
 
-    // Verify signature
+    // Try each registered key until one verifies
     const signatureBuffer = Buffer.from(body.signature, 'base64')
-    const isValid = verifyEd25519Signature(sshKey.publicKey, body.challenge, signatureBuffer)
+    let isValid = false
+    for (const key of keys) {
+      if (verifyEd25519Signature(key.publicKey, body.challenge, signatureBuffer)) {
+        isValid = true
+        break
+      }
+    }
     if (!isValid) {
       throw createProblemError({ status: 401, title: 'Invalid signature', type: 'https://ddisa.org/errors/invalid_token' })
     }

--- a/packages/server/src/idp/handlers/session.ts
+++ b/packages/server/src/idp/handlers/session.ts
@@ -47,23 +47,20 @@ export function createSessionLoginHandler(stores: IdPStores, config: IdPConfig) 
       throw createProblemError({ status: 403, title: 'User is inactive' })
     }
 
-    // Determine which SSH key to use for verification
-    let sshKey
+    // Determine which SSH key(s) to verify against
+    let keys
     if (body.public_key) {
-      sshKey = await stores.sshKeyStore.findByPublicKey(body.public_key)
+      const sshKey = await stores.sshKeyStore.findByPublicKey(body.public_key)
       if (!sshKey || sshKey.userEmail !== body.id) {
         throw createProblemError({ status: 404, title: 'SSH key not found for this user' })
       }
+      keys = [sshKey]
     }
     else {
-      const keys = await stores.sshKeyStore.findByUser(body.id)
+      keys = await stores.sshKeyStore.findByUser(body.id)
       if (keys.length === 0) {
         throw createProblemError({ status: 404, title: 'No SSH keys found for this user' })
       }
-      if (keys.length > 1) {
-        throw createProblemError({ status: 400, title: 'Multiple SSH keys registered. Specify public_key to identify which key to use.' })
-      }
-      sshKey = keys[0]!
     }
 
     // Consume challenge
@@ -72,9 +69,15 @@ export function createSessionLoginHandler(stores: IdPStores, config: IdPConfig) 
       throw createProblemError({ status: 401, title: 'Invalid, expired, or already used challenge' })
     }
 
-    // Verify signature
+    // Try each registered key until one verifies
     const signatureBuffer = Buffer.from(body.signature, 'base64')
-    const isValid = verifyEd25519Signature(sshKey.publicKey, body.challenge, signatureBuffer)
+    let isValid = false
+    for (const key of keys) {
+      if (verifyEd25519Signature(key.publicKey, body.challenge, signatureBuffer)) {
+        isValid = true
+        break
+      }
+    }
     if (!isValid) {
       throw createProblemError({ status: 401, title: 'Invalid signature', type: 'https://ddisa.org/errors/invalid_token' })
     }


### PR DESCRIPTION
Try all registered keys instead of rejecting users with multiple SSH keys. Mirrors SSH agent behavior.