### PR TITLE
fix: avoid pulling @openape/grants into browser bundle

### DIFF
--- a/modules/nuxt-auth-idp/src/runtime/pages/agents/[email].vue
+++ b/modules/nuxt-auth-idp/src/runtime/pages/agents/[email].vue
@@ -1,8 +1,8 @@
 <script setup>
 import { computed, onMounted, ref } from 'vue'
-import { SAFE_COMMAND_DEFAULTS, isSafeCommandGrant } from '@openape/grants'
 import { navigateTo, useRoute } from '#imports'
 import { useIdpAuth } from '../../composables/useIdpAuth'
+import { isSafeCommandGrant, SAFE_COMMAND_DEFAULTS } from '../../utils/safe-commands'
 import {
   formatRelativeTime,
   formatStandingGrantScope,

--- a/modules/nuxt-auth-idp/src/runtime/utils/safe-commands.ts
+++ b/modules/nuxt-auth-idp/src/runtime/utils/safe-commands.ts
@@ -1,0 +1,41 @@
+/**
+ * Client-safe mirror of the safe-commands defaults and predicate from
+ * `@openape/grants`. The canonical implementation lives there, but
+ * importing `@openape/grants` from a Vue page pulls in server-only
+ * modules (node:crypto via the resolver), which breaks the browser
+ * bundle. This file duplicates the data intentionally — keep it in
+ * sync with `packages/grants/src/safe-commands.ts`.
+ */
+
+export interface SafeCommandDefinition {
+  cli_id: string
+  action: 'exec' | 'read'
+  display: string
+  description: string
+}
+
+export const SAFE_COMMAND_DEFAULTS: readonly SafeCommandDefinition[] = [
+  { cli_id: 'ls', action: 'read', display: 'List directory contents', description: 'Read-only directory listing' },
+  { cli_id: 'cat', action: 'read', display: 'Print file contents', description: 'Read-only file read' },
+  { cli_id: 'head', action: 'read', display: 'Show top of file', description: 'Read-only partial file read' },
+  { cli_id: 'tail', action: 'read', display: 'Show bottom of file', description: 'Read-only partial file read' },
+  { cli_id: 'wc', action: 'read', display: 'Count lines/words/bytes', description: 'Read-only counter' },
+  { cli_id: 'file', action: 'read', display: 'Detect file type', description: 'Read-only metadata inspection' },
+  { cli_id: 'stat', action: 'read', display: 'File metadata', description: 'Read-only metadata' },
+  { cli_id: 'which', action: 'read', display: 'Locate executable', description: 'Read-only PATH lookup' },
+  { cli_id: 'echo', action: 'exec', display: 'Echo arguments', description: 'Pure output, no side effects' },
+  { cli_id: 'date', action: 'read', display: 'Show date/time', description: 'Read-only clock' },
+  { cli_id: 'whoami', action: 'read', display: 'Current user identity', description: 'Read-only identity' },
+  { cli_id: 'pwd', action: 'read', display: 'Working directory', description: 'Read-only directory info' },
+  { cli_id: 'find', action: 'read', display: 'Search filesystem', description: 'Read-only filesystem search' },
+  { cli_id: 'grep', action: 'read', display: 'Search file contents', description: 'Read-only text search' },
+] as const
+
+export const SAFE_COMMAND_REASON_DEFAULT = 'safe-command:default'
+export const SAFE_COMMAND_REASON_CUSTOM = 'safe-command:custom'
+
+export function isSafeCommandGrant(grant: { request?: unknown }): boolean {
+  const r = grant.request as { reason?: unknown } | undefined
+  const reason = r?.reason
+  return reason === SAFE_COMMAND_REASON_DEFAULT || reason === SAFE_COMMAND_REASON_CUSTOM
+}


### PR DESCRIPTION
## Summary

Phase 4's `/agents/:email` page imported `SAFE_COMMAND_DEFAULTS` + `isSafeCommandGrant` from `@openape/grants`. That barrel re-exports the server resolver, which imports `node:crypto`'s `createHash`. When Vite bundles the Vue page for the browser, it trips on the server-only import:

```
RollupError: "createHash" is not exported by "__vite-browser-external",
imported by "../../packages/grants/dist/index.js"
```

Break the dependency by mirroring the 14 defaults + predicate in a tiny client-safe `runtime/utils/safe-commands.ts`. Server code still uses the canonical `@openape/grants` version.

Regression was only on the Vercel build — local `pnpm build --filter @openape/nuxt-auth-idp` tsup output is server-only and succeeded.

## Test plan

- [x] `pnpm turbo run build --filter openape-free-idp` — passes locally
- [x] `pnpm --filter '@openape/nuxt-auth-idp' test` — 89/89
- [ ] Vercel prod deploy after merge