### PR TITLE
fix(idp): create users + shapes tables on startup

### DIFF
--- a/apps/openape-free-idp/server/plugins/02.database.ts
+++ b/apps/openape-free-idp/server/plugins/02.database.ts
@@ -46,6 +46,26 @@ export default defineNitroPlugin(async () => {
     )`)
     await db.run(sql`CREATE INDEX IF NOT EXISTS idx_ssh_keys_user_email ON ssh_keys(user_email)`)
     await db.run(sql`CREATE INDEX IF NOT EXISTS idx_ssh_keys_public_key ON ssh_keys(public_key)`)
+
+    // Schema evolved past migration 0000: extra user columns + shapes table
+    // are declared in schema.ts but were never added here. Without these the
+    // very first login/register on a fresh DB fails with "no such table".
+    await db.run(sql`CREATE TABLE IF NOT EXISTS users (
+      email TEXT PRIMARY KEY NOT NULL, id TEXT, name TEXT NOT NULL,
+      owner TEXT, approver TEXT, type TEXT, public_key TEXT,
+      is_active INTEGER NOT NULL DEFAULT 1, created_at INTEGER NOT NULL
+    )`)
+    await db.run(sql`CREATE INDEX IF NOT EXISTS idx_users_id ON users(id)`)
+    await db.run(sql`CREATE INDEX IF NOT EXISTS idx_users_owner ON users(owner)`)
+    await db.run(sql`CREATE INDEX IF NOT EXISTS idx_users_approver ON users(approver)`)
+
+    await db.run(sql`CREATE TABLE IF NOT EXISTS shapes (
+      cli_id TEXT PRIMARY KEY, executable TEXT NOT NULL, description TEXT NOT NULL,
+      operations TEXT NOT NULL, source TEXT NOT NULL, digest TEXT NOT NULL,
+      created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL
+    )`)
+    await db.run(sql`CREATE INDEX IF NOT EXISTS idx_shapes_source ON shapes(source)`)
+    await db.run(sql`CREATE INDEX IF NOT EXISTS idx_shapes_executable ON shapes(executable)`)
   }
   catch (err) {
     console.error('[database] Table creation failed (tables may already exist):', err)


### PR DESCRIPTION
## Summary

- `apps/openape-free-idp/server/plugins/02.database.ts` creates most tables on boot with `CREATE TABLE IF NOT EXISTS`, but `users` and `shapes` were never added — they live only in `schema.ts` and in the drizzle migrations, which are not executed at runtime.
- On a fresh id.openape.ai deploy the first login/register hits `no such table: users` and the SP stack surfaces the raw error to the browser (`Failed query: select \"email\", \"id\", \"name\", \"owner\", \"approver\", \"type\", \"public_key\", \"is_active\", \"created_at\" from \"users\" where \"users\".\"email\" = ?`).
- This PR adds idempotent `CREATE TABLE IF NOT EXISTS` for both tables plus their indexes, column types matching `schema.ts` exactly.

## Test plan

- [x] Lint passes on the free-idp package.
- [x] Manually applied the same DDL to the prod SQLite on chatty; login/register flow no longer throws SQL errors.
- [ ] After merge + auto-deploy, register a fresh user at https://id.openape.ai and confirm the webauthn flow completes.