### PR TITLE
ci: auto-deploy id.openape.ai to chatty + dedicated openape service user

### DIFF
--- a/.github/workflows/deploy-chatty.yml
+++ b/.github/workflows/deploy-chatty.yml
@@ -1,0 +1,105 @@
+name: Deploy id.openape.ai
+
+# Auto-deploys apps/openape-free-idp to chatty.delta-mind.at on main push.
+# Uses scripts/deploy-chatty.sh for build + rsync + restart + health check.
+# Independent of ci.yml — no test gate. Public HTTPS health check + auto-rollback
+# cover failing deploys. See plan: .claude/plans/openape-policy-shift/ci-deploy-chatty.md
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/openape-free-idp/**'
+      - 'modules/nuxt-auth-idp/**'
+      - 'packages/auth/**'
+      - 'packages/core/**'
+      - 'packages/grants/**'
+      - 'scripts/deploy-chatty.sh'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/deploy-chatty.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-chatty
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      CHATTY_HOST: chatty
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Setup SSH
+        env:
+          SSH_KEY: ${{ secrets.CHATTY_SSH_KEY }}
+          KNOWN_HOSTS: ${{ secrets.CHATTY_KNOWN_HOSTS }}
+        run: |
+          mkdir -p ~/.ssh
+          umask 077
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/chatty
+          chmod 600 ~/.ssh/chatty
+          printf '%s\n' "$KNOWN_HOSTS" > ~/.ssh/known_hosts
+          cat > ~/.ssh/config <<'EOF'
+          Host chatty
+            HostName chatty.delta-mind.at
+            User openape
+            IdentityFile ~/.ssh/chatty
+            IdentitiesOnly yes
+            StrictHostKeyChecking yes
+            UserKnownHostsFile ~/.ssh/known_hosts
+          EOF
+          chmod 600 ~/.ssh/config
+
+      - name: Capture previous release (for rollback)
+        id: prev
+        run: |
+          PREV=$(ssh chatty "readlink /home/openape/projects/openape-free-idp/current 2>/dev/null" || echo "")
+          echo "release=$PREV" >> "$GITHUB_OUTPUT"
+          echo "Previous release: ${PREV:-<none>}"
+
+      - name: Deploy
+        run: ./scripts/deploy-chatty.sh
+
+      - name: Public HTTPS health check
+        run: |
+          set -euo pipefail
+          for i in 1 2 3 4 5; do
+            N=$(curl -fsS https://id.openape.ai/api/shapes 2>/dev/null | jq 'length' || echo 0)
+            if [ "$N" -ge 50 ]; then
+              echo "✓ https://id.openape.ai serves $N shapes"
+              exit 0
+            fi
+            echo "attempt $i: got $N shapes, retrying..."
+            sleep 3
+          done
+          echo "✗ public health check failed after 5 attempts"
+          exit 1
+
+      - name: Rollback on failure
+        if: failure() && steps.prev.outputs.release != ''
+        env:
+          PREV_RELEASE: ${{ steps.prev.outputs.release }}
+        run: |
+          set -euo pipefail
+          # Validate timestamp shape (YYYY-MM-DDTHH-MM-SS) before using in remote shell
+          if [[ ! "$PREV_RELEASE" =~ ^/home/openape/projects/openape-free-idp/releases/[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}-[0-9]{2}-[0-9]{2}$ ]]; then
+            echo "refusing to roll back to unexpected path: $PREV_RELEASE"
+            exit 1
+          fi
+          echo "↩ Rolling back to $PREV_RELEASE"
+          ssh chatty "ln -sfn $PREV_RELEASE /home/openape/projects/openape-free-idp/current && sudo systemctl restart openape-free-idp.service"
+          echo "✓ rollback complete"

--- a/scripts/deploy-chatty.sh
+++ b/scripts/deploy-chatty.sh
@@ -5,13 +5,17 @@
 # Usage: ./scripts/deploy-chatty.sh
 #
 # Requires:
-#   - SSH access to chatty.delta-mind.at (ssh alias in ~/.ssh/config)
-#   - sudo on chatty for systemctl restart
-#   - Local node/pnpm, run from the monorepo root
+#   - SSH access to chatty.delta-mind.at as the service user (default: openape).
+#     Configure via ~/.ssh/config "Host chatty" with "User openape", or override
+#     via CHATTY_HOST. The GitHub Actions deploy-chatty workflow sets that up
+#     from repo secrets.
+#   - Passwordless sudo on chatty for `systemctl restart openape-free-idp.service`
+#     (installed in /etc/sudoers.d/openape-free-idp, scoped to user openape).
+#   - Local node/pnpm, run from the monorepo root.
 #
 # Release layout on chatty:
-#   ~/projects/openape-free-idp/
-#     ├─ releases/<TS>/        timestamped, kept for rollback
+#   /home/openape/projects/openape-free-idp/
+#     ├─ releases/<TS>/        timestamped, kept for rollback (last 3)
 #     ├─ current -> releases/<TS>/
 #     └─ shared/.env           chmod 600, persistent across deploys
 #
@@ -21,7 +25,7 @@
 set -euo pipefail
 
 HOST="${CHATTY_HOST:-chatty.delta-mind.at}"
-BASE="${CHATTY_BASE:-/home/ubuntu/projects/openape-free-idp}"
+BASE="${CHATTY_BASE:-/home/openape/projects/openape-free-idp}"
 TS=$(date -u +%Y-%m-%dT%H-%M-%S)
 
 echo "→ Build .output locally"
@@ -30,10 +34,10 @@ pnpm turbo run build --filter openape-free-idp
 echo "→ Rsync release to ${HOST}:${BASE}/releases/${TS}/"
 rsync -az --delete \
   apps/openape-free-idp/.output/ \
-  "${HOST}:${BASE}/releases/${TS}/"
+  "${CHATTY_USER:-openape}@${HOST}:${BASE}/releases/${TS}/"
 
 echo "→ Pin matching linux-x64-gnu native binding (0.4.7)"
-ssh "${HOST}" bash -s <<REMOTE
+ssh -l "${CHATTY_USER:-openape}" "${HOST}" bash -s <<REMOTE
 set -euo pipefail
 cd /tmp
 rm -rf libsql-pkg && mkdir libsql-pkg && cd libsql-pkg
@@ -44,13 +48,13 @@ cp package/* ${BASE}/releases/${TS}/server/node_modules/@libsql/linux-x64-gnu/
 REMOTE
 
 echo "→ Swap current symlink"
-ssh "${HOST}" "ln -sfn ${BASE}/releases/${TS} ${BASE}/current"
+ssh -l "${CHATTY_USER:-openape}" "${HOST}" "ln -sfn ${BASE}/releases/${TS} ${BASE}/current"
 
 echo "→ Restart systemd service"
-ssh "${HOST}" "sudo systemctl restart openape-free-idp.service"
+ssh -l "${CHATTY_USER:-openape}" "${HOST}" "sudo systemctl restart openape-free-idp.service"
 
 echo "→ Wait for socket + health"
-ssh "${HOST}" "
+ssh -l "${CHATTY_USER:-openape}" "${HOST}" "
   for i in 1 2 3 4 5 6 7 8 9 10; do
     if curl -fsS -o /dev/null http://127.0.0.1:3003/api/shapes; then echo 'up after '\$i's'; exit 0; fi
     sleep 1
@@ -61,7 +65,7 @@ ssh "${HOST}" "
 "
 
 echo "→ Prune old releases (keep last 3)"
-ssh "${HOST}" "ls -1t ${BASE}/releases/ | tail -n +4 | xargs -r -I{} rm -rf ${BASE}/releases/{}"
+ssh -l "${CHATTY_USER:-openape}" "${HOST}" "ls -1t ${BASE}/releases/ | tail -n +4 | xargs -r -I{} rm -rf ${BASE}/releases/{}"
 
 echo
 echo "✓ Deployed ${TS} to https://id.openape.ai"


### PR DESCRIPTION
## Summary

Automates deploy of `apps/openape-free-idp` to `chatty.delta-mind.at` on `main` push. Service now runs as dedicated `openape` Unix user (migrated from `ubuntu`) for privilege separation.

### What's included

- **`.github/workflows/deploy-chatty.yml`**: auto-triggered on push to main when free-idp / its workspace deps / the deploy script / pnpm-lock change. Also `workflow_dispatch`. Concurrency `group: deploy-chatty`, `cancel-in-progress: false`.
  - Steps: checkout → pnpm install → SSH setup from `CHATTY_SSH_KEY`+`CHATTY_KNOWN_HOSTS` secrets → capture current release → run `scripts/deploy-chatty.sh` → public HTTPS health check (5 retries) → **auto-rollback** on failure (path-validated symlink swap).
- **`scripts/deploy-chatty.sh`**: new defaults `CHATTY_USER=openape` + `CHATTY_BASE=/home/openape/projects/openape-free-idp`. All `ssh/rsync` now go through `openape@chatty` explicitly.

### Security-Härtung (done out-of-band; not shipped in this PR, only required for the workflow to succeed)

- Dedicated Unix user `openape` on chatty (system user, login shell, SSH-key-only).
- Files moved: `/home/ubuntu/projects/openape-free-idp/` → `/home/openape/projects/openape-free-idp/`, chowned `openape:openape`.
- systemd unit switched to `User=openape, Group=openape`.
- Scoped sudoers: `openape ALL=(root) NOPASSWD: /bin/systemctl restart openape-free-idp.service`.
- Dedicated ed25519 CI deploy keypair generated; private → GitHub secret `CHATTY_SSH_KEY`; public → `/home/openape/.ssh/authorized_keys` on chatty.
- `CHATTY_KNOWN_HOSTS` = `ssh-keyscan chatty.delta-mind.at`.

### Why independent of ci.yml

Per current-state observation (and user feedback): `ci.yml` has flaky tests (e.g. `@openape/apes` shell-login-integration). Gating deploy on green CI would produce false-negative blocks. Instead: public HTTPS health check + auto-rollback is the reliable gate. Tests remain developer responsibility (local Mac / remote chatty smoke).

## Test plan

- [x] M0 user migration run (chatty): `ps -o user,cmd -p $(pgrep -f openape-free-idp/current)` → `openape /usr/bin/node ...`
- [x] M1 CI key + sudoers scoped to `openape`: `ssh -i key openape@chatty sudo -n systemctl restart openape-free-idp.service` works
- [x] M2 secrets uploaded (`gh secret list` shows `CHATTY_SSH_KEY`, `CHATTY_KNOWN_HOSTS`)
- [x] Script updated + lint/typecheck clean
- [ ] Post-merge: `gh workflow run deploy-chatty.yml` manually triggers a green run
- [ ] Path-filter verified via no-op commit on `scripts/deploy-chatty.sh`
- [ ] (optional) Auto-rollback verified with intentional failing build

## Plan

Full plan: `.claude/plans/openape-policy-shift/ci-deploy-chatty.md` (master doc Part 3).