### PR TITLE
fix(free-idp): Safe Commands UI on app-level agents pages

### DIFF
--- a/apps/openape-free-idp/app/pages/agents/[id].vue
+++ b/apps/openape-free-idp/app/pages/agents/[id].vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import { useIdpAuth } from '#imports'
+import { isSafeCommandGrant, SAFE_COMMAND_DEFAULTS } from '../../utils/safe-commands'
 
 const { user, loading: authLoading, fetchUser } = useIdpAuth()
 const route = useRoute()
@@ -15,10 +16,29 @@ interface Agent {
   createdAt: number
 }
 
+interface StandingGrant {
+  id: string
+  status: string
+  type: string
+  request: {
+    reason?: string
+    cli_id?: string
+    action?: string
+    delegate?: string
+    [key: string]: unknown
+  }
+  created_at: number
+}
+
 const agent = ref<Agent | null>(null)
 const loading = ref(true)
 const deleting = ref(false)
 const deleteError = ref('')
+
+const standingGrants = ref<StandingGrant[]>([])
+const safeCommandsBusy = ref<string | null>(null)
+const customInput = ref('')
+const safeCommandError = ref('')
 
 useSeoMeta({ title: computed(() => agent.value ? `Agent: ${agent.value.name}` : 'Agent') })
 
@@ -37,9 +57,128 @@ async function loadAgent() {
   }
 }
 
+async function loadStandingGrants() {
+  if (!agent.value) return
+  try {
+    const all = await ($fetch as any)('/api/standing-grants') as StandingGrant[]
+    standingGrants.value = all.filter(g => g.request?.delegate === agent.value!.email && g.status === 'approved')
+  }
+  catch {
+    standingGrants.value = []
+  }
+}
+
+async function loadAll() {
+  await loadAgent()
+  await loadStandingGrants()
+}
+
 watch(user, (u) => {
-  if (u) loadAgent()
+  if (u) loadAll()
 }, { immediate: true })
+
+// Safe-command helpers
+const safeCommandByCliId = computed(() => {
+  const map = new Map<string, StandingGrant>()
+  for (const g of standingGrants.value) {
+    if (!isSafeCommandGrant(g)) continue
+    const cliId = g.request?.cli_id
+    if (typeof cliId === 'string') map.set(cliId, g)
+  }
+  return map
+})
+const customSafeCommands = computed(() =>
+  standingGrants.value.filter(g => g.request?.reason === 'safe-command:custom'),
+)
+const scopedStandingGrants = computed(() =>
+  standingGrants.value.filter(g => !isSafeCommandGrant(g)),
+)
+
+async function toggleSafeCommand(cliId: string, action: 'exec' | 'read') {
+  if (!agent.value) return
+  safeCommandError.value = ''
+  safeCommandsBusy.value = cliId
+  try {
+    const existing = safeCommandByCliId.value.get(cliId)
+    if (existing) {
+      await $fetch(`/api/standing-grants/${encodeURIComponent(existing.id)}`, { method: 'DELETE' })
+    }
+    else {
+      await $fetch('/api/standing-grants', {
+        method: 'POST',
+        body: {
+          delegate: agent.value.email,
+          audience: 'shapes',
+          target_host: '*',
+          cli_id: cliId,
+          resource_chain_template: [],
+          action,
+          max_risk: 'low',
+          grant_type: 'always',
+          reason: 'safe-command:default',
+        },
+      })
+    }
+    await loadStandingGrants()
+  }
+  catch (err: unknown) {
+    const e = err as { data?: { detail?: string, title?: string } }
+    safeCommandError.value = e.data?.detail ?? e.data?.title ?? `Toggle ${cliId} failed`
+  }
+  finally {
+    safeCommandsBusy.value = null
+  }
+}
+
+async function addCustomSafeCommand() {
+  if (!agent.value) return
+  const cliId = customInput.value.trim()
+  if (!cliId) return
+  safeCommandError.value = ''
+  safeCommandsBusy.value = cliId
+  try {
+    await $fetch('/api/standing-grants', {
+      method: 'POST',
+      body: {
+        delegate: agent.value.email,
+        audience: 'shapes',
+        target_host: '*',
+        cli_id: cliId,
+        resource_chain_template: [],
+        action: 'exec',
+        max_risk: 'low',
+        grant_type: 'always',
+        reason: 'safe-command:custom',
+      },
+    })
+    customInput.value = ''
+    await loadStandingGrants()
+  }
+  catch (err: unknown) {
+    const e = err as { data?: { detail?: string, title?: string } }
+    safeCommandError.value = e.data?.detail ?? e.data?.title ?? `Add ${cliId} failed`
+  }
+  finally {
+    safeCommandsBusy.value = null
+  }
+}
+
+async function removeCustomSafeCommand(grant: StandingGrant) {
+  safeCommandError.value = ''
+  const cliId = grant.request?.cli_id || grant.id
+  safeCommandsBusy.value = cliId
+  try {
+    await $fetch(`/api/standing-grants/${encodeURIComponent(grant.id)}`, { method: 'DELETE' })
+    await loadStandingGrants()
+  }
+  catch (err: unknown) {
+    const e = err as { data?: { detail?: string, title?: string } }
+    safeCommandError.value = e.data?.detail ?? e.data?.title ?? 'Remove failed'
+  }
+  finally {
+    safeCommandsBusy.value = null
+  }
+}
 
 const authInstructions = computed(() => {
   if (!agent.value) return ''
@@ -335,6 +474,120 @@ async function handleDelete() {
                     @click="copyField(item.label, item.cmd)"
                   />
                 </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Safe Commands section -->
+          <div>
+            <p class="text-sm text-gray-400 mb-2">
+              Safe Commands
+            </p>
+            <p class="text-xs text-gray-500 mb-3">
+              Niedrigrisiko-CLIs, die ohne Rückfrage auto-approved werden.
+            </p>
+
+            <UAlert
+              v-if="safeCommandError"
+              color="error"
+              :title="safeCommandError"
+              class="mb-3"
+              @close="safeCommandError = ''"
+            />
+
+            <div class="grid grid-cols-2 gap-2 sm:grid-cols-3">
+              <label
+                v-for="def in SAFE_COMMAND_DEFAULTS"
+                :key="def.cli_id"
+                class="flex items-start gap-2 p-2 rounded-md border border-gray-700 bg-gray-800/50 hover:bg-gray-800 cursor-pointer"
+                :title="def.description"
+              >
+                <UCheckbox
+                  :model-value="safeCommandByCliId.has(def.cli_id)"
+                  :disabled="safeCommandsBusy === def.cli_id"
+                  @update:model-value="toggleSafeCommand(def.cli_id, def.action)"
+                />
+                <div class="text-xs min-w-0">
+                  <div class="font-mono font-semibold text-gray-100">{{ def.cli_id }}</div>
+                  <div class="text-gray-400 truncate">{{ def.display }}</div>
+                </div>
+              </label>
+            </div>
+
+            <div class="mt-3">
+              <p class="text-xs text-gray-500 mb-2">
+                Custom safe commands
+              </p>
+              <div v-if="customSafeCommands.length === 0" class="text-xs text-gray-500 mb-2">
+                Keine. Füge eine beliebige CLI hinzu, um Low-Risk-Aufrufe zu auto-approven.
+              </div>
+              <div v-else class="flex flex-wrap gap-2 mb-2">
+                <UBadge
+                  v-for="g in customSafeCommands"
+                  :key="g.id"
+                  color="neutral"
+                  variant="soft"
+                  class="font-mono text-xs"
+                >
+                  {{ g.request?.cli_id }}
+                  <UButton
+                    variant="link"
+                    size="xs"
+                    color="error"
+                    icon="i-lucide-x"
+                    class="!p-0 ml-1"
+                    :disabled="safeCommandsBusy === (g.request?.cli_id || g.id)"
+                    @click="removeCustomSafeCommand(g)"
+                  />
+                </UBadge>
+              </div>
+              <div class="flex gap-2">
+                <UInput
+                  v-model="customInput"
+                  placeholder="e.g. jq"
+                  size="sm"
+                  class="font-mono flex-1"
+                  @keydown.enter="addCustomSafeCommand"
+                />
+                <UButton
+                  size="sm"
+                  :disabled="!customInput.trim() || safeCommandsBusy !== null"
+                  icon="i-lucide-plus"
+                  @click="addCustomSafeCommand"
+                >
+                  Add
+                </UButton>
+              </div>
+            </div>
+          </div>
+
+          <!-- Scoped standing grants -->
+          <div v-if="scopedStandingGrants.length > 0">
+            <p class="text-sm text-gray-400 mb-2">
+              Scoped Standing Grants
+            </p>
+            <div class="space-y-2">
+              <div
+                v-for="g in scopedStandingGrants"
+                :key="g.id"
+                class="flex items-center justify-between p-2 rounded-md border border-gray-700 bg-gray-800/50"
+              >
+                <div class="min-w-0 flex-1">
+                  <code class="text-xs font-mono text-gray-200 break-all">
+                    {{ g.request?.cli_id ?? '*' }} · {{ g.request?.action ?? 'any' }}
+                  </code>
+                  <div v-if="g.request?.reason" class="text-xs text-gray-500 mt-0.5">
+                    {{ g.request.reason }}
+                  </div>
+                </div>
+                <UButton
+                  variant="ghost"
+                  size="xs"
+                  color="error"
+                  icon="i-lucide-trash-2"
+                  :disabled="safeCommandsBusy === g.id"
+                  @click="removeCustomSafeCommand(g)"
+                />
               </div>
             </div>
           </div>

--- a/apps/openape-free-idp/app/pages/agents/index.vue
+++ b/apps/openape-free-idp/app/pages/agents/index.vue
@@ -65,6 +65,55 @@ function copyText(text: string) {
   copied.value = 'text'
   setTimeout(() => copied.value = '', 2000)
 }
+
+// Bulk-apply safe commands
+const bulkOpen = ref(false)
+const bulkSelected = ref<Set<string>>(new Set())
+const bulkBusy = ref(false)
+const bulkResults = ref<Array<{ delegate: string, created: number, skipped: number }> | null>(null)
+const bulkError = ref('')
+
+function openBulk() {
+  bulkSelected.value = new Set(agents.value.map(a => a.email))
+  bulkResults.value = null
+  bulkError.value = ''
+  bulkOpen.value = true
+}
+
+function toggleBulkSelect(email: string, checked: boolean) {
+  const next = new Set(bulkSelected.value)
+  if (checked) next.add(email)
+  else next.delete(email)
+  bulkSelected.value = next
+}
+
+async function applyBulk() {
+  bulkBusy.value = true
+  bulkError.value = ''
+  try {
+    const res = await ($fetch as any)('/api/standing-grants/bulk-seed', {
+      method: 'POST',
+      body: { delegates: [...bulkSelected.value] },
+    }) as { results: Array<{ delegate: string, created: number, skipped: number }> }
+    bulkResults.value = res.results
+  }
+  catch (err: unknown) {
+    const e = err as { data?: { detail?: string, title?: string } }
+    bulkError.value = e.data?.detail ?? e.data?.title ?? 'Bulk-apply fehlgeschlagen'
+  }
+  finally {
+    bulkBusy.value = false
+  }
+}
+
+function closeBulk() {
+  if (bulkBusy.value) return
+  bulkOpen.value = false
+}
+
+const bulkTotalCreated = computed(() =>
+  bulkResults.value ? bulkResults.value.reduce((s, r) => s + r.created, 0) : 0,
+)
 </script>
 
 <template>
@@ -79,6 +128,16 @@ function copyText(text: string) {
             <UBadge color="neutral" variant="subtle">
               {{ agents.length }}/{{ maxAgents }}
             </UBadge>
+            <UButton
+              v-if="agents.length > 0"
+              color="primary"
+              variant="soft"
+              size="xs"
+              icon="i-lucide-shield-check"
+              @click="openBulk"
+            >
+              Safe Commands
+            </UButton>
             <UButton
               to="/"
               color="neutral"
@@ -236,5 +295,78 @@ function copyText(text: string) {
         </template>
       </template>
     </UCard>
+
+    <UModal v-model:open="bulkOpen" :dismissible="!bulkBusy">
+      <template #content>
+        <UCard class="bg-gray-900 border border-gray-800">
+          <template #header>
+            <h3 class="text-lg font-semibold text-white">
+              Safe Commands auf alle Agents anwenden
+            </h3>
+            <p class="text-sm text-gray-400 mt-1">
+              Jeder ausgewählte Agent erhält die 14 Default-Safe-Command-Standing-Grants. Bereits vorhandene Einträge werden übersprungen.
+            </p>
+          </template>
+
+          <UAlert
+            v-if="bulkError"
+            color="error"
+            :title="bulkError"
+            class="mb-3"
+            @close="bulkError = ''"
+          />
+
+          <div v-if="!bulkResults" class="space-y-2 max-h-80 overflow-y-auto">
+            <label
+              v-for="a in agents"
+              :key="a.email"
+              class="flex items-center gap-2 p-2 rounded-md hover:bg-gray-800 cursor-pointer"
+            >
+              <UCheckbox
+                :model-value="bulkSelected.has(a.email)"
+                @update:model-value="(v: boolean | 'indeterminate') => toggleBulkSelect(a.email, v === true)"
+              />
+              <div class="text-sm min-w-0">
+                <div class="font-medium text-white truncate">{{ a.name }}</div>
+                <div class="text-xs text-gray-400 font-mono truncate">{{ a.email }}</div>
+              </div>
+            </label>
+          </div>
+
+          <div v-else class="space-y-2 text-sm">
+            <div class="text-xs text-gray-400 mb-2">
+              {{ bulkTotalCreated }} neue Standing Grant{{ bulkTotalCreated === 1 ? '' : 's' }} über {{ bulkResults.length }} Agent{{ bulkResults.length === 1 ? '' : 's' }} erzeugt.
+            </div>
+            <div
+              v-for="r in bulkResults"
+              :key="r.delegate"
+              class="flex items-center justify-between px-2 py-1 border-b border-gray-700"
+            >
+              <code class="text-xs font-mono text-gray-200 break-all">{{ r.delegate }}</code>
+              <span class="text-xs text-gray-500 shrink-0 ml-2">
+                +{{ r.created }} · {{ r.skipped }} skipped
+              </span>
+            </div>
+          </div>
+
+          <template #footer>
+            <div class="flex justify-end gap-2">
+              <UButton variant="ghost" :disabled="bulkBusy" @click="closeBulk">
+                {{ bulkResults ? 'Schließen' : 'Abbrechen' }}
+              </UButton>
+              <UButton
+                v-if="!bulkResults"
+                color="primary"
+                :loading="bulkBusy"
+                :disabled="bulkBusy || bulkSelected.size === 0"
+                @click="applyBulk"
+              >
+                Anwenden
+              </UButton>
+            </div>
+          </template>
+        </UCard>
+      </template>
+    </UModal>
   </div>
 </template>

--- a/apps/openape-free-idp/app/utils/safe-commands.ts
+++ b/apps/openape-free-idp/app/utils/safe-commands.ts
@@ -1,0 +1,39 @@
+/**
+ * Client-safe mirror of the safe-commands defaults and predicate from
+ * `@openape/grants`. Importing that package from a Vue page pulls in
+ * server-only modules via the resolver, which breaks the browser bundle.
+ * Keep this in sync with `packages/grants/src/safe-commands.ts`.
+ */
+
+export interface SafeCommandDefinition {
+  cli_id: string
+  action: 'exec' | 'read'
+  display: string
+  description: string
+}
+
+export const SAFE_COMMAND_DEFAULTS: readonly SafeCommandDefinition[] = [
+  { cli_id: 'ls', action: 'read', display: 'List directory contents', description: 'Read-only directory listing' },
+  { cli_id: 'cat', action: 'read', display: 'Print file contents', description: 'Read-only file read' },
+  { cli_id: 'head', action: 'read', display: 'Show top of file', description: 'Read-only partial file read' },
+  { cli_id: 'tail', action: 'read', display: 'Show bottom of file', description: 'Read-only partial file read' },
+  { cli_id: 'wc', action: 'read', display: 'Count lines/words/bytes', description: 'Read-only counter' },
+  { cli_id: 'file', action: 'read', display: 'Detect file type', description: 'Read-only metadata inspection' },
+  { cli_id: 'stat', action: 'read', display: 'File metadata', description: 'Read-only metadata' },
+  { cli_id: 'which', action: 'read', display: 'Locate executable', description: 'Read-only PATH lookup' },
+  { cli_id: 'echo', action: 'exec', display: 'Echo arguments', description: 'Pure output, no side effects' },
+  { cli_id: 'date', action: 'read', display: 'Show date/time', description: 'Read-only clock' },
+  { cli_id: 'whoami', action: 'read', display: 'Current user identity', description: 'Read-only identity' },
+  { cli_id: 'pwd', action: 'read', display: 'Working directory', description: 'Read-only directory info' },
+  { cli_id: 'find', action: 'read', display: 'Search filesystem', description: 'Read-only filesystem search' },
+  { cli_id: 'grep', action: 'read', display: 'Search file contents', description: 'Read-only text search' },
+] as const
+
+export const SAFE_COMMAND_REASON_DEFAULT = 'safe-command:default'
+export const SAFE_COMMAND_REASON_CUSTOM = 'safe-command:custom'
+
+export function isSafeCommandGrant(grant: { request?: unknown }): boolean {
+  const r = grant.request as { reason?: unknown } | undefined
+  const reason = r?.reason
+  return reason === SAFE_COMMAND_REASON_DEFAULT || reason === SAFE_COMMAND_REASON_CUSTOM
+}


### PR DESCRIPTION
## Why

Phase 4's Safe Commands UI landed in `modules/nuxt-auth-idp/src/runtime/pages/agents/`, but `apps/openape-free-idp/app/pages/agents/` has its own page components (on `/api/my-agents`) that **shadow** the module-provided routes in the deployed free-idp. Result: prod `/agents` and `/agents/:id` on `id.openape.at` never rendered the new Safe Commands section. The module pages work fine for any other host of `@openape/nuxt-auth-idp`, just not free-idp itself.

## What

Add the same Safe Commands UX directly to the free-idp app pages:

- `apps/openape-free-idp/app/pages/agents/[id].vue`:
  - fetches `/api/standing-grants` and filters to this agent's delegate
  - renders 14 Default-Safe-Command toggles (click to create/revoke the standing grant)
  - lists + removes custom safe commands with an inline add input
  - lists remaining scoped (non-safe) standing grants with a revoke button
- `apps/openape-free-idp/app/pages/agents/index.vue`:
  - "Safe Commands" header button opens a bulk-apply modal
  - modal calls `POST /api/standing-grants/bulk-seed` with the selected agents' emails

`apps/openape-free-idp/app/utils/safe-commands.ts` mirrors the 14 defaults + `isSafeCommandGrant` predicate to keep the canonical server-side `@openape/grants` out of the browser bundle (same reason as PR #129's module-level mirror).

## Test plan

- [x] `pnpm turbo run build typecheck --filter openape-free-idp` green
- [ ] Vercel prod deploy post-merge → visit `/agents/<existing-agent>` and confirm the Safe Commands card is visible
- [ ] Click one toggle, refresh, confirm persistence via `GET /api/standing-grants`
- [ ] Back on `/agents`, click "Safe Commands" → select an agent → Apply, then verify that agent's detail page shows the 14 toggles checked