### PR TITLE
fix(idp): surface Resend delivery failures instead of silent-dropping

### DIFF
--- a/apps/openape-free-idp/server/utils/email.ts
+++ b/apps/openape-free-idp/server/utils/email.ts
@@ -1,3 +1,4 @@
+import { createError } from 'h3'
 import { Resend } from 'resend'
 import { useRuntimeConfig } from '#imports'
 
@@ -15,7 +16,10 @@ export async function sendRegistrationEmail(email: string, registerUrl: string) 
   const config = useRuntimeConfig()
   const resend = getResend()
 
-  await resend.emails.send({
+  // The Resend SDK returns { data, error } and does NOT throw on API failures
+  // (invalid key, unverified sender domain, rate limit, etc.). Without checking
+  // `error` we'd return 200 to the caller while the email is silently dropped.
+  const { data, error } = await resend.emails.send({
     from: config.resendFrom,
     to: email,
     subject: 'Dein Account — OpenApe',
@@ -42,4 +46,14 @@ export async function sendRegistrationEmail(email: string, registerUrl: string) 
       </div>
     `,
   })
+
+  if (error) {
+    console.error('[email] resend failed for', email, 'from', config.resendFrom, error)
+    throw createError({
+      statusCode: 502,
+      statusMessage: 'Email delivery failed',
+      data: { title: 'Email delivery failed', detail: error.message ?? error.name ?? 'unknown Resend error' },
+    })
+  }
+  console.info(`[email] registration email queued id=${data?.id ?? 'unknown'} to=${email}`)
 }


### PR DESCRIPTION
## Summary

- `apps/openape-free-idp/server/utils/email.ts` called `await resend.emails.send(...)` and threw the return value away.
- Resend's JS SDK v4 returns `{ data, error }` and **does not throw** on API failures (invalid key, unverified sender domain, rate limit, bad `from`). Every failed send returned `{ ok: true }` to the browser while the email was silently dropped, with nothing in `journalctl`.
- This PR checks `error` and throws a 502 with the Resend message attached, and logs the `data.id` on success so deliveries are traceable end-to-end.

## Repro

1. Deploy id.openape.ai with any misconfigured Resend setup (in this case the `users` table was also missing — see #135 — but even with that fixed, email dropped silently).
2. `POST /api/register { email: "you@example.com" }` → `200 { ok: true }` with no email arriving and no logs.

## After this PR

- Same request surfaces the real Resend error (e.g. "Invalid \`from\` field" / "Domain not verified") in the browser and in journald.

## Test plan

- [x] Lint + typecheck pass.
- [ ] After merge + auto-deploy, re-trigger registration and confirm the real Resend error shows up in `journalctl -u openape-free-idp`.
- [ ] Once the Resend-side config is fixed, confirm a success log line `[email] registration email queued id=...`.

Stacks logically on #135 (together they fix the full registration path), but independent.