### PR TITLE
feat(nuxt-auth-idp): Phase 2 UI — agents view + standing grants

### DIFF
--- a/.changeset/feat-phase-2-agents-ui.md
+++ b/.changeset/feat-phase-2-agents-ui.md
@@ -1,0 +1,36 @@
+---
+'@openape/nuxt-auth-idp': minor
+---
+
+Phase 2 of the policy shift: Web UI for agent management and
+pre-authorization.
+
+## What's new
+
+Two new pages on `id.openape.at`:
+
+- **`/agents`** — list of all agents owned by the logged-in user, with
+  grant-activity counters and standing-grant count.
+- **`/agents/:email`** — per-agent detail page with:
+  - Existing approved standing grants (scope description + revoke action)
+  - Inline form to create a new standing grant: CLI picker (populated
+    from the server-side shape registry), wildcard resource-chain
+    textarea (`resource:key=value` format), max-risk selector, grant
+    type (always/timed), optional duration + reason.
+  - Recent activity table (last 20 grants from this agent), with
+    ⚡ marker on rows that were auto-approved by a standing grant.
+
+## Helper utilities (new)
+
+- `modules/nuxt-auth-idp/src/runtime/utils/standing-grants.ts`
+  - `formatStandingGrantScope(sg)` — render scope as a human string
+  - `formatResourceChainTemplate(chain)` — summarise wildcards/selectors
+  - `parseResourceChainInput(text)` — parse the textarea input into
+    `OpenApeCliResourceRef[]`
+  - `formatRelativeTime(seconds)` — "just now" / "Nm ago" / "Nh ago"
+
+Tests cover the parser, formatter, scope rendering, and time helper (+19 tests).
+
+## Backward-compatibility
+
+Fully backward-compatible — pages are additive, no existing API changes.

--- a/modules/nuxt-auth-idp/src/module.ts
+++ b/modules/nuxt-auth-idp/src/module.ts
@@ -188,6 +188,9 @@ export default defineNuxtModule<ModuleOptions>({
             { name: 'openape-grant-approval', path: '/grant-approval', file: resolve('./runtime/pages/grant-approval.vue') },
             { name: 'openape-grants', path: '/grants', file: resolve('./runtime/pages/grants.vue') },
             { name: 'openape-enroll', path: '/enroll', file: resolve('./runtime/pages/enroll.vue') },
+            // Phase 2: Agents view + standing-grant management
+            { name: 'openape-agents', path: '/agents', file: resolve('./runtime/pages/agents.vue') },
+            { name: 'openape-agents-detail', path: '/agents/:email', file: resolve('./runtime/pages/agents/[email].vue') },
           )
         }
 

--- a/modules/nuxt-auth-idp/src/runtime/pages/agents.vue
+++ b/modules/nuxt-auth-idp/src/runtime/pages/agents.vue
@@ -1,0 +1,155 @@
+<script setup>
+import { onMounted, ref } from 'vue'
+import { navigateTo } from '#imports'
+import { useIdpAuth } from '../composables/useIdpAuth'
+
+const { user, loading: authLoading, fetchUser } = useIdpAuth()
+const agents = ref([])
+const loading = ref(true)
+const error = ref('')
+
+onMounted(async () => {
+  await fetchUser()
+  if (!user.value) {
+    await navigateTo('/login')
+    return
+  }
+  await loadAgents()
+})
+
+async function loadAgents() {
+  loading.value = true
+  error.value = ''
+  try {
+    agents.value = await $fetch(`/api/users/${encodeURIComponent(user.value.email)}/agents`)
+  }
+  catch (err) {
+    error.value = err?.data?.title || 'Failed to load agents'
+    agents.value = []
+  }
+  finally {
+    loading.value = false
+  }
+}
+
+function standingCount(agent) {
+  return (agent.standing_grants ?? []).length
+}
+</script>
+
+<template>
+  <div class="min-h-screen py-8 px-4">
+    <div class="max-w-4xl mx-auto">
+      <div class="flex items-center justify-between mb-6">
+        <div>
+          <h1 class="text-2xl font-bold">
+            Agents
+          </h1>
+          <p v-if="user" class="text-sm text-muted">
+            {{ user.email }}
+          </p>
+        </div>
+        <UButton to="/account" color="neutral" variant="soft" size="sm">
+          Account
+        </UButton>
+      </div>
+
+      <div v-if="authLoading || loading" class="text-center text-muted mt-10">
+        Loading…
+      </div>
+
+      <UAlert v-else-if="error" color="error" :title="error" class="mb-4" />
+
+      <div v-else-if="agents.length === 0" class="text-center mt-10 space-y-3">
+        <p class="text-muted">
+          No agents yet.
+        </p>
+        <p class="text-sm text-muted">
+          Enroll one with <code class="bg-gray-800 px-1 rounded">apes enroll</code>
+          or see the <a href="https://docs.openape.at" class="text-primary underline" target="_blank" rel="noreferrer">docs</a>.
+        </p>
+      </div>
+
+      <template v-else>
+        <UCard :ui="{ body: 'p-0' }">
+          <template #header>
+            <h2 class="text-lg font-semibold">
+              Your agents
+            </h2>
+            <p class="text-sm text-muted mt-1">
+              Grant activity per agent. Click an agent to manage standing grants.
+            </p>
+          </template>
+
+          <table class="w-full">
+            <thead class="border-b border-(--ui-border)">
+              <tr>
+                <th class="text-left px-4 py-3 text-xs font-medium text-muted uppercase">
+                  Agent
+                </th>
+                <th class="text-left px-4 py-3 text-xs font-medium text-muted uppercase">
+                  Standing Grants
+                </th>
+                <th class="text-left px-4 py-3 text-xs font-medium text-muted uppercase">
+                  Activity
+                </th>
+                <th class="text-right px-4 py-3 text-xs font-medium text-muted uppercase">
+                  Actions
+                </th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-(--ui-border)">
+              <tr
+                v-for="agent in agents"
+                :key="agent.email"
+                class="odd:bg-(--ui-bg-elevated)/40 even:bg-(--ui-bg) hover:bg-(--ui-bg-elevated)"
+              >
+                <td class="px-4 py-3">
+                  <div class="text-sm font-medium">
+                    {{ agent.display_name || agent.email }}
+                  </div>
+                  <div class="text-xs text-muted break-all font-mono">
+                    {{ agent.email }}
+                  </div>
+                </td>
+                <td class="px-4 py-3">
+                  <UBadge v-if="standingCount(agent) > 0" color="success" variant="subtle" size="sm">
+                    {{ standingCount(agent) }} active
+                  </UBadge>
+                  <span v-else class="text-xs text-muted">none</span>
+                </td>
+                <td class="px-4 py-3 text-xs">
+                  <div class="flex gap-2 flex-wrap">
+                    <UBadge v-if="agent.grant_counts?.pending" color="warning" variant="subtle" size="sm">
+                      {{ agent.grant_counts.pending }} pending
+                    </UBadge>
+                    <UBadge v-if="agent.grant_counts?.approved" color="success" variant="subtle" size="sm">
+                      {{ agent.grant_counts.approved }} approved
+                    </UBadge>
+                    <UBadge v-if="agent.grant_counts?.denied" color="error" variant="subtle" size="sm">
+                      {{ agent.grant_counts.denied }} denied
+                    </UBadge>
+                    <UBadge v-if="agent.grant_counts?.used" color="neutral" variant="subtle" size="sm">
+                      {{ agent.grant_counts.used }} used
+                    </UBadge>
+                    <span v-if="!agent.grant_counts || Object.values(agent.grant_counts).every(v => !v)" class="text-muted">no grants</span>
+                  </div>
+                </td>
+                <td class="px-4 py-3 text-right">
+                  <UButton
+                    :to="`/agents/${encodeURIComponent(agent.email)}`"
+                    color="primary"
+                    variant="soft"
+                    size="xs"
+                  >
+                    Manage
+                  </UButton>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </UCard>
+      </template>
+    </div>
+  </div>
+</template>

--- a/modules/nuxt-auth-idp/src/runtime/pages/agents/[email].vue
+++ b/modules/nuxt-auth-idp/src/runtime/pages/agents/[email].vue
@@ -1,0 +1,422 @@
+<script setup>
+import { computed, onMounted, ref } from 'vue'
+import { navigateTo, useRoute } from '#imports'
+import { useIdpAuth } from '../../composables/useIdpAuth'
+import {
+  formatRelativeTime,
+  formatStandingGrantScope,
+  parseResourceChainInput,
+} from '../../utils/standing-grants'
+
+const { user, loading: authLoading, fetchUser } = useIdpAuth()
+const route = useRoute()
+const targetEmail = computed(() => decodeURIComponent(route.params.email))
+
+const agent = ref(null)
+const loading = ref(true)
+const error = ref('')
+const success = ref('')
+
+// Shapes for CLI picker
+const shapes = ref([])
+
+// Add-SG form state
+const form = ref({
+  cli_id: '',
+  resource_chain_text: '',
+  max_risk: 'low',
+  grant_type: 'always',
+  duration: 3600,
+  reason: '',
+})
+const formSubmitting = ref(false)
+const formError = ref('')
+
+// Revoke dialog state
+const revokeTarget = ref(null) // the SG object being revoked
+const revoking = ref(false)
+
+onMounted(async () => {
+  await fetchUser()
+  if (!user.value) {
+    await navigateTo('/login')
+    return
+  }
+  await Promise.all([loadAgent(), loadShapes()])
+})
+
+async function loadAgent() {
+  loading.value = true
+  error.value = ''
+  try {
+    const all = await $fetch(`/api/users/${encodeURIComponent(user.value.email)}/agents`)
+    agent.value = all.find(a => a.email === targetEmail.value) ?? null
+    if (!agent.value) {
+      error.value = `Agent not found: ${targetEmail.value}`
+    }
+  }
+  catch (err) {
+    error.value = err?.data?.title || 'Failed to load agent'
+  }
+  finally {
+    loading.value = false
+  }
+}
+
+async function loadShapes() {
+  try {
+    shapes.value = await $fetch('/api/shapes')
+  }
+  catch {
+    shapes.value = []
+  }
+}
+
+const cliOptions = computed(() => [
+  { label: 'Any CLI (wildcard)', value: '' },
+  ...shapes.value.map(s => ({ label: s.cli_id, value: s.cli_id })),
+])
+
+const riskOptions = [
+  { label: 'Low', value: 'low' },
+  { label: 'Medium', value: 'medium' },
+  { label: 'High', value: 'high' },
+  { label: 'Critical', value: 'critical' },
+]
+
+const grantTypeOptions = [
+  { label: 'Always', value: 'always' },
+  { label: 'Timed', value: 'timed' },
+]
+
+function commandCell(g) {
+  const cmd = g.request?.command
+  if (!cmd || cmd.length === 0) return '—'
+  return cmd.join(' ')
+}
+
+function statusColor(status) {
+  switch (status) {
+    case 'approved': return 'success'
+    case 'pending': return 'warning'
+    case 'denied':
+    case 'revoked':
+    case 'expired': return 'error'
+    default: return 'neutral'
+  }
+}
+
+async function handleAddSg() {
+  formError.value = ''
+  formSubmitting.value = true
+  try {
+    const resource_chain_template = parseResourceChainInput(form.value.resource_chain_text)
+    const body = {
+      delegate: targetEmail.value,
+      audience: 'shapes',
+      resource_chain_template,
+      max_risk: form.value.max_risk,
+      grant_type: form.value.grant_type,
+      ...(form.value.cli_id ? { cli_id: form.value.cli_id } : {}),
+      ...(form.value.grant_type === 'timed' ? { duration: Number(form.value.duration) } : {}),
+      ...(form.value.reason ? { reason: form.value.reason } : {}),
+    }
+    await $fetch('/api/standing-grants', { method: 'POST', body })
+    success.value = 'Standing grant created'
+    resetForm()
+    await loadAgent()
+  }
+  catch (err) {
+    formError.value = err?.data?.title || err?.message || 'Failed to create standing grant'
+  }
+  finally {
+    formSubmitting.value = false
+  }
+}
+
+function resetForm() {
+  form.value = {
+    cli_id: '',
+    resource_chain_text: '',
+    max_risk: 'low',
+    grant_type: 'always',
+    duration: 3600,
+    reason: '',
+  }
+}
+
+function askRevoke(sg) {
+  revokeTarget.value = sg
+}
+
+async function confirmRevoke() {
+  if (!revokeTarget.value) return
+  revoking.value = true
+  try {
+    await $fetch(`/api/standing-grants/${encodeURIComponent(revokeTarget.value.id)}`, { method: 'DELETE' })
+    success.value = 'Standing grant revoked'
+    revokeTarget.value = null
+    await loadAgent()
+  }
+  catch (err) {
+    error.value = err?.data?.title || 'Failed to revoke'
+  }
+  finally {
+    revoking.value = false
+  }
+}
+
+function cancelRevoke() {
+  revokeTarget.value = null
+}
+</script>
+
+<template>
+  <div class="min-h-screen py-8 px-4">
+    <div class="max-w-4xl mx-auto">
+      <div class="flex items-center justify-between mb-6">
+        <div>
+          <h1 class="text-2xl font-bold">
+            {{ agent?.display_name || targetEmail }}
+          </h1>
+          <p class="text-sm text-muted font-mono break-all">
+            {{ targetEmail }}
+          </p>
+        </div>
+        <UButton to="/agents" color="neutral" variant="soft" size="sm">
+          ← All agents
+        </UButton>
+      </div>
+
+      <div v-if="authLoading || loading" class="text-center text-muted mt-10">
+        Loading…
+      </div>
+
+      <UAlert v-else-if="error" color="error" :title="error" class="mb-4" />
+
+      <template v-else-if="agent">
+        <UAlert v-if="success" color="success" :title="success" class="mb-4" @close="success = ''" />
+
+        <!-- Standing Grants Section -->
+        <UCard :ui="{ body: 'p-0' }" class="mb-6">
+          <template #header>
+            <h2 class="text-lg font-semibold">
+              Standing grants
+            </h2>
+            <p class="text-sm text-muted mt-1">
+              Pre-authorized patterns that auto-approve matching agent requests.
+            </p>
+          </template>
+
+          <div v-if="agent.standing_grants.length === 0" class="p-6 text-center text-muted text-sm">
+            No standing grants yet.
+          </div>
+          <table v-else class="w-full">
+            <thead class="border-b border-(--ui-border)">
+              <tr>
+                <th class="text-left px-4 py-3 text-xs font-medium text-muted uppercase">
+                  Scope
+                </th>
+                <th class="text-left px-4 py-3 text-xs font-medium text-muted uppercase">
+                  Created
+                </th>
+                <th class="text-right px-4 py-3 text-xs font-medium text-muted uppercase">
+                  Actions
+                </th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-(--ui-border)">
+              <tr
+                v-for="sg in agent.standing_grants"
+                :key="sg.id"
+                class="odd:bg-(--ui-bg-elevated)/40 even:bg-(--ui-bg)"
+              >
+                <td class="px-4 py-3 text-sm font-mono">
+                  {{ formatStandingGrantScope(sg) }}
+                  <div v-if="sg.request?.reason" class="text-xs text-muted font-sans mt-1">
+                    {{ sg.request.reason }}
+                  </div>
+                </td>
+                <td class="px-4 py-3 text-xs text-muted">
+                  {{ formatRelativeTime(sg.created_at) }}
+                </td>
+                <td class="px-4 py-3 text-right">
+                  <UButton
+                    variant="ghost"
+                    size="xs"
+                    color="error"
+                    icon="i-lucide-trash-2"
+                    @click="askRevoke(sg)"
+                  >
+                    Revoke
+                  </UButton>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </UCard>
+
+        <!-- Add Standing Grant Form -->
+        <UCard class="mb-6">
+          <template #header>
+            <h2 class="text-lg font-semibold">
+              Add standing grant
+            </h2>
+            <p class="text-sm text-muted mt-1">
+              Matching incoming agent requests will auto-approve — no prompt.
+            </p>
+          </template>
+
+          <UAlert v-if="formError" color="error" :title="formError" class="mb-4" @close="formError = ''" />
+
+          <div class="space-y-3">
+            <UFormField label="CLI">
+              <USelect v-model="form.cli_id" :items="cliOptions" />
+            </UFormField>
+            <UAlert
+              v-if="form.cli_id === ''"
+              color="warning"
+              variant="soft"
+              title="Wildcard across all CLIs"
+              description="This grants the agent auto-approval for any CLI that matches the resource chain below. Use with caution."
+              class="text-xs"
+            />
+
+            <UFormField label="Resource-chain template" description="One entry per line. Format: resource or resource:key=value,key2=value2. Empty = wildcard within CLI.">
+              <UTextarea
+                v-model="form.resource_chain_text"
+                :rows="3"
+                class="font-mono text-xs"
+                placeholder="e.g.&#10;repo:owner=patrick&#10;or leave blank for wildcard"
+              />
+            </UFormField>
+
+            <UFormField label="Max risk">
+              <USelect v-model="form.max_risk" :items="riskOptions" />
+            </UFormField>
+
+            <UFormField label="Grant type">
+              <USelect v-model="form.grant_type" :items="grantTypeOptions" />
+            </UFormField>
+
+            <UFormField v-if="form.grant_type === 'timed'" label="Duration (seconds)">
+              <UInput v-model.number="form.duration" type="number" min="60" />
+            </UFormField>
+
+            <UFormField label="Reason (optional)">
+              <UInput v-model="form.reason" placeholder="e.g. CI agent — safe commands only" />
+            </UFormField>
+
+            <div class="flex gap-2">
+              <UButton
+                color="primary"
+                :loading="formSubmitting"
+                :disabled="formSubmitting"
+                icon="i-lucide-plus"
+                @click="handleAddSg"
+              >
+                Add standing grant
+              </UButton>
+              <UButton variant="ghost" :disabled="formSubmitting" @click="resetForm">
+                Reset
+              </UButton>
+            </div>
+          </div>
+        </UCard>
+
+        <!-- Recent Activity -->
+        <UCard :ui="{ body: 'p-0' }">
+          <template #header>
+            <h2 class="text-lg font-semibold">
+              Recent activity
+            </h2>
+            <p class="text-sm text-muted mt-1">
+              Last 20 grant requests from this agent.
+            </p>
+          </template>
+
+          <div v-if="agent.recent_grants.length === 0" class="p-6 text-center text-muted text-sm">
+            No recent activity.
+          </div>
+          <table v-else class="w-full">
+            <thead class="border-b border-(--ui-border)">
+              <tr>
+                <th class="text-left px-4 py-3 text-xs font-medium text-muted uppercase">
+                  Command
+                </th>
+                <th class="text-left px-4 py-3 text-xs font-medium text-muted uppercase">
+                  Status
+                </th>
+                <th class="text-left px-4 py-3 text-xs font-medium text-muted uppercase">
+                  When
+                </th>
+                <th class="text-right px-4 py-3 text-xs font-medium text-muted uppercase">
+                  Auto?
+                </th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-(--ui-border)">
+              <tr
+                v-for="g in agent.recent_grants"
+                :key="g.id"
+                class="odd:bg-(--ui-bg-elevated)/40 even:bg-(--ui-bg)"
+              >
+                <td class="px-4 py-3 text-xs font-mono break-all">
+                  {{ commandCell(g) }}
+                </td>
+                <td class="px-4 py-3">
+                  <UBadge :color="statusColor(g.status)" variant="subtle" size="sm">
+                    {{ g.status }}
+                  </UBadge>
+                </td>
+                <td class="px-4 py-3 text-xs text-muted">
+                  {{ formatRelativeTime(g.created_at) }}
+                </td>
+                <td class="px-4 py-3 text-right">
+                  <UIcon
+                    v-if="g.decided_by_standing_grant"
+                    name="i-lucide-zap"
+                    class="text-primary inline-block"
+                    :title="`Auto-approved by standing grant ${g.decided_by_standing_grant}`"
+                  />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </UCard>
+      </template>
+    </div>
+
+    <!-- Revoke confirmation modal -->
+    <UModal v-model:open="revokeTarget" :dismissible="!revoking">
+      <template #content>
+        <UCard>
+          <template #header>
+            <h3 class="text-lg font-semibold">
+              Revoke standing grant?
+            </h3>
+          </template>
+          <p v-if="revokeTarget" class="text-sm">
+            This will stop auto-approval for:
+            <br>
+            <code class="text-xs bg-gray-800 px-1 rounded">
+              {{ formatStandingGrantScope(revokeTarget) }}
+            </code>
+            <br>
+            Cannot be undone — you'll have to re-create it.
+          </p>
+          <template #footer>
+            <div class="flex justify-end gap-2">
+              <UButton variant="ghost" :disabled="revoking" @click="cancelRevoke">
+                Cancel
+              </UButton>
+              <UButton color="error" :loading="revoking" :disabled="revoking" @click="confirmRevoke">
+                Revoke
+              </UButton>
+            </div>
+          </template>
+        </UCard>
+      </template>
+    </UModal>
+  </div>
+</template>

--- a/modules/nuxt-auth-idp/src/runtime/utils/standing-grants.ts
+++ b/modules/nuxt-auth-idp/src/runtime/utils/standing-grants.ts
@@ -1,0 +1,103 @@
+import type { OpenApeCliResourceRef, OpenApeGrant } from '@openape/core'
+import type { StandingGrantRequest } from '@openape/grants'
+
+/**
+ * Small UI-facing helpers for standing grants. Server-side logic lives in
+ * `@openape/grants/standing-grants.ts`; this module handles display
+ * formatting and form-to-request conversion for the Phase 2 web UI.
+ */
+
+/**
+ * Render a human-readable scope string for a standing grant.
+ *
+ * Examples:
+ *   "git (repo: owner=patrick), risk≤high, always"
+ *   "any CLI (wildcard), risk≤medium, timed 3600s"
+ *   "echo (any resource), risk≤low, always"
+ */
+export function formatStandingGrantScope(sg: OpenApeGrant): string {
+  if (!sg.request || (sg.request as unknown as { type?: string }).type !== 'standing') {
+    return 'unknown'
+  }
+  const req = sg.request as unknown as StandingGrantRequest
+  const cli = req.cli_id ? req.cli_id : 'any CLI'
+  const resources = formatResourceChainTemplate(req.resource_chain_template)
+  const risk = req.max_risk ? `risk≤${req.max_risk}` : 'any risk'
+  const grantType = req.grant_type === 'timed' && req.duration
+    ? `timed ${req.duration}s`
+    : req.grant_type
+  return `${cli} (${resources}), ${risk}, ${grantType}`
+}
+
+/**
+ * Compact resource-chain preview:
+ *   []                                       → "any resource"
+ *   [{repo}]                                 → "repo (any)"
+ *   [{repo, selector: {owner: 'patrick'}}]   → "repo: owner=patrick"
+ *   multiple                                  → joined with " / "
+ */
+export function formatResourceChainTemplate(chain: OpenApeCliResourceRef[]): string {
+  if (chain.length === 0) return 'any resource'
+  return chain.map((ref) => {
+    if (!ref.selector || Object.keys(ref.selector).length === 0) {
+      return `${ref.resource} (any)`
+    }
+    const sel = Object.entries(ref.selector)
+      .map(([k, v]) => `${k}=${v}`)
+      .join(', ')
+    return `${ref.resource}: ${sel}`
+  }).join(' / ')
+}
+
+/**
+ * Parse textarea input into a `OpenApeCliResourceRef[]`. Format is one
+ * line per resource:
+ *
+ *   repo                               → { resource: 'repo' } (wildcard)
+ *   repo:owner=patrick                 → { resource: 'repo', selector: { owner: 'patrick' } }
+ *   repo:owner=patrick,name=app        → { resource: 'repo', selector: { owner: 'patrick', name: 'app' } }
+ *
+ * Blank input → [] (wildcard across CLI).
+ * Throws on malformed lines so the UI surfaces a 400-ish error inline.
+ */
+export function parseResourceChainInput(text: string): OpenApeCliResourceRef[] {
+  const lines = text.split('\n').map(l => l.trim()).filter(Boolean)
+  return lines.map((line) => {
+    const colonIdx = line.indexOf(':')
+    if (colonIdx === -1) {
+      return { resource: line }
+    }
+    const resource = line.slice(0, colonIdx).trim()
+    const selectorSpec = line.slice(colonIdx + 1).trim()
+    if (!resource) {
+      throw new Error(`Missing resource in: "${line}"`)
+    }
+    if (!selectorSpec) {
+      return { resource }
+    }
+    const selector: Record<string, string> = {}
+    for (const seg of selectorSpec.split(',')) {
+      const eq = seg.indexOf('=')
+      if (eq === -1) throw new Error(`Selector segment needs "key=value": "${seg}"`)
+      const key = seg.slice(0, eq).trim()
+      const value = seg.slice(eq + 1).trim()
+      if (!key || !value) throw new Error(`Empty key or value in: "${seg}"`)
+      selector[key] = value
+    }
+    return { resource, selector }
+  })
+}
+
+/**
+ * Relative-time string for created_at / decided_at timestamps (seconds).
+ * UI-only — loose precision OK.
+ */
+export function formatRelativeTime(seconds: number): string {
+  if (!seconds) return '—'
+  const diff = Math.floor(Date.now() / 1000) - seconds
+  if (diff < 60) return 'just now'
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`
+  if (diff < 86400 * 30) return `${Math.floor(diff / 86400)}d ago`
+  return new Date(seconds * 1000).toLocaleDateString()
+}

--- a/modules/nuxt-auth-idp/test/standing-grants-utils.test.ts
+++ b/modules/nuxt-auth-idp/test/standing-grants-utils.test.ts
@@ -1,0 +1,120 @@
+import type { OpenApeGrant } from '@openape/core'
+import type { StandingGrantRequest } from '@openape/grants'
+import { describe, expect, it } from 'vitest'
+import {
+  formatRelativeTime,
+  formatResourceChainTemplate,
+  formatStandingGrantScope,
+  parseResourceChainInput,
+} from '../src/runtime/utils/standing-grants'
+
+function makeSg(overrides: Partial<StandingGrantRequest> = {}): OpenApeGrant {
+  const req: StandingGrantRequest = {
+    type: 'standing',
+    owner: 'patrick@example.com',
+    delegate: 'agent@example.com',
+    audience: 'shapes',
+    resource_chain_template: [],
+    grant_type: 'always',
+    ...overrides,
+  }
+  return {
+    id: 'sg-1',
+    status: 'approved',
+    type: 'standing',
+    request: req as unknown as OpenApeGrant['request'],
+    created_at: 0,
+    decided_at: 0,
+  }
+}
+
+describe('formatResourceChainTemplate', () => {
+  it('returns "any resource" for empty chain', () => {
+    expect(formatResourceChainTemplate([])).toBe('any resource')
+  })
+  it('returns "resource (any)" for wildcard resource', () => {
+    expect(formatResourceChainTemplate([{ resource: 'repo' }])).toBe('repo (any)')
+  })
+  it('formats single-selector resource', () => {
+    expect(formatResourceChainTemplate([{ resource: 'repo', selector: { owner: 'patrick' } }]))
+      .toBe('repo: owner=patrick')
+  })
+  it('formats multi-selector resource', () => {
+    expect(formatResourceChainTemplate([
+      { resource: 'repo', selector: { owner: 'patrick', name: 'app' } },
+    ])).toBe('repo: owner=patrick, name=app')
+  })
+  it('joins multiple resources with /', () => {
+    expect(formatResourceChainTemplate([
+      { resource: 'repo' },
+      { resource: 'branch', selector: { name: 'main' } },
+    ])).toBe('repo (any) / branch: name=main')
+  })
+})
+
+describe('formatStandingGrantScope', () => {
+  it('renders wildcard CLI, wildcard resources, any-risk, always', () => {
+    const sg = makeSg({ cli_id: undefined, resource_chain_template: [], max_risk: undefined, grant_type: 'always' })
+    expect(formatStandingGrantScope(sg)).toBe('any CLI (any resource), any risk, always')
+  })
+  it('renders specific CLI + selector + max_risk + timed', () => {
+    const sg = makeSg({
+      cli_id: 'git',
+      resource_chain_template: [{ resource: 'repo', selector: { owner: 'patrick' } }],
+      max_risk: 'high',
+      grant_type: 'timed',
+      duration: 3600,
+    })
+    expect(formatStandingGrantScope(sg)).toBe('git (repo: owner=patrick), risk≤high, timed 3600s')
+  })
+  it('returns "unknown" for non-standing grants', () => {
+    const g = { ...makeSg(), request: { type: 'command' } as unknown as OpenApeGrant['request'] }
+    expect(formatStandingGrantScope(g)).toBe('unknown')
+  })
+})
+
+describe('parseResourceChainInput', () => {
+  it('returns [] for empty string', () => {
+    expect(parseResourceChainInput('')).toEqual([])
+  })
+  it('returns [] for whitespace-only', () => {
+    expect(parseResourceChainInput('\n  \n')).toEqual([])
+  })
+  it('parses a single wildcard resource', () => {
+    expect(parseResourceChainInput('repo')).toEqual([{ resource: 'repo' }])
+  })
+  it('parses a resource with one selector', () => {
+    expect(parseResourceChainInput('repo:owner=patrick')).toEqual([
+      { resource: 'repo', selector: { owner: 'patrick' } },
+    ])
+  })
+  it('parses multi-selector', () => {
+    expect(parseResourceChainInput('repo:owner=patrick,name=app')).toEqual([
+      { resource: 'repo', selector: { owner: 'patrick', name: 'app' } },
+    ])
+  })
+  it('parses multiple lines', () => {
+    expect(parseResourceChainInput('repo:owner=patrick\nbranch')).toEqual([
+      { resource: 'repo', selector: { owner: 'patrick' } },
+      { resource: 'branch' },
+    ])
+  })
+  it('throws on malformed selector segment', () => {
+    expect(() => parseResourceChainInput('repo:bad')).toThrow(/needs "key=value"/)
+  })
+  it('throws on missing resource', () => {
+    expect(() => parseResourceChainInput(':owner=patrick')).toThrow(/Missing resource/)
+  })
+})
+
+describe('formatRelativeTime', () => {
+  it('returns em-dash for 0', () => {
+    expect(formatRelativeTime(0)).toBe('—')
+  })
+  it('returns "just now" for recent', () => {
+    expect(formatRelativeTime(Math.floor(Date.now() / 1000) - 30)).toBe('just now')
+  })
+  it('returns minutes for <1h', () => {
+    expect(formatRelativeTime(Math.floor(Date.now() / 1000) - 300)).toMatch(/^\d+m ago$/)
+  })
+})


### PR DESCRIPTION
## Summary

Phase 2 of the policy-shift plan. Adds two pages for managing agent pre-auth via the web UI on \`id.openape.at\`:

- \`/agents\` — list of all agents with grant activity
- \`/agents/:email\` — per-agent detail: standing grants CRUD + recent activity

Uses Phase 1 APIs exclusively (\`/api/shapes\`, \`/api/standing-grants\`, \`/api/users/:email/agents\`). No API changes.

See \`.claude/plans/openape-policy-shift/phase-2-ui.md\` for the full plan.

## Test plan

- [x] 84 unit tests green (+19 for standing-grants utils)
- [x] Typecheck green
- [x] Lint green
- [ ] CI green
- [ ] E2E after deploy:
  - [ ] \`https://id.openape.at/agents\` lists my agents
  - [ ] Click agent → detail page renders standing grants + recent activity + form
  - [ ] Submit form → SG created → appears in list
  - [ ] Run \`apes run --wait -- <matching cmd>\` → auto-approves with ⚡ marker
  - [ ] Revoke SG → confirm dialog → row disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)