### PR TITLE
fix(idp): add OAuth codes + refresh tokens + jtis + signing_keys on startup

### DIFF
--- a/apps/openape-free-idp/server/plugins/02.database.ts
+++ b/apps/openape-free-idp/server/plugins/02.database.ts
@@ -66,6 +66,40 @@ export default defineNitroPlugin(async () => {
     )`)
     await db.run(sql`CREATE INDEX IF NOT EXISTS idx_shapes_source ON shapes(source)`)
     await db.run(sql`CREATE INDEX IF NOT EXISTS idx_shapes_executable ON shapes(executable)`)
+
+    // OAuth/OIDC auth-code + refresh-token + JWT id + signing-key tables.
+    // Declared in schema.ts but missing from this init plugin — every first
+    // /authorize round-trip or token refresh on a fresh DB failed with
+    // "no such table: codes | refresh_tokens | jtis | signing_keys".
+    await db.run(sql`CREATE TABLE IF NOT EXISTS codes (
+      code TEXT PRIMARY KEY, client_id TEXT NOT NULL, redirect_uri TEXT NOT NULL,
+      code_challenge TEXT NOT NULL, user_id TEXT NOT NULL, nonce TEXT,
+      expires_at INTEGER NOT NULL, extra_data TEXT
+    )`)
+
+    await db.run(sql`CREATE TABLE IF NOT EXISTS jtis (
+      jti TEXT PRIMARY KEY, expires_at INTEGER NOT NULL
+    )`)
+
+    await db.run(sql`CREATE TABLE IF NOT EXISTS refresh_token_families (
+      family_id TEXT PRIMARY KEY, user_id TEXT NOT NULL, client_id TEXT NOT NULL,
+      current_token_hash TEXT NOT NULL, created_at INTEGER NOT NULL,
+      expires_at INTEGER NOT NULL, revoked INTEGER NOT NULL DEFAULT 0
+    )`)
+    await db.run(sql`CREATE INDEX IF NOT EXISTS idx_refresh_families_user_id ON refresh_token_families(user_id)`)
+    await db.run(sql`CREATE INDEX IF NOT EXISTS idx_refresh_families_client_id ON refresh_token_families(client_id)`)
+
+    await db.run(sql`CREATE TABLE IF NOT EXISTS refresh_tokens (
+      token_hash TEXT PRIMARY KEY, family_id TEXT NOT NULL, user_id TEXT NOT NULL,
+      client_id TEXT NOT NULL, expires_at INTEGER NOT NULL,
+      used INTEGER NOT NULL DEFAULT 0
+    )`)
+    await db.run(sql`CREATE INDEX IF NOT EXISTS idx_refresh_tokens_family_id ON refresh_tokens(family_id)`)
+
+    await db.run(sql`CREATE TABLE IF NOT EXISTS signing_keys (
+      kid TEXT PRIMARY KEY, private_key_jwk TEXT NOT NULL, public_key_jwk TEXT NOT NULL,
+      is_active INTEGER NOT NULL DEFAULT 1, created_at INTEGER NOT NULL
+    )`)
   }
   catch (err) {
     console.error('[database] Table creation failed (tables may already exist):', err)


### PR DESCRIPTION
Follow-up to #135. After fixing users + shapes, the OAuth /authorize flow still fails on any fresh DB because five additional tables declared in schema.ts are missing from the init plugin:

- `codes` — auth codes (hit by every /authorize on first use)
- `jtis` — one-time JWT id store
- `refresh_token_families` + `refresh_tokens` — token refresh chain
- `signing_keys` — OIDC signing keys

Same idempotent `CREATE TABLE IF NOT EXISTS` pattern, column types + indexes verbatim from schema.ts.

Already applied manually to id.openape.ai prod for immediate unblock; this PR brings the code in line so the next fresh deploy starts clean.

## Test plan

- [x] Lint + typecheck pass.
- [ ] After merge + auto-deploy, complete `plans.openape.ai` → id.openape.ai authorize → callback → session roundtrip without SQL errors.