### PR TITLE
chore(idp): switch from openape.at to openape.ai (Resend sender + hardcoded URLs)

### DIFF
--- a/apps/openape-free-idp/app/pages/agents/[id].vue
+++ b/apps/openape-free-idp/app/pages/agents/[id].vue
@@ -88,7 +88,7 @@ async function onWizardCreated() {
 const authInstructions = computed(() => {
   if (!agent.value) return ''
   const email = agent.value.email
-  const base = 'https://id.openape.at'
+  const base = 'https://id.openape.ai'
   return `You can authenticate at ${base} using Ed25519 challenge-response:
 
 Agent email: ${email}
@@ -114,11 +114,11 @@ const escapesCommands = computed(() => {
   return [
     {
       label: 'Enroll (neuer Server)',
-      cmd: `sudo escapes enroll --server https://id.openape.at --agent-email "${email}" --agent-name "${name}" --key /etc/openape/agent.key --existing`,
+      cmd: `sudo escapes enroll --server https://id.openape.ai --agent-email "${email}" --agent-name "${name}" --key /etc/openape/agent.key --existing`,
     },
     {
       label: 'Server-URL ändern',
-      cmd: `sudo escapes update --email "${email}" --server https://id.openape.at`,
+      cmd: `sudo escapes update --email "${email}" --server https://id.openape.ai`,
     },
     {
       label: 'Agent entfernen (nur lokal)',

--- a/apps/openape-free-idp/app/pages/agents/index.vue
+++ b/apps/openape-free-idp/app/pages/agents/index.vue
@@ -47,15 +47,15 @@ function formatDate(ts: number) {
 }
 
 const agentInstructions = computed(() => {
-  return `Generate an Ed25519 keypair and open this URL in the user's browser:\n\nhttps://id.openape.at/enroll?name=<agent-name>&key=<url-encoded-public-key>\n\nParameters:\n- name: your agent's display name\n- key: the full public key in OpenSSH format (ssh-ed25519 AAAA...), URL-encoded (percent-encode spaces as %20)\n\nThe agent email will be automatically derived from the logged-in user's email.`
+  return `Generate an Ed25519 keypair and open this URL in the user's browser:\n\nhttps://id.openape.ai/enroll?name=<agent-name>&key=<url-encoded-public-key>\n\nParameters:\n- name: your agent's display name\n- key: the full public key in OpenSSH format (ssh-ed25519 AAAA...), URL-encoded (percent-encode spaces as %20)\n\nThe agent email will be automatically derived from the logged-in user's email.`
 })
 
 const sudoCommand = computed(() => {
   const email = user.value?.email ?? ''
   const name = email.split('@')[0] ?? 'agent'
   const [local, domain] = email.split('@')
-  const agentEmail = `agent+${local}+${(domain ?? '').replace(/\./g, '_')}@id.openape.at`
-  return `sudo escapes enroll \\\n  --server https://id.openape.at \\\n  --agent-email "${agentEmail}" \\\n  --agent-name "${name}-agent" \\\n  --key /etc/openape/agent.key`
+  const agentEmail = `agent+${local}+${(domain ?? '').replace(/\./g, '_')}@id.openape.ai`
+  return `sudo escapes enroll \\\n  --server https://id.openape.ai \\\n  --agent-email "${agentEmail}" \\\n  --agent-name "${name}-agent" \\\n  --key /etc/openape/agent.key`
 })
 
 const copied = ref('')

--- a/apps/openape-free-idp/app/pages/index.vue
+++ b/apps/openape-free-idp/app/pages/index.vue
@@ -110,7 +110,7 @@ async function handleLogout() {
       </div>
 
       <p class="mt-8 text-sm text-gray-500">
-        Powered by <NuxtLink to="https://openape.at" external class="text-gray-400 hover:text-white transition-colors">
+        Powered by <NuxtLink to="https://openape.ai" external class="text-gray-400 hover:text-white transition-colors">
           OpenApe
         </NuxtLink>
       </p>

--- a/apps/openape-free-idp/app/pages/login.vue
+++ b/apps/openape-free-idp/app/pages/login.vue
@@ -266,7 +266,7 @@ onUnmounted(() => {
       </div>
 
       <p class="mt-8 text-sm text-gray-500">
-        Powered by <NuxtLink to="https://openape.at" external class="text-gray-400 hover:text-white transition-colors">
+        Powered by <NuxtLink to="https://openape.ai" external class="text-gray-400 hover:text-white transition-colors">
           OpenApe
         </NuxtLink>
       </p>

--- a/apps/openape-free-idp/nuxt.config.ts
+++ b/apps/openape-free-idp/nuxt.config.ts
@@ -23,7 +23,7 @@ export default defineNuxtConfig({
 
   runtimeConfig: {
     resendApiKey: '',
-    resendFrom: 'auth@openape.at',
+    resendFrom: 'auth@openape.ai',
     tursoUrl: '',
     tursoAuthToken: '',
     public: {

--- a/apps/openape-free-idp/scripts/apply-migration.mjs
+++ b/apps/openape-free-idp/scripts/apply-migration.mjs
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs'
+import { createClient } from '@libsql/client'
+
+const url = process.env.TURSO_URL
+const authToken = process.env.TURSO_AUTH_TOKEN
+const client = createClient({ url, authToken })
+
+// Check if shapes table exists
+const exists = await client.execute('SELECT name FROM sqlite_master WHERE type=\'table\' AND name=\'shapes\'')
+if (exists.rows.length > 0) {
+  console.log('shapes table already exists, skipping')
+}
+else {
+  const sql = readFileSync('./server/database/migrations/0001_shapes_and_standing_grants.sql', 'utf-8')
+  const statements = sql.split('--> statement-breakpoint').map(s => s.trim()).filter(Boolean)
+  for (const stmt of statements) {
+    console.log('Executing:', stmt.slice(0, 80))
+    await client.execute(stmt)
+  }
+  console.log('Migration applied.')
+}

--- a/apps/openape-free-idp/server/api/enroll.post.ts
+++ b/apps/openape-free-idp/server/api/enroll.post.ts
@@ -8,7 +8,7 @@ function sanitizeName(name: string): string {
 function deriveAgentEmail(ownerEmail: string, agentName: string): string {
   const [local, domain] = ownerEmail.split('@')
   const safeName = sanitizeName(agentName)
-  return `${safeName}+${local}+${domain!.replace(/\./g, '_')}@id.openape.at`
+  return `${safeName}+${local}+${domain!.replace(/\./g, '_')}@id.openape.ai`
 }
 
 export default defineEventHandler(async (event) => {


### PR DESCRIPTION
## Summary

- Resend's `openape.ai` domain is now verified (DKIM + SPF TXT + MX records on exoscale); prod env vars already updated: `NUXT_RESEND_FROM=auth@openape.ai`.
- Brings the codebase defaults and hardcoded UI/CLI surfaces in line so fresh deploys use the right sender and no longer tell users to enroll at `https://id.openape.at` (not live).

## Changes

- `nuxt.config.ts`: `runtimeConfig.resendFrom` default → `auth@openape.ai`
- `server/api/enroll.post.ts`: synthesized agent emails use `@id.openape.ai`
- `app/pages/agents/*.vue`: enrollment snippets point at `https://id.openape.ai`
- `app/pages/{index,login}.vue`: "Powered by" footer link → `https://openape.ai`

Also sweeps in an orphan `scripts/apply-migration.mjs` that was an untracked helper from the earlier `shapes`-table rollout — inert code, no runtime impact.

## Test plan

- [x] Lint + typecheck pass.
- [ ] After merge + auto-deploy, re-trigger registration and confirm the email arrives \`from: auth@openape.ai\`.