### PR TITLE
feat: Phase 1 policy-shift — server-side shape registry + standing grants

### DIFF
--- a/.changeset/feat-server-policy-foundation.md
+++ b/.changeset/feat-server-policy-foundation.md
@@ -1,0 +1,62 @@
+---
+'@openape/core': minor
+'@openape/grants': minor
+'@openape/nuxt-auth-idp': minor
+'@openape/idp-test-suite': minor
+---
+
+Phase 1 of the policy shift: server-side shape registry + standing
+grants (pre-authorization patterns) + auto-approval.
+
+## What's new
+
+**Shape Registry (server-side):** the IdP now hosts shapes in a DB table
+(seeded from the shapes-registry repo via `pnpm seed:shapes`) and exposes
+them via three public endpoints:
+
+- `GET /api/shapes` — list all registered shapes
+- `GET /api/shapes/:cliId` — fetch single shape
+- `POST /api/shapes/resolve` — resolve `{cli_id, argv}` → structured
+  `ServerResolvedCommand` (same shape the client `resolveCommand()`
+  returns; falls back to `_generic.exec` when no shape matches)
+
+**Standing Grants:** users can pre-authorize a (delegate, resource-chain)
+pattern so matching future agent grant requests auto-approve without
+human intervention:
+
+- `POST /api/standing-grants` — create (auto-approved by creator)
+- `GET /api/standing-grants` — list own
+- `DELETE /api/standing-grants/:id` — revoke
+
+`POST /api/grants` now checks standing grants between reuse and
+similarity. A match creates the grant with `status='approved'`,
+`decided_by = <standing-grant owner>`, and `decided_by_standing_grant =
+<id>` for audit trail. The response includes `approved_automatically:
+true` so clients can distinguish auto-approved from manually-approved
+grants.
+
+**Agent View:** `GET /api/users/:email/agents` returns per-agent
+standing grants + recent activity + status counts (for the Phase 2 UI).
+
+## Public surface
+
+**`@openape/grants`** — new exports:
+- `ServerShape`, `ServerShapeOperation`, `ShapeStore`,
+  `createInMemoryShapeStore`
+- `resolveServerShape`, `ServerResolvedCommand`, `GENERIC_OPERATION_ID`
+- `StandingGrantRequest`, `StandingGrantMatch`,
+  `evaluateStandingGrants`, `isStandingGrantRequest`,
+  `buildCoverageDetailFromStandingGrant`
+
+**`@openape/core`** — extensions:
+- `GrantCategory` now includes `'standing'`
+- `OpenApeGrant.decided_by_standing_grant` audit column
+
+**`@openape/nuxt-auth-idp`** — new `defineShapeStore()` for registering
+a production ShapeStore (drizzle-backed in openape-free-idp).
+
+## Backward compatibility
+
+Phase 1 is fully backward-compatible — existing `apes` CLI installations
+continue to work unchanged. Phase 3 (apes CLI cutover) is the breaking
+change; Phase 1+2 build the foundation without touching the client.

--- a/apps/openape-free-idp/server/database/migrations/0001_shapes_and_standing_grants.sql
+++ b/apps/openape-free-idp/server/database/migrations/0001_shapes_and_standing_grants.sql
@@ -1,0 +1,18 @@
+-- Shapes registry table — server-side shape definitions (replaces
+-- client-side ~/.openape/shapes/adapters/*.toml lookup in Phase 3).
+CREATE TABLE `shapes` (
+	`cli_id` text PRIMARY KEY NOT NULL,
+	`executable` text NOT NULL,
+	`description` text NOT NULL,
+	`operations` text NOT NULL,
+	`source` text NOT NULL,
+	`digest` text NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL
+);--> statement-breakpoint
+CREATE INDEX `idx_shapes_source` ON `shapes` (`source`);--> statement-breakpoint
+CREATE INDEX `idx_shapes_executable` ON `shapes` (`executable`);--> statement-breakpoint
+
+-- Grants: add decided_by_standing_grant column for audit-trail when an
+-- incoming grant request auto-approves via a matching standing grant.
+ALTER TABLE `grants` ADD `decided_by_standing_grant` text;

--- a/apps/openape-free-idp/server/database/migrations/meta/_journal.json
+++ b/apps/openape-free-idp/server/database/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1775218793504,
       "tag": "0000_blue_enchantress",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1776650000000,
+      "tag": "0001_shapes_and_standing_grants",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/openape-free-idp/server/database/schema.ts
+++ b/apps/openape-free-idp/server/database/schema.ts
@@ -14,11 +14,36 @@ export const grants = sqliteTable('grants', {
   decidedBy: text('decided_by'),
   expiresAt: integer('expires_at'),
   usedAt: integer('used_at'),
+  // When this grant was auto-approved by matching a standing grant, this
+  // column records the standing grant's id for audit-trail purposes.
+  // Null for grants decided via the normal manual approval path.
+  decidedByStandingGrant: text('decided_by_standing_grant'),
 }, table => [
   index('idx_grants_status').on(table.status),
   index('idx_grants_requester').on(table.requester),
   index('idx_grants_created_at').on(table.createdAt),
   index('idx_grants_type').on(table.type),
+])
+
+// --- Server-side shape registry ---
+// Replaces client-side ~/.openape/shapes/adapters/*.toml — the IdP is the
+// canonical source of CLI operation definitions. Populated via the seed
+// script (scripts/seed-shapes.ts) and eventually user uploads.
+export const shapes = sqliteTable('shapes', {
+  cliId: text('cli_id').primaryKey(),
+  executable: text('executable').notNull(),
+  description: text('description').notNull(),
+  // JSON-encoded ServerShapeOperation[]; see packages/grants/src/shape-registry.ts
+  operations: text('operations', { mode: 'json' }).notNull(),
+  // 'builtin' (seeded from monorepo) or 'custom' (uploaded by user)
+  source: text('source').notNull(),
+  // sha256:<hex> of the serialized shape for drift detection
+  digest: text('digest').notNull(),
+  createdAt: integer('created_at').notNull(),
+  updatedAt: integer('updated_at').notNull(),
+}, table => [
+  index('idx_shapes_source').on(table.source),
+  index('idx_shapes_executable').on(table.executable),
 ])
 
 export const grantChallenges = sqliteTable('grant_challenges', {

--- a/apps/openape-free-idp/server/plugins/05.shape-store.ts
+++ b/apps/openape-free-idp/server/plugins/05.shape-store.ts
@@ -1,0 +1,14 @@
+import { createDrizzleShapeStore } from '../utils/drizzle-shape-store'
+
+/**
+ * Wire the Drizzle-backed ShapeStore into the nuxt-auth-idp module's
+ * store registry so `useShapeStore()` (called by the shape API handlers)
+ * returns a DB-backed instance in production.
+ *
+ * Skipped under OPENAPE_E2E=1 so Vitest integration tests can use the
+ * in-memory default from the module without needing a real Turso client.
+ */
+export default defineNitroPlugin(() => {
+  if (process.env.OPENAPE_E2E === '1') return
+  defineShapeStore(() => createDrizzleShapeStore())
+})

--- a/apps/openape-free-idp/server/utils/drizzle-shape-store.ts
+++ b/apps/openape-free-idp/server/utils/drizzle-shape-store.ts
@@ -1,0 +1,66 @@
+import type { ServerShape, ServerShapeOperation, ShapeStore } from '@openape/grants'
+import { asc, eq } from 'drizzle-orm'
+import { useDb } from '../database/drizzle'
+import { shapes } from '../database/schema'
+
+/**
+ * Drizzle-backed ShapeStore. Wraps CRUD over the `shapes` table for the
+ * openape-free-idp deployment. Tests use the in-memory variant from
+ * `@openape/grants` (`createInMemoryShapeStore`).
+ */
+export function createDrizzleShapeStore(): ShapeStore {
+  const db = useDb()
+
+  return {
+    async listShapes() {
+      const rows = await db.select().from(shapes).orderBy(asc(shapes.cliId))
+      return rows.map(rowToShape)
+    },
+
+    async getShape(cliId) {
+      const row = await db.select().from(shapes).where(eq(shapes.cliId, cliId)).get()
+      return row ? rowToShape(row) : null
+    },
+
+    async saveShape(shape) {
+      const values = {
+        cliId: shape.cli_id,
+        executable: shape.executable,
+        description: shape.description,
+        operations: shape.operations,
+        source: shape.source,
+        digest: shape.digest,
+        createdAt: shape.createdAt,
+        updatedAt: shape.updatedAt,
+      }
+      await db.insert(shapes).values(values).onConflictDoUpdate({
+        target: shapes.cliId,
+        set: {
+          executable: values.executable,
+          description: values.description,
+          operations: values.operations,
+          source: values.source,
+          digest: values.digest,
+          updatedAt: values.updatedAt,
+        },
+      })
+    },
+
+    async deleteShape(cliId) {
+      await db.delete(shapes).where(eq(shapes.cliId, cliId))
+    },
+  }
+}
+
+function rowToShape(row: typeof shapes.$inferSelect): ServerShape {
+  return {
+    cli_id: row.cliId,
+    executable: row.executable,
+    description: row.description,
+    operations: row.operations as ServerShapeOperation[],
+    source: row.source as 'builtin' | 'custom',
+    digest: row.digest,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  }
+}

--- a/modules/nuxt-auth-idp/src/module.ts
+++ b/modules/nuxt-auth-idp/src/module.ts
@@ -301,6 +301,12 @@ export default defineNuxtModule<ModuleOptions>({
       addServerHandler({ route: '/api/shapes', handler: resolve('./runtime/server/api/shapes/index.get') })
       addServerHandler({ route: '/api/shapes/:cliId', handler: resolve('./runtime/server/api/shapes/[cliId].get') })
       addServerHandler({ route: '/api/shapes/resolve', method: 'post', handler: resolve('./runtime/server/api/shapes/resolve.post') })
+
+      // Standing grants — user-created pre-authorizations that auto-approve
+      // matching agent grant requests. Phase 1 Milestone 5.
+      addServerHandler({ route: '/api/standing-grants', handler: resolve('./runtime/server/api/standing-grants/index.get') })
+      addServerHandler({ route: '/api/standing-grants', method: 'post', handler: resolve('./runtime/server/api/standing-grants/index.post') })
+      addServerHandler({ route: '/api/standing-grants/:id', method: 'delete', handler: resolve('./runtime/server/api/standing-grants/[id].delete') })
     }
 
     // Server route handlers — Agent

--- a/modules/nuxt-auth-idp/src/module.ts
+++ b/modules/nuxt-auth-idp/src/module.ts
@@ -294,6 +294,13 @@ export default defineNuxtModule<ModuleOptions>({
       addServerHandler({ route: '/api/delegations', method: 'post', handler: resolve('./runtime/server/api/delegations/index.post') })
       addServerHandler({ route: '/api/delegations/:id', method: 'delete', handler: resolve('./runtime/server/api/delegations/[id].delete') })
       addServerHandler({ route: '/api/delegations/:id/validate', method: 'post', handler: resolve('./runtime/server/api/delegations/[id]/validate.post') })
+
+      // Server-side shape registry (Phase 1 of policy-shift). Gated with
+      // `grants` because shapes drive the grant-creation pipeline (argv
+      // resolution, risk scoring, display strings).
+      addServerHandler({ route: '/api/shapes', handler: resolve('./runtime/server/api/shapes/index.get') })
+      addServerHandler({ route: '/api/shapes/:cliId', handler: resolve('./runtime/server/api/shapes/[cliId].get') })
+      addServerHandler({ route: '/api/shapes/resolve', method: 'post', handler: resolve('./runtime/server/api/shapes/resolve.post') })
     }
 
     // Server route handlers — Agent

--- a/modules/nuxt-auth-idp/src/module.ts
+++ b/modules/nuxt-auth-idp/src/module.ts
@@ -307,6 +307,10 @@ export default defineNuxtModule<ModuleOptions>({
       addServerHandler({ route: '/api/standing-grants', handler: resolve('./runtime/server/api/standing-grants/index.get') })
       addServerHandler({ route: '/api/standing-grants', method: 'post', handler: resolve('./runtime/server/api/standing-grants/index.post') })
       addServerHandler({ route: '/api/standing-grants/:id', method: 'delete', handler: resolve('./runtime/server/api/standing-grants/[id].delete') })
+
+      // Agent-view aggregate (per-agent standing grants + recent activity).
+      // Phase 1 Milestone 7. Self-service only (requireAuth + caller == email).
+      addServerHandler({ route: '/api/users/:email/agents', handler: resolve('./runtime/server/api/users/[email]/agents.get') })
     }
 
     // Server route handlers — Agent

--- a/modules/nuxt-auth-idp/src/runtime/server/api/grants/index.post.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/api/grants/index.post.ts
@@ -1,6 +1,6 @@
 import type { GrantType, OpenApeAuthorizationDetail, OpenApeCliAuthorizationDetail, OpenApeGrantRequest } from '@openape/core'
 import { computeCmdHash } from '@openape/core'
-import { canonicalizeCliPermission, cliAuthorizationDetailsCover, computeArgvHash, createGrant, findSimilarCliGrants, isCliAuthorizationDetailExact, validateCliAuthorizationDetail } from '@openape/grants'
+import { canonicalizeCliPermission, cliAuthorizationDetailsCover, computeArgvHash, createGrant, evaluateStandingGrants, findSimilarCliGrants, isCliAuthorizationDetailExact, validateCliAuthorizationDetail } from '@openape/grants'
 import { defineEventHandler, readBody, setResponseStatus } from 'h3'
 import { tryBearerAuth } from '../../utils/agent-auth'
 import { useGrantStores } from '../../utils/grant-stores'
@@ -168,6 +168,28 @@ export default defineEventHandler(async (event) => {
     })
     if (reusable) {
       return reusable
+    }
+
+    // Standing-grant auto-approval: if any of the requester's (=delegate's)
+    // standing grants covers the incoming authorization_details, create
+    // the grant with status='approved' directly and record the standing
+    // grant's id for audit trail. This is the Phase 1 policy-shift hook.
+    const standingMatch = await evaluateStandingGrants(body, grantStore)
+    if (standingMatch) {
+      const pendingGrant = await createGrant(body, grantStore)
+      const now = Math.floor(Date.now() / 1000)
+      const approvedExtra = {
+        status: 'approved' as const,
+        decided_at: now,
+        // decided_by = the standing grant's owner (the user who pre-authorized).
+        // We derive it from the standing grant via its id — look up once.
+        decided_by: (await grantStore.findById(standingMatch.standing_grant_id))?.decided_by ?? undefined,
+        decided_by_standing_grant: standingMatch.standing_grant_id,
+      }
+      await grantStore.updateStatus(pendingGrant.id, 'approved', approvedExtra)
+      const approvedGrant = await grantStore.findById(pendingGrant.id)
+      setResponseStatus(event, 201)
+      return { ...approvedGrant, approved_automatically: true }
     }
 
     // Similarity check: find approved CLI grants that overlap but don't cover

--- a/modules/nuxt-auth-idp/src/runtime/server/api/shapes/[cliId].get.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/api/shapes/[cliId].get.ts
@@ -1,0 +1,20 @@
+import { defineEventHandler, getRouterParam } from 'h3'
+import { useShapeStore } from '../../utils/shape-store'
+import { createProblemError } from '../../utils/problem'
+
+/**
+ * GET /api/shapes/:cliId
+ *
+ * Returns a single shape by CLI id or 404 if not found. Public.
+ */
+export default defineEventHandler(async (event) => {
+  const cliId = decodeURIComponent(getRouterParam(event, 'cliId') ?? '')
+  if (!cliId) {
+    throw createProblemError({ status: 400, title: 'Missing cli_id' })
+  }
+  const shape = await useShapeStore().getShape(cliId)
+  if (!shape) {
+    throw createProblemError({ status: 404, title: `Shape not found: ${cliId}` })
+  }
+  return shape
+})

--- a/modules/nuxt-auth-idp/src/runtime/server/api/shapes/index.get.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/api/shapes/index.get.ts
@@ -1,0 +1,14 @@
+import { defineEventHandler } from 'h3'
+import { useShapeStore } from '../../utils/shape-store'
+
+/**
+ * GET /api/shapes
+ *
+ * Returns every registered shape, sorted by `cli_id`. Public — shapes are
+ * non-sensitive adapter descriptions; exposing them lets UIs and third-party
+ * tools discover what's supported.
+ */
+export default defineEventHandler(async () => {
+  const store = useShapeStore()
+  return await store.listShapes()
+})

--- a/modules/nuxt-auth-idp/src/runtime/server/api/shapes/resolve.post.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/api/shapes/resolve.post.ts
@@ -1,0 +1,33 @@
+import { defineEventHandler, readBody } from 'h3'
+import { resolveServerShape } from '@openape/grants'
+import { useShapeStore } from '../../utils/shape-store'
+import { createProblemError } from '../../utils/problem'
+
+/**
+ * POST /api/shapes/resolve
+ *
+ * Body: `{ cli_id: string, argv: string[], target_host?: string }`
+ *
+ * Resolves raw argv against the server-side shape registry and returns a
+ * structured `ServerResolvedCommand`. When no shape matches, returns the
+ * generic fallback (`operation_id: "_generic.exec"`, `risk: "high"`,
+ * `exact_command: true`).
+ *
+ * Public endpoint — resolution is pure and non-sensitive; callers still
+ * need to post the full grant request to `/api/grants` to actually request
+ * access. This endpoint exists so clients (and future the UI) can preview
+ * a request's shape before creating a grant.
+ */
+export default defineEventHandler(async (event) => {
+  const body = await readBody<{ cli_id?: string, argv?: string[], target_host?: string }>(event)
+  if (!body?.cli_id || typeof body.cli_id !== 'string') {
+    throw createProblemError({ status: 400, title: 'Missing required field: cli_id' })
+  }
+  if (!Array.isArray(body.argv) || body.argv.length === 0) {
+    throw createProblemError({ status: 400, title: 'argv must be a non-empty array (first element is the executable)' })
+  }
+  if (body.argv.some(t => typeof t !== 'string')) {
+    throw createProblemError({ status: 400, title: 'argv entries must be strings' })
+  }
+  return await resolveServerShape(useShapeStore(), body.cli_id, body.argv)
+})

--- a/modules/nuxt-auth-idp/src/runtime/server/api/standing-grants/[id].delete.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/api/standing-grants/[id].delete.ts
@@ -1,0 +1,31 @@
+import { defineEventHandler, getRouterParam } from 'h3'
+import { isStandingGrantRequest, revokeGrant } from '@openape/grants'
+import { useGrantStores } from '../../utils/grant-stores'
+import { requireAuth } from '../../utils/admin'
+import { createProblemError } from '../../utils/problem'
+
+/**
+ * DELETE /api/standing-grants/:id
+ *
+ * Revokes a standing grant. Only the owner (original creator) may revoke.
+ * Revocation flips status to 'revoked' — the audit row stays for trail.
+ */
+export default defineEventHandler(async (event) => {
+  const owner = await requireAuth(event)
+  const id = decodeURIComponent(getRouterParam(event, 'id') ?? '')
+  if (!id) {
+    throw createProblemError({ status: 400, title: 'Missing id' })
+  }
+
+  const { grantStore } = useGrantStores()
+  const grant = await grantStore.findById(id)
+  if (!grant || grant.type !== 'standing' || !isStandingGrantRequest(grant.request)) {
+    throw createProblemError({ status: 404, title: 'Standing grant not found' })
+  }
+  if (grant.request.owner !== owner) {
+    throw createProblemError({ status: 403, title: 'Not the owner of this standing grant' })
+  }
+
+  await revokeGrant(id, grantStore)
+  return { ok: true }
+})

--- a/modules/nuxt-auth-idp/src/runtime/server/api/standing-grants/index.get.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/api/standing-grants/index.get.ts
@@ -1,0 +1,22 @@
+import { defineEventHandler } from 'h3'
+import { isStandingGrantRequest } from '@openape/grants'
+import { useGrantStores } from '../../utils/grant-stores'
+import { requireAuth } from '../../utils/admin'
+
+/**
+ * GET /api/standing-grants
+ *
+ * Returns all standing grants owned by the logged-in user. Includes
+ * expired and revoked ones — callers filter by status client-side if
+ * they only want active pre-auths.
+ */
+export default defineEventHandler(async (event) => {
+  const owner = await requireAuth(event)
+  const { grantStore } = useGrantStores()
+  const all = await grantStore.listGrants({})
+  return all.data.filter((g) => {
+    if (g.type !== 'standing') return false
+    if (!isStandingGrantRequest(g.request)) return false
+    return g.request.owner === owner
+  })
+})

--- a/modules/nuxt-auth-idp/src/runtime/server/api/standing-grants/index.get.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/api/standing-grants/index.get.ts
@@ -13,6 +13,9 @@ import { requireAuth } from '../../utils/admin'
 export default defineEventHandler(async (event) => {
   const owner = await requireAuth(event)
   const { grantStore } = useGrantStores()
+  // Standing grants are stored with requester=delegate, so listGrants
+  // with a status filter + type=standing + owner-check in JS is the
+  // cheapest way to get a user's own pre-auths.
   const all = await grantStore.listGrants({})
   return all.data.filter((g) => {
     if (g.type !== 'standing') return false

--- a/modules/nuxt-auth-idp/src/runtime/server/api/standing-grants/index.post.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/api/standing-grants/index.post.ts
@@ -60,13 +60,24 @@ export default defineEventHandler(async (event) => {
 
   const { grantStore } = useGrantStores()
   const now = Math.floor(Date.now() / 1000)
+
+  // Store requester = delegate so findByRequester(agent) returns the
+  // standing grants that apply to this agent — enables the fast path
+  // in evaluateStandingGrants(). target_host/audience/grant_type use
+  // values that satisfy the grants-table NOT NULL columns.
+  const storedRequest = {
+    ...request,
+    requester: request.delegate,
+    target_host: request.target_host ?? '*',
+    audience: request.audience,
+    grant_type: grantType,
+  } as unknown as OpenApeGrant['request']
+
   const grant: OpenApeGrant = {
     id: crypto.randomUUID(),
     status: 'approved',
     type: 'standing',
-    // request is typed as OpenApeGrantRequest but stored verbatim — the
-    // store is JSON-backed and the evaluator reads via isStandingGrantRequest.
-    request: request as unknown as OpenApeGrant['request'],
+    request: storedRequest,
     created_at: now,
     decided_at: now,
     decided_by: owner,

--- a/modules/nuxt-auth-idp/src/runtime/server/api/standing-grants/index.post.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/api/standing-grants/index.post.ts
@@ -1,0 +1,80 @@
+import type { OpenApeGrant } from '@openape/core'
+import type { StandingGrantRequest } from '@openape/grants'
+import { defineEventHandler, readBody, setResponseStatus } from 'h3'
+import { useGrantStores } from '../../utils/grant-stores'
+import { requireAuth } from '../../utils/admin'
+import { createProblemError } from '../../utils/problem'
+
+/**
+ * POST /api/standing-grants
+ *
+ * Body: StandingGrantRequest (sans `owner` — filled from session).
+ *
+ * Creates a pre-approved pattern grant for (owner, delegate). Future agent
+ * grant requests from `delegate` that match the `resource_chain_template`
+ * will auto-approve via `evaluateStandingGrants()` in the grant-create
+ * handler (Milestone 6).
+ *
+ * Auto-approval semantics: the standing grant is written with
+ * status='approved' immediately — the creator IS the approver. Mirrors
+ * how `createDelegation()` works for agent-on-behalf-of-human delegations.
+ */
+export default defineEventHandler(async (event) => {
+  const owner = await requireAuth(event)
+  const body = await readBody<Partial<StandingGrantRequest>>(event)
+
+  if (!body.delegate || typeof body.delegate !== 'string') {
+    throw createProblemError({ status: 400, title: 'Missing delegate' })
+  }
+  if (!body.audience || typeof body.audience !== 'string') {
+    throw createProblemError({ status: 400, title: 'Missing audience' })
+  }
+  if (!Array.isArray(body.resource_chain_template)) {
+    throw createProblemError({ status: 400, title: 'resource_chain_template must be an array' })
+  }
+  const grantType = body.grant_type ?? 'always'
+  if (grantType !== 'timed' && grantType !== 'always') {
+    throw createProblemError({ status: 400, title: "grant_type must be 'timed' or 'always'" })
+  }
+  if (grantType === 'timed' && typeof body.duration !== 'number') {
+    throw createProblemError({ status: 400, title: 'duration (seconds) required for timed standing grants' })
+  }
+  if (body.max_risk && !['low', 'medium', 'high', 'critical'].includes(body.max_risk)) {
+    throw createProblemError({ status: 400, title: 'Invalid max_risk' })
+  }
+
+  const request: StandingGrantRequest = {
+    type: 'standing',
+    owner,
+    delegate: body.delegate,
+    audience: body.audience,
+    resource_chain_template: body.resource_chain_template,
+    grant_type: grantType,
+    ...(body.target_host ? { target_host: body.target_host } : {}),
+    ...(body.cli_id ? { cli_id: body.cli_id } : {}),
+    ...(body.action ? { action: body.action } : {}),
+    ...(body.max_risk ? { max_risk: body.max_risk } : {}),
+    ...(body.duration !== undefined ? { duration: body.duration } : {}),
+    ...(body.reason ? { reason: body.reason } : {}),
+  }
+
+  const { grantStore } = useGrantStores()
+  const now = Math.floor(Date.now() / 1000)
+  const grant: OpenApeGrant = {
+    id: crypto.randomUUID(),
+    status: 'approved',
+    type: 'standing',
+    // request is typed as OpenApeGrantRequest but stored verbatim — the
+    // store is JSON-backed and the evaluator reads via isStandingGrantRequest.
+    request: request as unknown as OpenApeGrant['request'],
+    created_at: now,
+    decided_at: now,
+    decided_by: owner,
+    ...(grantType === 'timed' && body.duration
+      ? { expires_at: now + body.duration }
+      : {}),
+  }
+  await grantStore.save(grant)
+  setResponseStatus(event, 201)
+  return grant
+})

--- a/modules/nuxt-auth-idp/src/runtime/server/api/standing-grants/index.post.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/api/standing-grants/index.post.ts
@@ -34,7 +34,7 @@ export default defineEventHandler(async (event) => {
   }
   const grantType = body.grant_type ?? 'always'
   if (grantType !== 'timed' && grantType !== 'always') {
-    throw createProblemError({ status: 400, title: "grant_type must be 'timed' or 'always'" })
+    throw createProblemError({ status: 400, title: 'grant_type must be \'timed\' or \'always\'' })
   }
   if (grantType === 'timed' && typeof body.duration !== 'number') {
     throw createProblemError({ status: 400, title: 'duration (seconds) required for timed standing grants' })

--- a/modules/nuxt-auth-idp/src/runtime/server/api/users/[email]/agents.get.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/api/users/[email]/agents.get.ts
@@ -1,0 +1,70 @@
+import type { GrantStatus, OpenApeGrant } from '@openape/core'
+import { isStandingGrantRequest } from '@openape/grants'
+import { defineEventHandler, getRouterParam } from 'h3'
+import { requireAuth } from '../../../utils/admin'
+import { useGrantStores } from '../../../utils/grant-stores'
+import { useIdpStores } from '../../../utils/stores'
+import { createProblemError } from '../../../utils/problem'
+
+/**
+ * GET /api/users/:email/agents
+ *
+ * Aggregated view of all agents owned by the given user. Returns per-agent:
+ *   - standing_grants: approved standing grants where agent = delegate
+ *   - recent_grants: last 20 non-standing grants (requester = agent)
+ *   - grant_counts: per-status tally across all non-standing grants
+ *
+ * Phase 1 is self-service only (caller must equal :email). Admin-on-behalf
+ * access lands in a later phase.
+ */
+export default defineEventHandler(async (event) => {
+  const caller = await requireAuth(event)
+  const email = decodeURIComponent(getRouterParam(event, 'email') ?? '')
+  if (!email) {
+    throw createProblemError({ status: 400, title: 'Missing email' })
+  }
+  if (caller !== email) {
+    throw createProblemError({ status: 403, title: 'Forbidden' })
+  }
+
+  const { userStore } = useIdpStores()
+  const { grantStore } = useGrantStores()
+  const agents = await userStore.findByOwner(email)
+
+  return await Promise.all(agents.map(async (agent) => {
+    // Standing grants are stored with requester=delegate (see
+    // standing-grants/index.post.ts), so findByRequester(agent.email)
+    // returns both normal agent grants AND standing grants that apply.
+    // Split them by `type`.
+    const allAgentGrants = await grantStore.findByRequester(agent.email)
+    const nonStanding: OpenApeGrant[] = []
+    const standingForAgent: OpenApeGrant[] = []
+    for (const g of allAgentGrants) {
+      if (g.type === 'standing') {
+        if (!isStandingGrantRequest(g.request)) continue
+        if (g.request.owner !== email) continue // only list standing grants this user created
+        if (g.status !== 'approved') continue
+        standingForAgent.push(g)
+      }
+      else {
+        nonStanding.push(g)
+      }
+    }
+
+    const counts: Record<GrantStatus, number> = {
+      pending: 0, approved: 0, denied: 0, revoked: 0, expired: 0, used: 0,
+    }
+    for (const g of nonStanding) {
+      counts[g.status] = (counts[g.status] ?? 0) + 1
+    }
+    const recent = nonStanding.toSorted((a, b) => b.created_at - a.created_at).slice(0, 20)
+
+    return {
+      email: agent.email,
+      display_name: agent.name,
+      standing_grants: standingForAgent,
+      recent_grants: recent,
+      grant_counts: counts,
+    }
+  }))
+})

--- a/modules/nuxt-auth-idp/src/runtime/server/utils/define-stores.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/utils/define-stores.ts
@@ -1,5 +1,6 @@
 import type { H3Event } from 'h3'
 import type { ChallengeStore as WebAuthnChallengeStore, CodeStore, CredentialStore, JtiStore, KeyStore, RefreshTokenStore, RegistrationUrlStore, UserStore } from '@openape/auth'
+import type { ShapeStore } from '@openape/grants'
 import type { ExtendedGrantStore } from './grant-store'
 import type { ChallengeStore as GrantChallengeStore } from './grant-challenge-store'
 import type { SshKeyStore } from './ssh-key-store'
@@ -53,4 +54,10 @@ export function defineRefreshTokenStore(factory: (event: H3Event) => RefreshToke
 
 export function defineSshKeyStore(factory: (event: H3Event) => SshKeyStore) {
   registerStoreFactory('sshKeyStore', factory)
+}
+
+// Shape Store (Phase 1 — server-side shape registry)
+
+export function defineShapeStore(factory: (event: H3Event) => ShapeStore) {
+  registerStoreFactory('shapeStore', factory)
 }

--- a/modules/nuxt-auth-idp/src/runtime/server/utils/shape-store.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/utils/shape-store.ts
@@ -1,0 +1,43 @@
+import type { ShapeStore } from '@openape/grants'
+import { createInMemoryShapeStore } from '@openape/grants'
+import { useEvent } from 'nitropack/runtime'
+import { getStoreFactory } from './store-registry'
+
+/**
+ * Module-level fallback — used when the consuming app has not registered a
+ * production store via `defineShapeStore()`. Empty by default; callers can
+ * seed it for tests via `createInMemoryShapeStore(...)` + `defineShapeStore`.
+ */
+let _defaultStore: ShapeStore | null = null
+
+function getDefaultShapeStore(): ShapeStore {
+  if (!_defaultStore) {
+    _defaultStore = createInMemoryShapeStore()
+  }
+  return _defaultStore
+}
+
+/**
+ * Return the `ShapeStore` for the current request. Follows the same pattern
+ * as `useIdpStores()`/`useGrantStores()`: if a factory is registered via
+ * `defineShapeStore(factory)` (in openape-free-idp: a Drizzle-backed impl),
+ * use that per-event. Otherwise fall back to a shared in-memory store.
+ */
+export function useShapeStore(): ShapeStore {
+  try {
+    const event = useEvent()
+    if (event) {
+      const cached = (event.context as Record<string, unknown>)._shapeStore as ShapeStore | undefined
+      if (cached) return cached
+      const factory = getStoreFactory<ShapeStore>('shapeStore')
+      const store = factory ? factory(event) : getDefaultShapeStore()
+      ;(event.context as Record<string, unknown>)._shapeStore = store
+      return store
+    }
+  }
+  catch {
+    // Fall through to module-level default when called outside a request
+    // context (e.g. from tests that instantiate handlers directly).
+  }
+  return getDefaultShapeStore()
+}

--- a/modules/nuxt-auth-sp/src/runtime/components/OpenApeAuth.vue
+++ b/modules/nuxt-auth-sp/src/runtime/components/OpenApeAuth.vue
@@ -1,39 +1,40 @@
 <script setup>
 defineProps({
-  title: { type: String, required: false, default: "Sign in" },
-  subtitle: { type: String, required: false, default: "Enter your email to continue" },
-  buttonText: { type: String, required: false, default: "Continue" },
-  placeholder: { type: String, required: false, default: "you@example.com" }
-});
-const emit = defineEmits(["error"]);
-const { user, loading, fetchUser, login } = useOpenApeAuth();
-const email = ref("");
-const error = ref("");
-const submitting = ref(false);
-const route = useRoute();
+  title: { type: String, required: false, default: 'Sign in' },
+  subtitle: { type: String, required: false, default: 'Enter your email to continue' },
+  buttonText: { type: String, required: false, default: 'Continue' },
+  placeholder: { type: String, required: false, default: 'you@example.com' },
+})
+const emit = defineEmits(['error'])
+const { user, loading, fetchUser, login } = useOpenApeAuth()
+const email = ref('')
+const error = ref('')
+const submitting = ref(false)
+const route = useRoute()
 onMounted(async () => {
-  await fetchUser();
+  await fetchUser()
   if (user.value) {
-    navigateTo("/dashboard");
+    navigateTo('/dashboard')
   }
   if (route.query.error) {
-    error.value = String(route.query.error);
+    error.value = String(route.query.error)
   }
-});
+})
 async function handleSubmit() {
-  error.value = "";
-  if (!email.value || !email.value.includes("@")) {
-    error.value = "Please enter a valid email address";
-    return;
+  error.value = ''
+  if (!email.value || !email.value.includes('@')) {
+    error.value = 'Please enter a valid email address'
+    return
   }
-  submitting.value = true;
+  submitting.value = true
   try {
-    await login(email.value);
-  } catch (e) {
-    const err = e instanceof Error ? e : new Error("Login failed");
-    error.value = e?.data?.message || err.message;
-    emit("error", err);
-    submitting.value = false;
+    await login(email.value)
+  }
+  catch (e) {
+    const err = e instanceof Error ? e : new Error('Login failed')
+    error.value = e?.data?.message || err.message
+    emit('error', err)
+    submitting.value = false
   }
 }
 </script>

--- a/modules/nuxt-auth-sp/src/runtime/components/OpenApeAuth.vue
+++ b/modules/nuxt-auth-sp/src/runtime/components/OpenApeAuth.vue
@@ -1,40 +1,39 @@
 <script setup>
 defineProps({
-  title: { type: String, required: false, default: 'Sign in' },
-  subtitle: { type: String, required: false, default: 'Enter your email to continue' },
-  buttonText: { type: String, required: false, default: 'Continue' },
-  placeholder: { type: String, required: false, default: 'you@example.com' },
-})
-const emit = defineEmits(['error'])
-const { user, loading, fetchUser, login } = useOpenApeAuth()
-const email = ref('')
-const error = ref('')
-const submitting = ref(false)
-const route = useRoute()
+  title: { type: String, required: false, default: "Sign in" },
+  subtitle: { type: String, required: false, default: "Enter your email to continue" },
+  buttonText: { type: String, required: false, default: "Continue" },
+  placeholder: { type: String, required: false, default: "you@example.com" }
+});
+const emit = defineEmits(["error"]);
+const { user, loading, fetchUser, login } = useOpenApeAuth();
+const email = ref("");
+const error = ref("");
+const submitting = ref(false);
+const route = useRoute();
 onMounted(async () => {
-  await fetchUser()
+  await fetchUser();
   if (user.value) {
-    navigateTo('/dashboard')
+    navigateTo("/dashboard");
   }
   if (route.query.error) {
-    error.value = String(route.query.error)
+    error.value = String(route.query.error);
   }
-})
+});
 async function handleSubmit() {
-  error.value = ''
-  if (!email.value || !email.value.includes('@')) {
-    error.value = 'Please enter a valid email address'
-    return
+  error.value = "";
+  if (!email.value || !email.value.includes("@")) {
+    error.value = "Please enter a valid email address";
+    return;
   }
-  submitting.value = true
+  submitting.value = true;
   try {
-    await login(email.value)
-  }
-  catch (e) {
-    const err = e instanceof Error ? e : new Error('Login failed')
-    error.value = e?.data?.message || err.message
-    emit('error', err)
-    submitting.value = false
+    await login(email.value);
+  } catch (e) {
+    const err = e instanceof Error ? e : new Error("Login failed");
+    error.value = e?.data?.message || err.message;
+    emit("error", err);
+    submitting.value = false;
   }
 }
 </script>

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "release": "node scripts/publish-chain.mjs",
     "release:dry": "node scripts/publish-chain.mjs --dry-run",
     "sync:openclaw": "bash scripts/sync-openclaw-skills.sh",
+    "seed:shapes": "tsx scripts/seed-shapes.ts",
     "prepare": "git config core.hooksPath .githooks || true"
   },
   "pnpm": {
@@ -38,8 +39,12 @@
     "@antfu/eslint-config": "catalog:",
     "@changesets/changelog-github": "^0.5.0",
     "@changesets/cli": "catalog:",
+    "@libsql/client": "^0.14.0",
     "@vitest/coverage-istanbul": "^2.1.9",
+    "drizzle-orm": "^0.44.7",
     "eslint": "catalog:",
+    "smol-toml": "^1.6.0",
+    "tsx": "^4.19.0",
     "turbo": "^2.5.0"
   }
 }

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -184,8 +184,8 @@ export interface OpenApeGrantRequest {
   scopes?: string[]
 }
 
-/** Grant category */
-export type GrantCategory = 'command' | 'delegation'
+/** Grant category. `standing` = user pre-authorization pattern that auto-approves matching incoming grants (Phase 1 of policy-shift). */
+export type GrantCategory = 'command' | 'delegation' | 'standing'
 
 /** OpenApe grant */
 export interface OpenApeGrant {

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -207,6 +207,12 @@ export interface OpenApeGrant {
   expires_at?: number
   /** When the grant was used (for 'once' grants) */
   used_at?: number
+  /**
+   * Audit-trail marker when this grant was auto-approved by matching a
+   * standing grant (Phase 1 policy-shift). Holds the standing grant's id.
+   * Null/undefined for grants decided via the normal manual approval flow.
+   */
+  decided_by_standing_grant?: string
 }
 
 /** OpenApe AuthZ-JWT claims */

--- a/packages/grants/src/index.ts
+++ b/packages/grants/src/index.ts
@@ -43,6 +43,13 @@ export {
   type ServerResolvedCommand,
 } from './server-resolver.js'
 export { findSimilarCliGrants, type SimilarGrantMatch, type SimilarGrantsResult } from './similarity.js'
+export {
+  buildCoverageDetailFromStandingGrant,
+  evaluateStandingGrants,
+  isStandingGrantRequest,
+  type StandingGrantMatch,
+  type StandingGrantRequest,
+} from './standing-grants.js'
 export { type GrantListParams, type GrantStore, InMemoryGrantStore } from './stores.js'
 export {
   buildWideningSuggestionsForGrant,

--- a/packages/grants/src/index.ts
+++ b/packages/grants/src/index.ts
@@ -37,6 +37,11 @@ export {
   type ServerShapeOperation,
   type ShapeStore,
 } from './shape-registry.js'
+export {
+  GENERIC_OPERATION_ID,
+  resolveServerShape,
+  type ServerResolvedCommand,
+} from './server-resolver.js'
 export { findSimilarCliGrants, type SimilarGrantMatch, type SimilarGrantsResult } from './similarity.js'
 export { type GrantListParams, type GrantStore, InMemoryGrantStore } from './stores.js'
 export {

--- a/packages/grants/src/index.ts
+++ b/packages/grants/src/index.ts
@@ -31,6 +31,12 @@ export {
   useGrant,
   validateDelegation,
 } from './grants.js'
+export {
+  createInMemoryShapeStore,
+  type ServerShape,
+  type ServerShapeOperation,
+  type ShapeStore,
+} from './shape-registry.js'
 export { findSimilarCliGrants, type SimilarGrantMatch, type SimilarGrantsResult } from './similarity.js'
 export { type GrantListParams, type GrantStore, InMemoryGrantStore } from './stores.js'
 export {

--- a/packages/grants/src/server-resolver.ts
+++ b/packages/grants/src/server-resolver.ts
@@ -1,0 +1,300 @@
+import { createHash } from 'node:crypto'
+import type { OpenApeCliAuthorizationDetail, OpenApeCliResourceRef } from '@openape/core'
+import { canonicalizeCliPermission, computeArgvHash } from './cli-permissions.js'
+import type { ServerShape, ServerShapeOperation, ShapeStore } from './shape-registry.js'
+
+/**
+ * The synthetic operation id used when no registered shape matches the
+ * incoming argv. Mirrors the client-side constant in
+ * `packages/apes/src/shapes/generic.ts`. When the IdP becomes the sole
+ * resolver (Phase 3), this is the only fallback path for unshaped CLIs.
+ */
+export const GENERIC_OPERATION_ID = '_generic.exec'
+
+/** Result of server-side shape resolution — shape-compatible with the client `ResolvedCommand`. */
+export interface ServerResolvedCommand {
+  cli_id: string
+  operation_id: string
+  executable: string
+  commandArgv: string[]
+  bindings: Record<string, string>
+  detail: OpenApeCliAuthorizationDetail
+  executionContext: {
+    argv: string[]
+    argv_hash: string
+    adapter_id: string
+    adapter_version: string
+    adapter_digest: string
+    resolved_executable: string
+    context_bindings: Record<string, string>
+  }
+  permission: string
+  /** True when no shape matched and the generic fallback was produced. */
+  synthetic: boolean
+}
+
+/**
+ * Server-side port of `packages/apes/src/shapes/parser.ts resolveCommand()`.
+ * Looks up the shape for `cli_id` in the store, runs argv-matching against
+ * its operations, and returns a structured authorization detail. When no
+ * shape is found OR no operation matches, falls back to a generic
+ * high-risk exact-command grant (same semantics as
+ * `packages/apes/src/shapes/generic.ts:buildGenericResolved`).
+ *
+ * Pure logic — no DB writes, no HTTP calls, safe to call from any handler.
+ */
+export async function resolveServerShape(
+  store: ShapeStore,
+  cliId: string,
+  fullArgv: string[],
+): Promise<ServerResolvedCommand> {
+  if (fullArgv.length === 0)
+    throw new Error('resolveServerShape: fullArgv must include the executable')
+
+  const shape = await store.getShape(cliId)
+  if (!shape) {
+    return buildGenericResolvedServer(cliId, fullArgv)
+  }
+  const resolved = await tryMatchShape(shape, fullArgv)
+  if (resolved) return resolved
+  return buildGenericResolvedServer(cliId, fullArgv)
+}
+
+// ---------------------------------------------------------------------------
+// Ported helpers (from packages/apes/src/shapes/parser.ts)
+// ---------------------------------------------------------------------------
+
+function parseOptionArgs(
+  tokens: string[],
+  valueOptions?: string[],
+): { options: Record<string, string>, positionals: string[] } {
+  const options: Record<string, string> = {}
+  const positionals: string[] = []
+  const takesValue = new Set(valueOptions ?? [])
+
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index]!
+    if (token.startsWith('--')) {
+      const stripped = token.slice(2)
+      const eqIndex = stripped.indexOf('=')
+      if (eqIndex >= 0) {
+        options[stripped.slice(0, eqIndex)] = stripped.slice(eqIndex + 1)
+        continue
+      }
+      const next = tokens[index + 1]
+      if (next && !next.startsWith('-')) {
+        options[stripped] = next
+        index += 1
+        continue
+      }
+      options[stripped] = 'true'
+    }
+    else if (token.startsWith('-') && token.length > 1 && !/^-\d/.test(token)) {
+      const key = token.slice(1)
+      if (key.length === 1 && !takesValue.has(key)) {
+        options[key] = 'true'
+      }
+      else {
+        const next = tokens[index + 1]
+        if (next && !next.startsWith('-')) {
+          options[key] = next
+          index += 1
+        }
+        else {
+          options[key] = 'true'
+        }
+      }
+    }
+    else {
+      positionals.push(token)
+    }
+  }
+  return { options, positionals }
+}
+
+function resolveBindingToken(binding: string, bindings: Record<string, string>): string {
+  const match = binding.match(/^\{([^}|]+)(?:\|([^}]+))?\}$/)
+  if (!match) return binding
+  const [, name, transform] = match
+  const value = bindings[name!]
+  if (!value) throw new Error(`Missing binding: ${name}`)
+  if (!transform) return value
+  if (transform === 'owner' || transform === 'name') {
+    const [owner, repo] = value.split('/')
+    if (!owner || !repo) throw new Error(`Binding ${name} must be in owner/name form`)
+    return transform === 'owner' ? owner : repo
+  }
+  throw new Error(`Unsupported binding transform: ${transform}`)
+}
+
+function renderTemplate(template: string, bindings: Record<string, string>): string {
+  return template.replace(/\{([^}]+)\}/g, (_, expression: string) => resolveBindingToken(`{${expression}}`, bindings))
+}
+
+function parseResourceChain(chain: string[], bindings: Record<string, string>): OpenApeCliResourceRef[] {
+  return chain.map((entry) => {
+    const [resource, selectorSpec = '*'] = entry.split(':', 2)
+    if (!resource) throw new Error(`Invalid resource chain entry: ${entry}`)
+    if (selectorSpec === '*') return { resource }
+    const selector = Object.fromEntries(
+      selectorSpec.split(',').map((segment) => {
+        const [key, rawValue] = segment.split('=', 2)
+        if (!key || !rawValue) throw new Error(`Invalid selector segment: ${segment}`)
+        return [key, renderTemplate(rawValue, bindings)]
+      }),
+    )
+    return { resource, selector }
+  })
+}
+
+function matchOperation(
+  operation: ServerShapeOperation,
+  argv: string[],
+): Record<string, string> | null {
+  if (argv.length < operation.command.length) return null
+  const prefix = argv.slice(0, operation.command.length)
+  if (prefix.join('\0') !== operation.command.join('\0')) return null
+  const remainder = argv.slice(operation.command.length)
+  const { options, positionals } = parseOptionArgs(remainder, operation.required_options)
+  const expectedPositionals = operation.positionals ?? []
+  if (positionals.length !== expectedPositionals.length) return null
+  for (const option of operation.required_options ?? []) {
+    if (!options[option]) return null
+  }
+  const bindings: Record<string, string> = { ...options }
+  for (let index = 0; index < expectedPositionals.length; index += 1) {
+    const name = expectedPositionals[index]!
+    const value = positionals[index]!
+    if (name.startsWith('=')) {
+      if (value !== name.slice(1)) return null
+      continue
+    }
+    bindings[name] = value
+  }
+  return bindings
+}
+
+function expandCombinedFlags(argv: string[]): string[] {
+  return argv.flatMap((token) => {
+    if (token.startsWith('-') && !token.startsWith('--') && token.length > 2 && /^-[a-z]+$/i.test(token)) {
+      return Array.from(token.slice(1), c => `-${c}`)
+    }
+    return [token]
+  })
+}
+
+function tryMatch(
+  operations: ServerShapeOperation[],
+  argv: string[],
+): Array<{ operation: ServerShapeOperation, bindings: Record<string, string> }> {
+  return operations.flatMap((operation) => {
+    try {
+      const bindings = matchOperation(operation, argv)
+      return bindings ? [{ operation, bindings }] : []
+    }
+    catch {
+      return []
+    }
+  })
+}
+
+async function tryMatchShape(
+  shape: ServerShape,
+  fullArgv: string[],
+): Promise<ServerResolvedCommand | null> {
+  const [executable, ...commandArgv] = fullArgv
+  if (!executable) return null
+
+  // Server resolver is lenient about executable mismatch (client already
+  // verified). Just proceed with shape's operations.
+  let matches = tryMatch(shape.operations, commandArgv)
+  if (matches.length === 0) {
+    const expanded = expandCombinedFlags(commandArgv)
+    if (expanded.length !== commandArgv.length) {
+      matches = tryMatch(shape.operations, expanded)
+    }
+  }
+  if (matches.length === 0) return null
+  if (matches.length > 1) {
+    matches.sort((a, b) => b.operation.command.length - a.operation.command.length)
+    matches = [matches[0]!]
+  }
+
+  const { operation, bindings } = matches[0]!
+  const resource_chain = parseResourceChain(operation.resource_chain, bindings)
+  const detail: OpenApeCliAuthorizationDetail = {
+    type: 'openape_cli',
+    cli_id: shape.cli_id,
+    operation_id: operation.id,
+    resource_chain,
+    action: operation.action,
+    permission: '',
+    display: renderTemplate(operation.display, bindings),
+    risk: operation.risk,
+    ...(operation.exact_command ? { constraints: { exact_command: true } } : {}),
+  }
+  detail.permission = canonicalizeCliPermission(detail)
+
+  return {
+    cli_id: shape.cli_id,
+    operation_id: operation.id,
+    executable,
+    commandArgv,
+    bindings,
+    detail,
+    executionContext: {
+      argv: fullArgv,
+      argv_hash: await computeArgvHash(fullArgv),
+      adapter_id: shape.cli_id,
+      adapter_version: 'server',
+      adapter_digest: shape.digest,
+      resolved_executable: executable,
+      context_bindings: bindings,
+    },
+    permission: detail.permission,
+    synthetic: false,
+  }
+}
+
+function buildGenericResolvedServer(cliId: string, fullArgv: string[]): ServerResolvedCommand {
+  const executable = fullArgv[0]!
+  const commandArgv = fullArgv.slice(1)
+  const argvHash = `SHA-256:${createHash('sha256').update(fullArgv.join('\u0000')).digest('hex')}`
+  const display = `Execute (unshaped): \`${cliId} ${commandArgv.join(' ')}\``
+
+  const detail: OpenApeCliAuthorizationDetail = {
+    type: 'openape_cli',
+    cli_id: cliId,
+    operation_id: GENERIC_OPERATION_ID,
+    resource_chain: [
+      { resource: 'cli', selector: { name: cliId } },
+      { resource: 'argv', selector: { hash: argvHash } },
+    ],
+    action: 'exec',
+    permission: '',
+    display,
+    risk: 'high',
+    constraints: { exact_command: true },
+  }
+  detail.permission = canonicalizeCliPermission(detail)
+
+  return {
+    cli_id: cliId,
+    operation_id: GENERIC_OPERATION_ID,
+    executable,
+    commandArgv,
+    bindings: {},
+    detail,
+    executionContext: {
+      argv: fullArgv,
+      argv_hash: argvHash,
+      adapter_id: cliId,
+      adapter_version: 'openape-shapes/v1',
+      adapter_digest: 'synthetic',
+      resolved_executable: executable,
+      context_bindings: {},
+    },
+    permission: detail.permission,
+    synthetic: true,
+  }
+}

--- a/packages/grants/src/shape-registry.ts
+++ b/packages/grants/src/shape-registry.ts
@@ -1,0 +1,120 @@
+/**
+ * Server-side shape registry: canonical adapter definitions stored and served
+ * by the IdP. Replaces the client-side `~/.openape/shapes/adapters/*.toml`
+ * lookup with an API-backed source of truth.
+ *
+ * A `ServerShape` describes one CLI (e.g. `git`) and its recognizable
+ * operations (e.g. `git.clone`). Incoming agent requests are matched against
+ * these shapes via `resolveServerShape()` (see server-resolver.ts).
+ */
+
+/** One recognizable operation within a shape. */
+export interface ServerShapeOperation {
+  /**
+   * Opaque operation id, e.g. `git.clone` or `_generic.exec` for the
+   * synthetic fallback that matches any argv.
+   */
+  id: string
+
+  /**
+   * Prefix tokens that the argv (after the executable) must start with.
+   * Empty array matches any argv (used by the generic operation only).
+   */
+  command: string[]
+
+  /**
+   * Named positional arguments. Entries prefixed with `=` are literal
+   * matchers — the corresponding argv token must equal the suffix rather
+   * than binding as a variable. Enables interleaved-literal command
+   * shapes like `iurio project <id> workspace <id> task <id> archive`.
+   */
+  positionals?: string[]
+
+  /** Flags (`--foo` or `-f`) that MUST be present for this operation to match. */
+  required_options?: string[]
+
+  /** Template string like `Clone {repo}` rendered with resolved bindings. */
+  display: string
+
+  /** Abstract action label, e.g. `exec`, `read`, `write`, `delete`. */
+  action: string
+
+  /** Risk category for approver UX. */
+  risk: 'low' | 'medium' | 'high' | 'critical'
+
+  /**
+   * Resource-chain template strings. Each string is of the form
+   * `resource:key1={var1},key2={var2}`. Rendered with `parseResourceChain`
+   * into `OpenApeCliResourceRef[]`.
+   */
+  resource_chain: string[]
+
+  /**
+   * When true, a grant based on this operation binds to the exact argv
+   * hash — i.e. `apes run` enforces that the executed argv matches the
+   * approved argv byte-for-byte. Default false.
+   */
+  exact_command?: boolean
+}
+
+/** One CLI's complete shape definition. */
+export interface ServerShape {
+  /** Short identifier (typically matches the executable). */
+  cli_id: string
+  /** Executable name as invoked on the command line. */
+  executable: string
+  /** Human-readable description surfaced in UI. */
+  description: string
+  /** All recognizable operations, matched in declared order. */
+  operations: ServerShapeOperation[]
+  /**
+   * `'builtin'` — seeded from the monorepo adapter directory.
+   * `'custom'` — uploaded by a user via API (future feature).
+   */
+  source: 'builtin' | 'custom'
+  /** `sha256:<hex>` digest of the serialized shape (for drift detection). */
+  digest: string
+  /** Unix seconds. */
+  createdAt: number
+  /** Unix seconds. */
+  updatedAt: number
+}
+
+/**
+ * Persistence contract. Implemented by
+ * `apps/openape-free-idp/server/utils/drizzle-shape-store.ts` for production
+ * and `createInMemoryShapeStore()` below for tests.
+ */
+export interface ShapeStore {
+  /** Returns all shapes sorted by `cli_id` ascending. */
+  listShapes: () => Promise<ServerShape[]>
+  /** Returns a single shape or null. */
+  getShape: (cliId: string) => Promise<ServerShape | null>
+  /** Upserts a shape by `cli_id`. */
+  saveShape: (shape: ServerShape) => Promise<void>
+  /** No-op if the cli_id does not exist. */
+  deleteShape: (cliId: string) => Promise<void>
+}
+
+/**
+ * In-memory `ShapeStore` — for unit tests and local fallbacks. Production
+ * uses the Drizzle-backed store in openape-free-idp.
+ */
+export function createInMemoryShapeStore(seed: ServerShape[] = []): ShapeStore {
+  const map = new Map<string, ServerShape>(seed.map(s => [s.cli_id, s]))
+  return {
+    async listShapes() {
+      // eslint-disable-next-line e18e/prefer-array-to-sorted -- MapIterator has no toSorted()
+      return [...map.values()].sort((a, b) => a.cli_id.localeCompare(b.cli_id))
+    },
+    async getShape(cliId) {
+      return map.get(cliId) ?? null
+    },
+    async saveShape(shape) {
+      map.set(shape.cli_id, shape)
+    },
+    async deleteShape(cliId) {
+      map.delete(cliId)
+    },
+  }
+}

--- a/packages/grants/src/standing-grants.ts
+++ b/packages/grants/src/standing-grants.ts
@@ -130,23 +130,23 @@ export async function evaluateStandingGrants(
     .filter((d): d is OpenApeCliAuthorizationDetail => d.type === 'openape_cli')
   if (incomingCli.length === 0) return null
 
-  // Fetch candidate standing grants. Minimal filter here — the caller
-  // should pre-filter by delegate if the store supports it, but we still
-  // redo the checks below for correctness.
-  //
-  // Standing grants have requester=owner (the user creating the pre-auth)
-  // and delegate=agent. Incoming grant.requester is the agent, so we
-  // search all approved grants and narrow by request.delegate below.
-  const approved = await grantStore.listGrants({ status: 'approved' })
-  const candidates = approved.data
+  // Standing grants are stored with `requester = delegate`, so
+  // findByRequester(agent) returns the full candidate set directly —
+  // no monorepo-wide scan. See standing-grants/index.post.ts for the
+  // normalization rationale.
+  const candidates = await grantStore.findByRequester(incoming.requester)
 
   const now = Math.floor(Date.now() / 1000)
   for (const grant of candidates) {
+    if (grant.status !== 'approved') continue
     const req = grant.request as unknown
     if (!isStandingGrantRequest(req)) continue
     if (req.delegate !== incoming.requester) continue
     if (req.audience !== incoming.audience) continue
-    if (req.target_host && req.target_host !== incoming.target_host) continue
+    // target_host: undefined or '*' means "any host"; specific value must match.
+    // '*' is the stored sentinel because the grants table has target_host
+    // as NOT NULL — see standing-grants/index.post.ts normalization.
+    if (req.target_host && req.target_host !== '*' && req.target_host !== incoming.target_host) continue
     if (grant.expires_at && grant.expires_at < now) continue
 
     const maxRisk = req.max_risk ? RISK_ORDER[req.max_risk] : Number.POSITIVE_INFINITY

--- a/packages/grants/src/standing-grants.ts
+++ b/packages/grants/src/standing-grants.ts
@@ -1,4 +1,4 @@
-import type { OpenApeCliAuthorizationDetail, OpenApeCliResourceRef, OpenApeGrant, OpenApeGrantRequest } from '@openape/core'
+import type { OpenApeCliAuthorizationDetail, OpenApeCliResourceRef, OpenApeGrantRequest } from '@openape/core'
 import { canonicalizeCliPermission, cliAuthorizationDetailCovers } from './cli-permissions.js'
 import type { GrantStore } from './stores.js'
 
@@ -43,8 +43,10 @@ export interface StandingGrantRequest {
 /** What `evaluateStandingGrants` returns on a match. */
 export interface StandingGrantMatch {
   standing_grant_id: string
-  /** The original incoming authorization_details — unchanged. The match
-   *  itself is the proof that the standing grant covers them. */
+  /**
+   * The original incoming authorization_details — unchanged. The match
+   *  itself is the proof that the standing grant covers them.
+   */
   derived_authorization_details: OpenApeCliAuthorizationDetail[]
 }
 

--- a/packages/grants/src/standing-grants.ts
+++ b/packages/grants/src/standing-grants.ts
@@ -1,0 +1,169 @@
+import type { OpenApeCliAuthorizationDetail, OpenApeCliResourceRef, OpenApeGrant, OpenApeGrantRequest } from '@openape/core'
+import { canonicalizeCliPermission, cliAuthorizationDetailCovers } from './cli-permissions.js'
+import type { GrantStore } from './stores.js'
+
+/**
+ * Body format for `POST /api/standing-grants`. Stored in the `grants`
+ * table as `request` with `type: 'standing'` and `status: 'approved'`
+ * (auto-approved — creator IS the approver).
+ *
+ * Unlike a normal grant-request, this encodes a *pattern* that future
+ * incoming grants from the specified delegate will be matched against
+ * during `POST /api/grants`. When a match is found, the incoming grant
+ * is created with `status: 'approved'` and `decided_by_standing_grant`
+ * set to the standing-grant's id for audit-trail.
+ */
+export interface StandingGrantRequest {
+  /** Discriminator — must be 'standing'. */
+  type: 'standing'
+  /** Who is creating this pre-auth (always the logged-in user). */
+  owner: string
+  /** Agent email that may have grants auto-approved. */
+  delegate: string
+  /** Audience restriction (must match incoming grant.audience). */
+  audience: string
+  /** Optional host restriction — undefined matches any host. */
+  target_host?: string
+  /** Optional CLI restriction — undefined matches any CLI. */
+  cli_id?: string
+  /** Resource-chain template with wildcards (selector: undefined = any). */
+  resource_chain_template: OpenApeCliResourceRef[]
+  /** Action restriction — undefined matches any action. */
+  action?: string
+  /** Risk cap — auto-approval only fires when incoming.risk <= this. */
+  max_risk?: 'low' | 'medium' | 'high' | 'critical'
+  /** Standing grants are 'timed' or 'always'; 'once' makes no sense for pre-auth. */
+  grant_type: 'timed' | 'always'
+  /** Required for 'timed' — seconds until this standing grant expires. */
+  duration?: number
+  /** Human-readable note surfaced in UI. */
+  reason?: string
+}
+
+/** What `evaluateStandingGrants` returns on a match. */
+export interface StandingGrantMatch {
+  standing_grant_id: string
+  /** The original incoming authorization_details — unchanged. The match
+   *  itself is the proof that the standing grant covers them. */
+  derived_authorization_details: OpenApeCliAuthorizationDetail[]
+}
+
+/** Risk ordering for `max_risk` cap check. */
+const RISK_ORDER: Record<'low' | 'medium' | 'high' | 'critical', number> = {
+  low: 0,
+  medium: 1,
+  high: 2,
+  critical: 3,
+}
+
+/**
+ * Type guard for standing-grant shaped requests.
+ */
+export function isStandingGrantRequest(req: unknown): req is StandingGrantRequest {
+  return (
+    req !== null
+    && typeof req === 'object'
+    && (req as { type?: unknown }).type === 'standing'
+    && typeof (req as StandingGrantRequest).delegate === 'string'
+    && typeof (req as StandingGrantRequest).audience === 'string'
+    && Array.isArray((req as StandingGrantRequest).resource_chain_template)
+  )
+}
+
+/**
+ * Construct a `OpenApeCliAuthorizationDetail` that represents the standing
+ * grant's pattern, suitable for passing to `cliAuthorizationDetailCovers()`
+ * as the "granted" side.
+ *
+ * The template's `resource_chain_template` becomes the detail's
+ * `resource_chain` verbatim — wildcards are expressed as
+ * `{ resource: 'x', selector: undefined }` which the existing coverage
+ * logic already handles.
+ */
+export function buildCoverageDetailFromStandingGrant(
+  req: StandingGrantRequest,
+  incoming: OpenApeCliAuthorizationDetail,
+): OpenApeCliAuthorizationDetail {
+  const detail: OpenApeCliAuthorizationDetail = {
+    type: 'openape_cli',
+    cli_id: req.cli_id ?? incoming.cli_id,
+    operation_id: incoming.operation_id, // coverage ignores operation_id
+    resource_chain: req.resource_chain_template,
+    action: req.action ?? incoming.action,
+    permission: '',
+    display: req.reason ?? `standing:${req.delegate}`,
+    risk: req.max_risk ?? 'critical',
+  }
+  detail.permission = canonicalizeCliPermission(detail)
+  return detail
+}
+
+/**
+ * Evaluate whether any approved standing grant for the incoming request's
+ * (owner, delegate, audience) triple covers all of the incoming
+ * authorization details.
+ *
+ * Called from the grant-create endpoint AFTER the existing reuse-check
+ * (exact-match against approved grants) and BEFORE the similarity check
+ * that produces `pending` grants. Returns `null` when no standing grant
+ * matches, in which case the normal pending-approval flow continues.
+ *
+ * Matching logic for each standing grant:
+ *   1. `type === 'standing'` and `status === 'approved'`
+ *   2. `delegate === incoming.requester`
+ *   3. `audience === incoming.audience`
+ *   4. `target_host` undefined OR matches incoming.target_host
+ *   5. `cli_id` undefined OR matches each incoming detail's cli_id
+ *   6. `action` undefined OR matches each incoming detail's action
+ *   7. `max_risk` undefined OR incoming details' risk <= max_risk
+ *   8. `cliAuthorizationDetailCovers(template, incoming)` returns true
+ *      for EVERY incoming detail
+ *   9. Not expired (checked via grant.request.duration + grant.decided_at)
+ *
+ * Returns the first matching standing grant (stable order: oldest first).
+ */
+export async function evaluateStandingGrants(
+  incoming: OpenApeGrantRequest,
+  grantStore: GrantStore,
+): Promise<StandingGrantMatch | null> {
+  const incomingCli = (incoming.authorization_details ?? [])
+    .filter((d): d is OpenApeCliAuthorizationDetail => d.type === 'openape_cli')
+  if (incomingCli.length === 0) return null
+
+  // Fetch candidate standing grants. Minimal filter here — the caller
+  // should pre-filter by delegate if the store supports it, but we still
+  // redo the checks below for correctness.
+  //
+  // Standing grants have requester=owner (the user creating the pre-auth)
+  // and delegate=agent. Incoming grant.requester is the agent, so we
+  // search all approved grants and narrow by request.delegate below.
+  const approved = await grantStore.listGrants({ status: 'approved' })
+  const candidates = approved.data
+
+  const now = Math.floor(Date.now() / 1000)
+  for (const grant of candidates) {
+    const req = grant.request as unknown
+    if (!isStandingGrantRequest(req)) continue
+    if (req.delegate !== incoming.requester) continue
+    if (req.audience !== incoming.audience) continue
+    if (req.target_host && req.target_host !== incoming.target_host) continue
+    if (grant.expires_at && grant.expires_at < now) continue
+
+    const maxRisk = req.max_risk ? RISK_ORDER[req.max_risk] : Number.POSITIVE_INFINITY
+    let allCovered = true
+    for (const incomingDetail of incomingCli) {
+      if (req.cli_id && req.cli_id !== incomingDetail.cli_id) { allCovered = false; break }
+      if (req.action && req.action !== incomingDetail.action) { allCovered = false; break }
+      if (RISK_ORDER[incomingDetail.risk] > maxRisk) { allCovered = false; break }
+      const template = buildCoverageDetailFromStandingGrant(req, incomingDetail)
+      if (!cliAuthorizationDetailCovers(template, incomingDetail)) { allCovered = false; break }
+    }
+    if (!allCovered) continue
+
+    return {
+      standing_grant_id: grant.id,
+      derived_authorization_details: incomingCli,
+    }
+  }
+  return null
+}

--- a/packages/grants/test/server-resolver.test.ts
+++ b/packages/grants/test/server-resolver.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest'
+import { createInMemoryShapeStore, type ServerShape } from '../src/shape-registry.js'
+import { GENERIC_OPERATION_ID, resolveServerShape } from '../src/server-resolver.js'
+
+const gitShape: ServerShape = {
+  cli_id: 'git',
+  executable: 'git',
+  description: 'Git CLI',
+  operations: [
+    {
+      id: 'git.clone',
+      command: ['clone'],
+      positionals: ['url'],
+      display: 'Clone {url}',
+      action: 'exec',
+      risk: 'medium',
+      resource_chain: ['repo:url={url}'],
+    },
+    {
+      id: 'git.status',
+      command: ['status'],
+      positionals: [],
+      display: 'Show git status',
+      action: 'read',
+      risk: 'low',
+      resource_chain: [],
+    },
+  ],
+  source: 'builtin',
+  digest: 'sha256:deadbeef',
+  createdAt: 0,
+  updatedAt: 0,
+}
+
+describe('resolveServerShape', () => {
+  it('matches a known operation by command prefix + positionals', async () => {
+    const store = createInMemoryShapeStore([gitShape])
+    const r = await resolveServerShape(store, 'git', ['git', 'clone', 'git@github.com:foo/bar.git'])
+    expect(r.operation_id).toBe('git.clone')
+    expect(r.synthetic).toBe(false)
+    expect(r.detail.risk).toBe('medium')
+    expect(r.detail.resource_chain).toEqual([
+      { resource: 'repo', selector: { url: 'git@github.com:foo/bar.git' } },
+    ])
+    expect(r.detail.display).toBe('Clone git@github.com:foo/bar.git')
+    expect(r.executable).toBe('git')
+    expect(r.commandArgv).toEqual(['clone', 'git@github.com:foo/bar.git'])
+    expect(r.permission.length).toBeGreaterThan(0)
+  })
+
+  it('matches a zero-positional operation', async () => {
+    const store = createInMemoryShapeStore([gitShape])
+    const r = await resolveServerShape(store, 'git', ['git', 'status'])
+    expect(r.operation_id).toBe('git.status')
+    expect(r.detail.risk).toBe('low')
+    expect(r.synthetic).toBe(false)
+  })
+
+  it('falls back to _generic.exec for unknown CLI', async () => {
+    const store = createInMemoryShapeStore()
+    const r = await resolveServerShape(store, 'kubectl', ['kubectl', 'get', 'pods'])
+    expect(r.operation_id).toBe(GENERIC_OPERATION_ID)
+    expect(r.detail.risk).toBe('high')
+    expect(r.detail.constraints?.exact_command).toBe(true)
+    expect(r.synthetic).toBe(true)
+    expect(r.detail.resource_chain[0]).toEqual({ resource: 'cli', selector: { name: 'kubectl' } })
+    expect(r.detail.resource_chain[1]!.resource).toBe('argv')
+    expect(r.detail.resource_chain[1]!.selector?.hash).toMatch(/^SHA-256:[a-f0-9]{64}$/)
+  })
+
+  it('falls back to _generic.exec when argv does not match any operation', async () => {
+    const store = createInMemoryShapeStore([gitShape])
+    const r = await resolveServerShape(store, 'git', ['git', 'bizarre-subcommand'])
+    expect(r.operation_id).toBe(GENERIC_OPERATION_ID)
+    expect(r.synthetic).toBe(true)
+  })
+
+  it('falls back to _generic.exec when shape has operations but none match argv length', async () => {
+    const store = createInMemoryShapeStore([gitShape])
+    // clone wants 1 positional, we give 0
+    const r = await resolveServerShape(store, 'git', ['git', 'clone'])
+    expect(r.operation_id).toBe(GENERIC_OPERATION_ID)
+  })
+
+  it('produces a stable argv_hash across runs for the same argv', async () => {
+    const store = createInMemoryShapeStore()
+    const a = await resolveServerShape(store, 'kubectl', ['kubectl', 'get', 'pods'])
+    const b = await resolveServerShape(store, 'kubectl', ['kubectl', 'get', 'pods'])
+    expect(a.executionContext.argv_hash).toBe(b.executionContext.argv_hash)
+  })
+
+  it('throws when fullArgv is empty', async () => {
+    const store = createInMemoryShapeStore()
+    await expect(resolveServerShape(store, 'kubectl', [])).rejects.toThrow(/must include the executable/)
+  })
+})

--- a/packages/grants/test/server-resolver.test.ts
+++ b/packages/grants/test/server-resolver.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { createInMemoryShapeStore, type ServerShape } from '../src/shape-registry.js'
+import { createInMemoryShapeStore  } from '../src/shape-registry.js'
+import type { ServerShape } from '../src/shape-registry.js'
 import { GENERIC_OPERATION_ID, resolveServerShape } from '../src/server-resolver.js'
 
 const gitShape: ServerShape = {

--- a/packages/grants/test/shape-registry.test.ts
+++ b/packages/grants/test/shape-registry.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import { createInMemoryShapeStore  } from '../src/shape-registry.js'
+import type { ServerShape } from '../src/shape-registry.js'
+
+function makeShape(cliId: string, extras: Partial<ServerShape> = {}): ServerShape {
+  return {
+    cli_id: cliId,
+    executable: cliId,
+    description: `${cliId} CLI`,
+    operations: [{
+      id: `${cliId}.default`,
+      command: [],
+      display: `Run ${cliId}`,
+      action: 'exec',
+      risk: 'medium',
+      resource_chain: [],
+    }],
+    source: 'builtin',
+    digest: `sha256:${cliId}`,
+    createdAt: 1_000_000,
+    updatedAt: 1_000_000,
+    ...extras,
+  }
+}
+
+describe('createInMemoryShapeStore', () => {
+  it('returns an empty list when seeded with nothing', async () => {
+    const store = createInMemoryShapeStore()
+    expect(await store.listShapes()).toEqual([])
+  })
+
+  it('returns seeded shapes sorted by cli_id', async () => {
+    const store = createInMemoryShapeStore([makeShape('zsh'), makeShape('alpha'), makeShape('mid')])
+    const list = await store.listShapes()
+    expect(list.map(s => s.cli_id)).toEqual(['alpha', 'mid', 'zsh'])
+  })
+
+  it('getShape returns the stored shape or null', async () => {
+    const store = createInMemoryShapeStore([makeShape('git')])
+    expect((await store.getShape('git'))?.cli_id).toBe('git')
+    expect(await store.getShape('nope')).toBeNull()
+  })
+
+  it('saveShape upserts', async () => {
+    const store = createInMemoryShapeStore()
+    await store.saveShape(makeShape('git', { description: 'initial' }))
+    await store.saveShape(makeShape('git', { description: 'updated' }))
+    expect((await store.getShape('git'))?.description).toBe('updated')
+  })
+
+  it('deleteShape removes the shape', async () => {
+    const store = createInMemoryShapeStore([makeShape('git')])
+    await store.deleteShape('git')
+    expect(await store.getShape('git')).toBeNull()
+    expect(await store.listShapes()).toEqual([])
+  })
+
+  it('deleteShape is a no-op for unknown cli_id', async () => {
+    const store = createInMemoryShapeStore([makeShape('git')])
+    await store.deleteShape('nope')
+    expect((await store.listShapes()).length).toBe(1)
+  })
+})

--- a/packages/grants/test/standing-grants.test.ts
+++ b/packages/grants/test/standing-grants.test.ts
@@ -17,12 +17,20 @@ function makeStandingGrant(
     grant_type: 'always',
     ...overrides,
   }
+  // The store normalizes standing grants to have requester=delegate so
+  // findByRequester(agent) returns them. Mirror that here.
+  const storedRequest = {
+    ...req,
+    requester: req.delegate,
+    target_host: req.target_host ?? '*',
+    audience: req.audience,
+    grant_type: req.grant_type,
+  } as unknown as OpenApeGrant['request']
   return {
     id: `sg-${Math.random().toString(36).slice(2, 10)}`,
     status: 'approved',
-    // @ts-expect-error — OpenApeGrant.request is typed as OpenApeGrantRequest but
-    // standing grants use StandingGrantRequest; the DB stores it verbatim.
-    request: req,
+    type: 'standing',
+    request: storedRequest,
     created_at: Math.floor(Date.now() / 1000) - 60,
     decided_at: Math.floor(Date.now() / 1000) - 30,
     decided_by: overrides.owner,

--- a/packages/grants/test/standing-grants.test.ts
+++ b/packages/grants/test/standing-grants.test.ts
@@ -5,8 +5,9 @@ import { canonicalizeCliPermission } from '../src/cli-permissions.js'
 import {
   evaluateStandingGrants,
   isStandingGrantRequest,
-  type StandingGrantRequest,
+
 } from '../src/standing-grants.js'
+import type { StandingGrantRequest } from '../src/standing-grants.js'
 
 function makeStandingGrant(
   overrides: Partial<StandingGrantRequest> & Pick<StandingGrantRequest, 'owner' | 'delegate' | 'resource_chain_template'>,

--- a/packages/grants/test/standing-grants.test.ts
+++ b/packages/grants/test/standing-grants.test.ts
@@ -1,0 +1,243 @@
+import type { OpenApeGrant, OpenApeGrantRequest } from '@openape/core'
+import { describe, expect, it } from 'vitest'
+import { InMemoryGrantStore } from '../src/stores.js'
+import { canonicalizeCliPermission } from '../src/cli-permissions.js'
+import {
+  evaluateStandingGrants,
+  isStandingGrantRequest,
+  type StandingGrantRequest,
+} from '../src/standing-grants.js'
+
+function makeStandingGrant(
+  overrides: Partial<StandingGrantRequest> & Pick<StandingGrantRequest, 'owner' | 'delegate' | 'resource_chain_template'>,
+): OpenApeGrant {
+  const req: StandingGrantRequest = {
+    type: 'standing',
+    audience: 'shapes',
+    grant_type: 'always',
+    ...overrides,
+  }
+  return {
+    id: `sg-${Math.random().toString(36).slice(2, 10)}`,
+    status: 'approved',
+    // @ts-expect-error — OpenApeGrant.request is typed as OpenApeGrantRequest but
+    // standing grants use StandingGrantRequest; the DB stores it verbatim.
+    request: req,
+    created_at: Math.floor(Date.now() / 1000) - 60,
+    decided_at: Math.floor(Date.now() / 1000) - 30,
+    decided_by: overrides.owner,
+  }
+}
+
+function makeIncomingGrantRequest(
+  overrides: Partial<OpenApeGrantRequest> = {},
+): OpenApeGrantRequest {
+  const detail = {
+    type: 'openape_cli' as const,
+    cli_id: 'git',
+    operation_id: 'git.clone',
+    resource_chain: [{ resource: 'repo', selector: { owner: 'patrick', name: 'app' } }],
+    action: 'exec',
+    permission: '',
+    display: 'Clone patrick/app',
+    risk: 'medium' as const,
+  }
+  detail.permission = canonicalizeCliPermission(detail)
+  return {
+    requester: 'claude@example.com',
+    target_host: 'macmini',
+    audience: 'shapes',
+    grant_type: 'once',
+    authorization_details: [detail],
+    ...overrides,
+  }
+}
+
+describe('isStandingGrantRequest', () => {
+  it('returns true for a valid standing grant request', () => {
+    expect(isStandingGrantRequest({
+      type: 'standing',
+      owner: 'patrick@',
+      delegate: 'claude@',
+      audience: 'shapes',
+      resource_chain_template: [],
+      grant_type: 'always',
+    })).toBe(true)
+  })
+
+  it('returns false for non-standing requests', () => {
+    expect(isStandingGrantRequest({ type: 'command' })).toBe(false)
+    expect(isStandingGrantRequest(null)).toBe(false)
+    expect(isStandingGrantRequest(undefined)).toBe(false)
+    expect(isStandingGrantRequest({})).toBe(false)
+  })
+})
+
+describe('evaluateStandingGrants', () => {
+  async function withStandingGrants(sgs: OpenApeGrant[]) {
+    const store = new InMemoryGrantStore()
+    for (const sg of sgs) await store.save(sg)
+    return store
+  }
+
+  it('matches when template owner selector covers incoming', async () => {
+    const store = await withStandingGrants([
+      makeStandingGrant({
+        owner: 'patrick@',
+        delegate: 'claude@example.com',
+        resource_chain_template: [{ resource: 'repo', selector: { owner: 'patrick' } }],
+      }),
+    ])
+    const match = await evaluateStandingGrants(makeIncomingGrantRequest(), store)
+    expect(match).not.toBeNull()
+    expect(match!.standing_grant_id).toMatch(/^sg-/)
+  })
+
+  it('matches with wildcard selector (no selector in template)', async () => {
+    const store = await withStandingGrants([
+      makeStandingGrant({
+        owner: 'patrick@',
+        delegate: 'claude@example.com',
+        resource_chain_template: [{ resource: 'repo' }], // no selector = wildcard
+      }),
+    ])
+    const match = await evaluateStandingGrants(makeIncomingGrantRequest(), store)
+    expect(match).not.toBeNull()
+  })
+
+  it('does not match when delegate differs', async () => {
+    const store = await withStandingGrants([
+      makeStandingGrant({
+        owner: 'patrick@',
+        delegate: 'someone-else@',
+        resource_chain_template: [{ resource: 'repo' }],
+      }),
+    ])
+    const match = await evaluateStandingGrants(makeIncomingGrantRequest(), store)
+    expect(match).toBeNull()
+  })
+
+  it('does not match when audience differs', async () => {
+    const store = await withStandingGrants([
+      makeStandingGrant({
+        owner: 'patrick@',
+        delegate: 'claude@example.com',
+        audience: 'escapes',
+        resource_chain_template: [{ resource: 'repo' }],
+      }),
+    ])
+    const match = await evaluateStandingGrants(makeIncomingGrantRequest(), store)
+    expect(match).toBeNull()
+  })
+
+  it('does not match when target_host is set and differs', async () => {
+    const store = await withStandingGrants([
+      makeStandingGrant({
+        owner: 'patrick@',
+        delegate: 'claude@example.com',
+        target_host: 'other-host',
+        resource_chain_template: [{ resource: 'repo' }],
+      }),
+    ])
+    const match = await evaluateStandingGrants(makeIncomingGrantRequest(), store)
+    expect(match).toBeNull()
+  })
+
+  it('matches when target_host is unset (wildcard host)', async () => {
+    const store = await withStandingGrants([
+      makeStandingGrant({
+        owner: 'patrick@',
+        delegate: 'claude@example.com',
+        resource_chain_template: [{ resource: 'repo' }],
+      }),
+    ])
+    const match = await evaluateStandingGrants(makeIncomingGrantRequest(), store)
+    expect(match).not.toBeNull()
+  })
+
+  it('does not match when cli_id restriction differs', async () => {
+    const store = await withStandingGrants([
+      makeStandingGrant({
+        owner: 'patrick@',
+        delegate: 'claude@example.com',
+        cli_id: 'kubectl', // incoming is git
+        resource_chain_template: [{ resource: 'repo' }],
+      }),
+    ])
+    const match = await evaluateStandingGrants(makeIncomingGrantRequest(), store)
+    expect(match).toBeNull()
+  })
+
+  it('does not match when max_risk is below incoming risk', async () => {
+    const store = await withStandingGrants([
+      makeStandingGrant({
+        owner: 'patrick@',
+        delegate: 'claude@example.com',
+        max_risk: 'low', // incoming is medium
+        resource_chain_template: [{ resource: 'repo' }],
+      }),
+    ])
+    const match = await evaluateStandingGrants(makeIncomingGrantRequest(), store)
+    expect(match).toBeNull()
+  })
+
+  it('matches when max_risk is at or above incoming risk', async () => {
+    const store = await withStandingGrants([
+      makeStandingGrant({
+        owner: 'patrick@',
+        delegate: 'claude@example.com',
+        max_risk: 'high',
+        resource_chain_template: [{ resource: 'repo' }],
+      }),
+    ])
+    const match = await evaluateStandingGrants(makeIncomingGrantRequest(), store)
+    expect(match).not.toBeNull()
+  })
+
+  it('does not match when template has a selector that does not cover incoming', async () => {
+    const store = await withStandingGrants([
+      makeStandingGrant({
+        owner: 'patrick@',
+        delegate: 'claude@example.com',
+        resource_chain_template: [{ resource: 'repo', selector: { owner: 'someone-else' } }],
+      }),
+    ])
+    const match = await evaluateStandingGrants(makeIncomingGrantRequest(), store)
+    expect(match).toBeNull()
+  })
+
+  it('ignores non-standing grants', async () => {
+    const store = new InMemoryGrantStore()
+    // A normal approved grant, not a standing grant, should not be a match source.
+    await store.save({
+      id: 'regular',
+      status: 'approved',
+      request: {
+        requester: 'claude@example.com',
+        target_host: 'macmini',
+        audience: 'shapes',
+        grant_type: 'always',
+        authorization_details: [],
+      },
+      created_at: 0,
+      decided_at: 0,
+    })
+    const match = await evaluateStandingGrants(makeIncomingGrantRequest(), store)
+    expect(match).toBeNull()
+  })
+
+  it('returns null for a grant request with no CLI authorization details', async () => {
+    const store = await withStandingGrants([
+      makeStandingGrant({
+        owner: 'patrick@',
+        delegate: 'claude@example.com',
+        resource_chain_template: [{ resource: 'repo' }],
+      }),
+    ])
+    const match = await evaluateStandingGrants(
+      makeIncomingGrantRequest({ authorization_details: [] }),
+      store,
+    )
+    expect(match).toBeNull()
+  })
+})

--- a/packages/idp-test-suite/src/config.ts
+++ b/packages/idp-test-suite/src/config.ts
@@ -2,7 +2,7 @@ export interface IdPTestConfig {
   /** Base URL or a function returning the base URL (resolved at test time). */
   baseUrl: string | (() => string)
   managementToken: string
-  skip?: string[] // suite names to skip: 'discovery', 'admin-users', 'ssh-keys', 'auth', 'session', 'oidc-flow', 'grants', 'delegations', 'security'
+  skip?: string[] // suite names to skip: 'discovery', 'admin-users', 'ssh-keys', 'auth', 'session', 'oidc-flow', 'grants', 'delegations', 'server-policy-shift', 'security'
 }
 
 /** Resolved config where baseUrl is always a string. Used inside test functions. */

--- a/packages/idp-test-suite/src/index.ts
+++ b/packages/idp-test-suite/src/index.ts
@@ -7,6 +7,7 @@ import { discoveryTests } from './suites/discovery.js'
 import { grantsTests } from './suites/grants.js'
 import { oidcFlowTests } from './suites/oidc-flow.js'
 import { securityTests } from './suites/security.js'
+import { serverPolicyShiftTests } from './suites/server-policy-shift.js'
 import { sessionTests } from './suites/session.js'
 import { sshKeyTests } from './suites/ssh-keys.js'
 
@@ -25,5 +26,6 @@ export function runIdPTestSuite(config: IdPTestConfig) {
   if (!skip.has('oidc-flow')) oidcFlowTests(resolved)
   if (!skip.has('grants')) grantsTests(resolved)
   if (!skip.has('delegations')) delegationsTests(resolved)
+  if (!skip.has('server-policy-shift')) serverPolicyShiftTests(resolved)
   if (!skip.has('security')) securityTests(resolved)
 }

--- a/packages/idp-test-suite/src/suites/server-policy-shift.ts
+++ b/packages/idp-test-suite/src/suites/server-policy-shift.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it } from 'vitest'
+import type { ResolvedConfig } from '../config.js'
+import { del, generateEd25519Key, get, loginWithKey, post } from '../helpers.js'
+
+/**
+ * E2E suite for the Phase 1 server-side policy foundation:
+ *
+ * 1. Shape registry GET/resolve endpoints
+ * 2. Standing-grants POST/GET/DELETE lifecycle
+ * 3. Auto-approval on /api/grants when a standing grant covers incoming
+ * 4. Non-matching requests still go to pending
+ * 5. Agent-view aggregate
+ *
+ * Assumes the shape registry has NOT been seeded (so the generic fallback
+ * is exercised for resolve). Admin-panel-style tests for seeded shapes
+ * belong to the consumer app's integration tests, not this portable suite.
+ */
+export function serverPolicyShiftTests(config: ResolvedConfig) {
+  describe('Server-side policy shift (Phase 1)', () => {
+    describe('Shape registry API', () => {
+      it('GET /api/shapes returns an array', async () => {
+        const { status, data } = await get(config.baseUrl, '/api/shapes')
+        expect(status).toBe(200)
+        expect(Array.isArray(data)).toBe(true)
+      })
+
+      it('GET /api/shapes/:cliId returns 404 for unknown CLI', async () => {
+        const { status } = await get(config.baseUrl, '/api/shapes/totally-not-a-shape-xyz')
+        expect(status).toBe(404)
+      })
+
+      it('POST /api/shapes/resolve returns generic fallback for unknown CLI', async () => {
+        const { status, data } = await post(
+          config.baseUrl,
+          '/api/shapes/resolve',
+          { cli_id: 'kubectl-fake', argv: ['kubectl-fake', 'get', 'pods'] },
+        )
+        expect(status).toBe(200)
+        expect(data.operation_id).toBe('_generic.exec')
+        expect(data.synthetic).toBe(true)
+        expect(data.detail.risk).toBe('high')
+        expect(data.detail.constraints?.exact_command).toBe(true)
+      })
+
+      it('POST /api/shapes/resolve rejects missing cli_id', async () => {
+        const { status } = await post(
+          config.baseUrl,
+          '/api/shapes/resolve',
+          { argv: ['x', 'y'] },
+        )
+        expect(status).toBe(400)
+      })
+
+      it('POST /api/shapes/resolve rejects empty argv', async () => {
+        const { status } = await post(
+          config.baseUrl,
+          '/api/shapes/resolve',
+          { cli_id: 'anything', argv: [] },
+        )
+        expect(status).toBe(400)
+      })
+    })
+
+    describe('Standing grants lifecycle + auto-approval', () => {
+      const humanEmail = `sgshift-human-${Date.now()}@example.com`
+      const agentEmail = `sgshift-agent-${Date.now()}@example.com`
+      const humanKey = generateEd25519Key()
+      const agentKey = generateEd25519Key()
+      let standingGrantId: string
+
+      it('setup: create human + agent', async () => {
+        const { status: s1 } = await post(
+          config.baseUrl,
+          '/api/auth/enroll',
+          { email: humanEmail, name: 'SG Human', publicKey: humanKey.publicKeySsh, owner: humanEmail, type: 'human' },
+          config.managementToken,
+        )
+        expect(s1).toBe(200)
+        const { status: s2 } = await post(
+          config.baseUrl,
+          '/api/auth/enroll',
+          { email: agentEmail, name: 'SG Agent', publicKey: agentKey.publicKeySsh, owner: humanEmail },
+          config.managementToken,
+        )
+        expect(s2).toBe(200)
+      })
+
+      it('human creates a standing grant for the agent', async () => {
+        const token = await loginWithKey(config.baseUrl, humanEmail, humanKey.privateKey)
+        const { status, data } = await post(
+          config.baseUrl,
+          '/api/standing-grants',
+          {
+            delegate: agentEmail,
+            audience: 'shapes',
+            grant_type: 'always',
+            resource_chain_template: [{ resource: 'cli', selector: { name: 'echo' } }],
+            max_risk: 'high',
+            reason: 'e2e: test pre-authorization for echo',
+          },
+          token,
+        )
+        expect(status).toBe(201)
+        expect(data.type).toBe('standing')
+        expect(data.status).toBe('approved')
+        expect(data.decided_by).toBe(humanEmail)
+        expect(data.request.delegate).toBe(agentEmail)
+        standingGrantId = data.id
+      })
+
+      it('listing standing grants as the owner returns it', async () => {
+        const token = await loginWithKey(config.baseUrl, humanEmail, humanKey.privateKey)
+        const { status, data } = await get(config.baseUrl, '/api/standing-grants', token)
+        expect(status).toBe(200)
+        expect(Array.isArray(data)).toBe(true)
+        expect(data.find((g: { id: string }) => g.id === standingGrantId)).toBeDefined()
+      })
+
+      it('agent grant request matching the SG auto-approves', async () => {
+        const agentToken = await loginWithKey(config.baseUrl, agentEmail, agentKey.privateKey)
+        const { status, data } = await post(
+          config.baseUrl,
+          '/api/grants',
+          {
+            requester: agentEmail,
+            target_host: 'hostA',
+            audience: 'shapes',
+            grant_type: 'once',
+            command: ['echo', 'hello'],
+            authorization_details: [{
+              type: 'openape_cli',
+              cli_id: 'echo',
+              operation_id: 'echo.say',
+              action: 'exec',
+              risk: 'low',
+              resource_chain: [{ resource: 'cli', selector: { name: 'echo' } }],
+              permission: 'echo.cli[name=echo]#exec',
+              display: 'echo hello',
+            }],
+          },
+          agentToken,
+        )
+        expect(status).toBe(201)
+        expect(data.status).toBe('approved')
+        expect(data.decided_by_standing_grant).toBe(standingGrantId)
+        expect(data.approved_automatically).toBe(true)
+      })
+
+      it('agent grant request NOT covered by SG falls through to pending', async () => {
+        const agentToken = await loginWithKey(config.baseUrl, agentEmail, agentKey.privateKey)
+        const { status, data } = await post(
+          config.baseUrl,
+          '/api/grants',
+          {
+            requester: agentEmail,
+            target_host: 'hostA',
+            audience: 'shapes',
+            grant_type: 'once',
+            command: ['rm', '/tmp/x'],
+            authorization_details: [{
+              type: 'openape_cli',
+              cli_id: 'rm',
+              operation_id: 'rm.delete',
+              action: 'exec',
+              risk: 'medium',
+              resource_chain: [{ resource: 'filesystem', selector: { path: '/tmp/x' } }],
+              permission: 'rm.filesystem[path=/tmp/x]#exec',
+              display: 'Delete /tmp/x',
+            }],
+          },
+          agentToken,
+        )
+        expect(status).toBe(201)
+        expect(data.status).toBe('pending')
+        expect(data.decided_by_standing_grant).toBeUndefined()
+      })
+
+      it('revoking the standing grant stops auto-approval', async () => {
+        const token = await loginWithKey(config.baseUrl, humanEmail, humanKey.privateKey)
+        const { status } = await del(config.baseUrl, `/api/standing-grants/${standingGrantId}`, token)
+        expect(status).toBe(200)
+
+        // Next request for echo should now land in pending
+        const agentToken = await loginWithKey(config.baseUrl, agentEmail, agentKey.privateKey)
+        const { data } = await post(
+          config.baseUrl,
+          '/api/grants',
+          {
+            requester: agentEmail,
+            target_host: 'hostA',
+            audience: 'shapes',
+            grant_type: 'once',
+            command: ['echo', 'world'],
+            authorization_details: [{
+              type: 'openape_cli',
+              cli_id: 'echo',
+              operation_id: 'echo.say',
+              action: 'exec',
+              risk: 'low',
+              resource_chain: [{ resource: 'cli', selector: { name: 'echo' } }],
+              permission: 'echo.cli[name=echo]#exec',
+              display: 'echo world',
+            }],
+          },
+          agentToken,
+        )
+        expect(data.status).toBe('pending')
+      })
+    })
+
+    describe('Agent-view endpoint', () => {
+      const humanEmail = `av-human-${Date.now()}@example.com`
+      const agentEmail = `av-agent-${Date.now()}@example.com`
+      const humanKey = generateEd25519Key()
+      const agentKey = generateEd25519Key()
+
+      it('setup: create human + agent', async () => {
+        await post(config.baseUrl, '/api/auth/enroll', { email: humanEmail, name: 'AV H', publicKey: humanKey.publicKeySsh, owner: humanEmail, type: 'human' }, config.managementToken)
+        await post(config.baseUrl, '/api/auth/enroll', { email: agentEmail, name: 'AV A', publicKey: agentKey.publicKeySsh, owner: humanEmail }, config.managementToken)
+      })
+
+      it('returns the agents owned by the caller', async () => {
+        const token = await loginWithKey(config.baseUrl, humanEmail, humanKey.privateKey)
+        const { status, data } = await get(config.baseUrl, `/api/users/${encodeURIComponent(humanEmail)}/agents`, token)
+        expect(status).toBe(200)
+        expect(Array.isArray(data)).toBe(true)
+        const agent = data.find((a: { email: string }) => a.email === agentEmail)
+        expect(agent).toBeDefined()
+        expect(agent.standing_grants).toEqual([])
+        expect(agent.recent_grants).toEqual([])
+        expect(agent.grant_counts).toMatchObject({ pending: 0, approved: 0, denied: 0, revoked: 0, expired: 0, used: 0 })
+      })
+
+      it('rejects cross-user access with 403', async () => {
+        const token = await loginWithKey(config.baseUrl, humanEmail, humanKey.privateKey)
+        const { status } = await get(config.baseUrl, '/api/users/someone-else@example.com/agents', token)
+        expect(status).toBe(403)
+      })
+    })
+  })
+}

--- a/packages/idp-test-suite/test/against-server.test.ts
+++ b/packages/idp-test-suite/test/against-server.test.ts
@@ -31,4 +31,8 @@ afterAll(() => {
 runIdPTestSuite({
   baseUrl: () => `http://localhost:${port}`,
   managementToken: MGMT,
+  // server-policy-shift needs the shape + standing-grants endpoints that
+  // live in @openape/nuxt-auth-idp; they're not exposed by @openape/server.
+  // Runs instead via against-free-idp.test.ts when FREE_IDP_MGMT_TOKEN is set.
+  skip: ['server-policy-shift'],
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,12 +47,24 @@ importers:
       '@changesets/cli':
         specifier: 'catalog:'
         version: 2.30.0(@types/node@25.5.0)
+      '@libsql/client':
+        specifier: ^0.14.0
+        version: 0.14.0
       '@vitest/coverage-istanbul':
         specifier: ^2.1.9
         version: 2.1.9(vitest@3.2.4(@types/debug@4.1.12)(@types/node@25.5.0)(happy-dom@18.0.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      drizzle-orm:
+        specifier: ^0.44.7
+        version: 0.44.7(@libsql/client@0.14.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(bun-types@1.3.10)(gel@2.2.0)
       eslint:
         specifier: ^9.35.0
         version: 9.39.4(jiti@2.6.1)
+      smol-toml:
+        specifier: ^1.6.0
+        version: 1.6.0
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
       turbo:
         specifier: ^2.5.0
         version: 2.8.16
@@ -21196,7 +21208,6 @@ snapshots:
       get-tsconfig: 4.13.6
     optionalDependencies:
       fsevents: 2.3.3
-    optional: true
 
   tunnel-agent@0.6.0:
     dependencies:

--- a/scripts/seed-shapes.ts
+++ b/scripts/seed-shapes.ts
@@ -1,0 +1,159 @@
+#!/usr/bin/env tsx
+/**
+ * Seed the IdP `shapes` table from the shapes-registry repo.
+ *
+ * Usage:
+ *   SHAPES_REGISTRY_PATH=/path/to/shapes-registry \
+ *   TURSO_URL=... TURSO_AUTH_TOKEN=... \
+ *   pnpm seed:shapes
+ *
+ * Defaults to `../shapes-registry` (sibling of openape-monorepo) when no
+ * env var is provided.
+ *
+ * The script is idempotent: it uses `onConflictDoUpdate` keyed on `cli_id`
+ * so re-running updates content but preserves created_at. Only `builtin`
+ * shapes are touched — any `custom` shapes in the table are left alone.
+ */
+
+import { createHash } from 'node:crypto'
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { parse as parseToml } from 'smol-toml'
+import { drizzle } from 'drizzle-orm/libsql'
+import { createClient } from '@libsql/client'
+import { shapes } from '../apps/openape-free-idp/server/database/schema'
+import type { ServerShape, ServerShapeOperation } from '@openape/grants'
+
+interface AdapterTomlOperation {
+  id: string
+  command?: string[]
+  positionals?: string[]
+  required_options?: string[]
+  display: string
+  action: string
+  risk: 'low' | 'medium' | 'high' | 'critical'
+  resource_chain?: string[]
+  exact_command?: boolean
+}
+
+interface AdapterToml {
+  schema: string
+  cli: { id: string, executable: string, audience?: string, version?: string }
+  operation?: AdapterTomlOperation[]
+}
+
+interface AdapterMeta {
+  id: string
+  name: string
+  description: string
+  executable: string
+}
+
+function resolveRegistryPath(): string {
+  if (process.env.SHAPES_REGISTRY_PATH) return resolve(process.env.SHAPES_REGISTRY_PATH)
+  return resolve(import.meta.dirname ?? __dirname, '..', '..', 'shapes-registry')
+}
+
+function loadShape(dir: string): ServerShape | null {
+  const adapterPath = join(dir, 'adapter.toml')
+  const metaPath = join(dir, 'meta.json')
+  if (!existsSync(adapterPath)) return null
+
+  const adapterContent = readFileSync(adapterPath, 'utf-8')
+  const adapter = parseToml(adapterContent) as unknown as AdapterToml
+  const meta: AdapterMeta | null = existsSync(metaPath)
+    ? (JSON.parse(readFileSync(metaPath, 'utf-8')) as AdapterMeta)
+    : null
+
+  const cliId = adapter.cli.id
+  const operations: ServerShapeOperation[] = (adapter.operation ?? []).map(op => ({
+    id: op.id,
+    command: op.command ?? [],
+    positionals: op.positionals,
+    required_options: op.required_options,
+    display: op.display,
+    action: op.action,
+    risk: op.risk,
+    resource_chain: op.resource_chain ?? [],
+    exact_command: op.exact_command,
+  }))
+
+  const now = Math.floor(Date.now() / 1000)
+  const digest = `sha256:${createHash('sha256').update(adapterContent).digest('hex')}`
+  return {
+    cli_id: cliId,
+    executable: adapter.cli.executable,
+    description: meta?.description ?? '',
+    operations,
+    source: 'builtin',
+    digest,
+    createdAt: now,
+    updatedAt: now,
+  }
+}
+
+async function main() {
+  const registryPath = resolveRegistryPath()
+  const adaptersDir = join(registryPath, 'adapters')
+  if (!existsSync(adaptersDir)) {
+    console.error(`Registry adapters dir not found: ${adaptersDir}`)
+    console.error(`Set SHAPES_REGISTRY_PATH to point at the shapes-registry repo.`)
+    process.exit(1)
+  }
+
+  const tursoUrl = process.env.TURSO_URL
+  const tursoToken = process.env.TURSO_AUTH_TOKEN
+  if (!tursoUrl) {
+    console.error(`TURSO_URL is required`)
+    process.exit(1)
+  }
+
+  const db = drizzle(createClient({ url: tursoUrl, authToken: tursoToken }))
+
+  const entries = readdirSync(adaptersDir).filter((name) => {
+    const full = join(adaptersDir, name)
+    return statSync(full).isDirectory() && existsSync(join(full, 'adapter.toml'))
+  })
+
+  console.log(`Seeding ${entries.length} shape(s) from ${registryPath}...`)
+  let seeded = 0
+  let skipped = 0
+
+  for (const entry of entries) {
+    const shape = loadShape(join(adaptersDir, entry))
+    if (!shape) {
+      skipped += 1
+      console.warn(`Skipped ${entry} (no adapter.toml)`)
+      continue
+    }
+    await db.insert(shapes).values({
+      cliId: shape.cli_id,
+      executable: shape.executable,
+      description: shape.description,
+      operations: shape.operations,
+      source: shape.source,
+      digest: shape.digest,
+      createdAt: shape.createdAt,
+      updatedAt: shape.updatedAt,
+    }).onConflictDoUpdate({
+      target: shapes.cliId,
+      set: {
+        executable: shape.executable,
+        description: shape.description,
+        operations: shape.operations,
+        digest: shape.digest,
+        updatedAt: shape.updatedAt,
+        source: 'builtin',
+      },
+    })
+    seeded += 1
+    console.log(`  ✓ ${shape.cli_id} (${shape.operations.length} operations)`)
+  }
+
+  console.log(`Done: ${seeded} seeded, ${skipped} skipped.`)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary

Phase 1 of the server-side policy shift. Moves shape/resource knowledge and auto-approval from the apes CLI to the IdP, while keeping existing clients fully backward-compatible.

See `.claude/plans/openape-policy-shift/phase-1-server.md` for the full plan.

## What's new

**Server-side shape registry:** IdP hosts shapes in a DB table, seeded from the shapes-registry repo. Three public endpoints — list, get, resolve.

**Standing grants:** users create pre-auth patterns via `POST /api/standing-grants`. Matching agent requests auto-approve at grant-creation time, with an audit column (`decided_by_standing_grant`) pointing back to the standing grant.

**Agent-view endpoint:** `GET /api/users/:email/agents` returns per-agent standing grants + recent activity + status counts (prepares Phase 2 UI).

**Seed script:** `pnpm seed:shapes` reads shapes-registry adapter TOMLs and upserts them into the DB. Idempotent.

## Commits

- \`ShapeStore interface + shapes DB table + drizzle migration\`
- \`server-side shape resolver (port from apes parser.ts)\`
- \`shape API endpoints + DB-backed store\`
- \`seed shapes registry into IdP DB\`
- \`standing-grants API + evaluation\`
- \`auto-approve grants via standing grants + agent view\`
- \`server-policy-shift E2E suite\`
- \`changeset for Phase 1 policy-shift\`

## Backward compatibility

Phase 1 is fully backward-compatible — existing \`apes\` clients keep working. Phase 3 (CLI cutover, major bump) is the breaking step.

## Test plan

- [x] Unit tests (\`pnpm turbo run test\`): 202 @openape/grants + 65 @openape/nuxt-auth-idp + 20 openape-free-idp green
- [x] Typecheck: green across all affected packages
- [ ] CI green
- [ ] After merge: run \`pnpm seed:shapes\` against prod Turso
- [ ] Deploy free-idp to Vercel
- [ ] E2E suite against deployed IdP via \`FREE_IDP_MGMT_TOKEN\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)