### PR TITLE
feat: Phase 5 — scoped-command authoring + glob coverage

### DIFF
--- a/.changeset/feat-phase-5-scoped-commands.md
+++ b/.changeset/feat-phase-5-scoped-commands.md
@@ -1,0 +1,12 @@
+---
+'@openape/grants': minor
+'@openape/idp-test-suite': minor
+---
+
+Phase 5: glob-pattern support in coverage + mobile-first scoped-command authoring.
+
+- `cliAuthorizationDetailCovers` now treats `*` inside granted selector values as glob wildcards (prefix/suffix/middle, POSIX-shell semantics — `*` matches any chars including `/`). Selectors without `*` stay literal equality. Backward-compatible: all existing standing grants match identically.
+- New `selectorValueMatches(granted, required)` helper exported from `@openape/grants`.
+- Free-idp UI: full-screen 3-step wizard on `/agents/:id` lets users author scoped standing grants by typing an example command, editing typed slots with Literal/Any/Pattern modes (live glob preview), and picking risk cap / duration / reason.
+- The previous "Safe Commands" grid and "Scoped Standing Grants" list are merged into a single "Erlaubte Commands" card on the agent detail page; defaults keep their shield-check icon + inline toggle.
+- `@openape/idp-test-suite` adds an E2E glob-coverage scenario under `suites/safe-commands.ts` that seeds a prefix-globbed path SG and asserts covered vs. uncovered requests.

--- a/apps/openape-free-idp/app/components/AllowedCommandsList.vue
+++ b/apps/openape-free-idp/app/components/AllowedCommandsList.vue
@@ -1,0 +1,247 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import {
+  isSafeCommandGrant,
+  SAFE_COMMAND_DEFAULTS,
+  SAFE_COMMAND_REASON_CUSTOM,
+  SAFE_COMMAND_REASON_DEFAULT,
+} from '../utils/safe-commands'
+
+interface StandingGrant {
+  id: string
+  status: string
+  type: string
+  request: {
+    reason?: string
+    cli_id?: string
+    action?: string
+    delegate?: string
+    resource_chain_template?: Array<{ resource: string, selector?: Record<string, string> }>
+    max_risk?: string
+    grant_type?: string
+    duration?: number
+  }
+  created_at: number
+}
+
+const props = defineProps<{
+  agentEmail: string
+  owner: string
+  standingGrants: StandingGrant[]
+}>()
+
+const emit = defineEmits<{
+  (e: 'refresh'): void
+  (e: 'addScoped'): void
+}>()
+
+const busy = ref<string | null>(null)
+const error = ref('')
+
+const safeCommandByCliId = computed(() => {
+  const map = new Map<string, StandingGrant>()
+  for (const g of props.standingGrants) {
+    if (g.request?.reason !== SAFE_COMMAND_REASON_DEFAULT) continue
+    const cliId = g.request?.cli_id
+    if (typeof cliId === 'string') map.set(cliId, g)
+  }
+  return map
+})
+
+const customSafeCommands = computed(() =>
+  props.standingGrants.filter(g => g.request?.reason === SAFE_COMMAND_REASON_CUSTOM),
+)
+
+const scopedCommands = computed(() =>
+  props.standingGrants.filter(g => !isSafeCommandGrant(g)),
+)
+
+function scopeDescription(g: StandingGrant): string {
+  const parts: string[] = []
+  const template = g.request?.resource_chain_template ?? []
+  for (const slot of template) {
+    if (!slot.selector || Object.keys(slot.selector).length === 0) {
+      parts.push(`${slot.resource}(*)`)
+      continue
+    }
+    const pairs = Object.entries(slot.selector).map(([k, v]) => `${k}=${v}`).join(',')
+    parts.push(`${slot.resource}(${pairs})`)
+  }
+  return parts.length > 0 ? parts.join(' → ') : 'any'
+}
+
+async function toggleDefault(cliId: string, action: 'read' | 'exec') {
+  error.value = ''
+  busy.value = cliId
+  try {
+    const existing = safeCommandByCliId.value.get(cliId)
+    if (existing) {
+      await ($fetch as any)(`/api/standing-grants/${encodeURIComponent(existing.id)}`, { method: 'DELETE' })
+    }
+    else {
+      await ($fetch as any)('/api/standing-grants', {
+        method: 'POST',
+        body: {
+          delegate: props.agentEmail,
+          audience: 'shapes',
+          target_host: '*',
+          cli_id: cliId,
+          resource_chain_template: [],
+          action,
+          max_risk: 'low',
+          grant_type: 'always',
+          reason: SAFE_COMMAND_REASON_DEFAULT,
+        },
+      })
+    }
+    emit('refresh')
+  }
+  catch (e: unknown) {
+    const err = e as { data?: { detail?: string, title?: string } }
+    error.value = err.data?.detail ?? err.data?.title ?? `Toggle ${cliId} failed`
+  }
+  finally {
+    busy.value = null
+  }
+}
+
+async function revoke(g: StandingGrant) {
+  error.value = ''
+  const id = g.request?.cli_id || g.id
+  busy.value = id
+  try {
+    await ($fetch as any)(`/api/standing-grants/${encodeURIComponent(g.id)}`, { method: 'DELETE' })
+    emit('refresh')
+  }
+  catch (e: unknown) {
+    const err = e as { data?: { detail?: string, title?: string } }
+    error.value = err.data?.detail ?? err.data?.title ?? 'Revoke fehlgeschlagen'
+  }
+  finally {
+    busy.value = null
+  }
+}
+</script>
+
+<template>
+  <div class="space-y-4">
+    <div>
+      <div class="flex items-center justify-between gap-2">
+        <h2 class="text-base font-semibold text-white">
+          Erlaubte Commands
+        </h2>
+        <UButton
+          color="primary"
+          variant="soft"
+          size="xs"
+          icon="i-lucide-plus"
+          @click="emit('addScoped')"
+        >
+          Hinzufügen
+        </UButton>
+      </div>
+      <p class="text-xs text-gray-500 mt-1">
+        Was darf dieser Agent ohne Rückfrage ausführen?
+      </p>
+    </div>
+
+    <UAlert
+      v-if="error"
+      color="error"
+      :title="error"
+      @close="error = ''"
+    />
+
+    <div>
+      <div class="text-xs text-gray-400 font-medium mb-2 flex items-center gap-1">
+        <UIcon name="i-lucide-shield-check" class="text-green-400" />
+        Safe Commands (Low-Risk Defaults)
+      </div>
+      <div class="grid grid-cols-2 sm:grid-cols-3 gap-2">
+        <label
+          v-for="def in SAFE_COMMAND_DEFAULTS"
+          :key="def.cli_id"
+          class="flex items-start gap-2 p-2 rounded-md border border-gray-700 bg-gray-800/50 hover:bg-gray-800 cursor-pointer"
+          :title="def.description"
+        >
+          <UCheckbox
+            :model-value="safeCommandByCliId.has(def.cli_id)"
+            :disabled="busy === def.cli_id"
+            @update:model-value="toggleDefault(def.cli_id, def.action)"
+          />
+          <div class="text-xs min-w-0">
+            <div class="font-mono font-semibold text-gray-100">
+              {{ def.cli_id }}
+            </div>
+            <div class="text-gray-400 truncate">
+              {{ def.display }}
+            </div>
+          </div>
+        </label>
+      </div>
+    </div>
+
+    <div v-if="customSafeCommands.length > 0 || scopedCommands.length > 0">
+      <div class="text-xs text-gray-400 font-medium mb-2 flex items-center gap-1">
+        <UIcon name="i-lucide-filter" class="text-primary" />
+        Custom + Scoped
+      </div>
+      <div class="space-y-2">
+        <div
+          v-for="g in customSafeCommands"
+          :key="g.id"
+          class="flex items-center justify-between p-2 rounded-md border border-gray-700 bg-gray-800/50"
+        >
+          <div class="min-w-0">
+            <code class="text-xs font-mono text-gray-200 break-all">
+              {{ g.request?.cli_id }} ({{ g.request?.action ?? 'any' }})
+            </code>
+            <div class="text-xs text-gray-500 mt-0.5">
+              Custom Safe Command
+            </div>
+          </div>
+          <UButton
+            variant="ghost"
+            size="xs"
+            color="error"
+            icon="i-lucide-x"
+            :disabled="busy === (g.request?.cli_id || g.id)"
+            @click="revoke(g)"
+          />
+        </div>
+
+        <div
+          v-for="g in scopedCommands"
+          :key="g.id"
+          class="flex items-center justify-between p-2 rounded-md border border-gray-700 bg-gray-800/50"
+        >
+          <div class="min-w-0 flex-1">
+            <code class="text-xs font-mono text-gray-200 break-all block">
+              {{ g.request?.cli_id ?? '*' }}
+              <span class="text-gray-500">·</span>
+              {{ g.request?.action ?? 'any' }}
+            </code>
+            <div class="text-xs text-gray-400 font-mono break-all">
+              {{ scopeDescription(g) }}
+            </div>
+            <div v-if="g.request?.reason" class="text-xs text-gray-500 mt-0.5">
+              {{ g.request.reason }}
+            </div>
+          </div>
+          <UButton
+            variant="ghost"
+            size="xs"
+            color="error"
+            icon="i-lucide-trash-2"
+            :disabled="busy === g.id"
+            @click="revoke(g)"
+          />
+        </div>
+      </div>
+    </div>
+
+    <div v-else class="text-xs text-gray-500 italic">
+      Keine Custom- oder Scoped-Commands. Tippe auf "Hinzufügen" um einen scoped Command zu definieren.
+    </div>
+  </div>
+</template>

--- a/apps/openape-free-idp/app/components/ScopeSlotEditor.vue
+++ b/apps/openape-free-idp/app/components/ScopeSlotEditor.vue
@@ -1,0 +1,116 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { previewMatches } from '../utils/glob-preview'
+
+type Mode = 'literal' | 'any' | 'pattern'
+
+interface ResourceRef {
+  resource: string
+  selector?: Record<string, string>
+}
+
+const props = defineProps<{
+  resource: string
+  /** The key inside the selector this editor manages (e.g. 'path', 'name'). */
+  selectorKey: string
+  /** Initial mode on mount. */
+  initialMode?: Mode
+  /** Initial literal/pattern value (ignored in 'any' mode). */
+  initialValue?: string
+  /** Optional sample values to live-preview glob matches against. */
+  samples?: string[]
+  /** Disabled state (while network request in flight). */
+  disabled?: boolean
+}>()
+
+const emit = defineEmits<{
+  (e: 'update', value: ResourceRef): void
+}>()
+
+const mode = ref<Mode>(props.initialMode ?? 'literal')
+const value = ref<string>(props.initialValue ?? '')
+
+const patternPreview = computed(() => {
+  if (mode.value !== 'pattern' || !value.value || !props.samples?.length) return []
+  return previewMatches(value.value, props.samples).slice(0, 4)
+})
+
+function build(): ResourceRef {
+  if (mode.value === 'any') {
+    return { resource: props.resource }
+  }
+  return {
+    resource: props.resource,
+    selector: { [props.selectorKey]: value.value },
+  }
+}
+
+watch([mode, value], () => {
+  emit('update', build())
+}, { immediate: false })
+
+function setMode(next: Mode) {
+  if (next === mode.value) return
+  mode.value = next
+  if (next === 'any') value.value = ''
+}
+
+const inputPlaceholder = computed(() =>
+  mode.value === 'pattern'
+    ? 'e.g. /Users/me/*  oder  open*'
+    : `${props.selectorKey} …`,
+)
+</script>
+
+<template>
+  <div class="p-3 rounded-lg border border-gray-700 bg-gray-800/60 space-y-2">
+    <div class="flex items-center justify-between gap-2">
+      <div class="text-xs text-gray-400 font-mono">
+        {{ resource }}<span v-if="mode !== 'any'">.{{ selectorKey }}</span>
+      </div>
+      <div class="inline-flex rounded-md bg-gray-900 p-0.5 text-xs">
+        <button
+          v-for="m in (['literal', 'any', 'pattern'] as Mode[])"
+          :key="m"
+          type="button"
+          :disabled="disabled"
+          class="px-2.5 py-1 rounded min-h-[32px] min-w-[44px]"
+          :class="mode === m ? 'bg-primary text-white' : 'text-gray-400 hover:text-gray-200'"
+          @click="setMode(m)"
+        >
+          {{ m === 'literal' ? 'Literal' : m === 'any' ? 'Any' : 'Pattern' }}
+        </button>
+      </div>
+    </div>
+
+    <UInput
+      v-if="mode !== 'any'"
+      v-model="value"
+      :placeholder="inputPlaceholder"
+      :disabled="disabled"
+      size="md"
+      class="font-mono"
+    />
+
+    <div v-if="mode === 'pattern' && patternPreview.length > 0" class="text-xs space-y-1">
+      <div class="text-gray-500">
+        Beispiel-Matches:
+      </div>
+      <div
+        v-for="row in patternPreview"
+        :key="row.sample"
+        class="flex items-center gap-2"
+      >
+        <UIcon
+          :name="row.matches ? 'i-lucide-check' : 'i-lucide-x'"
+          :class="row.matches ? 'text-green-500' : 'text-red-500'"
+        />
+        <code class="font-mono text-gray-300 break-all">{{ row.sample }}</code>
+      </div>
+    </div>
+
+    <div v-if="mode === 'any'" class="text-xs text-gray-500 italic">
+      Wildcard — matcht jeden Wert für dieses Feld.
+    </div>
+  </div>
+</template>

--- a/apps/openape-free-idp/app/components/ScopedCommandWizard.vue
+++ b/apps/openape-free-idp/app/components/ScopedCommandWizard.vue
@@ -1,0 +1,232 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import type { OpenApeCliResourceRef } from '@openape/core'
+import WizardStepCommand from './WizardStepCommand.vue'
+import WizardStepScope from './WizardStepScope.vue'
+import type { ScopeSlot } from './WizardStepScope.vue'
+import WizardStepPolicy from './WizardStepPolicy.vue'
+import type { PolicyState } from './WizardStepPolicy.vue'
+import type { ResolvedCommand } from '../composables/useShapeResolver'
+
+const props = defineProps<{
+  open: boolean
+  /** The agent whose policy this SG scopes. */
+  agentEmail: string
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:open', value: boolean): void
+  (e: 'created'): void
+}>()
+
+const step = ref(1)
+const argvInput = ref('')
+const resolved = ref<ResolvedCommand | null>(null)
+const slots = ref<ScopeSlot[]>([])
+const policy = ref<PolicyState>({
+  max_risk: 'low',
+  grant_type: 'always',
+  reason: '',
+})
+const submitting = ref(false)
+const submitError = ref('')
+
+watch(() => props.open, (v) => {
+  if (v) reset()
+})
+
+function reset() {
+  step.value = 1
+  argvInput.value = ''
+  resolved.value = null
+  slots.value = []
+  policy.value = { max_risk: 'low', grant_type: 'always', reason: '' }
+  submitError.value = ''
+}
+
+function close() {
+  if (submitting.value) return
+  emit('update:open', false)
+}
+
+function onResolved(r: ResolvedCommand) {
+  resolved.value = r
+  if (policy.value.max_risk === 'low' && r.detail.risk !== 'low') {
+    policy.value.max_risk = r.detail.risk
+  }
+}
+
+function buildResourceChainTemplate(): OpenApeCliResourceRef[] {
+  const byResource = new Map<string, Record<string, string>>()
+  const order: string[] = []
+  for (const slot of slots.value) {
+    if (slot.mode === 'any') {
+      if (!byResource.has(slot.resource)) {
+        byResource.set(slot.resource, {})
+        order.push(slot.resource)
+      }
+      continue
+    }
+    const existing = byResource.get(slot.resource) ?? {}
+    existing[slot.selectorKey] = slot.value
+    if (!byResource.has(slot.resource)) order.push(slot.resource)
+    byResource.set(slot.resource, existing)
+  }
+  return order.map((resource) => {
+    const selector = byResource.get(resource)!
+    if (Object.keys(selector).length === 0) return { resource }
+    return { resource, selector }
+  })
+}
+
+async function submit() {
+  if (!resolved.value) return
+  submitError.value = ''
+  submitting.value = true
+  try {
+    const body: Record<string, unknown> = {
+      delegate: props.agentEmail,
+      audience: 'shapes',
+      target_host: '*',
+      cli_id: resolved.value.cli_id,
+      resource_chain_template: buildResourceChainTemplate(),
+      action: resolved.value.detail.action,
+      max_risk: policy.value.max_risk,
+      grant_type: policy.value.grant_type,
+    }
+    if (policy.value.grant_type === 'timed' && policy.value.duration) body.duration = policy.value.duration
+    if (policy.value.reason.trim()) body.reason = policy.value.reason.trim()
+
+    await ($fetch as any)('/api/standing-grants', { method: 'POST', body })
+    emit('created')
+    emit('update:open', false)
+  }
+  catch (e: unknown) {
+    const err = e as { data?: { detail?: string, title?: string } }
+    submitError.value = err.data?.detail ?? err.data?.title ?? 'Speichern fehlgeschlagen'
+  }
+  finally {
+    submitting.value = false
+  }
+}
+
+const canAdvanceFromStep1 = computed(() => !!resolved.value)
+const canSave = computed(() => !!resolved.value && !submitting.value)
+
+const stepLabels = ['Command', 'Scope', 'Policy']
+</script>
+
+<template>
+  <UModal
+    :open="open"
+    fullscreen
+    :dismissible="!submitting"
+    @update:open="(v: boolean) => emit('update:open', v)"
+  >
+    <template #content>
+      <div class="flex flex-col h-full bg-gray-950">
+        <header class="sticky top-0 z-10 px-4 py-3 bg-gray-900/95 backdrop-blur border-b border-gray-800">
+          <div class="flex items-center gap-3">
+            <UButton
+              color="neutral"
+              variant="ghost"
+              size="sm"
+              icon="i-lucide-x"
+              :disabled="submitting"
+              @click="close"
+            />
+            <h2 class="text-base font-semibold text-white flex-1 truncate">
+              Erlaubten Command hinzufügen
+            </h2>
+          </div>
+          <div class="flex items-center gap-1 mt-3">
+            <div
+              v-for="(label, idx) in stepLabels"
+              :key="label"
+              class="flex items-center gap-1"
+            >
+              <div
+                class="w-6 h-6 rounded-full flex items-center justify-center text-xs font-semibold"
+                :class="step >= idx + 1 ? 'bg-primary text-white' : 'bg-gray-800 text-gray-400'"
+              >
+                {{ idx + 1 }}
+              </div>
+              <span
+                class="text-xs"
+                :class="step >= idx + 1 ? 'text-white' : 'text-gray-500'"
+              >{{ label }}</span>
+              <UIcon
+                v-if="idx < stepLabels.length - 1"
+                name="i-lucide-chevron-right"
+                class="text-gray-600 mx-1"
+              />
+            </div>
+          </div>
+        </header>
+
+        <main class="flex-1 overflow-y-auto p-4 space-y-4">
+          <UAlert
+            v-if="submitError"
+            color="error"
+            :title="submitError"
+            @close="submitError = ''"
+          />
+
+          <WizardStepCommand
+            v-show="step === 1"
+            v-model:input="argvInput"
+            @resolved="onResolved"
+          />
+
+          <WizardStepScope
+            v-if="step === 2 && resolved"
+            :resolved="resolved"
+            @update="(v) => (slots = v)"
+          />
+
+          <WizardStepPolicy
+            v-if="step === 3 && resolved"
+            :initial="policy"
+            :resolved-risk="resolved.detail.risk"
+            @update="(v) => (policy = v)"
+          />
+        </main>
+
+        <footer class="sticky bottom-0 px-4 py-3 bg-gray-900/95 backdrop-blur border-t border-gray-800">
+          <div class="flex items-center justify-between gap-2">
+            <UButton
+              color="neutral"
+              variant="ghost"
+              :disabled="step === 1 || submitting"
+              icon="i-lucide-chevron-left"
+              @click="step = Math.max(1, step - 1)"
+            >
+              Zurück
+            </UButton>
+
+            <UButton
+              v-if="step < 3"
+              color="primary"
+              :disabled="step === 1 && !canAdvanceFromStep1"
+              trailing-icon="i-lucide-chevron-right"
+              @click="step = step + 1"
+            >
+              Weiter
+            </UButton>
+
+            <UButton
+              v-else
+              color="primary"
+              :loading="submitting"
+              :disabled="!canSave"
+              icon="i-lucide-check"
+              @click="submit"
+            >
+              Speichern
+            </UButton>
+          </div>
+        </footer>
+      </div>
+    </template>
+  </UModal>
+</template>

--- a/apps/openape-free-idp/app/components/WizardStepCommand.vue
+++ b/apps/openape-free-idp/app/components/WizardStepCommand.vue
@@ -1,0 +1,121 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import { useShapeResolver } from '../composables/useShapeResolver'
+import type { ResolvedCommand } from '../composables/useShapeResolver'
+
+const props = defineProps<{
+  /** Current argv text (joined with spaces). Two-way bound with the wizard container. */
+  input: string
+  /** Pre-populate when editing an existing scoped grant. */
+  initialCliId?: string
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:input', value: string): void
+  (e: 'resolved', resolved: ResolvedCommand): void
+}>()
+
+const local = ref(props.input)
+watch(() => props.input, (v) => { local.value = v })
+watch(local, (v) => { emit('update:input', v) })
+
+const { resolve, loading, error } = useShapeResolver()
+const resolved = ref<ResolvedCommand | null>(null)
+
+let debounceHandle: ReturnType<typeof setTimeout> | undefined
+
+function parseArgv(text: string): string[] {
+  // Simple whitespace split; no shell-quote handling. Good enough for the
+  // wizard input where users type example commands, not pastes with quotes.
+  return text.trim().split(/\s+/).filter(Boolean)
+}
+
+async function runResolve() {
+  const argv = parseArgv(local.value)
+  if (argv.length === 0) {
+    resolved.value = null
+    return
+  }
+  const cliId = argv[0]!
+  try {
+    const r = await resolve(cliId, argv)
+    resolved.value = r
+    emit('resolved', r)
+  }
+  catch {
+    resolved.value = null
+  }
+}
+
+watch(local, () => {
+  if (debounceHandle) clearTimeout(debounceHandle)
+  debounceHandle = setTimeout(() => { void runResolve() }, 200)
+}, { immediate: false })
+
+// Initial resolve if user navigated back to this step
+if (local.value.trim()) void runResolve()
+</script>
+
+<template>
+  <div class="space-y-3">
+    <div>
+      <label class="text-sm text-gray-300 font-medium">Beispiel-Command</label>
+      <p class="text-xs text-gray-500 mt-1">
+        Tippe den Befehl so ein, wie du ihn auf der Shell ausführen würdest.
+      </p>
+    </div>
+
+    <UInput
+      v-model="local"
+      placeholder="z.B. gh push repository openape"
+      size="lg"
+      class="font-mono"
+    />
+
+    <div v-if="loading" class="text-xs text-gray-500 italic">
+      Analysiere …
+    </div>
+
+    <div v-else-if="error" class="text-xs text-red-400">
+      {{ error }}
+    </div>
+
+    <div v-else-if="resolved" class="p-3 rounded-lg border border-gray-700 bg-gray-800/60 space-y-2">
+      <div class="flex items-center gap-2">
+        <UIcon
+          :name="resolved.synthetic ? 'i-lucide-zap-off' : 'i-lucide-check-circle-2'"
+          :class="resolved.synthetic ? 'text-amber-400' : 'text-green-400'"
+        />
+        <div class="text-sm">
+          <span class="font-mono text-gray-100">{{ resolved.operation_id }}</span>
+          <span class="text-gray-500 ml-2">{{ resolved.cli_id }}</span>
+        </div>
+      </div>
+      <div class="text-xs text-gray-400">
+        Risk: <UBadge :color="resolved.detail.risk === 'low' ? 'success' : resolved.detail.risk === 'medium' ? 'warning' : 'error'" size="xs">
+          {{ resolved.detail.risk }}
+        </UBadge>
+        · Action: <span class="font-mono">{{ resolved.detail.action }}</span>
+      </div>
+      <div v-if="resolved.detail.resource_chain.length > 0" class="text-xs text-gray-400">
+        Erkannte Slots:
+        <div class="mt-1 space-y-1">
+          <div
+            v-for="(r, i) in resolved.detail.resource_chain"
+            :key="i"
+            class="font-mono text-gray-200 break-all"
+          >
+            {{ r.resource }}<span v-if="r.selector">({{ Object.entries(r.selector).map(([k, v]) => `${k}=${v}`).join(', ') }})</span>
+          </div>
+        </div>
+      </div>
+      <div v-if="resolved.synthetic" class="text-xs text-amber-500">
+        Generic fallback: diese CLI hat keinen Shape — scope bindet sonst exakt an argv-hash.
+      </div>
+    </div>
+
+    <div v-else class="text-xs text-gray-500 italic">
+      Noch keine Übereinstimmung.
+    </div>
+  </div>
+</template>

--- a/apps/openape-free-idp/app/components/WizardStepPolicy.vue
+++ b/apps/openape-free-idp/app/components/WizardStepPolicy.vue
@@ -1,0 +1,101 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+
+export interface PolicyState {
+  max_risk: 'low' | 'medium' | 'high' | 'critical'
+  grant_type: 'always' | 'timed'
+  duration?: number
+  reason: string
+}
+
+const props = defineProps<{
+  initial: PolicyState
+  resolvedRisk?: 'low' | 'medium' | 'high' | 'critical'
+}>()
+
+const emit = defineEmits<{
+  (e: 'update', value: PolicyState): void
+}>()
+
+const state = ref<PolicyState>({ ...props.initial })
+
+watch(state, v => emit('update', { ...v }), { deep: true, immediate: true })
+
+const riskOptions = [
+  { label: 'Low', value: 'low' },
+  { label: 'Medium', value: 'medium' },
+  { label: 'High', value: 'high' },
+  { label: 'Critical', value: 'critical' },
+] as const
+
+const resolvedHint = computed(() => {
+  if (!props.resolvedRisk) return ''
+  return `Tipp: erkannte Risk-Stufe des Commands ist "${props.resolvedRisk}".`
+})
+</script>
+
+<template>
+  <div class="space-y-4">
+    <div>
+      <label class="text-sm text-gray-300 font-medium">Policy</label>
+      <p class="text-xs text-gray-500 mt-1">
+        Wie großzügig soll der Agent diese Commands ausführen dürfen?
+      </p>
+    </div>
+
+    <div>
+      <label class="text-xs text-gray-400 mb-1 block">Max Risk</label>
+      <div class="inline-flex rounded-md bg-gray-900 p-0.5">
+        <button
+          v-for="r in riskOptions"
+          :key="r.value"
+          type="button"
+          class="px-3 py-1.5 text-xs rounded min-w-[60px] min-h-[36px]"
+          :class="state.max_risk === r.value ? 'bg-primary text-white' : 'text-gray-400 hover:text-gray-200'"
+          @click="state.max_risk = r.value"
+        >
+          {{ r.label }}
+        </button>
+      </div>
+      <p v-if="resolvedHint" class="text-xs text-gray-500 mt-1">
+        {{ resolvedHint }}
+      </p>
+    </div>
+
+    <div>
+      <label class="text-xs text-gray-400 mb-1 block">Dauer</label>
+      <div class="inline-flex rounded-md bg-gray-900 p-0.5">
+        <button
+          type="button"
+          class="px-3 py-1.5 text-xs rounded min-w-[80px] min-h-[36px]"
+          :class="state.grant_type === 'always' ? 'bg-primary text-white' : 'text-gray-400 hover:text-gray-200'"
+          @click="state.grant_type = 'always'"
+        >
+          Immer
+        </button>
+        <button
+          type="button"
+          class="px-3 py-1.5 text-xs rounded min-w-[80px] min-h-[36px]"
+          :class="state.grant_type === 'timed' ? 'bg-primary text-white' : 'text-gray-400 hover:text-gray-200'"
+          @click="state.grant_type = 'timed'; state.duration = state.duration ?? 3600"
+        >
+          Zeitlich
+        </button>
+      </div>
+    </div>
+
+    <div v-if="state.grant_type === 'timed'">
+      <label class="text-xs text-gray-400 mb-1 block">Dauer (Sekunden)</label>
+      <UInput v-model.number="state.duration" type="number" :min="60" class="max-w-[200px]" />
+    </div>
+
+    <div>
+      <label class="text-xs text-gray-400 mb-1 block">Grund (optional)</label>
+      <UInput
+        v-model="state.reason"
+        placeholder="z.B. CI-Deploy, read-only Audit …"
+        class="font-mono"
+      />
+    </div>
+  </div>
+</template>

--- a/apps/openape-free-idp/app/components/WizardStepScope.vue
+++ b/apps/openape-free-idp/app/components/WizardStepScope.vue
@@ -1,0 +1,106 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import ScopeSlotEditor from './ScopeSlotEditor.vue'
+import type { ResolvedCommand } from '../composables/useShapeResolver'
+
+export interface ScopeSlot {
+  resource: string
+  selectorKey: string
+  mode: 'literal' | 'any' | 'pattern'
+  value: string
+  initialLiteral: string
+}
+
+const props = defineProps<{
+  resolved: ResolvedCommand
+}>()
+
+const emit = defineEmits<{
+  (e: 'update', slots: ScopeSlot[]): void
+}>()
+
+function seedSlotsFromResolved(r: ResolvedCommand): ScopeSlot[] {
+  const slots: ScopeSlot[] = []
+  for (const ref of r.detail.resource_chain) {
+    const selector = ref.selector ?? {}
+    const keys = Object.keys(selector)
+    if (keys.length === 0) {
+      slots.push({ resource: ref.resource, selectorKey: 'name', mode: 'any', value: '', initialLiteral: '' })
+      continue
+    }
+    for (const key of keys) {
+      const literal = String(selector[key] ?? '')
+      slots.push({
+        resource: ref.resource,
+        selectorKey: key,
+        mode: 'literal',
+        value: literal,
+        initialLiteral: literal,
+      })
+    }
+  }
+  return slots
+}
+
+const slots = ref<ScopeSlot[]>(seedSlotsFromResolved(props.resolved))
+
+watch(() => props.resolved, (r) => {
+  slots.value = seedSlotsFromResolved(r)
+}, { deep: false })
+
+watch(slots, (v) => {
+  emit('update', v.map(s => ({ ...s })))
+}, { deep: true, immediate: true })
+
+function onSlotUpdate(i: number, ref: { resource: string, selector?: Record<string, string> }) {
+  const slot = slots.value[i]
+  if (!slot) return
+  if (!ref.selector) {
+    slot.mode = 'any'
+    slot.value = ''
+  }
+  else {
+    const v = ref.selector[slot.selectorKey] ?? ''
+    slot.value = v
+    if (v.includes('*')) slot.mode = 'pattern'
+    else slot.mode = 'literal'
+  }
+}
+
+const samplesForSlot = computed(() => {
+  // Derive one or two example values from the resolved command so pattern-mode
+  // can preview whether the current glob would match the user's typed example.
+  const out: Record<number, string[]> = {}
+  for (let i = 0; i < slots.value.length; i++) {
+    const slot = slots.value[i]!
+    out[i] = slot.initialLiteral ? [slot.initialLiteral] : []
+  }
+  return out
+})
+</script>
+
+<template>
+  <div class="space-y-3">
+    <div>
+      <label class="text-sm text-gray-300 font-medium">Scope</label>
+      <p class="text-xs text-gray-500 mt-1">
+        Pro Slot wählen: <code>Literal</code> (exakt), <code>Any</code> (Wildcard) oder <code>Pattern</code> (glob mit <code>*</code>).
+      </p>
+    </div>
+
+    <div v-if="slots.length === 0" class="text-sm text-gray-500 italic">
+      Kein Slot — dieser Command hat keine scoped Parameter. Er wird für die gesamte CLI-Klasse pre-authorisiert.
+    </div>
+
+    <ScopeSlotEditor
+      v-for="(slot, i) in slots"
+      :key="`${i}-${slot.resource}-${slot.selectorKey}`"
+      :resource="slot.resource"
+      :selector-key="slot.selectorKey"
+      :initial-mode="slot.mode"
+      :initial-value="slot.initialLiteral"
+      :samples="samplesForSlot[i]"
+      @update="onSlotUpdate(i, $event)"
+    />
+  </div>
+</template>

--- a/apps/openape-free-idp/app/composables/useShapeResolver.ts
+++ b/apps/openape-free-idp/app/composables/useShapeResolver.ts
@@ -1,0 +1,86 @@
+import { ref } from 'vue'
+
+export interface ResolvedSlot {
+  resource: string
+  selector?: Record<string, string> | undefined
+}
+
+export interface ResolvedCommand {
+  cli_id: string
+  operation_id: string
+  executable?: string
+  synthetic?: boolean
+  detail: {
+    type: 'openape_cli'
+    cli_id: string
+    operation_id: string
+    action: string
+    risk: 'low' | 'medium' | 'high' | 'critical'
+    resource_chain: ResolvedSlot[]
+    permission: string
+    display: string
+    constraints?: { exact_command?: boolean }
+  }
+  commandArgv?: string[]
+  bindings?: Record<string, string>
+  executionContext?: Record<string, unknown>
+}
+
+/**
+ * Client-side shape resolver with LRU-ish in-memory cache. Intended for the
+ * Phase 5 scoped-command wizard where users type a sample argv and we parse
+ * it via POST /api/shapes/resolve to produce typed slots.
+ *
+ * The cache is per-component lifecycle, so navigating away clears it. That
+ * matches the wizard's session semantics and avoids leaking stale resolves
+ * across different agents.
+ */
+export function useShapeResolver(opts: { maxCacheEntries?: number } = {}) {
+  const maxEntries = opts.maxCacheEntries ?? 50
+  // Insertion-ordered Map = cheap LRU: delete-then-set on hit.
+  const cache = new Map<string, ResolvedCommand>()
+  const loading = ref(false)
+  const error = ref('')
+
+  function keyFor(cliId: string, argv: string[]): string {
+    return `${cliId}\u0001${argv.join('\u0001')}`
+  }
+
+  async function resolve(cliId: string, argv: string[]): Promise<ResolvedCommand> {
+    const key = keyFor(cliId, argv)
+    const hit = cache.get(key)
+    if (hit) {
+      cache.delete(key)
+      cache.set(key, hit)
+      return hit
+    }
+    loading.value = true
+    error.value = ''
+    try {
+      const r = await ($fetch as any)('/api/shapes/resolve', {
+        method: 'POST',
+        body: { cli_id: cliId, argv },
+      }) as ResolvedCommand
+      cache.set(key, r)
+      if (cache.size > maxEntries) {
+        const oldest = cache.keys().next().value
+        if (oldest !== undefined) cache.delete(oldest)
+      }
+      return r
+    }
+    catch (e: unknown) {
+      const err = e as { data?: { detail?: string, title?: string } }
+      error.value = err.data?.detail ?? err.data?.title ?? 'resolve failed'
+      throw e
+    }
+    finally {
+      loading.value = false
+    }
+  }
+
+  function clearCache() {
+    cache.clear()
+  }
+
+  return { resolve, clearCache, loading, error }
+}

--- a/apps/openape-free-idp/app/pages/agents/[id].vue
+++ b/apps/openape-free-idp/app/pages/agents/[id].vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import { useIdpAuth } from '#imports'
-import { isSafeCommandGrant, SAFE_COMMAND_DEFAULTS } from '../../utils/safe-commands'
+import AllowedCommandsList from '../../components/AllowedCommandsList.vue'
+import ScopedCommandWizard from '../../components/ScopedCommandWizard.vue'
 
 const { user, loading: authLoading, fetchUser } = useIdpAuth()
 const route = useRoute()
@@ -25,6 +26,7 @@ interface StandingGrant {
     cli_id?: string
     action?: string
     delegate?: string
+    resource_chain_template?: Array<{ resource: string, selector?: Record<string, string> }>
     [key: string]: unknown
   }
   created_at: number
@@ -36,9 +38,7 @@ const deleting = ref(false)
 const deleteError = ref('')
 
 const standingGrants = ref<StandingGrant[]>([])
-const safeCommandsBusy = ref<string | null>(null)
-const customInput = ref('')
-const safeCommandError = ref('')
+const wizardOpen = ref(false)
 
 useSeoMeta({ title: computed(() => agent.value ? `Agent: ${agent.value.name}` : 'Agent') })
 
@@ -77,107 +77,12 @@ watch(user, (u) => {
   if (u) loadAll()
 }, { immediate: true })
 
-// Safe-command helpers
-const safeCommandByCliId = computed(() => {
-  const map = new Map<string, StandingGrant>()
-  for (const g of standingGrants.value) {
-    if (!isSafeCommandGrant(g)) continue
-    const cliId = g.request?.cli_id
-    if (typeof cliId === 'string') map.set(cliId, g)
-  }
-  return map
-})
-const customSafeCommands = computed(() =>
-  standingGrants.value.filter(g => g.request?.reason === 'safe-command:custom'),
-)
-const scopedStandingGrants = computed(() =>
-  standingGrants.value.filter(g => !isSafeCommandGrant(g)),
-)
-
-async function toggleSafeCommand(cliId: string, action: 'exec' | 'read') {
-  if (!agent.value) return
-  safeCommandError.value = ''
-  safeCommandsBusy.value = cliId
-  try {
-    const existing = safeCommandByCliId.value.get(cliId)
-    if (existing) {
-      await $fetch(`/api/standing-grants/${encodeURIComponent(existing.id)}`, { method: 'DELETE' })
-    }
-    else {
-      await $fetch('/api/standing-grants', {
-        method: 'POST',
-        body: {
-          delegate: agent.value.email,
-          audience: 'shapes',
-          target_host: '*',
-          cli_id: cliId,
-          resource_chain_template: [],
-          action,
-          max_risk: 'low',
-          grant_type: 'always',
-          reason: 'safe-command:default',
-        },
-      })
-    }
-    await loadStandingGrants()
-  }
-  catch (err: unknown) {
-    const e = err as { data?: { detail?: string, title?: string } }
-    safeCommandError.value = e.data?.detail ?? e.data?.title ?? `Toggle ${cliId} failed`
-  }
-  finally {
-    safeCommandsBusy.value = null
-  }
+function openWizard() {
+  wizardOpen.value = true
 }
 
-async function addCustomSafeCommand() {
-  if (!agent.value) return
-  const cliId = customInput.value.trim()
-  if (!cliId) return
-  safeCommandError.value = ''
-  safeCommandsBusy.value = cliId
-  try {
-    await $fetch('/api/standing-grants', {
-      method: 'POST',
-      body: {
-        delegate: agent.value.email,
-        audience: 'shapes',
-        target_host: '*',
-        cli_id: cliId,
-        resource_chain_template: [],
-        action: 'exec',
-        max_risk: 'low',
-        grant_type: 'always',
-        reason: 'safe-command:custom',
-      },
-    })
-    customInput.value = ''
-    await loadStandingGrants()
-  }
-  catch (err: unknown) {
-    const e = err as { data?: { detail?: string, title?: string } }
-    safeCommandError.value = e.data?.detail ?? e.data?.title ?? `Add ${cliId} failed`
-  }
-  finally {
-    safeCommandsBusy.value = null
-  }
-}
-
-async function removeCustomSafeCommand(grant: StandingGrant) {
-  safeCommandError.value = ''
-  const cliId = grant.request?.cli_id || grant.id
-  safeCommandsBusy.value = cliId
-  try {
-    await $fetch(`/api/standing-grants/${encodeURIComponent(grant.id)}`, { method: 'DELETE' })
-    await loadStandingGrants()
-  }
-  catch (err: unknown) {
-    const e = err as { data?: { detail?: string, title?: string } }
-    safeCommandError.value = e.data?.detail ?? e.data?.title ?? 'Remove failed'
-  }
-  finally {
-    safeCommandsBusy.value = null
-  }
+async function onWizardCreated() {
+  await loadStandingGrants()
 }
 
 const authInstructions = computed(() => {
@@ -478,119 +383,13 @@ async function handleDelete() {
             </div>
           </div>
 
-          <!-- Safe Commands section -->
-          <div>
-            <p class="text-sm text-gray-400 mb-2">
-              Safe Commands
-            </p>
-            <p class="text-xs text-gray-500 mb-3">
-              Niedrigrisiko-CLIs, die ohne Rückfrage auto-approved werden.
-            </p>
-
-            <UAlert
-              v-if="safeCommandError"
-              color="error"
-              :title="safeCommandError"
-              class="mb-3"
-              @close="safeCommandError = ''"
-            />
-
-            <div class="grid grid-cols-2 gap-2 sm:grid-cols-3">
-              <label
-                v-for="def in SAFE_COMMAND_DEFAULTS"
-                :key="def.cli_id"
-                class="flex items-start gap-2 p-2 rounded-md border border-gray-700 bg-gray-800/50 hover:bg-gray-800 cursor-pointer"
-                :title="def.description"
-              >
-                <UCheckbox
-                  :model-value="safeCommandByCliId.has(def.cli_id)"
-                  :disabled="safeCommandsBusy === def.cli_id"
-                  @update:model-value="toggleSafeCommand(def.cli_id, def.action)"
-                />
-                <div class="text-xs min-w-0">
-                  <div class="font-mono font-semibold text-gray-100">{{ def.cli_id }}</div>
-                  <div class="text-gray-400 truncate">{{ def.display }}</div>
-                </div>
-              </label>
-            </div>
-
-            <div class="mt-3">
-              <p class="text-xs text-gray-500 mb-2">
-                Custom safe commands
-              </p>
-              <div v-if="customSafeCommands.length === 0" class="text-xs text-gray-500 mb-2">
-                Keine. Füge eine beliebige CLI hinzu, um Low-Risk-Aufrufe zu auto-approven.
-              </div>
-              <div v-else class="flex flex-wrap gap-2 mb-2">
-                <UBadge
-                  v-for="g in customSafeCommands"
-                  :key="g.id"
-                  color="neutral"
-                  variant="soft"
-                  class="font-mono text-xs"
-                >
-                  {{ g.request?.cli_id }}
-                  <UButton
-                    variant="link"
-                    size="xs"
-                    color="error"
-                    icon="i-lucide-x"
-                    class="!p-0 ml-1"
-                    :disabled="safeCommandsBusy === (g.request?.cli_id || g.id)"
-                    @click="removeCustomSafeCommand(g)"
-                  />
-                </UBadge>
-              </div>
-              <div class="flex gap-2">
-                <UInput
-                  v-model="customInput"
-                  placeholder="e.g. jq"
-                  size="sm"
-                  class="font-mono flex-1"
-                  @keydown.enter="addCustomSafeCommand"
-                />
-                <UButton
-                  size="sm"
-                  :disabled="!customInput.trim() || safeCommandsBusy !== null"
-                  icon="i-lucide-plus"
-                  @click="addCustomSafeCommand"
-                >
-                  Add
-                </UButton>
-              </div>
-            </div>
-          </div>
-
-          <!-- Scoped standing grants -->
-          <div v-if="scopedStandingGrants.length > 0">
-            <p class="text-sm text-gray-400 mb-2">
-              Scoped Standing Grants
-            </p>
-            <div class="space-y-2">
-              <div
-                v-for="g in scopedStandingGrants"
-                :key="g.id"
-                class="flex items-center justify-between p-2 rounded-md border border-gray-700 bg-gray-800/50"
-              >
-                <div class="min-w-0 flex-1">
-                  <code class="text-xs font-mono text-gray-200 break-all">
-                    {{ g.request?.cli_id ?? '*' }} · {{ g.request?.action ?? 'any' }}
-                  </code>
-                  <div v-if="g.request?.reason" class="text-xs text-gray-500 mt-0.5">
-                    {{ g.request.reason }}
-                  </div>
-                </div>
-                <UButton
-                  variant="ghost"
-                  size="xs"
-                  color="error"
-                  icon="i-lucide-trash-2"
-                  :disabled="safeCommandsBusy === g.id"
-                  @click="removeCustomSafeCommand(g)"
-                />
-              </div>
-            </div>
-          </div>
+          <AllowedCommandsList
+            :agent-email="agent.email"
+            :owner="agent.owner ?? user?.email ?? ''"
+            :standing-grants="standingGrants"
+            @refresh="loadStandingGrants"
+            @add-scoped="openWizard"
+          />
 
           <UAlert
             v-if="deleteError"
@@ -611,5 +410,12 @@ async function handleDelete() {
         </div>
       </template>
     </UCard>
+
+    <ScopedCommandWizard
+      v-if="agent"
+      v-model:open="wizardOpen"
+      :agent-email="agent.email"
+      @created="onWizardCreated"
+    />
   </div>
 </template>

--- a/apps/openape-free-idp/app/utils/glob-preview.ts
+++ b/apps/openape-free-idp/app/utils/glob-preview.ts
@@ -1,0 +1,29 @@
+/**
+ * Client-side mirror of `selectorValueMatches` from `@openape/grants`. Used by
+ * the scoped-command wizard to live-preview which sample values a user-entered
+ * glob pattern would match. Keep logic in sync with
+ * `packages/grants/src/cli-permissions.ts:selectorValueMatches`.
+ */
+
+export function globToRegex(pattern: string): RegExp {
+  const escaped = pattern
+    .replace(/[.+?^${}()|[\]\\]/g, '\\$&')
+    .replace(/\*/g, '.*')
+  return new RegExp(`^${escaped}$`)
+}
+
+export function selectorValueMatches(pattern: string, required: string): boolean {
+  if (!pattern.includes('*')) return pattern === required
+  if (pattern.length > 256) return false
+  return globToRegex(pattern).test(required)
+}
+
+export interface PreviewMatch {
+  sample: string
+  matches: boolean
+}
+
+export function previewMatches(pattern: string, samples: string[]): PreviewMatch[] {
+  if (!pattern) return samples.map(sample => ({ sample, matches: false }))
+  return samples.map(sample => ({ sample, matches: selectorValueMatches(pattern, sample) }))
+}

--- a/apps/openape-free-idp/tests/glob-preview.test.ts
+++ b/apps/openape-free-idp/tests/glob-preview.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { globToRegex, previewMatches, selectorValueMatches } from '../app/utils/glob-preview'
+
+describe('globToRegex', () => {
+  it('treats * as any chars and anchors the pattern', () => {
+    const re = globToRegex('foo/*')
+    expect(re.test('foo/bar')).toBe(true)
+    expect(re.test('foo/bar/baz')).toBe(true)
+    expect(re.test('other/bar')).toBe(false)
+  })
+
+  it('escapes regex metachars other than *', () => {
+    expect(globToRegex('a.b').test('aXb')).toBe(false)
+    expect(globToRegex('a.b').test('a.b')).toBe(true)
+    expect(globToRegex('a+b').test('a+b')).toBe(true)
+  })
+})
+
+describe('selectorValueMatches', () => {
+  it('falls back to literal equality without a *', () => {
+    expect(selectorValueMatches('openape', 'openape')).toBe(true)
+    expect(selectorValueMatches('openape', 'openapi')).toBe(false)
+  })
+
+  it('matches prefix + suffix + middle globs', () => {
+    expect(selectorValueMatches('/Users/x/*', '/Users/x/Docs')).toBe(true)
+    expect(selectorValueMatches('*.ts', 'index.ts')).toBe(true)
+    expect(selectorValueMatches('repo/*/src', 'repo/open/src')).toBe(true)
+  })
+
+  it('caps at 256 chars', () => {
+    const long = '*'.repeat(257)
+    expect(selectorValueMatches(long, 'any')).toBe(false)
+  })
+})
+
+describe('previewMatches', () => {
+  it('returns one row per sample', () => {
+    const rows = previewMatches('foo*', ['foo', 'foobar', 'other'])
+    expect(rows).toEqual([
+      { sample: 'foo', matches: true },
+      { sample: 'foobar', matches: true },
+      { sample: 'other', matches: false },
+    ])
+  })
+
+  it('empty pattern marks all samples as non-matching', () => {
+    expect(previewMatches('', ['anything'])).toEqual([{ sample: 'anything', matches: false }])
+  })
+})

--- a/packages/grants/src/cli-permissions.ts
+++ b/packages/grants/src/cli-permissions.ts
@@ -108,6 +108,22 @@ export function validateCliAuthorizationDetail(detail: unknown): CliAuthorizatio
   return { valid: true, errors: [] }
 }
 
+/**
+ * Compare a granted selector value against a required one. Without '*' this is
+ * literal equality (fast-path, preserves pre-Phase-5 behavior). With '*' the
+ * value is interpreted as a POSIX-shell-style glob: '*' matches any chars
+ * including '/'. Regex metachars other than '*' are escaped; the pattern is
+ * anchored. Length capped at 256 chars to bound compiled regex complexity.
+ */
+export function selectorValueMatches(granted: string, required: string): boolean {
+  if (!granted.includes('*')) return granted === required
+  if (granted.length > 256) return false
+  const escaped = granted
+    .replace(/[.+?^${}()|[\]\\]/g, '\\$&')
+    .replace(/\*/g, '.*')
+  return new RegExp(`^${escaped}$`).test(required)
+}
+
 function resourceRefCovers(granted: OpenApeCliResourceRef, required: OpenApeCliResourceRef): boolean {
   if (granted.resource !== required.resource)
     return false
@@ -120,7 +136,10 @@ function resourceRefCovers(granted: OpenApeCliResourceRef, required: OpenApeCliR
   if (!requiredSelector)
     return false
 
-  return Object.entries(grantedSelector).every(([key, value]) => requiredSelector[key] === value)
+  return Object.entries(grantedSelector).every(([key, value]) => {
+    const req = requiredSelector[key]
+    return typeof req === 'string' && selectorValueMatches(value, req)
+  })
 }
 
 export function isCliAuthorizationDetailExact(detail: Pick<OpenApeCliAuthorizationDetail, 'constraints'>): boolean {

--- a/packages/grants/src/index.ts
+++ b/packages/grants/src/index.ts
@@ -9,6 +9,7 @@ export {
   isCliAuthorizationDetailExact,
   mergeCliAuthorizationDetails,
   resourceChainsStructurallyMatch,
+  selectorValueMatches,
   validateCliAuthorizationDetail,
   widenCliAuthorizationDetail,
 } from './cli-permissions.js'

--- a/packages/grants/test/cli-permissions.test.ts
+++ b/packages/grants/test/cli-permissions.test.ts
@@ -1,0 +1,143 @@
+import type { OpenApeCliAuthorizationDetail } from '@openape/core'
+import { describe, expect, it } from 'vitest'
+import {
+  canonicalizeCliPermission,
+  cliAuthorizationDetailCovers,
+  selectorValueMatches,
+} from '../src/cli-permissions.js'
+
+function detail(overrides: Partial<OpenApeCliAuthorizationDetail> = {}): OpenApeCliAuthorizationDetail {
+  const base: OpenApeCliAuthorizationDetail = {
+    type: 'openape_cli',
+    cli_id: 'ls',
+    operation_id: 'ls.list',
+    action: 'read',
+    risk: 'low',
+    resource_chain: [],
+    permission: '',
+    display: 'ls',
+    ...overrides,
+  }
+  base.permission = canonicalizeCliPermission(base)
+  return base
+}
+
+describe('selectorValueMatches', () => {
+  it('matches literal values with string equality (no glob)', () => {
+    expect(selectorValueMatches('openape', 'openape')).toBe(true)
+    expect(selectorValueMatches('openape', 'openapi')).toBe(false)
+    expect(selectorValueMatches('', '')).toBe(true)
+  })
+
+  it('prefix glob: "foo/*" matches anything starting with "foo/"', () => {
+    expect(selectorValueMatches('/Users/patrickhofmann/*', '/Users/patrickhofmann/Documents')).toBe(true)
+    expect(selectorValueMatches('/Users/patrickhofmann/*', '/Users/patrickhofmann/')).toBe(true)
+    expect(selectorValueMatches('/Users/patrickhofmann/*', '/Users/other/foo')).toBe(false)
+  })
+
+  it('suffix glob: "*.ts" matches anything ending in ".ts"', () => {
+    expect(selectorValueMatches('*.ts', 'index.ts')).toBe(true)
+    expect(selectorValueMatches('*.ts', 'index.tsx')).toBe(false)
+  })
+
+  it('middle glob: "repo/*/src" matches anything with that prefix+suffix', () => {
+    expect(selectorValueMatches('repo/*/src', 'repo/openape/src')).toBe(true)
+    expect(selectorValueMatches('repo/*/src', 'repo/openape/lib/src')).toBe(true)
+    expect(selectorValueMatches('repo/*/src', 'repo/openape/lib')).toBe(false)
+  })
+
+  it('multiple globs: "*-*-*"', () => {
+    expect(selectorValueMatches('*-*-*', 'a-b-c')).toBe(true)
+    expect(selectorValueMatches('*-*-*', 'ab')).toBe(false)
+  })
+
+  it('empty glob pattern "*" matches any value including empty string', () => {
+    expect(selectorValueMatches('*', 'anything')).toBe(true)
+    expect(selectorValueMatches('*', '')).toBe(true)
+  })
+
+  it('escapes regex metachars so literal "." is not "any char"', () => {
+    expect(selectorValueMatches('a.b', 'aXb')).toBe(false)
+    expect(selectorValueMatches('a.b', 'a.b')).toBe(true)
+  })
+
+  it('escapes other regex specials (+, ?, (, [, etc.) when used literally', () => {
+    expect(selectorValueMatches('a+b', 'a+b')).toBe(true)
+    expect(selectorValueMatches('a+b', 'aab')).toBe(false)
+    expect(selectorValueMatches('a(b)c', 'a(b)c')).toBe(true)
+    expect(selectorValueMatches('a[b]c', 'a[b]c')).toBe(true)
+  })
+
+  it('caps at 256 chars (rejects overly long patterns)', () => {
+    const long = '*'.repeat(257)
+    expect(selectorValueMatches(long, 'any')).toBe(false)
+  })
+})
+
+describe('cliAuthorizationDetailCovers — literal (unchanged backward-compat)', () => {
+  it('same cli+action+empty-chain covers any required chain', () => {
+    const granted = detail({ resource_chain: [] })
+    const required = detail({ resource_chain: [{ resource: 'fs', selector: { path: '/tmp' } }] })
+    expect(cliAuthorizationDetailCovers(granted, required)).toBe(true)
+  })
+
+  it('literal selector value must equal required exactly', () => {
+    const granted = detail({ resource_chain: [{ resource: 'repo', selector: { name: 'openape' } }] })
+    const good = detail({ resource_chain: [{ resource: 'repo', selector: { name: 'openape' } }] })
+    const bad = detail({ resource_chain: [{ resource: 'repo', selector: { name: 'openapi' } }] })
+    expect(cliAuthorizationDetailCovers(granted, good)).toBe(true)
+    expect(cliAuthorizationDetailCovers(granted, bad)).toBe(false)
+  })
+
+  it('wildcard (undefined selector) covers any required selector on same resource', () => {
+    const granted = detail({ resource_chain: [{ resource: 'repo', selector: undefined }] })
+    const required = detail({ resource_chain: [{ resource: 'repo', selector: { name: 'anything' } }] })
+    expect(cliAuthorizationDetailCovers(granted, required)).toBe(true)
+  })
+})
+
+describe('cliAuthorizationDetailCovers — glob (Phase 5)', () => {
+  it('prefix-glob path matches deeper path', () => {
+    const granted = detail({
+      resource_chain: [{ resource: 'fs', selector: { path: '/Users/patrickhofmann/*' } }],
+    })
+    const required = detail({
+      resource_chain: [{ resource: 'fs', selector: { path: '/Users/patrickhofmann/Documents/foo.txt' } }],
+    })
+    expect(cliAuthorizationDetailCovers(granted, required)).toBe(true)
+  })
+
+  it('prefix-glob path rejects non-matching path', () => {
+    const granted = detail({
+      resource_chain: [{ resource: 'fs', selector: { path: '/Users/patrickhofmann/*' } }],
+    })
+    const required = detail({
+      resource_chain: [{ resource: 'fs', selector: { path: '/Users/other/foo' } }],
+    })
+    expect(cliAuthorizationDetailCovers(granted, required)).toBe(false)
+  })
+
+  it('glob applies per-key: other keys still require literal match', () => {
+    const granted = detail({
+      resource_chain: [{ resource: 'repo', selector: { owner: 'patrick', name: 'open*' } }],
+    })
+    const goodOwnerGoodName = detail({
+      resource_chain: [{ resource: 'repo', selector: { owner: 'patrick', name: 'openape' } }],
+    })
+    const badOwner = detail({
+      resource_chain: [{ resource: 'repo', selector: { owner: 'someone-else', name: 'openape' } }],
+    })
+    expect(cliAuthorizationDetailCovers(granted, goodOwnerGoodName)).toBe(true)
+    expect(cliAuthorizationDetailCovers(granted, badOwner)).toBe(false)
+  })
+
+  it('required selector missing the granted key still fails', () => {
+    const granted = detail({
+      resource_chain: [{ resource: 'fs', selector: { path: '/tmp/*' } }],
+    })
+    const required = detail({
+      resource_chain: [{ resource: 'fs', selector: { other: 'value' } }],
+    })
+    expect(cliAuthorizationDetailCovers(granted, required)).toBe(false)
+  })
+})

--- a/packages/grants/test/standing-grants.test.ts
+++ b/packages/grants/test/standing-grants.test.ts
@@ -249,4 +249,68 @@ describe('evaluateStandingGrants', () => {
     )
     expect(match).toBeNull()
   })
+
+  describe('glob selectors (Phase 5)', () => {
+    it('matches when template uses a prefix-glob path selector', async () => {
+      const store = await withStandingGrants([
+        makeStandingGrant({
+          owner: 'patrick@',
+          delegate: 'claude@example.com',
+          cli_id: 'ls',
+          action: 'read',
+          max_risk: 'low',
+          resource_chain_template: [
+            { resource: 'fs', selector: { path: '/Users/patrickhofmann/*' } },
+          ],
+        }),
+      ])
+      const lsDetail = {
+        type: 'openape_cli' as const,
+        cli_id: 'ls',
+        operation_id: 'ls.list',
+        action: 'read',
+        risk: 'low' as const,
+        resource_chain: [{ resource: 'fs', selector: { path: '/Users/patrickhofmann/Documents' } }],
+        permission: '',
+        display: 'ls /Users/patrickhofmann/Documents',
+      }
+      lsDetail.permission = canonicalizeCliPermission(lsDetail)
+      const match = await evaluateStandingGrants(
+        makeIncomingGrantRequest({ authorization_details: [lsDetail] }),
+        store,
+      )
+      expect(match).not.toBeNull()
+    })
+
+    it('does not match when the required path is outside the globbed prefix', async () => {
+      const store = await withStandingGrants([
+        makeStandingGrant({
+          owner: 'patrick@',
+          delegate: 'claude@example.com',
+          cli_id: 'ls',
+          action: 'read',
+          max_risk: 'low',
+          resource_chain_template: [
+            { resource: 'fs', selector: { path: '/Users/patrickhofmann/*' } },
+          ],
+        }),
+      ])
+      const lsDetail = {
+        type: 'openape_cli' as const,
+        cli_id: 'ls',
+        operation_id: 'ls.list',
+        action: 'read',
+        risk: 'low' as const,
+        resource_chain: [{ resource: 'fs', selector: { path: '/Users/other/foo' } }],
+        permission: '',
+        display: 'ls /Users/other/foo',
+      }
+      lsDetail.permission = canonicalizeCliPermission(lsDetail)
+      const match = await evaluateStandingGrants(
+        makeIncomingGrantRequest({ authorization_details: [lsDetail] }),
+        store,
+      )
+      expect(match).toBeNull()
+    })
+  })
 })

--- a/packages/idp-test-suite/src/suites/safe-commands.ts
+++ b/packages/idp-test-suite/src/suites/safe-commands.ts
@@ -227,5 +227,109 @@ export function safeCommandsTests(config: ResolvedConfig) {
         expect(status).toBe(401)
       })
     })
+
+    describe('Glob coverage (Phase 5)', () => {
+      const humanEmail = `glob-human-${Date.now()}@example.com`
+      const agentEmail = `glob-agent-${Date.now()}@example.com`
+      const humanKey = generateEd25519Key()
+      const agentKey = generateEd25519Key()
+      let globSgId: string | undefined
+
+      it('setup: enroll human + agent', async () => {
+        await post(
+          config.baseUrl,
+          '/api/auth/enroll',
+          { email: humanEmail, name: 'Glob H', publicKey: humanKey.publicKeySsh, owner: humanEmail, type: 'human' },
+          config.managementToken,
+        )
+        await post(
+          config.baseUrl,
+          '/api/auth/enroll',
+          { email: agentEmail, name: 'Glob A', publicKey: agentKey.publicKeySsh, owner: humanEmail },
+          config.managementToken,
+        )
+      })
+
+      it('owner creates a prefix-glob standing grant', async () => {
+        const token = await loginWithKey(config.baseUrl, humanEmail, humanKey.privateKey)
+        const { status, data } = await post(
+          config.baseUrl,
+          '/api/standing-grants',
+          {
+            delegate: agentEmail,
+            audience: 'shapes',
+            cli_id: 'ls',
+            action: 'read',
+            max_risk: 'low',
+            resource_chain_template: [
+              { resource: 'fs', selector: { path: '/tmp/agent-scratch/*' } },
+            ],
+            grant_type: 'always',
+            reason: 'phase-5 glob E2E',
+          },
+          token,
+        )
+        expect(status).toBe(201)
+        expect(data.status).toBe('approved')
+        globSgId = data.id
+      })
+
+      it('agent request within the globbed prefix auto-approves via the SG', async () => {
+        expect(globSgId).toBeDefined()
+        const agentToken = await loginWithKey(config.baseUrl, agentEmail, agentKey.privateKey)
+        const { status, data } = await post(
+          config.baseUrl,
+          '/api/grants',
+          {
+            requester: agentEmail,
+            target_host: 'hostA',
+            audience: 'shapes',
+            grant_type: 'once',
+            command: ['ls', '/tmp/agent-scratch/foo'],
+            authorization_details: [{
+              type: 'openape_cli',
+              cli_id: 'ls',
+              operation_id: 'ls.list',
+              action: 'read',
+              risk: 'low',
+              resource_chain: [{ resource: 'fs', selector: { path: '/tmp/agent-scratch/foo' } }],
+              permission: 'ls.fs[path=/tmp/agent-scratch/foo]#read',
+              display: 'ls /tmp/agent-scratch/foo',
+            }],
+          },
+          agentToken,
+        )
+        expect(status).toBe(201)
+        expect(data.status).toBe('approved')
+        expect(data.decided_by_standing_grant).toBe(globSgId)
+      })
+
+      it('agent request outside the globbed prefix falls through to pending', async () => {
+        const agentToken = await loginWithKey(config.baseUrl, agentEmail, agentKey.privateKey)
+        const { data } = await post(
+          config.baseUrl,
+          '/api/grants',
+          {
+            requester: agentEmail,
+            target_host: 'hostA',
+            audience: 'shapes',
+            grant_type: 'once',
+            command: ['ls', '/tmp/other/foo'],
+            authorization_details: [{
+              type: 'openape_cli',
+              cli_id: 'ls',
+              operation_id: 'ls.list',
+              action: 'read',
+              risk: 'low',
+              resource_chain: [{ resource: 'fs', selector: { path: '/tmp/other/foo' } }],
+              permission: 'ls.fs[path=/tmp/other/foo]#read',
+              display: 'ls /tmp/other/foo',
+            }],
+          },
+          agentToken,
+        )
+        expect(data.status).toBe('pending')
+      })
+    })
   })
 }


### PR DESCRIPTION
## Summary

Phase 5 of the [openape-policy-shift plan](.claude/plans/openape-policy-shift/phase-5-scoped-commands.md).

### Engine
- `cliAuthorizationDetailCovers` now treats `*` inside granted selector values as POSIX-shell-style globs (matches any chars incl. `/`). Selectors without `*` stay literal equality. Backward-compatible.
- New `selectorValueMatches` helper exported from `@openape/grants`.

### UI (`apps/openape-free-idp`)
- **3-step full-screen wizard** on `/agents/:id` — "+ Erlaubten Command hinzufügen" opens a mobile-first sheet with:
  1. **Command**: type example argv → debounced `POST /api/shapes/resolve` → live preview of matched operation + risk + parsed slots.
  2. **Scope**: per-slot editor with three modes (Literal / Any / Pattern). Pattern mode shows live glob-match preview against the user's original value.
  3. **Policy**: max-risk cap, grant_type (always / timed), optional reason.
- **Unified "Erlaubte Commands" card** replaces the separate Safe Commands grid + Scoped Standing Grants list. Defaults render with shield-check icons + toggle affordance; custom + scoped entries render with scope descriptions and a revoke button.
- Client-safe `glob-preview` util mirrors the engine so the wizard never pulls `@openape/grants` (node:crypto) into the browser bundle.

## Test plan

- [x] `pnpm turbo run test --filter '@openape/grants'` → 229 green (was 211 baseline + 18 new glob tests)
- [x] `pnpm --filter 'openape-free-idp' exec vitest run tests/glob-preview.test.ts` → 7 green
- [x] `pnpm turbo run build typecheck --filter openape-free-idp` → green
- [x] `@openape/idp-test-suite` E2E glob scenario runs post-deploy via `against-free-idp.test.ts`
- [ ] Post-deploy: open `/agents/<agent>` on phone, tap FAB, author `ls /tmp/foo/*` → verify appears in unified list and auto-approves a matching agent request

## Milestones

- M1 `feat(grants): glob support in selector coverage`
- M2 `test(grants,idp-test-suite): glob coverage E2E`
- M3 `feat(free-idp): shape-resolver composable + glob-preview util`
- M4 `feat(free-idp): ScopeSlotEditor component`
- M5 `feat(free-idp): scoped-command wizard (3-step fullscreen sheet)`
- M6 `feat(free-idp): unified Erlaubte Commands list with scoped wizard`