### PR TITLE
feat: Phase 4 — safe-commands seeding + UX

### DIFF
--- a/.changeset/feat-phase-4-safe-commands.md
+++ b/.changeset/feat-phase-4-safe-commands.md
@@ -1,0 +1,15 @@
+---
+'@openape/grants': minor
+'@openape/nuxt-auth-idp': minor
+'@openape/idp-test-suite': minor
+---
+
+Phase 4: Safe-Commands seeding + UX.
+
+- Agent enrollment now auto-seeds 14 default safe-command standing grants for the new agent (ls, cat, head, tail, wc, file, stat, which, echo, date, whoami, pwd, find, grep). Low-risk read-only invocations of those CLIs auto-approve without a prompt.
+- New UI section on `/agents/:email` to toggle defaults and add custom safe commands.
+- New `/agents` page modal to bulk-apply safe commands across all of a user's agents (idempotent — already-present entries are skipped).
+- New endpoint `POST /api/standing-grants/bulk-seed` for the bulk-apply flow.
+- Recent-activity table on `/agents/:email` now shows a distinct "Safe cmd" badge for auto-approvals traced to a safe-command standing grant.
+
+Existing agents are not retroactively modified; use the bulk-apply modal to opt in.

--- a/modules/nuxt-auth-idp/src/module.ts
+++ b/modules/nuxt-auth-idp/src/module.ts
@@ -309,6 +309,7 @@ export default defineNuxtModule<ModuleOptions>({
       // matching agent grant requests. Phase 1 Milestone 5.
       addServerHandler({ route: '/api/standing-grants', handler: resolve('./runtime/server/api/standing-grants/index.get') })
       addServerHandler({ route: '/api/standing-grants', method: 'post', handler: resolve('./runtime/server/api/standing-grants/index.post') })
+      addServerHandler({ route: '/api/standing-grants/bulk-seed', method: 'post', handler: resolve('./runtime/server/api/standing-grants/bulk-seed.post') })
       addServerHandler({ route: '/api/standing-grants/:id', method: 'delete', handler: resolve('./runtime/server/api/standing-grants/[id].delete') })
 
       // Agent-view aggregate (per-agent standing grants + recent activity).

--- a/modules/nuxt-auth-idp/src/runtime/pages/agents.vue
+++ b/modules/nuxt-auth-idp/src/runtime/pages/agents.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { onMounted, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { navigateTo } from '#imports'
 import { useIdpAuth } from '../composables/useIdpAuth'
 
@@ -7,6 +7,13 @@ const { user, loading: authLoading, fetchUser } = useIdpAuth()
 const agents = ref([])
 const loading = ref(true)
 const error = ref('')
+
+// Bulk-apply modal state
+const bulkOpen = ref(false)
+const bulkSelected = ref(new Set())
+const bulkBusy = ref(false)
+const bulkResults = ref(null)
+const bulkError = ref('')
 
 onMounted(async () => {
   await fetchUser()
@@ -35,6 +42,48 @@ async function loadAgents() {
 function standingCount(agent) {
   return (agent.standing_grants ?? []).length
 }
+
+function openBulk() {
+  bulkSelected.value = new Set(agents.value.map(a => a.email))
+  bulkResults.value = null
+  bulkError.value = ''
+  bulkOpen.value = true
+}
+
+function toggleBulkSelect(email, checked) {
+  const next = new Set(bulkSelected.value)
+  if (checked) next.add(email)
+  else next.delete(email)
+  bulkSelected.value = next
+}
+
+async function applyBulk() {
+  bulkBusy.value = true
+  bulkError.value = ''
+  try {
+    const res = await $fetch('/api/standing-grants/bulk-seed', {
+      method: 'POST',
+      body: { delegates: [...bulkSelected.value] },
+    })
+    bulkResults.value = res.results
+    await loadAgents()
+  }
+  catch (err) {
+    bulkError.value = err?.data?.title || 'Bulk-apply failed'
+  }
+  finally {
+    bulkBusy.value = false
+  }
+}
+
+function closeBulk() {
+  if (bulkBusy.value) return
+  bulkOpen.value = false
+}
+
+const bulkTotalCreated = computed(() =>
+  bulkResults.value ? bulkResults.value.reduce((s, r) => s + r.created, 0) : 0,
+)
 </script>
 
 <template>
@@ -49,9 +98,21 @@ function standingCount(agent) {
             {{ user.email }}
           </p>
         </div>
-        <UButton to="/account" color="neutral" variant="soft" size="sm">
-          Account
-        </UButton>
+        <div class="flex gap-2">
+          <UButton
+            v-if="agents.length > 0"
+            color="primary"
+            variant="soft"
+            size="sm"
+            icon="i-lucide-shield-check"
+            @click="openBulk"
+          >
+            Apply safe commands
+          </UButton>
+          <UButton to="/account" color="neutral" variant="soft" size="sm">
+            Account
+          </UButton>
+        </div>
       </div>
 
       <div v-if="authLoading || loading" class="text-center text-muted mt-10">
@@ -151,5 +212,72 @@ function standingCount(agent) {
         </UCard>
       </template>
     </div>
+
+    <UModal v-model:open="bulkOpen" :dismissible="!bulkBusy">
+      <template #content>
+        <UCard>
+          <template #header>
+            <h3 class="text-lg font-semibold">
+              Apply safe commands to all agents
+            </h3>
+            <p class="text-sm text-muted mt-1">
+              Each selected agent will receive the default safe-command standing grants. Already-present entries are skipped.
+            </p>
+          </template>
+
+          <UAlert v-if="bulkError" color="error" :title="bulkError" class="mb-3" @close="bulkError = ''" />
+
+          <div v-if="!bulkResults" class="space-y-2 max-h-80 overflow-y-auto">
+            <label
+              v-for="a in agents"
+              :key="a.email"
+              class="flex items-center gap-2 p-2 rounded-md hover:bg-(--ui-bg-elevated)/60 cursor-pointer"
+            >
+              <UCheckbox
+                :model-value="bulkSelected.has(a.email)"
+                @update:model-value="(v) => toggleBulkSelect(a.email, v)"
+              />
+              <div class="text-sm">
+                <div class="font-medium">{{ a.display_name || a.email }}</div>
+                <div class="text-xs text-muted font-mono">{{ a.email }}</div>
+              </div>
+            </label>
+          </div>
+
+          <div v-else class="space-y-2 text-sm">
+            <div class="text-xs text-muted mb-2">
+              Created {{ bulkTotalCreated }} new standing grant{{ bulkTotalCreated === 1 ? '' : 's' }} across {{ bulkResults.length }} agent{{ bulkResults.length === 1 ? '' : 's' }}.
+            </div>
+            <div
+              v-for="r in bulkResults"
+              :key="r.delegate"
+              class="flex items-center justify-between px-2 py-1 border-b border-(--ui-border)"
+            >
+              <code class="text-xs font-mono break-all">{{ r.delegate }}</code>
+              <span class="text-xs text-muted">
+                +{{ r.created }} · {{ r.skipped }} skipped
+              </span>
+            </div>
+          </div>
+
+          <template #footer>
+            <div class="flex justify-end gap-2">
+              <UButton variant="ghost" :disabled="bulkBusy" @click="closeBulk">
+                {{ bulkResults ? 'Close' : 'Cancel' }}
+              </UButton>
+              <UButton
+                v-if="!bulkResults"
+                color="primary"
+                :loading="bulkBusy"
+                :disabled="bulkBusy || bulkSelected.size === 0"
+                @click="applyBulk"
+              >
+                Apply
+              </UButton>
+            </div>
+          </template>
+        </UCard>
+      </template>
+    </UModal>
   </div>
 </template>

--- a/modules/nuxt-auth-idp/src/runtime/pages/agents/[email].vue
+++ b/modules/nuxt-auth-idp/src/runtime/pages/agents/[email].vue
@@ -564,8 +564,18 @@ async function removeCustomSafeCommand(grant) {
                   {{ formatRelativeTime(g.created_at) }}
                 </td>
                 <td class="px-4 py-3 text-right">
+                  <UBadge
+                    v-if="g.decided_by_safe_command"
+                    color="success"
+                    variant="subtle"
+                    size="xs"
+                    icon="i-lucide-shield-check"
+                    title="Auto-approved via Safe Command"
+                  >
+                    Safe cmd
+                  </UBadge>
                   <UIcon
-                    v-if="g.decided_by_standing_grant"
+                    v-else-if="g.decided_by_standing_grant"
                     name="i-lucide-zap"
                     class="text-primary inline-block"
                     :title="`Auto-approved by standing grant ${g.decided_by_standing_grant}`"

--- a/modules/nuxt-auth-idp/src/runtime/pages/agents/[email].vue
+++ b/modules/nuxt-auth-idp/src/runtime/pages/agents/[email].vue
@@ -1,5 +1,6 @@
 <script setup>
 import { computed, onMounted, ref } from 'vue'
+import { SAFE_COMMAND_DEFAULTS, isSafeCommandGrant } from '@openape/grants'
 import { navigateTo, useRoute } from '#imports'
 import { useIdpAuth } from '../../composables/useIdpAuth'
 import {
@@ -35,6 +36,30 @@ const formError = ref('')
 // Revoke dialog state
 const revokeTarget = ref(null) // the SG object being revoked
 const revoking = ref(false)
+
+// Safe Commands state
+const safeCommandsBusy = ref(null) // cli_id currently being toggled/added
+const customInput = ref('')
+const safeCommandError = ref('')
+
+// Partition standing grants: safe-commands vs. "rich" custom grants
+const safeCommandGrants = computed(() =>
+  agent.value ? agent.value.standing_grants.filter(isSafeCommandGrant) : [],
+)
+const richStandingGrants = computed(() =>
+  agent.value ? agent.value.standing_grants.filter(g => !isSafeCommandGrant(g)) : [],
+)
+const safeCommandByCliId = computed(() => {
+  const map = new Map()
+  for (const g of safeCommandGrants.value) {
+    const cliId = g.request?.cli_id
+    if (typeof cliId === 'string') map.set(cliId, g)
+  }
+  return map
+})
+const customSafeCommands = computed(() =>
+  safeCommandGrants.value.filter(g => g.request?.reason === 'safe-command:custom'),
+)
 
 onMounted(async () => {
   await fetchUser()
@@ -169,6 +194,87 @@ async function confirmRevoke() {
 function cancelRevoke() {
   revokeTarget.value = null
 }
+
+async function toggleSafeCommand(cliId, action) {
+  safeCommandError.value = ''
+  safeCommandsBusy.value = cliId
+  try {
+    const existing = safeCommandByCliId.value.get(cliId)
+    if (existing) {
+      await $fetch(`/api/standing-grants/${encodeURIComponent(existing.id)}`, { method: 'DELETE' })
+    }
+    else {
+      await $fetch('/api/standing-grants', {
+        method: 'POST',
+        body: {
+          delegate: targetEmail.value,
+          audience: 'shapes',
+          target_host: '*',
+          cli_id: cliId,
+          resource_chain_template: [],
+          action,
+          max_risk: 'low',
+          grant_type: 'always',
+          reason: 'safe-command:default',
+        },
+      })
+    }
+    await loadAgent()
+  }
+  catch (err) {
+    safeCommandError.value = err?.data?.title || `Failed to toggle ${cliId}`
+  }
+  finally {
+    safeCommandsBusy.value = null
+  }
+}
+
+async function addCustomSafeCommand() {
+  const cliId = customInput.value.trim()
+  if (!cliId) return
+  safeCommandError.value = ''
+  safeCommandsBusy.value = cliId
+  try {
+    await $fetch('/api/standing-grants', {
+      method: 'POST',
+      body: {
+        delegate: targetEmail.value,
+        audience: 'shapes',
+        target_host: '*',
+        cli_id: cliId,
+        resource_chain_template: [],
+        action: 'exec',
+        max_risk: 'low',
+        grant_type: 'always',
+        reason: 'safe-command:custom',
+      },
+    })
+    customInput.value = ''
+    await loadAgent()
+  }
+  catch (err) {
+    safeCommandError.value = err?.data?.title || `Failed to add ${cliId}`
+  }
+  finally {
+    safeCommandsBusy.value = null
+  }
+}
+
+async function removeCustomSafeCommand(grant) {
+  safeCommandError.value = ''
+  const cliId = grant?.request?.cli_id
+  safeCommandsBusy.value = cliId || grant.id
+  try {
+    await $fetch(`/api/standing-grants/${encodeURIComponent(grant.id)}`, { method: 'DELETE' })
+    await loadAgent()
+  }
+  catch (err) {
+    safeCommandError.value = err?.data?.title || 'Failed to remove custom safe command'
+  }
+  finally {
+    safeCommandsBusy.value = null
+  }
+}
 </script>
 
 <template>
@@ -197,6 +303,91 @@ function cancelRevoke() {
       <template v-else-if="agent">
         <UAlert v-if="success" color="success" :title="success" class="mb-4" @close="success = ''" />
 
+        <!-- Safe Commands Section -->
+        <UCard class="mb-6">
+          <template #header>
+            <h2 class="text-lg font-semibold">
+              Safe commands
+            </h2>
+            <p class="text-sm text-muted mt-1">
+              Low-risk read-only CLIs that auto-approve without a prompt.
+            </p>
+          </template>
+
+          <UAlert
+            v-if="safeCommandError"
+            color="error"
+            :title="safeCommandError"
+            class="mb-3"
+            @close="safeCommandError = ''"
+          />
+
+          <div class="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4">
+            <label
+              v-for="def in SAFE_COMMAND_DEFAULTS"
+              :key="def.cli_id"
+              class="flex items-start gap-2 p-2 rounded-md border border-(--ui-border) hover:bg-(--ui-bg-elevated)/60 cursor-pointer"
+              :title="def.description"
+            >
+              <UCheckbox
+                :model-value="safeCommandByCliId.has(def.cli_id)"
+                :disabled="safeCommandsBusy === def.cli_id"
+                @update:model-value="toggleSafeCommand(def.cli_id, def.action)"
+              />
+              <div class="text-xs">
+                <div class="font-mono font-semibold">{{ def.cli_id }}</div>
+                <div class="text-muted">{{ def.display }}</div>
+              </div>
+            </label>
+          </div>
+
+          <div class="mt-4">
+            <div class="text-sm font-semibold mb-2">
+              Custom safe commands
+            </div>
+            <div v-if="customSafeCommands.length === 0" class="text-xs text-muted mb-2">
+              None yet. Add any CLI below to auto-approve low-risk invocations.
+            </div>
+            <div v-else class="flex flex-wrap gap-2 mb-3">
+              <UBadge
+                v-for="g in customSafeCommands"
+                :key="g.id"
+                color="neutral"
+                variant="soft"
+                class="font-mono text-xs"
+              >
+                {{ g.request?.cli_id }}
+                <UButton
+                  variant="link"
+                  size="xs"
+                  color="error"
+                  icon="i-lucide-x"
+                  class="!p-0 ml-1"
+                  :disabled="safeCommandsBusy === (g.request?.cli_id || g.id)"
+                  @click="removeCustomSafeCommand(g)"
+                />
+              </UBadge>
+            </div>
+            <div class="flex gap-2">
+              <UInput
+                v-model="customInput"
+                placeholder="e.g. jq"
+                size="sm"
+                class="font-mono"
+                @keydown.enter="addCustomSafeCommand"
+              />
+              <UButton
+                size="sm"
+                :disabled="!customInput.trim() || safeCommandsBusy !== null"
+                icon="i-lucide-plus"
+                @click="addCustomSafeCommand"
+              >
+                Add
+              </UButton>
+            </div>
+          </div>
+        </UCard>
+
         <!-- Standing Grants Section -->
         <UCard :ui="{ body: 'p-0' }" class="mb-6">
           <template #header>
@@ -204,12 +395,12 @@ function cancelRevoke() {
               Standing grants
             </h2>
             <p class="text-sm text-muted mt-1">
-              Pre-authorized patterns that auto-approve matching agent requests.
+              Pre-authorized scoped patterns (beyond the safe-command defaults).
             </p>
           </template>
 
-          <div v-if="agent.standing_grants.length === 0" class="p-6 text-center text-muted text-sm">
-            No standing grants yet.
+          <div v-if="richStandingGrants.length === 0" class="p-6 text-center text-muted text-sm">
+            No scoped standing grants yet.
           </div>
           <table v-else class="w-full">
             <thead class="border-b border-(--ui-border)">
@@ -227,7 +418,7 @@ function cancelRevoke() {
             </thead>
             <tbody class="divide-y divide-(--ui-border)">
               <tr
-                v-for="sg in agent.standing_grants"
+                v-for="sg in richStandingGrants"
                 :key="sg.id"
                 class="odd:bg-(--ui-bg-elevated)/40 even:bg-(--ui-bg)"
               >

--- a/modules/nuxt-auth-idp/src/runtime/server/api/agent/enroll.post.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/api/agent/enroll.post.ts
@@ -2,8 +2,10 @@
 import { createHash } from 'node:crypto'
 import { defineEventHandler, readBody } from 'h3'
 import { useIdpStores } from '../../utils/stores'
+import { useGrantStores } from '../../utils/grant-stores'
 import { requireAdmin } from '../../utils/admin'
 import { createProblemError } from '../../utils/problem'
+import { seedDefaultSafeCommands } from '../../utils/seed-safe-commands'
 
 export default defineEventHandler(async (event) => {
   const adminEmail = await requireAdmin(event)
@@ -80,10 +82,25 @@ export default defineEventHandler(async (event) => {
     createdAt: Math.floor(Date.now() / 1000),
   })
 
+  // Seed default safe-command standing grants for agents. Non-fatal on failure:
+  // enrollment already succeeded, the user can still use the bulk-apply flow later.
+  let seededSafeCommands = 0
+  if (!isHuman && owner) {
+    try {
+      const { grantStore } = useGrantStores()
+      const seeded = await seedDefaultSafeCommands(body.email, owner, grantStore)
+      seededSafeCommands = seeded.created
+    }
+    catch (err) {
+      console.error('[enroll] failed to seed safe commands for', body.email, err)
+    }
+  }
+
   return {
     email: body.email,
     name: body.name,
     owner: owner || body.email,
     status: 'active',
+    seeded_safe_commands: seededSafeCommands,
   }
 })

--- a/modules/nuxt-auth-idp/src/runtime/server/api/standing-grants/bulk-seed.post.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/api/standing-grants/bulk-seed.post.ts
@@ -1,0 +1,53 @@
+import { defineEventHandler, readBody } from 'h3'
+import { useIdpStores } from '../../utils/stores'
+import { useGrantStores } from '../../utils/grant-stores'
+import { requireAuth } from '../../utils/admin'
+import { createProblemError } from '../../utils/problem'
+import { seedDefaultSafeCommands } from '../../utils/seed-safe-commands'
+
+/**
+ * POST /api/standing-grants/bulk-seed
+ *
+ * Body: { delegates: string[] }
+ *
+ * For each delegate in the list that is owned by the caller (session user),
+ * seed the canonical default safe-command standing grants. Unowned or unknown
+ * delegates are silently skipped (0 created, 0 skipped) to avoid leaking
+ * ownership info.
+ *
+ * Idempotent: already-present default safe-command SGs are counted as skipped.
+ */
+export default defineEventHandler(async (event) => {
+  const owner = await requireAuth(event)
+  const body = await readBody<{ delegates?: unknown }>(event)
+
+  if (!Array.isArray(body?.delegates) || body.delegates.length === 0) {
+    throw createProblemError({ status: 400, title: 'delegates must be a non-empty array' })
+  }
+  if (body.delegates.length > 50) {
+    throw createProblemError({ status: 400, title: 'delegates may not exceed 50 entries' })
+  }
+  const delegates: string[] = []
+  for (const d of body.delegates) {
+    if (typeof d !== 'string' || d.length === 0 || d.length > 255) {
+      throw createProblemError({ status: 400, title: 'each delegate must be a non-empty string (≤255 chars)' })
+    }
+    delegates.push(d)
+  }
+
+  const { userStore } = useIdpStores()
+  const { grantStore } = useGrantStores()
+  const myAgents = await userStore.findByOwner(owner)
+  const ownedEmails = new Set(myAgents.map(a => a.email))
+
+  const results: Array<{ delegate: string, created: number, skipped: number }> = []
+  for (const delegate of delegates) {
+    if (!ownedEmails.has(delegate)) {
+      results.push({ delegate, created: 0, skipped: 0 })
+      continue
+    }
+    const r = await seedDefaultSafeCommands(delegate, owner, grantStore)
+    results.push({ delegate, ...r })
+  }
+  return { results }
+})

--- a/modules/nuxt-auth-idp/src/runtime/server/api/users/[email]/agents.get.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/api/users/[email]/agents.get.ts
@@ -1,5 +1,5 @@
 import type { GrantStatus, OpenApeGrant } from '@openape/core'
-import { isStandingGrantRequest } from '@openape/grants'
+import { isSafeCommandGrant, isStandingGrantRequest } from '@openape/grants'
 import { defineEventHandler, getRouterParam } from 'h3'
 import { requireAuth } from '../../../utils/admin'
 import { useGrantStores } from '../../../utils/grant-stores'
@@ -59,11 +59,34 @@ export default defineEventHandler(async (event) => {
     }
     const recent = nonStanding.toSorted((a, b) => b.created_at - a.created_at).slice(0, 20)
 
+    // Resolve each referenced standing grant once so the UI can render a
+    // distinct "Safe Command auto-approve" badge vs. a scoped-SG badge.
+    // N+1 is fine here: recent is bounded to 20 and distinct ids are cached.
+    const sgReasonCache = new Map<string, string | null>()
+    async function lookupSgReason(id: string): Promise<string | null> {
+      if (sgReasonCache.has(id)) return sgReasonCache.get(id) ?? null
+      const sg = await grantStore.findById(id)
+      const reason = (sg?.request as { reason?: unknown } | undefined)?.reason
+      const resolved = typeof reason === 'string' ? reason : null
+      sgReasonCache.set(id, resolved)
+      return resolved
+    }
+    const recentAnnotated = await Promise.all(recent.map(async (g) => {
+      if (!g.decided_by_standing_grant) return g
+      const reason = await lookupSgReason(g.decided_by_standing_grant)
+      const isSafe = reason ? isSafeCommandGrant({ request: { reason } }) : false
+      return {
+        ...g,
+        decided_by_standing_grant_reason: reason,
+        decided_by_safe_command: isSafe,
+      }
+    }))
+
     return {
       email: agent.email,
       display_name: agent.name,
       standing_grants: standingForAgent,
-      recent_grants: recent,
+      recent_grants: recentAnnotated,
       grant_counts: counts,
     }
   }))

--- a/modules/nuxt-auth-idp/src/runtime/server/utils/seed-safe-commands.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/utils/seed-safe-commands.ts
@@ -1,0 +1,67 @@
+import type { OpenApeGrant } from '@openape/core'
+import { buildSafeCommandRequest, SAFE_COMMAND_DEFAULTS } from '@openape/grants'
+import type { ExtendedGrantStore } from './grant-store'
+
+export interface SeedSafeCommandsResult {
+  created: number
+  skipped: number
+}
+
+/**
+ * Seed the canonical 14 default safe-command standing grants for a given
+ * (delegate, owner) pair. Idempotent: `cli_id`s already covered by a
+ * default-reason standing grant are skipped.
+ *
+ * Storage shape mirrors `POST /api/standing-grants`: the request is
+ * normalized with `requester=delegate` and `target_host='*'` so the
+ * grants-table NOT NULL columns are satisfied and `findByRequester(agent)`
+ * still returns these entries.
+ */
+export async function seedDefaultSafeCommands(
+  delegate: string,
+  owner: string,
+  grantStore: ExtendedGrantStore,
+): Promise<SeedSafeCommandsResult> {
+  const existing = await grantStore.findByRequester(delegate)
+  const existingDefaults = new Set<string>()
+  for (const g of existing) {
+    if (g.type !== 'standing') continue
+    if (g.status !== 'approved') continue
+    const req = g.request as { reason?: unknown, cli_id?: unknown } | undefined
+    if (req?.reason !== 'safe-command:default') continue
+    if (typeof req.cli_id === 'string') existingDefaults.add(req.cli_id)
+  }
+
+  const now = Math.floor(Date.now() / 1000)
+  let created = 0
+  let skipped = 0
+  for (const def of SAFE_COMMAND_DEFAULTS) {
+    if (existingDefaults.has(def.cli_id)) {
+      skipped++
+      continue
+    }
+    const req = buildSafeCommandRequest({
+      cliId: def.cli_id,
+      action: def.action,
+      owner,
+      delegate,
+    })
+    const storedRequest = {
+      ...req,
+      requester: delegate,
+      target_host: '*',
+    } as unknown as OpenApeGrant['request']
+    const grant: OpenApeGrant = {
+      id: crypto.randomUUID(),
+      status: 'approved',
+      type: 'standing',
+      request: storedRequest,
+      created_at: now,
+      decided_at: now,
+      decided_by: owner,
+    }
+    await grantStore.save(grant)
+    created++
+  }
+  return { created, skipped }
+}

--- a/modules/nuxt-auth-idp/test/seed-safe-commands.test.ts
+++ b/modules/nuxt-auth-idp/test/seed-safe-commands.test.ts
@@ -1,0 +1,153 @@
+import type { OpenApeGrant, PaginatedResponse } from '@openape/core'
+import type { GrantListParams, GrantStore } from '@openape/grants'
+import { SAFE_COMMAND_DEFAULTS } from '@openape/grants'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { seedDefaultSafeCommands } from '../src/runtime/server/utils/seed-safe-commands'
+import type { ExtendedGrantStore } from '../src/runtime/server/utils/grant-store'
+
+function makeInMemoryStore(): ExtendedGrantStore {
+  const grants = new Map<string, OpenApeGrant>()
+
+  const base: GrantStore = {
+    async save(g) {
+      grants.set(g.id, g)
+    },
+    async findById(id) {
+      return grants.get(id) ?? null
+    },
+    async updateStatus(id, status, extra) {
+      const g = grants.get(id)
+      if (!g) throw new Error('not found')
+      grants.set(id, { ...g, status, ...extra })
+    },
+    async findPending() {
+      return [...grants.values()].filter(g => g.status === 'pending')
+    },
+    async findByRequester(requester) {
+      return [...grants.values()].filter(g => g.request.requester === requester)
+    },
+    async listGrants(_params?: GrantListParams): Promise<PaginatedResponse<OpenApeGrant>> {
+      return { items: [...grants.values()], nextCursor: null }
+    },
+  }
+
+  return {
+    ...base,
+    async findAll() {
+      return [...grants.values()]
+    },
+    async findByDelegate(delegate) {
+      return [...grants.values()].filter(g => g.type === 'delegation' && g.request.delegate === delegate)
+    },
+    async findByDelegator(delegator) {
+      return [...grants.values()].filter(g => g.type === 'delegation' && g.request.delegator === delegator)
+    },
+  }
+}
+
+describe('seedDefaultSafeCommands', () => {
+  let store: ExtendedGrantStore
+
+  beforeEach(() => {
+    store = makeInMemoryStore()
+  })
+
+  it('creates one standing grant per default on first run', async () => {
+    const result = await seedDefaultSafeCommands('agent@x', 'owner@x', store)
+    expect(result.created).toBe(SAFE_COMMAND_DEFAULTS.length)
+    expect(result.skipped).toBe(0)
+    const all = await store.findByRequester('agent@x')
+    expect(all).toHaveLength(SAFE_COMMAND_DEFAULTS.length)
+    for (const g of all) {
+      expect(g.type).toBe('standing')
+      expect(g.status).toBe('approved')
+      const req = g.request as { reason?: unknown, cli_id?: unknown }
+      expect(req.reason).toBe('safe-command:default')
+      expect(typeof req.cli_id).toBe('string')
+    }
+  })
+
+  it('is idempotent: second run creates zero more', async () => {
+    await seedDefaultSafeCommands('agent@x', 'owner@x', store)
+    const second = await seedDefaultSafeCommands('agent@x', 'owner@x', store)
+    expect(second.created).toBe(0)
+    expect(second.skipped).toBe(SAFE_COMMAND_DEFAULTS.length)
+  })
+
+  it('only counts existing entries with default reason when computing skips', async () => {
+    // Seed one grant with a DIFFERENT reason for the same cli_id to prove the
+    // skip logic keys on `reason === 'safe-command:default'`, not just cli_id.
+    await store.save({
+      id: 'unrelated-sg',
+      status: 'approved',
+      type: 'standing',
+      request: {
+        type: 'standing',
+        owner: 'owner@x',
+        delegate: 'agent@x',
+        requester: 'agent@x',
+        audience: 'shapes',
+        target_host: '*',
+        cli_id: 'ls',
+        resource_chain_template: [],
+        grant_type: 'always',
+        reason: 'user-custom-scope',
+      } as unknown as OpenApeGrant['request'],
+      created_at: 0,
+      decided_at: 0,
+    })
+    const result = await seedDefaultSafeCommands('agent@x', 'owner@x', store)
+    expect(result.created).toBe(SAFE_COMMAND_DEFAULTS.length)
+    expect(result.skipped).toBe(0)
+  })
+
+  it('skips a default that already exists and seeds the rest', async () => {
+    await store.save({
+      id: 'seed-ls',
+      status: 'approved',
+      type: 'standing',
+      request: {
+        type: 'standing',
+        owner: 'owner@x',
+        delegate: 'agent@x',
+        requester: 'agent@x',
+        audience: 'shapes',
+        target_host: '*',
+        cli_id: 'ls',
+        resource_chain_template: [],
+        grant_type: 'always',
+        reason: 'safe-command:default',
+      } as unknown as OpenApeGrant['request'],
+      created_at: 0,
+      decided_at: 0,
+    })
+    const result = await seedDefaultSafeCommands('agent@x', 'owner@x', store)
+    expect(result.created).toBe(SAFE_COMMAND_DEFAULTS.length - 1)
+    expect(result.skipped).toBe(1)
+  })
+
+  it('ignores revoked defaults when computing skips (treats as absent)', async () => {
+    await store.save({
+      id: 'revoked-ls',
+      status: 'revoked',
+      type: 'standing',
+      request: {
+        type: 'standing',
+        owner: 'owner@x',
+        delegate: 'agent@x',
+        requester: 'agent@x',
+        audience: 'shapes',
+        target_host: '*',
+        cli_id: 'ls',
+        resource_chain_template: [],
+        grant_type: 'always',
+        reason: 'safe-command:default',
+      } as unknown as OpenApeGrant['request'],
+      created_at: 0,
+      decided_at: 0,
+    })
+    const result = await seedDefaultSafeCommands('agent@x', 'owner@x', store)
+    expect(result.created).toBe(SAFE_COMMAND_DEFAULTS.length)
+    expect(result.skipped).toBe(0)
+  })
+})

--- a/packages/grants/src/index.ts
+++ b/packages/grants/src/index.ts
@@ -42,6 +42,16 @@ export {
   resolveServerShape,
   type ServerResolvedCommand,
 } from './server-resolver.js'
+export {
+  buildSafeCommandRequest,
+  type BuildSafeCommandRequestParams,
+  isDefaultSafeCommandGrant,
+  isSafeCommandGrant,
+  SAFE_COMMAND_DEFAULTS,
+  SAFE_COMMAND_REASON_CUSTOM,
+  SAFE_COMMAND_REASON_DEFAULT,
+  type SafeCommandDefinition,
+} from './safe-commands.js'
 export { findSimilarCliGrants, type SimilarGrantMatch, type SimilarGrantsResult } from './similarity.js'
 export {
   buildCoverageDetailFromStandingGrant,

--- a/packages/grants/src/safe-commands.ts
+++ b/packages/grants/src/safe-commands.ts
@@ -1,0 +1,85 @@
+import type { StandingGrantRequest } from './standing-grants.js'
+
+/**
+ * A single curated safe-command default — a low-risk CLI that is pre-authorized
+ * for freshly enrolled agents so common read-only work does not block on
+ * manual approval.
+ */
+export interface SafeCommandDefinition {
+  cli_id: string
+  action: 'exec' | 'read'
+  display: string
+  description: string
+}
+
+/**
+ * The canonical default set seeded on agent enrollment. Conservative by design:
+ * read-only tools + `echo`. Write-capable commands (`touch`, `mkdir`, `cp`, `mv`)
+ * are intentionally excluded and must be added explicitly as custom safe commands.
+ */
+export const SAFE_COMMAND_DEFAULTS: readonly SafeCommandDefinition[] = [
+  { cli_id: 'ls', action: 'read', display: 'List directory contents', description: 'Read-only directory listing' },
+  { cli_id: 'cat', action: 'read', display: 'Print file contents', description: 'Read-only file read' },
+  { cli_id: 'head', action: 'read', display: 'Show top of file', description: 'Read-only partial file read' },
+  { cli_id: 'tail', action: 'read', display: 'Show bottom of file', description: 'Read-only partial file read' },
+  { cli_id: 'wc', action: 'read', display: 'Count lines/words/bytes', description: 'Read-only counter' },
+  { cli_id: 'file', action: 'read', display: 'Detect file type', description: 'Read-only metadata inspection' },
+  { cli_id: 'stat', action: 'read', display: 'File metadata', description: 'Read-only metadata' },
+  { cli_id: 'which', action: 'read', display: 'Locate executable', description: 'Read-only PATH lookup' },
+  { cli_id: 'echo', action: 'exec', display: 'Echo arguments', description: 'Pure output, no side effects' },
+  { cli_id: 'date', action: 'read', display: 'Show date/time', description: 'Read-only clock' },
+  { cli_id: 'whoami', action: 'read', display: 'Current user identity', description: 'Read-only identity' },
+  { cli_id: 'pwd', action: 'read', display: 'Working directory', description: 'Read-only directory info' },
+  { cli_id: 'find', action: 'read', display: 'Search filesystem', description: 'Read-only filesystem search' },
+  { cli_id: 'grep', action: 'read', display: 'Search file contents', description: 'Read-only text search' },
+] as const
+
+export const SAFE_COMMAND_REASON_DEFAULT = 'safe-command:default'
+export const SAFE_COMMAND_REASON_CUSTOM = 'safe-command:custom'
+
+export interface BuildSafeCommandRequestParams {
+  cliId: string
+  action: 'exec' | 'read'
+  owner: string
+  delegate: string
+  custom?: boolean
+}
+
+/**
+ * Build the canonical `StandingGrantRequest` shape for a safe command.
+ * Stable across default and custom entries — the only difference is the
+ * `reason` marker, which later drives UI grouping and audit badges.
+ */
+export function buildSafeCommandRequest(params: BuildSafeCommandRequestParams): StandingGrantRequest {
+  return {
+    type: 'standing',
+    owner: params.owner,
+    delegate: params.delegate,
+    audience: 'shapes',
+    target_host: '*',
+    cli_id: params.cliId,
+    resource_chain_template: [],
+    action: params.action,
+    max_risk: 'low',
+    grant_type: 'always',
+    reason: params.custom ? SAFE_COMMAND_REASON_CUSTOM : SAFE_COMMAND_REASON_DEFAULT,
+  }
+}
+
+/**
+ * Narrow predicate: does this grant's stored `request.reason` indicate it
+ * was created via the safe-commands path (default or user-added custom)?
+ */
+export function isSafeCommandGrant(grant: { request?: unknown }): boolean {
+  const r = grant.request as { reason?: unknown } | undefined
+  const reason = r?.reason
+  return reason === SAFE_COMMAND_REASON_DEFAULT || reason === SAFE_COMMAND_REASON_CUSTOM
+}
+
+/**
+ * Stricter variant: only the canonical default set (excludes user-added customs).
+ */
+export function isDefaultSafeCommandGrant(grant: { request?: unknown }): boolean {
+  const r = grant.request as { reason?: unknown } | undefined
+  return r?.reason === SAFE_COMMAND_REASON_DEFAULT
+}

--- a/packages/grants/test/safe-commands.test.ts
+++ b/packages/grants/test/safe-commands.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildSafeCommandRequest,
+  isDefaultSafeCommandGrant,
+  isSafeCommandGrant,
+  SAFE_COMMAND_DEFAULTS,
+  SAFE_COMMAND_REASON_CUSTOM,
+  SAFE_COMMAND_REASON_DEFAULT,
+} from '../src/safe-commands.js'
+
+describe('SAFE_COMMAND_DEFAULTS', () => {
+  it('contains exactly 14 entries', () => {
+    expect(SAFE_COMMAND_DEFAULTS).toHaveLength(14)
+  })
+
+  it('has unique cli_ids', () => {
+    const ids = SAFE_COMMAND_DEFAULTS.map(d => d.cli_id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('every entry has display + description metadata', () => {
+    for (const d of SAFE_COMMAND_DEFAULTS) {
+      expect(d.display.length).toBeGreaterThan(0)
+      expect(d.description.length).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe('buildSafeCommandRequest', () => {
+  it('produces a StandingGrantRequest with default reason', () => {
+    const r = buildSafeCommandRequest({ cliId: 'ls', action: 'read', owner: 'a@x', delegate: 'b@x' })
+    expect(r.type).toBe('standing')
+    expect(r.owner).toBe('a@x')
+    expect(r.delegate).toBe('b@x')
+    expect(r.audience).toBe('shapes')
+    expect(r.target_host).toBe('*')
+    expect(r.cli_id).toBe('ls')
+    expect(r.resource_chain_template).toEqual([])
+    expect(r.action).toBe('read')
+    expect(r.max_risk).toBe('low')
+    expect(r.grant_type).toBe('always')
+    expect(r.reason).toBe(SAFE_COMMAND_REASON_DEFAULT)
+  })
+
+  it('custom flag switches the reason marker', () => {
+    const r = buildSafeCommandRequest({
+      cliId: 'jq',
+      action: 'exec',
+      owner: 'a@x',
+      delegate: 'b@x',
+      custom: true,
+    })
+    expect(r.reason).toBe(SAFE_COMMAND_REASON_CUSTOM)
+  })
+
+  it('respects requested action', () => {
+    const r = buildSafeCommandRequest({ cliId: 'echo', action: 'exec', owner: 'a@x', delegate: 'b@x' })
+    expect(r.action).toBe('exec')
+  })
+})
+
+describe('isSafeCommandGrant / isDefaultSafeCommandGrant', () => {
+  it('detects both default and custom via reason marker', () => {
+    expect(isSafeCommandGrant({ request: { reason: SAFE_COMMAND_REASON_DEFAULT } })).toBe(true)
+    expect(isSafeCommandGrant({ request: { reason: SAFE_COMMAND_REASON_CUSTOM } })).toBe(true)
+  })
+
+  it('rejects other reasons and missing reasons', () => {
+    expect(isSafeCommandGrant({ request: { reason: 'something-else' } })).toBe(false)
+    expect(isSafeCommandGrant({ request: {} })).toBe(false)
+    expect(isSafeCommandGrant({})).toBe(false)
+  })
+
+  it('isDefaultSafeCommandGrant rejects custom entries', () => {
+    expect(isDefaultSafeCommandGrant({ request: { reason: SAFE_COMMAND_REASON_DEFAULT } })).toBe(true)
+    expect(isDefaultSafeCommandGrant({ request: { reason: SAFE_COMMAND_REASON_CUSTOM } })).toBe(false)
+  })
+})

--- a/packages/idp-test-suite/src/config.ts
+++ b/packages/idp-test-suite/src/config.ts
@@ -2,7 +2,7 @@ export interface IdPTestConfig {
   /** Base URL or a function returning the base URL (resolved at test time). */
   baseUrl: string | (() => string)
   managementToken: string
-  skip?: string[] // suite names to skip: 'discovery', 'admin-users', 'ssh-keys', 'auth', 'session', 'oidc-flow', 'grants', 'delegations', 'server-policy-shift', 'security'
+  skip?: string[] // suite names to skip: 'discovery', 'admin-users', 'ssh-keys', 'auth', 'session', 'oidc-flow', 'grants', 'delegations', 'server-policy-shift', 'safe-commands', 'security'
 }
 
 /** Resolved config where baseUrl is always a string. Used inside test functions. */

--- a/packages/idp-test-suite/src/index.ts
+++ b/packages/idp-test-suite/src/index.ts
@@ -6,6 +6,7 @@ import { delegationsTests } from './suites/delegations.js'
 import { discoveryTests } from './suites/discovery.js'
 import { grantsTests } from './suites/grants.js'
 import { oidcFlowTests } from './suites/oidc-flow.js'
+import { safeCommandsTests } from './suites/safe-commands.js'
 import { securityTests } from './suites/security.js'
 import { serverPolicyShiftTests } from './suites/server-policy-shift.js'
 import { sessionTests } from './suites/session.js'
@@ -27,5 +28,6 @@ export function runIdPTestSuite(config: IdPTestConfig) {
   if (!skip.has('grants')) grantsTests(resolved)
   if (!skip.has('delegations')) delegationsTests(resolved)
   if (!skip.has('server-policy-shift')) serverPolicyShiftTests(resolved)
+  if (!skip.has('safe-commands')) safeCommandsTests(resolved)
   if (!skip.has('security')) securityTests(resolved)
 }

--- a/packages/idp-test-suite/src/suites/safe-commands.ts
+++ b/packages/idp-test-suite/src/suites/safe-commands.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it } from 'vitest'
+import type { ResolvedConfig } from '../config.js'
+import { del, generateEd25519Key, get, loginWithKey, post } from '../helpers.js'
+
+/**
+ * E2E suite for the Phase 4 safe-commands feature:
+ *
+ * 1. Enrolling an agent auto-seeds the default safe-command SGs
+ * 2. Enrolling a human does NOT seed safe-commands
+ * 3. Bulk-seed API creates/skips SGs correctly; validates input
+ * 4. Safe-command SG causes low-risk read grants to auto-approve
+ * 5. After revoking the SG, same request falls through to pending
+ */
+export function safeCommandsTests(config: ResolvedConfig) {
+  describe('Safe Commands (Phase 4)', () => {
+    describe('Seeding on enrollment', () => {
+      const humanEmail = `sc-human-${Date.now()}@example.com`
+      const agentEmail = `sc-agent-${Date.now()}@example.com`
+      const humanKey = generateEd25519Key()
+      const agentKey = generateEd25519Key()
+
+      it('setup: enroll a human — no safe-command SGs created', async () => {
+        const { status, data } = await post(
+          config.baseUrl,
+          '/api/auth/enroll',
+          { email: humanEmail, name: 'SC Human', publicKey: humanKey.publicKeySsh, owner: humanEmail, type: 'human' },
+          config.managementToken,
+        )
+        expect(status).toBe(200)
+        expect(data.seeded_safe_commands ?? 0).toBe(0)
+      })
+
+      it('enrolling an agent seeds 14 default safe-command SGs', async () => {
+        const { status, data } = await post(
+          config.baseUrl,
+          '/api/auth/enroll',
+          { email: agentEmail, name: 'SC Agent', publicKey: agentKey.publicKeySsh, owner: humanEmail },
+          config.managementToken,
+        )
+        expect(status).toBe(200)
+        expect(data.seeded_safe_commands).toBe(14)
+      })
+
+      it('the seeded SGs show up in the owner standing-grants listing', async () => {
+        const token = await loginWithKey(config.baseUrl, humanEmail, humanKey.privateKey)
+        const { status, data } = await get(config.baseUrl, '/api/standing-grants', token)
+        expect(status).toBe(200)
+        const mine = data.filter(
+          (g: { request: { reason?: string, delegate?: string } }) =>
+            g.request.reason === 'safe-command:default' && g.request.delegate === agentEmail,
+        )
+        expect(mine).toHaveLength(14)
+      })
+    })
+
+    describe('Auto-approval via safe-command SG', () => {
+      const humanEmail = `sc2-human-${Date.now()}@example.com`
+      const agentEmail = `sc2-agent-${Date.now()}@example.com`
+      const humanKey = generateEd25519Key()
+      const agentKey = generateEd25519Key()
+      let lsGrantId: string | undefined
+
+      it('setup: enroll owner + agent (agent gets safe-commands automatically)', async () => {
+        await post(
+          config.baseUrl,
+          '/api/auth/enroll',
+          { email: humanEmail, name: 'SC2 H', publicKey: humanKey.publicKeySsh, owner: humanEmail, type: 'human' },
+          config.managementToken,
+        )
+        await post(
+          config.baseUrl,
+          '/api/auth/enroll',
+          { email: agentEmail, name: 'SC2 A', publicKey: agentKey.publicKeySsh, owner: humanEmail },
+          config.managementToken,
+        )
+      })
+
+      it('low-risk `ls` read grant auto-approves via the seeded safe-command SG', async () => {
+        const agentToken = await loginWithKey(config.baseUrl, agentEmail, agentKey.privateKey)
+        const { status, data } = await post(
+          config.baseUrl,
+          '/api/grants',
+          {
+            requester: agentEmail,
+            target_host: 'hostA',
+            audience: 'shapes',
+            grant_type: 'once',
+            command: ['ls', '-la'],
+            authorization_details: [{
+              type: 'openape_cli',
+              cli_id: 'ls',
+              operation_id: 'ls.list',
+              action: 'read',
+              risk: 'low',
+              resource_chain: [{ resource: 'fs', selector: { path: '.' } }],
+              permission: 'ls.fs[path=.]#read',
+              display: 'ls -la',
+            }],
+          },
+          agentToken,
+        )
+        expect(status).toBe(201)
+        expect(data.status).toBe('approved')
+        expect(data.decided_by_standing_grant).toBeDefined()
+        expect(data.approved_automatically).toBe(true)
+        lsGrantId = data.decided_by_standing_grant
+      })
+
+      it('revoking the `ls` safe-command SG causes the next request to go pending', async () => {
+        expect(lsGrantId).toBeDefined()
+        const ownerToken = await loginWithKey(config.baseUrl, humanEmail, humanKey.privateKey)
+        const { status } = await del(config.baseUrl, `/api/standing-grants/${lsGrantId}`, ownerToken)
+        expect(status).toBe(200)
+
+        const agentToken = await loginWithKey(config.baseUrl, agentEmail, agentKey.privateKey)
+        const { data } = await post(
+          config.baseUrl,
+          '/api/grants',
+          {
+            requester: agentEmail,
+            target_host: 'hostA',
+            audience: 'shapes',
+            grant_type: 'once',
+            command: ['ls', '/etc'],
+            authorization_details: [{
+              type: 'openape_cli',
+              cli_id: 'ls',
+              operation_id: 'ls.list',
+              action: 'read',
+              risk: 'low',
+              resource_chain: [{ resource: 'fs', selector: { path: '/etc' } }],
+              permission: 'ls.fs[path=/etc]#read',
+              display: 'ls /etc',
+            }],
+          },
+          agentToken,
+        )
+        expect(data.status).toBe('pending')
+      })
+    })
+
+    describe('Bulk-seed endpoint', () => {
+      const humanEmail = `scb-human-${Date.now()}@example.com`
+      const agentA = `scb-a-${Date.now()}@example.com`
+      const agentB = `scb-b-${Date.now()}@example.com`
+      const humanKey = generateEd25519Key()
+      const keyA = generateEd25519Key()
+      const keyB = generateEd25519Key()
+
+      it('setup: human + two fresh agents', async () => {
+        await post(
+          config.baseUrl,
+          '/api/auth/enroll',
+          { email: humanEmail, name: 'SCB H', publicKey: humanKey.publicKeySsh, owner: humanEmail, type: 'human' },
+          config.managementToken,
+        )
+        await post(
+          config.baseUrl,
+          '/api/auth/enroll',
+          { email: agentA, name: 'SCB A', publicKey: keyA.publicKeySsh, owner: humanEmail },
+          config.managementToken,
+        )
+        await post(
+          config.baseUrl,
+          '/api/auth/enroll',
+          { email: agentB, name: 'SCB B', publicKey: keyB.publicKeySsh, owner: humanEmail },
+          config.managementToken,
+        )
+      })
+
+      it('rejects missing/empty delegates', async () => {
+        const token = await loginWithKey(config.baseUrl, humanEmail, humanKey.privateKey)
+        const r1 = await post(config.baseUrl, '/api/standing-grants/bulk-seed', {}, token)
+        expect(r1.status).toBe(400)
+        const r2 = await post(config.baseUrl, '/api/standing-grants/bulk-seed', { delegates: [] }, token)
+        expect(r2.status).toBe(400)
+      })
+
+      it('rejects >50 delegates', async () => {
+        const token = await loginWithKey(config.baseUrl, humanEmail, humanKey.privateKey)
+        const many = Array.from({ length: 51 }, (_, i) => `scb-many-${i}@example.com`)
+        const { status } = await post(
+          config.baseUrl,
+          '/api/standing-grants/bulk-seed',
+          { delegates: many },
+          token,
+        )
+        expect(status).toBe(400)
+      })
+
+      it('is idempotent: seeding agents that already have defaults returns skipped counts', async () => {
+        const token = await loginWithKey(config.baseUrl, humanEmail, humanKey.privateKey)
+        const { status, data } = await post(
+          config.baseUrl,
+          '/api/standing-grants/bulk-seed',
+          { delegates: [agentA, agentB] },
+          token,
+        )
+        expect(status).toBe(200)
+        expect(Array.isArray(data.results)).toBe(true)
+        const rA = data.results.find((r: { delegate: string }) => r.delegate === agentA)
+        const rB = data.results.find((r: { delegate: string }) => r.delegate === agentB)
+        expect(rA).toMatchObject({ created: 0, skipped: 14 })
+        expect(rB).toMatchObject({ created: 0, skipped: 14 })
+      })
+
+      it('silently reports 0/0 for unowned delegates (no enumeration leak)', async () => {
+        const token = await loginWithKey(config.baseUrl, humanEmail, humanKey.privateKey)
+        const { status, data } = await post(
+          config.baseUrl,
+          '/api/standing-grants/bulk-seed',
+          { delegates: ['unknown-someone-else@example.com'] },
+          token,
+        )
+        expect(status).toBe(200)
+        expect(data.results).toEqual([
+          { delegate: 'unknown-someone-else@example.com', created: 0, skipped: 0 },
+        ])
+      })
+
+      it('requires authentication (no bearer ⇒ 401)', async () => {
+        const { status } = await post(
+          config.baseUrl,
+          '/api/standing-grants/bulk-seed',
+          { delegates: [agentA] },
+        )
+        expect(status).toBe(401)
+      })
+    })
+  })
+}

--- a/packages/idp-test-suite/test/against-server.test.ts
+++ b/packages/idp-test-suite/test/against-server.test.ts
@@ -31,8 +31,9 @@ afterAll(() => {
 runIdPTestSuite({
   baseUrl: () => `http://localhost:${port}`,
   managementToken: MGMT,
-  // server-policy-shift needs the shape + standing-grants endpoints that
-  // live in @openape/nuxt-auth-idp; they're not exposed by @openape/server.
-  // Runs instead via against-free-idp.test.ts when FREE_IDP_MGMT_TOKEN is set.
-  skip: ['server-policy-shift'],
+  // server-policy-shift + safe-commands need the shape + standing-grants
+  // endpoints that live in @openape/nuxt-auth-idp; they're not exposed by
+  // @openape/server. These run via against-free-idp.test.ts when
+  // FREE_IDP_MGMT_TOKEN is set.
+  skip: ['server-policy-shift', 'safe-commands'],
 })


### PR DESCRIPTION
## Summary

Phase 4 of the [openape-policy-shift plan](.claude/plans/openape-policy-shift/phase-4-safe-cmds.md).

- Agent enrollment auto-seeds 14 default safe-command standing grants for the new agent. Low-risk read-only invocations of those CLIs (`ls`, `cat`, `head`, `tail`, `wc`, `file`, `stat`, `which`, `echo`, `date`, `whoami`, `pwd`, `find`, `grep`) auto-approve without a prompt.
- New **Safe Commands** section on `/agents/:email` with toggles + custom-command add.
- New **Apply safe commands** modal on `/agents` to bulk-propagate defaults across all owned agents (idempotent).
- New endpoint `POST /api/standing-grants/bulk-seed`.
- Recent-activity table shows a distinct "Safe cmd" badge for auto-approvals traced to a safe-command SG.

Additive on top of Phase 1 + 2 — does **not** require the Phase 3 apes-CLI cutover. Existing agents are unaffected unless the user opts in via bulk-apply.

## Test plan

- [x] `pnpm turbo run test --filter '@openape/grants' --filter '@openape/nuxt-auth-idp' --filter 'openape-free-idp' --filter '@openape/idp-test-suite'` — grants 211, nuxt-auth-idp 89, free-idp 20, idp-test-suite 104
- [x] `pnpm turbo run build typecheck --filter '@openape/nuxt-auth-idp'` green
- [ ] Post-merge: Vercel prod deploy + seed script unchanged
- [ ] Post-deploy: manual verification — enroll a fresh agent, confirm `seeded_safe_commands: 14` in response and 14 SGs visible on `/agents/<email>`
- [ ] Post-deploy: run full idp-test-suite against `id.openape.at` (safe-commands suite now included)

## Milestones (all done)

- M1 `feat(grants): safe-commands default list + helpers`
- M2 `feat(nuxt-auth-idp): seed default safe commands on agent enrollment`
- M3 `feat(nuxt-auth-idp): POST /api/standing-grants/bulk-seed`
- M4 `feat(nuxt-auth-idp): Safe Commands section on agent detail page`
- M5 `feat(nuxt-auth-idp): bulk-apply safe commands modal on /agents`
- M6 `feat(nuxt-auth-idp): audit badge for safe-command auto-approvals`
- M7 `test(idp-test-suite): safe-commands E2E suite`