### PR TITLE
feat(apes): generic-fallback mode for unshaped CLIs

### DIFF
--- a/.changeset/feat-generic-fallback.md
+++ b/.changeset/feat-generic-fallback.md
@@ -1,0 +1,52 @@
+---
+'@openape/apes': minor
+'@openape/nuxt-auth-idp': patch
+---
+
+Add generic-fallback mode for `apes run -- <cli>` when the CLI has no
+registered shape.
+
+**Before:** `apes run -- kubectl get pods` hard-failed with
+`"No adapter found for kubectl"` unless a full `kubectl.toml` shape was
+written first.
+
+**After:** `apes run -- kubectl get pods` creates a synthetic adapter
+in-memory, requests a single-use grant with `risk=high` and
+`exact_command=true`, and runs the command once approved. An stderr
+warning makes the fallback explicit:
+
+```
+⚠ No shape registered for `kubectl`.
+Generic mode active — single-use grant will be required.
+```
+
+**Safety layers:**
+- Forced `risk: "high"` on every generic grant
+- Forced `exact_command: true` — grant is bound to the exact argv hash
+- Single-use by default (enforced by IdP `usedAt` timestamp)
+- `~/.config/apes/generic-calls.log` captures every successful generic
+  execution as JSONL for later shape promotion
+- Free-IdP approval page shows a prominent "⚠ Unshaped CLI" banner
+
+**Opt-out:** `[generic] enabled = false` in `~/.config/apes/config.toml`
+restores the legacy hard-fail behaviour.
+
+**Compatibility:**
+- Existing shapes are unaffected — generic-fallback only activates when
+  `loadAdapter()` throws "No adapter found".
+- The synthetic path bypasses `resolveCommand()` entirely and feeds a
+  pre-built `ResolvedCommand` into the grant pipeline. Parser remains
+  unchanged.
+- The audit-log hook sits in `verifyAndExecute`, covering sync (`--wait`),
+  async-default (`apes run` → `apes grants run <id> --wait`), and REPL
+  one-shot paths with one implementation.
+- `apes run --as <user>` (escapes) and `ape-shell` one-shot session-grant
+  behaviour are unchanged.
+
+**New public surface (`@openape/apes`):**
+- `shapes/generic.ts`: `buildGenericAdapter`, `buildGenericResolved`,
+  `isGenericResolved`, `GENERIC_OPERATION_ID`
+- `shapes/adapters.ts`: `resolveGenericOrReject`
+- `audit/generic-log.ts`: `appendGenericCallLog`, `defaultGenericLogPath`
+- `config.ts`: `isGenericFallbackEnabled`, `getGenericAuditLogPath`,
+  `ApesConfig.generic`

--- a/modules/nuxt-auth-idp/src/runtime/pages/grant-approval.vue
+++ b/modules/nuxt-auth-idp/src/runtime/pages/grant-approval.vue
@@ -28,6 +28,15 @@ const EXTEND_MODE_OPTIONS = [
 ]
 const cliDetails = computed(() => getCliAuthorizationDetails(grant.value?.request?.authorization_details))
 const cliSummary = computed(() => summarizeCliGrant(grant.value?.request?.authorization_details))
+/**
+ * True when this grant was requested via the `apes` generic-fallback path.
+ * Such CLIs have no registered shape — the approver should see a prominent
+ * banner explaining the lack of structured validation and the single-use
+ * nature of the grant.
+ */
+const isGenericGrant = computed(() =>
+  cliDetails.value.some(d => d?.operation_id === '_generic.exec'),
+)
 const delegateDuration = computed(() => {
   const req = grant.value?.request
   if (!req?.duration) return null
@@ -227,6 +236,20 @@ function isExactCommand(detail) {
               <p v-else-if="grant.request?.grant_type === 'always'" class="mt-1 text-sm">
                 Permanent — until revoked.
               </p>
+            </template>
+          </UAlert>
+
+          <UAlert
+            v-if="isGenericGrant"
+            color="error"
+            icon="i-lucide-alert-triangle"
+            title="⚠ Unshaped CLI"
+            class="mb-4"
+          >
+            <template #description>
+              This command has no registered shape. Approving grants
+              <strong>single-use</strong> access to execute the exact command shown below.
+              No structured validation is possible — review carefully.
             </template>
           </UAlert>
 

--- a/packages/apes/src/audit/generic-log.ts
+++ b/packages/apes/src/audit/generic-log.ts
@@ -1,0 +1,49 @@
+import { mkdir, appendFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { dirname, join } from 'node:path'
+
+/**
+ * A single successful generic-fallback execution entry.
+ * Denied, timeout, and cancelled grants are NOT logged here — they are
+ * captured by the IdP's server-side audit trail.
+ */
+export interface GenericCallLogEntry {
+  /** ISO 8601 timestamp of execution completion */
+  ts: string
+  /** CLI id as requested by the user (e.g. "kubectl") */
+  cli: string
+  /** Full argv as executed, including the executable */
+  argv: string[]
+  /** SHA-256 of the argv — matches the `argv:hash` selector in resource_chain */
+  argv_hash: string
+  /** Grant that authorized this execution */
+  grant_id: string
+  /** Process exit code */
+  exit_code: number
+  /** Wall-clock duration from grant-approval to process exit, milliseconds */
+  duration_ms: number
+}
+
+/**
+ * Default audit log location. Lives under `~/.config/apes/` for consistency
+ * with the rest of apes' client state (`config.toml`, `auth.json`, …).
+ */
+export function defaultGenericLogPath(): string {
+  return join(homedir(), '.config', 'apes', 'generic-calls.log')
+}
+
+/**
+ * Append a single generic-call entry to the audit log in JSONL format.
+ * Creates the containing directory if needed.
+ *
+ * @param entry     The call record to append
+ * @param logPath   Optional override (usually from `config.generic.audit_log`)
+ */
+export async function appendGenericCallLog(
+  entry: GenericCallLogEntry,
+  logPath?: string,
+): Promise<void> {
+  const path = logPath ?? defaultGenericLogPath()
+  await mkdir(dirname(path), { recursive: true })
+  await appendFile(path, `${JSON.stringify(entry)}\n`, 'utf-8')
+}

--- a/packages/apes/src/commands/grants/run.ts
+++ b/packages/apes/src/commands/grants/run.ts
@@ -6,6 +6,7 @@ import { CliError, CliExit } from '../../errors'
 import { getPollMaxMinutes, pollGrantUntilResolved } from '../../grant-poll'
 import { apiFetch, getGrantsEndpoint } from '../../http'
 import { fetchGrantToken, resolveFromGrant, verifyAndExecute } from '../../shapes/index.js'
+import { buildGenericResolved, GENERIC_OPERATION_ID } from '../../shapes/generic.js'
 
 interface GrantDetail {
   id: string
@@ -19,7 +20,7 @@ interface GrantDetail {
     grant_type?: string
     target_host?: string
     execution_context?: { adapter_digest?: string, argv_hash?: string }
-    authorization_details?: Array<{ type?: string, permission?: string }>
+    authorization_details?: Array<{ type?: string, permission?: string, operation_id?: string, cli_id?: string }>
   }
 }
 
@@ -99,17 +100,31 @@ export const runGrantCommand = defineCommand({
     const isShapesGrant = hasOpenApeCliDetail || audience === 'shapes'
 
     if (isShapesGrant) {
-      // Re-resolve locally from the recorded command + adapter digest.
+      // Generic-fallback grants have no adapter to re-resolve against —
+      // their command is self-describing (argv + cli_id). Rebuild the
+      // ResolvedCommand in memory via buildGenericResolved instead of
+      // calling resolveFromGrant (which would try to loadOrInstallAdapter
+      // and fail with "No shapes adapter found").
+      const isGenericGrant = authDetails.some(d => d?.operation_id === GENERIC_OPERATION_ID)
       let resolved
-      try {
-        resolved = await resolveFromGrant(grant)
+      if (isGenericGrant) {
+        const argv = grant.request?.command ?? []
+        if (argv.length === 0)
+          throw new CliError(`Generic grant ${grant.id} is missing command argv`)
+        const cliId = authDetails.find(d => d?.operation_id === GENERIC_OPERATION_ID)?.cli_id ?? argv[0]!
+        resolved = await buildGenericResolved(cliId, argv)
       }
-      catch (err) {
-        const msg = err instanceof Error ? err.message : String(err)
-        throw new CliError(`Cannot re-resolve grant: ${msg}`)
+      else {
+        try {
+          resolved = await resolveFromGrant(grant)
+        }
+        catch (err) {
+          const msg = err instanceof Error ? err.message : String(err)
+          throw new CliError(`Cannot re-resolve grant: ${msg}`)
+        }
       }
       const token = await fetchGrantToken(idp, grant.id)
-      await verifyAndExecute(token, resolved)
+      await verifyAndExecute(token, resolved, grant.id)
       return
     }
 

--- a/packages/apes/src/commands/run.ts
+++ b/packages/apes/src/commands/run.ts
@@ -13,11 +13,13 @@ import {
   loadOrInstallAdapter,
   parseShellCommand,
   resolveCommand,
+  resolveGenericOrReject,
   verifyAndExecute,
   waitForGrantStatus,
 } from '../shapes/index.js'
+import type { ResolvedCommand } from '../shapes/index.js'
 import consola from 'consola'
-import { getIdpUrl, loadAuth, loadConfig } from '../config'
+import { getIdpUrl, isGenericFallbackEnabled, loadAuth, loadConfig } from '../config'
 import { getPollMaxMinutes } from '../grant-poll'
 import { apiFetch, getGrantsEndpoint } from '../http'
 import { CliError, CliExit } from '../errors'
@@ -388,7 +390,7 @@ async function tryAdapterModeFromShell(
   // path we must pass the basename, not the full path.
   const normalizedExecutable = basename(parsed.executable)
 
-  let resolved
+  let resolved: ResolvedCommand
   try {
     resolved = await resolveCommand(loaded, [normalizedExecutable, ...parsed.argv])
   }
@@ -403,7 +405,7 @@ async function tryAdapterModeFromShell(
     if (existingGrantId) {
       consola.info(`Reusing grant ${existingGrantId} for: ${resolved.detail.display}`)
       const token = await fetchGrantToken(idp, existingGrantId)
-      await verifyAndExecute(token, resolved)
+      await verifyAndExecute(token, resolved, existingGrantId)
       return true
     }
   }
@@ -443,7 +445,7 @@ async function tryAdapterModeFromShell(
       throw new CliError(`Grant ${status}`)
 
     const token = await fetchGrantToken(idp, grant.id)
-    await verifyAndExecute(token, resolved)
+    await verifyAndExecute(token, resolved, grant.id)
     return true
   }
 
@@ -496,6 +498,16 @@ function extractPositionals(rawArgs: string[]): string[] {
   return positionals
 }
 
+/**
+ * Print a stderr warning when an unshaped CLI is being run through the
+ * generic-fallback path. Written to stderr (not stdout) so shell pipelines
+ * capturing stdout see the command output, not the warning.
+ */
+function printGenericWarning(cliId: string): void {
+  process.stderr.write(`⚠ No shape registered for \`${cliId}\`.\n`)
+  process.stderr.write('Generic mode active — single-use grant will be required.\n')
+}
+
 async function runAdapterMode(
   command: string[],
   rawArgs: string[],
@@ -513,8 +525,23 @@ async function runAdapterMode(
   }
 
   const adapterOpt = extractOption(rawArgs, 'adapter')
-  const loaded = loadAdapter(command[0]!, adapterOpt)
-  const resolved = await resolveCommand(loaded, command)
+  const cliId = command[0]!
+  let resolved: ResolvedCommand
+  try {
+    const loaded = loadAdapter(cliId, adapterOpt)
+    resolved = await resolveCommand(loaded, command)
+  }
+  catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    const isNoAdapter = message.startsWith('No adapter found for ')
+    if (!isNoAdapter)
+      throw err
+    // Fallback to generic synthetic adapter (opt-out via [generic] enabled = false)
+    resolved = await resolveGenericOrReject(cliId, command, {
+      genericEnabled: isGenericFallbackEnabled(),
+    })
+    printGenericWarning(cliId)
+  }
   const approval = (args.approval ?? 'once') as 'once' | 'timed' | 'always'
 
   // Try reusing an existing timed/always grant (findExistingGrant skips once grants)
@@ -523,7 +550,7 @@ async function runAdapterMode(
     if (existingGrantId) {
       consola.info(`Reusing existing grant: ${existingGrantId}`)
       const token = await fetchGrantToken(idp, existingGrantId)
-      await verifyAndExecute(token, resolved)
+      await verifyAndExecute(token, resolved, existingGrantId)
       return
     }
   }
@@ -557,7 +584,7 @@ async function runAdapterMode(
       throw new Error(`Grant ${status}`)
 
     const token = await fetchGrantToken(idp, grant.id)
-    await verifyAndExecute(token, resolved)
+    await verifyAndExecute(token, resolved, grant.id)
     return
   }
 

--- a/packages/apes/src/config.ts
+++ b/packages/apes/src/config.ts
@@ -48,6 +48,22 @@ export interface ApesConfig {
   notifications?: {
     pending_command?: string
   }
+  /**
+   * Generic-fallback mode: when `apes run -- <cli>` is called with a CLI
+   * that has no registered shape, fall through to a synthetic adapter that
+   * requests a single-use, forced-high-risk grant for the exact argv.
+   * See `shapes/generic.ts`.
+   */
+  generic?: {
+    /**
+     * Master switch. Default `true` (permissive). Set to `false` to restore
+     * the legacy "No adapter found" hard-fail. Stored as string in TOML
+     * (hand-parser limitation) and parsed as `value !== 'false'` at read time.
+     */
+    enabled?: string
+    /** Override the audit-log location. Default `~/.config/apes/generic-calls.log`. Tilde-expanded at read time. */
+    audit_log?: string
+  }
 }
 
 const CONFIG_DIR = join(homedir(), '.config', 'apes')
@@ -117,7 +133,12 @@ function parseTOML(content: string): ApesConfig {
       continue
     }
 
-    const kvMatch = trimmed.match(/^(\w+)\s*=\s*"(.+)"$/)
+    // Accept quoted strings and bare booleans/tokens — the generic section
+    // uses `enabled = false` (no quotes) which the quoted-only match would
+    // silently drop.
+    const kvQuoted = trimmed.match(/^(\w+)\s*=\s*"(.*)"$/)
+    const kvBare = trimmed.match(/^(\w+)\s*=\s*([^"\s]\S*)$/)
+    const kvMatch = kvQuoted ?? kvBare
     if (kvMatch) {
       const [, key, value] = kvMatch
       if (section === 'defaults') {
@@ -131,6 +152,10 @@ function parseTOML(content: string): ApesConfig {
       else if (section === 'notifications') {
         config.notifications = config.notifications || {}
         ;(config.notifications as Record<string, string>)[key!] = value!
+      }
+      else if (section === 'generic') {
+        config.generic = config.generic || {}
+        ;(config.generic as Record<string, string>)[key!] = value!
       }
     }
   }
@@ -169,7 +194,41 @@ export function saveConfig(config: ApesConfig): void {
     lines.push('')
   }
 
+  if (config.generic) {
+    lines.push('[generic]')
+    for (const [key, value] of Object.entries(config.generic)) {
+      if (value)
+        lines.push(`${key} = "${value}"`)
+    }
+    lines.push('')
+  }
+
   writeFileSync(CONFIG_FILE, lines.join('\n'), { mode: 0o600 })
+}
+
+/**
+ * Is generic-fallback enabled? Permissive default: `true` unless the user
+ * explicitly sets `[generic] enabled = false`.
+ */
+export function isGenericFallbackEnabled(config?: ApesConfig): boolean {
+  const cfg = config ?? loadConfig()
+  const raw = cfg.generic?.enabled
+  if (raw === undefined) return true
+  return raw !== 'false'
+}
+
+/**
+ * Resolve the audit-log path for generic calls, expanding `~` to `$HOME`.
+ */
+export function getGenericAuditLogPath(config?: ApesConfig): string {
+  const cfg = config ?? loadConfig()
+  const raw = cfg.generic?.audit_log
+  const path = raw && raw.length > 0
+    ? raw
+    : join(homedir(), '.config', 'apes', 'generic-calls.log')
+  return path.startsWith('~/')
+    ? join(homedir(), path.slice(2))
+    : path
 }
 
 export function getIdpUrl(explicit?: string): string | null {

--- a/packages/apes/src/shapes/adapters.ts
+++ b/packages/apes/src/shapes/adapters.ts
@@ -2,8 +2,9 @@ import { createHash } from 'node:crypto'
 import { existsSync, readdirSync, readFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { basename, join } from 'node:path'
-import type { LoadedAdapter } from './types.js'
+import type { LoadedAdapter, ResolvedCommand } from './types.js'
 import { parseAdapterToml } from './toml.js'
+import { buildGenericResolved } from './generic.js'
 
 function digest(content: string): string {
   return `SHA-256:${createHash('sha256').update(content).digest('hex')}`
@@ -76,6 +77,27 @@ export function loadAdapter(cliId: string, explicitPath?: string): LoadedAdapter
     source,
     digest: digest(content),
   }
+}
+
+/**
+ * Called by `run.ts` when `loadAdapter(cliId)` has already failed with
+ * "No adapter found". If generic-fallback mode is enabled in config,
+ * return a synthetic `ResolvedCommand` that bypasses the parser. If
+ * disabled, re-throw the original error (restoring legacy behaviour).
+ *
+ * @param cliId     The CLI that had no registered shape
+ * @param fullArgv  Argv to execute (including the executable itself)
+ * @param opts      `genericEnabled: true` → return synthetic resolved;
+ *                  `false` → throw `"No adapter found for <cliId>"`.
+ */
+export async function resolveGenericOrReject(
+  cliId: string,
+  fullArgv: string[],
+  opts: { genericEnabled: boolean },
+): Promise<ResolvedCommand> {
+  if (!opts.genericEnabled)
+    throw new Error(`No adapter found for ${cliId}`)
+  return await buildGenericResolved(cliId, fullArgv)
 }
 
 /** Try to load an adapter locally, return null instead of throwing when not found. */

--- a/packages/apes/src/shapes/generic.ts
+++ b/packages/apes/src/shapes/generic.ts
@@ -1,0 +1,124 @@
+import type { OpenApeCliAuthorizationDetail } from '@openape/core'
+import { canonicalizeCliPermission, computeArgvHash } from '@openape/grants'
+import type { LoadedAdapter, ResolvedCommand, ShapesAdapter } from './types.js'
+
+/**
+ * The synthetic operation ID used for generic-fallback grants. Downstream
+ * code (audit logging, UI banner) keys off this exact string.
+ */
+export const GENERIC_OPERATION_ID = '_generic.exec'
+
+/**
+ * Schema version for synthetic adapters. Not persisted anywhere — exists
+ * only so the in-memory adapter shape matches `ShapesAdapter`.
+ */
+const SYNTHETIC_SCHEMA = 'openape-shapes/v1'
+
+/**
+ * Build a synthetic in-memory `LoadedAdapter` for a CLI that has no
+ * registered shape. The adapter is marked with `synthetic: true` so
+ * callers can branch on it if needed.
+ *
+ * NOTE: This does NOT produce a parser-matchable adapter. The generic
+ * pipeline bypasses `resolveCommand()` entirely — see `buildGenericResolved()`.
+ * This function exists for flow-control markers and tests.
+ */
+export function buildGenericAdapter(cliId: string): LoadedAdapter {
+  const adapter: ShapesAdapter = {
+    schema: SYNTHETIC_SCHEMA,
+    cli: {
+      id: cliId,
+      executable: cliId,
+      audience: 'shapes',
+      version: 'synthetic',
+    },
+    operations: [],
+  }
+  return {
+    adapter,
+    source: '<synthetic>',
+    digest: 'synthetic',
+    synthetic: true,
+  }
+}
+
+/**
+ * Build a `ResolvedCommand` directly for a CLI that has no registered shape.
+ *
+ * Unlike the normal flow (loadAdapter → resolveCommand), the generic path
+ * bypasses the parser entirely. Rationale:
+ *
+ *   - `resolveCommand()` matches argv against declarative operation specs
+ *     via `matchOperation()`, which requires `positionals.length ===
+ *     operation.positionals.length`. A "match-all" spec (`command: []`,
+ *     `positionals: []`) would reject any non-empty argv.
+ *
+ *   - Synthetic adapters have no declarative spec — we already know what
+ *     to execute. Running the parser is theatre.
+ *
+ * The returned `ResolvedCommand` has:
+ *   - `detail.operation_id === GENERIC_OPERATION_ID` — marker consumed by
+ *     the audit-log hook in `verifyAndExecute`.
+ *   - `detail.risk === 'high'` — forced.
+ *   - `detail.constraints.exact_command === true` — forced, binds the
+ *     grant to this exact argv via `argv_hash`.
+ *   - `resource_chain = [{resource: 'cli', selector: {name: cliId}},
+ *                        {resource: 'argv', selector: {hash: <sha256>}}]`
+ */
+export async function buildGenericResolved(
+  cliId: string,
+  fullArgv: string[],
+): Promise<ResolvedCommand> {
+  if (fullArgv.length === 0)
+    throw new Error('buildGenericResolved: fullArgv must include the executable')
+  const executable = fullArgv[0]!
+  const commandArgv = fullArgv.slice(1)
+  const argvHash = await computeArgvHash(fullArgv)
+
+  const display = `Execute (unshaped): \`${cliId} ${commandArgv.join(' ')}\``
+
+  const detail: OpenApeCliAuthorizationDetail = {
+    type: 'openape_cli',
+    cli_id: cliId,
+    operation_id: GENERIC_OPERATION_ID,
+    resource_chain: [
+      { resource: 'cli', selector: { name: cliId } },
+      { resource: 'argv', selector: { hash: argvHash } },
+    ],
+    action: 'exec',
+    permission: '',
+    display,
+    risk: 'high',
+    constraints: { exact_command: true },
+  }
+  detail.permission = canonicalizeCliPermission(detail)
+
+  const adapter = buildGenericAdapter(cliId)
+
+  return {
+    adapter: adapter.adapter,
+    source: adapter.source,
+    digest: adapter.digest,
+    executable,
+    commandArgv,
+    bindings: {},
+    detail,
+    executionContext: {
+      argv: fullArgv,
+      argv_hash: argvHash,
+      adapter_id: cliId,
+      adapter_version: SYNTHETIC_SCHEMA,
+      adapter_digest: adapter.digest,
+      resolved_executable: executable,
+      context_bindings: {},
+    },
+    permission: detail.permission,
+  }
+}
+
+/**
+ * Type guard: does this `ResolvedCommand` come from the generic fallback path?
+ */
+export function isGenericResolved(resolved: ResolvedCommand): boolean {
+  return resolved.detail.operation_id === GENERIC_OPERATION_ID
+}

--- a/packages/apes/src/shapes/grants.ts
+++ b/packages/apes/src/shapes/grants.ts
@@ -5,10 +5,13 @@ import { execFileSync } from 'node:child_process'
 import { hostname } from 'node:os'
 import consola from 'consola'
 import { getRequesterIdentity } from './config.js'
+import { getGenericAuditLogPath } from '../config.js'
 import { resolveCommand } from './parser.js'
 import { loadOrInstallAdapter } from './shell-parser.js'
 import type { ResolvedCommand } from './types.js'
 import { apiFetch, discoverEndpoints, getGrantsEndpoint } from './http.js'
+import { appendGenericCallLog } from '../audit/generic-log.js'
+import { isGenericResolved } from './generic.js'
 
 function decodePayload(token: string): Record<string, unknown> {
   const [, payload] = token.split('.')
@@ -191,10 +194,57 @@ export function executeResolvedViaExec(resolved: ResolvedCommand): void {
 /**
  * One-shot verify + consume + execute. Preserves the legacy behavior of
  * the `apes run --shell` path so existing callers keep working unchanged.
+ *
+ * When `resolved` carries the generic-fallback operation id
+ * (`_generic.exec`), a JSONL audit entry is appended to the generic-calls
+ * log after the child process exits. `grantId` is needed to write the
+ * entry — callers that know the grant id should pass it; if omitted, the
+ * log entry is skipped (the audit hook is best-effort, not a hard gate).
+ *
+ * This is the central exec path for sync (`--wait`), async-default
+ * (`apes grants run <id> --wait`), and REPL one-shot, so a hook here
+ * covers all three flows without duplicating logic in each caller.
  */
-export async function verifyAndExecute(token: string, resolved: ResolvedCommand): Promise<void> {
+export async function verifyAndExecute(
+  token: string,
+  resolved: ResolvedCommand,
+  grantId?: string,
+): Promise<void> {
   await verifyAndConsume(token, resolved)
-  executeResolvedViaExec(resolved)
+
+  const isGeneric = isGenericResolved(resolved)
+  const start = Date.now()
+  let exitCode = 0
+  try {
+    executeResolvedViaExec(resolved)
+  }
+  catch (err) {
+    exitCode = (err as { status?: number })?.status ?? 1
+    throw err
+  }
+  finally {
+    if (isGeneric && grantId) {
+      // Best-effort: swallow log errors so a broken audit file never
+      // blocks a successful command.
+      try {
+        await appendGenericCallLog(
+          {
+            ts: new Date().toISOString(),
+            cli: resolved.detail.cli_id,
+            argv: resolved.executionContext.argv ?? [resolved.executable, ...resolved.commandArgv],
+            argv_hash: resolved.executionContext.argv_hash ?? '',
+            grant_id: grantId,
+            exit_code: exitCode,
+            duration_ms: Date.now() - start,
+          },
+          getGenericAuditLogPath(),
+        )
+      }
+      catch (logErr) {
+        consola.debug('Failed to append generic-call audit entry:', logErr)
+      }
+    }
+  }
 }
 
 /**

--- a/packages/apes/src/shapes/index.ts
+++ b/packages/apes/src/shapes/index.ts
@@ -1,4 +1,5 @@
-export { loadAdapter, resolveAdapterPath, tryLoadAdapter } from './adapters.js'
+export { loadAdapter, resolveAdapterPath, resolveGenericOrReject, tryLoadAdapter } from './adapters.js'
+export { GENERIC_OPERATION_ID, buildGenericAdapter, buildGenericResolved, isGenericResolved } from './generic.js'
 export { appendAuditLog, type AuditEntry } from './audit.js'
 export { extractShellCommandString, loadOrInstallAdapter, parseShellCommand, type ParsedShellCommand } from './shell-parser.js'
 export { resolveCapabilityRequest } from './capabilities.js'

--- a/packages/apes/src/shapes/types.ts
+++ b/packages/apes/src/shapes/types.ts
@@ -33,6 +33,13 @@ export interface LoadedAdapter {
   adapter: ShapesAdapter
   source: string
   digest: string
+  /**
+   * True when this adapter was synthesized in-memory for a CLI that has no
+   * registered shape. Synthetic adapters bypass `resolveCommand()` and are
+   * fed into the grant pipeline via `buildGenericResolved()` directly.
+   * See `shapes/generic.ts`.
+   */
+  synthetic?: boolean
 }
 
 export interface ResolvedCommand {

--- a/packages/apes/test/audit-generic-log.test.ts
+++ b/packages/apes/test/audit-generic-log.test.ts
@@ -1,0 +1,83 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { appendGenericCallLog  } from '../src/audit/generic-log.js'
+import type { GenericCallLogEntry } from '../src/audit/generic-log.js'
+
+describe('appendGenericCallLog', () => {
+  let tmpDir: string
+  const logPath = () => join(tmpDir, 'generic-calls.log')
+
+  beforeAll(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'apes-generic-log-'))
+  })
+
+  afterAll(async () => {
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it('writes a single JSONL entry', async () => {
+    const entry: GenericCallLogEntry = {
+      ts: '2026-04-17T12:00:00.000Z',
+      cli: 'kubectl',
+      argv: ['kubectl', 'get', 'pods'],
+      argv_hash: 'SHA-256:aaaabbbb',
+      grant_id: 'grant-123',
+      exit_code: 0,
+      duration_ms: 1234,
+    }
+
+    await appendGenericCallLog(entry, logPath())
+    const content = await readFile(logPath(), 'utf-8')
+    expect(content.trimEnd()).toBe(JSON.stringify(entry))
+  })
+
+  it('appends (does not overwrite) on subsequent calls', async () => {
+    const second: GenericCallLogEntry = {
+      ts: '2026-04-17T12:00:01.000Z',
+      cli: 'kubectl',
+      argv: ['kubectl', 'get', 'nodes'],
+      argv_hash: 'SHA-256:cccc',
+      grant_id: 'grant-456',
+      exit_code: 0,
+      duration_ms: 500,
+    }
+    const third: GenericCallLogEntry = {
+      ts: '2026-04-17T12:00:02.000Z',
+      cli: 'terraform',
+      argv: ['terraform', 'plan'],
+      argv_hash: 'SHA-256:dddd',
+      grant_id: 'grant-789',
+      exit_code: 2,
+      duration_ms: 8000,
+    }
+
+    await appendGenericCallLog(second, logPath())
+    await appendGenericCallLog(third, logPath())
+
+    const content = await readFile(logPath(), 'utf-8')
+    const lines = content.trimEnd().split('\n')
+    expect(lines).toHaveLength(3) // includes the first from the previous test
+    const parsed = lines.map(l => JSON.parse(l)) as GenericCallLogEntry[]
+    expect(parsed[1]!.grant_id).toBe('grant-456')
+    expect(parsed[2]!.grant_id).toBe('grant-789')
+    expect(parsed[2]!.exit_code).toBe(2)
+  })
+
+  it('creates the containing directory if it does not exist', async () => {
+    const deep = join(tmpDir, 'nested', 'dir', 'log.jsonl')
+    const entry: GenericCallLogEntry = {
+      ts: '2026-04-17T12:00:03.000Z',
+      cli: 'aws',
+      argv: ['aws', 's3', 'ls'],
+      argv_hash: 'SHA-256:eeee',
+      grant_id: 'grant-aws',
+      exit_code: 0,
+      duration_ms: 200,
+    }
+    await appendGenericCallLog(entry, deep)
+    const content = await readFile(deep, 'utf-8')
+    expect(JSON.parse(content.trimEnd())).toEqual(entry)
+  })
+})

--- a/packages/apes/test/commands-grants-run.test.ts
+++ b/packages/apes/test/commands-grants-run.test.ts
@@ -88,7 +88,7 @@ describe('apes grants run <id>', () => {
 
     expect(resolveFromGrant).toHaveBeenCalledWith(grant)
     expect(fetchGrantToken).toHaveBeenCalledWith('http://idp.test', 'grant-abc')
-    expect(verifyAndExecute).toHaveBeenCalledWith('jwt-token', fakeResolved)
+    expect(verifyAndExecute).toHaveBeenCalledWith('jwt-token', fakeResolved, 'grant-abc')
   })
 
   it('executes an approved escapes grant via the escapes binary', async () => {
@@ -269,7 +269,7 @@ describe('apes grants run <id>', () => {
       await invoke('grant-wait-1', { wait: true })
 
       expect(pollGrantUntilResolved).toHaveBeenCalledWith('http://idp.test', 'grant-wait-1')
-      expect(verifyAndExecute).toHaveBeenCalledWith('jwt-tok', { executable: 'curl' })
+      expect(verifyAndExecute).toHaveBeenCalledWith('jwt-tok', { executable: 'curl' }, 'grant-wait-1')
     })
 
     it('with --wait: pending → poll → denied → CliError', async () => {

--- a/packages/apes/test/commands-run-async.test.ts
+++ b/packages/apes/test/commands-run-async.test.ts
@@ -20,6 +20,10 @@ vi.mock('../src/config.js', () => ({
   // so tests get the baked-in defaults; individual tests can override
   // via `vi.mocked(loadConfig).mockReturnValueOnce(...)`.
   loadConfig: vi.fn(() => ({})),
+  // Generic-fallback mode is permissive-default; individual tests override
+  // to `false` to verify the opt-out path.
+  isGenericFallbackEnabled: vi.fn(() => true),
+  getGenericAuditLogPath: vi.fn(() => '/tmp/test-generic-calls.log'),
 }))
 
 vi.mock('../src/http.js', () => ({
@@ -28,24 +32,34 @@ vi.mock('../src/http.js', () => ({
   ApiError: class extends Error {},
 }))
 
-vi.mock('../src/shapes/index.js', () => ({
-  createShapesGrant: vi.fn(),
-  fetchGrantToken: vi.fn(),
-  findExistingGrant: vi.fn(),
-  loadOrInstallAdapter: vi.fn(),
-  loadAdapter: vi.fn(),
-  parseShellCommand: vi.fn(),
-  resolveCommand: vi.fn(),
-  verifyAndExecute: vi.fn(),
-  verifyAndConsume: vi.fn(),
-  waitForGrantStatus: vi.fn(),
-  extractOption: vi.fn(() => undefined),
-  extractShellCommandString: vi.fn((cmd: string[]) => cmd.at(-1) ?? ''),
-  extractWrappedCommand: vi.fn((argv: string[]) => {
-    const idx = argv.indexOf('--')
-    return idx >= 0 ? argv.slice(idx + 1) : []
-  }),
-}))
+vi.mock('../src/shapes/index.js', async () => {
+  // Import the real generic helpers so resolveGenericOrReject produces
+  // real ResolvedCommand shapes in fallback tests. Everything else is
+  // mocked as a jest-style fn for per-test control.
+  const generic = await import('../src/shapes/generic.js')
+  return {
+    createShapesGrant: vi.fn(),
+    fetchGrantToken: vi.fn(),
+    findExistingGrant: vi.fn(),
+    loadOrInstallAdapter: vi.fn(),
+    loadAdapter: vi.fn(),
+    parseShellCommand: vi.fn(),
+    resolveCommand: vi.fn(),
+    resolveGenericOrReject: vi.fn((cliId: string, argv: string[], opts: { genericEnabled: boolean }) => {
+      if (!opts.genericEnabled) throw new Error(`No adapter found for ${cliId}`)
+      return generic.buildGenericResolved(cliId, argv)
+    }),
+    verifyAndExecute: vi.fn(),
+    verifyAndConsume: vi.fn(),
+    waitForGrantStatus: vi.fn(),
+    extractOption: vi.fn(() => undefined),
+    extractShellCommandString: vi.fn((cmd: string[]) => cmd.at(-1) ?? ''),
+    extractWrappedCommand: vi.fn((argv: string[]) => {
+      const idx = argv.indexOf('--')
+      return idx >= 0 ? argv.slice(idx + 1) : []
+    }),
+  }
+})
 
 vi.mock('../src/notifications.js', () => ({
   notifyGrantPending: vi.fn(),
@@ -227,7 +241,7 @@ describe('commands/run async default', () => {
       } as any)
 
       expect(shapes.createShapesGrant).not.toHaveBeenCalled()
-      expect(shapes.verifyAndExecute).toHaveBeenCalledWith('tok', expect.anything())
+      expect(shapes.verifyAndExecute).toHaveBeenCalledWith('tok', expect.anything(), expect.any(String))
       const allOutput = consoleLogSpy.mock.calls.map(c => c.join(' ')).join('\n')
       expect(allOutput).not.toContain('apes grants run')
     })
@@ -320,7 +334,53 @@ describe('commands/run async default', () => {
       } as any)
 
       expect(shapes.waitForGrantStatus).toHaveBeenCalledWith('http://idp.test', 'grant-xyz')
-      expect(shapes.verifyAndExecute).toHaveBeenCalledWith('tok', expect.anything())
+      expect(shapes.verifyAndExecute).toHaveBeenCalledWith('tok', expect.anything(), expect.any(String))
+    })
+
+    it('generic fallback: unshaped CLI falls through to synthetic resolved + stderr warning', async () => {
+      const shapes = await import('../src/shapes/index.js')
+      vi.mocked(shapes.loadAdapter).mockImplementation(() => {
+        throw new Error('No adapter found for kubectl')
+      })
+      vi.mocked(shapes.createShapesGrant).mockResolvedValue({ id: 'grant-generic' } as any)
+      const stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true)
+
+      const { runCommand } = await import('../src/commands/run.js')
+      await expectCliExit(runCommand.run!({
+        rawArgs: ['run', '--', 'kubectl', 'get', 'pods'],
+        args: { shell: false, wait: false, approval: 'once' } as any,
+      } as any))
+
+      const stderrOut = stderrSpy.mock.calls.map(c => String(c[0])).join('')
+      expect(stderrOut).toContain('No shape registered for `kubectl`')
+      expect(stderrOut).toContain('Generic mode active')
+      expect(shapes.createShapesGrant).toHaveBeenCalled()
+      const resolvedArg = vi.mocked(shapes.createShapesGrant).mock.calls[0]?.[0]
+      expect(resolvedArg?.detail.operation_id).toBe('_generic.exec')
+      expect(resolvedArg?.detail.risk).toBe('high')
+      stderrSpy.mockRestore()
+    })
+
+    it('generic fallback disabled via config: legacy No-adapter-found error', async () => {
+      const shapes = await import('../src/shapes/index.js')
+      vi.mocked(shapes.loadAdapter).mockImplementation(() => {
+        throw new Error('No adapter found for kubectl')
+      })
+      // Override the config mock to disable generic fallback for this test.
+      const configModule = await import('../src/config.js')
+      const origGen = vi.mocked(configModule.isGenericFallbackEnabled).getMockImplementation?.()
+      vi.mocked(configModule.isGenericFallbackEnabled).mockReturnValue(false)
+
+      const { runCommand } = await import('../src/commands/run.js')
+      await expect(runCommand.run!({
+        rawArgs: ['run', '--', 'kubectl', 'get', 'pods'],
+        args: { shell: false, wait: false, approval: 'once' } as any,
+      } as any)).rejects.toThrow(/No adapter found for kubectl/)
+
+      expect(shapes.createShapesGrant).not.toHaveBeenCalled()
+      // restore mock
+      if (origGen) vi.mocked(configModule.isGenericFallbackEnabled).mockImplementation(origGen)
+      else vi.mocked(configModule.isGenericFallbackEnabled).mockReset()
     })
   })
 

--- a/packages/apes/test/config-generic.test.ts
+++ b/packages/apes/test/config-generic.test.ts
@@ -1,0 +1,114 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const testHome = join(tmpdir(), `apes-config-generic-${process.pid}-${Date.now()}`)
+mkdirSync(testHome, { recursive: true })
+
+vi.mock('node:os', async (importOriginal) => {
+  const original = await importOriginal<typeof import('node:os')>()
+  return { ...original, homedir: () => testHome }
+})
+
+const configDir = join(testHome, '.config', 'apes')
+const configFile = join(configDir, 'config.toml')
+
+function writeConfig(toml: string) {
+  mkdirSync(configDir, { recursive: true })
+  writeFileSync(configFile, toml)
+}
+
+function clearConfig() {
+  rmSync(configDir, { recursive: true, force: true })
+}
+
+describe('[generic] config section', () => {
+  beforeEach(() => {
+    clearConfig()
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    clearConfig()
+  })
+
+  afterAll(() => {
+    rmSync(testHome, { recursive: true, force: true })
+  })
+
+  it('returns enabled=true by default (no config file)', async () => {
+    const { isGenericFallbackEnabled } = await import('../src/config.js')
+    expect(isGenericFallbackEnabled()).toBe(true)
+  })
+
+  it('returns enabled=true when config has no [generic] section', async () => {
+    writeConfig(`
+[defaults]
+idp = "https://id.openape.at"
+`)
+    const { isGenericFallbackEnabled } = await import('../src/config.js')
+    expect(isGenericFallbackEnabled()).toBe(true)
+  })
+
+  it('returns enabled=false when [generic] enabled = false', async () => {
+    writeConfig(`
+[generic]
+enabled = false
+`)
+    const { isGenericFallbackEnabled } = await import('../src/config.js')
+    expect(isGenericFallbackEnabled()).toBe(false)
+  })
+
+  it('returns enabled=true when [generic] enabled = true (explicit)', async () => {
+    writeConfig(`
+[generic]
+enabled = true
+`)
+    const { isGenericFallbackEnabled } = await import('../src/config.js')
+    expect(isGenericFallbackEnabled()).toBe(true)
+  })
+
+  it('accepts the generic config alongside defaults and agent sections', async () => {
+    writeConfig(`
+[defaults]
+idp = "https://id.openape.at"
+
+[agent]
+email = "me@example.com"
+
+[generic]
+enabled = false
+audit_log = "~/custom/generic.log"
+`)
+    const { loadConfig, isGenericFallbackEnabled, getGenericAuditLogPath } = await import('../src/config.js')
+    const cfg = loadConfig()
+    expect(cfg.defaults?.idp).toBe('https://id.openape.at')
+    expect(cfg.agent?.email).toBe('me@example.com')
+    expect(isGenericFallbackEnabled(cfg)).toBe(false)
+    expect(getGenericAuditLogPath(cfg)).toBe(join(testHome, 'custom/generic.log'))
+  })
+
+  it('getGenericAuditLogPath defaults to ~/.config/apes/generic-calls.log', async () => {
+    const { getGenericAuditLogPath } = await import('../src/config.js')
+    expect(getGenericAuditLogPath()).toBe(join(testHome, '.config', 'apes', 'generic-calls.log'))
+  })
+
+  it('getGenericAuditLogPath expands ~ to HOME', async () => {
+    writeConfig(`
+[generic]
+audit_log = "~/logs/apes.jsonl"
+`)
+    const { getGenericAuditLogPath } = await import('../src/config.js')
+    expect(getGenericAuditLogPath()).toBe(join(testHome, 'logs', 'apes.jsonl'))
+  })
+
+  it('getGenericAuditLogPath leaves absolute paths untouched', async () => {
+    writeConfig(`
+[generic]
+audit_log = "/var/log/apes/generic.jsonl"
+`)
+    const { getGenericAuditLogPath } = await import('../src/config.js')
+    expect(getGenericAuditLogPath()).toBe('/var/log/apes/generic.jsonl')
+  })
+})

--- a/packages/apes/test/shapes-generic.test.ts
+++ b/packages/apes/test/shapes-generic.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest'
+import {
+  GENERIC_OPERATION_ID,
+  buildGenericAdapter,
+  buildGenericResolved,
+  isGenericResolved,
+} from '../src/shapes/generic.js'
+
+describe('buildGenericAdapter', () => {
+  it('creates a synthetic adapter with the expected shape', () => {
+    const loaded = buildGenericAdapter('kubectl')
+    expect(loaded.synthetic).toBe(true)
+    expect(loaded.adapter.cli.id).toBe('kubectl')
+    expect(loaded.adapter.cli.executable).toBe('kubectl')
+    expect(loaded.adapter.operations).toEqual([])
+    expect(loaded.source).toBe('<synthetic>')
+  })
+})
+
+describe('buildGenericResolved', () => {
+  it('produces a ResolvedCommand for an unshaped CLI with full argv', async () => {
+    const resolved = await buildGenericResolved('kubectl', ['kubectl', 'get', 'pods'])
+
+    expect(resolved.detail.type).toBe('openape_cli')
+    expect(resolved.detail.operation_id).toBe(GENERIC_OPERATION_ID)
+    expect(resolved.detail.cli_id).toBe('kubectl')
+    expect(resolved.detail.risk).toBe('high')
+    expect(resolved.detail.constraints?.exact_command).toBe(true)
+    expect(resolved.detail.action).toBe('exec')
+    expect(resolved.detail.display).toBe('Execute (unshaped): `kubectl get pods`')
+  })
+
+  it('includes cli:name and argv:hash in the resource chain', async () => {
+    const resolved = await buildGenericResolved('kubectl', ['kubectl', 'get', 'pods'])
+
+    expect(resolved.detail.resource_chain).toHaveLength(2)
+    expect(resolved.detail.resource_chain[0]).toEqual({
+      resource: 'cli',
+      selector: { name: 'kubectl' },
+    })
+    expect(resolved.detail.resource_chain[1]!.resource).toBe('argv')
+    expect(resolved.detail.resource_chain[1]!.selector?.hash).toMatch(/^SHA-256:[a-f0-9]{64}$/)
+  })
+
+  it('puts argv_hash in executionContext matching the resource_chain', async () => {
+    const resolved = await buildGenericResolved('kubectl', ['kubectl', 'get', 'pods'])
+
+    const chainHash = resolved.detail.resource_chain[1]!.selector!.hash
+    expect(resolved.executionContext.argv_hash).toBe(chainHash)
+    expect(resolved.executionContext.argv).toEqual(['kubectl', 'get', 'pods'])
+  })
+
+  it('produces a stable argv_hash for identical inputs', async () => {
+    const a = await buildGenericResolved('kubectl', ['kubectl', 'get', 'pods'])
+    const b = await buildGenericResolved('kubectl', ['kubectl', 'get', 'pods'])
+    expect(a.executionContext.argv_hash).toBe(b.executionContext.argv_hash)
+  })
+
+  it('produces different argv_hash for different argv', async () => {
+    const a = await buildGenericResolved('kubectl', ['kubectl', 'get', 'pods'])
+    const b = await buildGenericResolved('kubectl', ['kubectl', 'get', 'nodes'])
+    expect(a.executionContext.argv_hash).not.toBe(b.executionContext.argv_hash)
+  })
+
+  it('populates executable and commandArgv from the argv', async () => {
+    const resolved = await buildGenericResolved('kubectl', ['kubectl', 'get', 'pods', '-n', 'default'])
+    expect(resolved.executable).toBe('kubectl')
+    expect(resolved.commandArgv).toEqual(['get', 'pods', '-n', 'default'])
+  })
+
+  it('computes a non-empty permission string', async () => {
+    const resolved = await buildGenericResolved('kubectl', ['kubectl', 'get', 'pods'])
+    expect(resolved.permission.length).toBeGreaterThan(0)
+    expect(resolved.detail.permission).toBe(resolved.permission)
+  })
+
+  it('throws when argv is empty', async () => {
+    await expect(buildGenericResolved('kubectl', [])).rejects.toThrow(/must include the executable/)
+  })
+
+  it('marks the wrapping adapter as synthetic', async () => {
+    const resolved = await buildGenericResolved('kubectl', ['kubectl', 'version'])
+    // Adapter comes from buildGenericAdapter — the synthetic flag lives on
+    // LoadedAdapter, but the ResolvedCommand only carries the ShapesAdapter.
+    // Verify via the adapter id/version sentinel.
+    expect(resolved.adapter.cli.version).toBe('synthetic')
+    expect(resolved.adapter.operations).toEqual([])
+  })
+})
+
+describe('isGenericResolved', () => {
+  it('returns true for a synthetic resolved command', async () => {
+    const resolved = await buildGenericResolved('kubectl', ['kubectl', 'get', 'pods'])
+    expect(isGenericResolved(resolved)).toBe(true)
+  })
+
+  it('returns false for a non-generic resolved command', async () => {
+    const resolved = await buildGenericResolved('kubectl', ['kubectl', 'get', 'pods'])
+    const mutated = {
+      ...resolved,
+      detail: { ...resolved.detail, operation_id: 'list-pods' },
+    }
+    expect(isGenericResolved(mutated)).toBe(false)
+  })
+})

--- a/packages/apes/test/shapes-resolve-generic-or-reject.test.ts
+++ b/packages/apes/test/shapes-resolve-generic-or-reject.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { resolveGenericOrReject } from '../src/shapes/adapters.js'
+import { GENERIC_OPERATION_ID } from '../src/shapes/generic.js'
+
+describe('resolveGenericOrReject', () => {
+  it('returns a synthetic ResolvedCommand when genericEnabled=true', async () => {
+    const resolved = await resolveGenericOrReject('kubectl', ['kubectl', 'get', 'pods'], {
+      genericEnabled: true,
+    })
+    expect(resolved.detail.operation_id).toBe(GENERIC_OPERATION_ID)
+    expect(resolved.detail.cli_id).toBe('kubectl')
+    expect(resolved.detail.risk).toBe('high')
+    expect(resolved.executable).toBe('kubectl')
+  })
+
+  it('throws the legacy "No adapter found" error when genericEnabled=false', async () => {
+    await expect(
+      resolveGenericOrReject('kubectl', ['kubectl', 'get', 'pods'], { genericEnabled: false }),
+    ).rejects.toThrow(/No adapter found for kubectl/)
+  })
+
+  it('does not touch the filesystem or network', async () => {
+    // Pure synthesis — no external I/O. A successful call with a name that
+    // clearly has no adapter file proves this.
+    const resolved = await resolveGenericOrReject('totally-made-up-cli', ['totally-made-up-cli', '--flag'], {
+      genericEnabled: true,
+    })
+    expect(resolved.detail.cli_id).toBe('totally-made-up-cli')
+  })
+})


### PR DESCRIPTION
## Summary

`apes run -- <cli>` now falls back to a synthetic adapter when no shape is registered, instead of hard-failing with "No adapter found".

The synthetic path bypasses the declarative parser entirely (which would reject empty positionals) and feeds a pre-built `ResolvedCommand` into the grant pipeline. The audit hook sits in `verifyAndExecute`, covering sync, async-default, and REPL paths with one implementation.

**Safety:**
- Forced `risk: "high"` + `exact_command: true` + single-use (IdP `usedAt`)
- stderr warning on every generic invocation
- Free-IdP approval page shows "⚠ Unshaped CLI" banner
- JSONL audit log at `~/.config/apes/generic-calls.log`

**Opt-out:** `[generic] enabled = false` in `~/.config/apes/config.toml`

## Test plan

- [x] 533 tests passing, 4 new test files (shapes-generic, shapes-resolve-generic-or-reject, config-generic, audit-generic-log)
- [x] Typecheck green across apes + nuxt-auth-idp + openape-free-idp
- [x] Lint clean
- [ ] CI green
- [ ] E2E: `apes run --wait -- kubectl version --client` → stderr warning → grant → banner on approval → execution → audit log entry
- [ ] E2E: `apes run -- kubectl version --client` (async) → `apes grants run <id> --wait` → audit log entry (openclaw path)
- [ ] E2E: existing shape (`gh repo list`) unaffected
- [ ] E2E: `[generic] enabled = false` → legacy "No adapter found" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)