### PR TITLE
fix(idp): default issuer to id.openape.ai (was id.openape.at)

### DIFF
--- a/apps/openape-free-idp/nuxt.config.ts
+++ b/apps/openape-free-idp/nuxt.config.ts
@@ -1,5 +1,5 @@
 const e2e = process.env.OPENAPE_E2E === '1'
-const localIssuer = process.env.OPENAPE_ISSUER || 'https://id.openape.at'
+const localIssuer = process.env.OPENAPE_ISSUER || 'https://id.openape.ai'
 
 export default defineNuxtConfig({
   future: { compatibilityVersion: 4 },


### PR DESCRIPTION
## Symptom

Browser shows 'The RP ID \"id.openape.at\" is invalid for this domain' on the passkey registration page at https://id.openape.ai/register?token=... The WebAuthn registration ceremony cannot proceed.

## Cause

`apps/openape-free-idp/nuxt.config.ts` falls back to `'https://id.openape.at'` when `OPENAPE_ISSUER` is not set at build time. The issuer is used to derive `rpID` (\`new URL(issuer).hostname\`). The deploy workflow builds without setting that env var, so the fallback is baked into the bundle, producing `rpID: 'id.openape.at'` — which browsers reject on the `id.openape.ai` origin.

## Fix

Default the fallback to `https://id.openape.ai` to match the canonical production deploy. Self-hosters still override via `OPENAPE_ISSUER=<their-url>` at build time.

## Test plan

- [ ] After merge + auto-deploy, the register page no longer shows the RP ID error and a passkey can be created for a fresh email.
- [x] Lint + typecheck pass.