### PR TITLE
feat: self-host mail.openape.ai + proxy.openape.ai on chatty, retire Vercel

### DIFF
--- a/.github/workflows/deploy-chatty-mail.yml
+++ b/.github/workflows/deploy-chatty-mail.yml
@@ -1,0 +1,90 @@
+name: Deploy mail.openape.ai
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/openape-agent-mail/**'
+      - 'modules/nuxt-auth-sp/**'
+      - 'packages/auth/**'
+      - 'packages/core/**'
+      - 'packages/grants/**'
+      - 'scripts/deploy-chatty-mail.sh'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/deploy-chatty-mail.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-chatty-mail
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      CHATTY_HOST: chatty
+
+    steps:
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+
+      - name: Setup SSH
+        env:
+          SSH_KEY: ${{ secrets.CHATTY_SSH_KEY }}
+          KNOWN_HOSTS: ${{ secrets.CHATTY_KNOWN_HOSTS }}
+        run: |
+          mkdir -p ~/.ssh
+          umask 077
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/chatty
+          chmod 600 ~/.ssh/chatty
+          printf '%s\n' "$KNOWN_HOSTS" > ~/.ssh/known_hosts
+          cat > ~/.ssh/config <<'EOF'
+          Host chatty
+            HostName chatty.delta-mind.at
+            User openape
+            IdentityFile ~/.ssh/chatty
+            IdentitiesOnly yes
+            StrictHostKeyChecking yes
+            UserKnownHostsFile ~/.ssh/known_hosts
+          EOF
+          chmod 600 ~/.ssh/config
+
+      - name: Capture previous release (for rollback)
+        id: prev
+        run: |
+          PREV=$(ssh chatty "readlink /home/openape/projects/openape-agent-mail/current 2>/dev/null" || echo "")
+          echo "release=$PREV" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy
+        run: ./scripts/deploy-chatty-mail.sh
+
+      - name: Public HTTPS health check
+        run: |
+          set -euo pipefail
+          for i in 1 2 3 4 5; do
+            status=$(curl -s -o /dev/null -w '%{http_code}' https://mail.openape.ai/ || echo 000)
+            case $status in 200|301|302|401|403)
+              echo "https://mail.openape.ai/ returned $status"
+              exit 0 ;;
+            esac
+            sleep 3
+          done
+          exit 1
+
+      - name: Rollback on failure
+        if: failure() && steps.prev.outputs.release != ''
+        env:
+          PREV_RELEASE: ${{ steps.prev.outputs.release }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$PREV_RELEASE" =~ ^/home/openape/projects/openape-agent-mail/releases/[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}-[0-9]{2}-[0-9]{2}$ ]]; then
+            echo "refusing to roll back to unexpected path: $PREV_RELEASE"
+            exit 1
+          fi
+          ssh chatty "ln -sfn $PREV_RELEASE /home/openape/projects/openape-agent-mail/current && sudo systemctl restart openape-agent-mail.service"

--- a/.github/workflows/deploy-chatty-proxy.yml
+++ b/.github/workflows/deploy-chatty-proxy.yml
@@ -1,0 +1,90 @@
+name: Deploy proxy.openape.ai
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/openape-agent-proxy/**'
+      - 'modules/nuxt-auth-sp/**'
+      - 'packages/auth/**'
+      - 'packages/core/**'
+      - 'packages/grants/**'
+      - 'scripts/deploy-chatty-proxy.sh'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/deploy-chatty-proxy.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-chatty-proxy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      CHATTY_HOST: chatty
+
+    steps:
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+
+      - name: Setup SSH
+        env:
+          SSH_KEY: ${{ secrets.CHATTY_SSH_KEY }}
+          KNOWN_HOSTS: ${{ secrets.CHATTY_KNOWN_HOSTS }}
+        run: |
+          mkdir -p ~/.ssh
+          umask 077
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/chatty
+          chmod 600 ~/.ssh/chatty
+          printf '%s\n' "$KNOWN_HOSTS" > ~/.ssh/known_hosts
+          cat > ~/.ssh/config <<'EOF'
+          Host chatty
+            HostName chatty.delta-mind.at
+            User openape
+            IdentityFile ~/.ssh/chatty
+            IdentitiesOnly yes
+            StrictHostKeyChecking yes
+            UserKnownHostsFile ~/.ssh/known_hosts
+          EOF
+          chmod 600 ~/.ssh/config
+
+      - name: Capture previous release (for rollback)
+        id: prev
+        run: |
+          PREV=$(ssh chatty "readlink /home/openape/projects/openape-agent-proxy/current 2>/dev/null" || echo "")
+          echo "release=$PREV" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy
+        run: ./scripts/deploy-chatty-proxy.sh
+
+      - name: Public HTTPS health check
+        run: |
+          set -euo pipefail
+          for i in 1 2 3 4 5; do
+            status=$(curl -s -o /dev/null -w '%{http_code}' https://proxy.openape.ai/ || echo 000)
+            case $status in 200|301|302|401|403)
+              echo "https://proxy.openape.ai/ returned $status"
+              exit 0 ;;
+            esac
+            sleep 3
+          done
+          exit 1
+
+      - name: Rollback on failure
+        if: failure() && steps.prev.outputs.release != ''
+        env:
+          PREV_RELEASE: ${{ steps.prev.outputs.release }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$PREV_RELEASE" =~ ^/home/openape/projects/openape-agent-proxy/releases/[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}-[0-9]{2}-[0-9]{2}$ ]]; then
+            echo "refusing to roll back to unexpected path: $PREV_RELEASE"
+            exit 1
+          fi
+          ssh chatty "ln -sfn $PREV_RELEASE /home/openape/projects/openape-agent-proxy/current && sudo systemctl restart openape-agent-proxy.service"

--- a/scripts/deploy-chatty-mail.sh
+++ b/scripts/deploy-chatty-mail.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# Deploy apps/openape-agent-mail to chatty (mail.openape.ai).
+# Shape mirrors scripts/deploy-chatty.sh (id). Includes libsql native pin
+# because mail uses @libsql/client for its drizzle DB.
+
+set -euo pipefail
+
+HOST="${CHATTY_HOST:-chatty.delta-mind.at}"
+USER_="${CHATTY_USER:-openape}"
+BASE="${CHATTY_BASE:-/home/openape/projects/openape-agent-mail}"
+TS=$(date -u +%Y-%m-%dT%H-%M-%S)
+
+echo "→ Build .output locally"
+pnpm turbo run build --filter openape-agent-mail
+
+echo "→ Rsync release to ${USER_}@${HOST}:${BASE}/releases/${TS}/"
+rsync -az --delete apps/openape-agent-mail/.output/ "${USER_}@${HOST}:${BASE}/releases/${TS}/"
+
+echo "→ Pin libsql native binding (0.4.7)"
+ssh -l "${USER_}" "${HOST}" bash -s <<REMOTE
+set -euo pipefail
+cd /tmp
+rm -rf libsql-pkg && mkdir libsql-pkg && cd libsql-pkg
+npm pack @libsql/linux-x64-gnu@0.4.7 >/dev/null 2>&1
+tar -xzf libsql-linux-x64-gnu-0.4.7.tgz
+mkdir -p ${BASE}/releases/${TS}/server/node_modules/@libsql/linux-x64-gnu
+cp package/* ${BASE}/releases/${TS}/server/node_modules/@libsql/linux-x64-gnu/
+REMOTE
+
+echo "→ Swap current symlink"
+ssh -l "${USER_}" "${HOST}" "ln -sfn ${BASE}/releases/${TS} ${BASE}/current"
+
+echo "→ Restart openape-agent-mail.service"
+ssh -l "${USER_}" "${HOST}" "sudo systemctl restart openape-agent-mail.service"
+
+echo "→ Wait for local health"
+ssh -l "${USER_}" "${HOST}" "
+  for i in 1 2 3 4 5 6 7 8 9 10; do
+    status=\$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:3005/ || echo 000)
+    case \$status in 200|301|302|401|403) echo 'up after '\$i's (HTTP '\$status')'; exit 0 ;; esac
+    sleep 1
+  done
+  echo 'health check failed after 10s'
+  sudo journalctl -u openape-agent-mail -n 30 --no-pager
+  exit 1
+"
+
+echo "→ Prune old releases (keep last 3)"
+ssh -l "${USER_}" "${HOST}" "ls -1t ${BASE}/releases/ | tail -n +4 | xargs -r -I{} rm -rf ${BASE}/releases/{}"
+
+echo
+echo "✓ Deployed ${TS} to https://mail.openape.ai"

--- a/scripts/deploy-chatty-proxy.sh
+++ b/scripts/deploy-chatty-proxy.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Deploy apps/openape-agent-proxy to chatty (proxy.openape.ai).
+# No DB → no libsql native pin, otherwise identical to the mail deploy.
+
+set -euo pipefail
+
+HOST="${CHATTY_HOST:-chatty.delta-mind.at}"
+USER_="${CHATTY_USER:-openape}"
+BASE="${CHATTY_BASE:-/home/openape/projects/openape-agent-proxy}"
+TS=$(date -u +%Y-%m-%dT%H-%M-%S)
+
+echo "→ Build .output locally"
+pnpm turbo run build --filter openape-agent-proxy
+
+echo "→ Rsync release to ${USER_}@${HOST}:${BASE}/releases/${TS}/"
+rsync -az --delete apps/openape-agent-proxy/.output/ "${USER_}@${HOST}:${BASE}/releases/${TS}/"
+
+echo "→ Swap current symlink"
+ssh -l "${USER_}" "${HOST}" "ln -sfn ${BASE}/releases/${TS} ${BASE}/current"
+
+echo "→ Restart openape-agent-proxy.service"
+ssh -l "${USER_}" "${HOST}" "sudo systemctl restart openape-agent-proxy.service"
+
+echo "→ Wait for local health"
+ssh -l "${USER_}" "${HOST}" "
+  for i in 1 2 3 4 5 6 7 8 9 10; do
+    status=\$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:3006/ || echo 000)
+    case \$status in 200|301|302|401|403) echo 'up after '\$i's (HTTP '\$status')'; exit 0 ;; esac
+    sleep 1
+  done
+  echo 'health check failed after 10s'
+  sudo journalctl -u openape-agent-proxy -n 30 --no-pager
+  exit 1
+"
+
+echo "→ Prune old releases (keep last 3)"
+ssh -l "${USER_}" "${HOST}" "ls -1t ${BASE}/releases/ | tail -n +4 | xargs -r -I{} rm -rf ${BASE}/releases/{}"
+
+echo
+echo "✓ Deployed ${TS} to https://proxy.openape.ai"


### PR DESCRIPTION
Migrates the last two Vercel-hosted Nitro apps to the chatty recipe. Canonical moves from .at to .ai; legacy .at 301-redirects.

Plan: https://plans.openape.ai/teams/01KPV1XN2S4FEGHFVPR3ZZ7VN1/plans/01KPWQDV7BCG77H7W5AGDRH8Z5

## Changes
- `scripts/deploy-chatty-mail.sh`, `scripts/deploy-chatty-proxy.sh`
- `.github/workflows/deploy-chatty-mail.yml`, `deploy-chatty-proxy.yml`

## Out of band
- DNS (exoscale): A `mail.openape.ai`, `proxy.openape.ai`, `mail.openape.at`, `proxy.openape.at` → chatty.
- Host setup: systemd units `openape-agent-mail.service` (port 3005) + `openape-agent-proxy.service` (port 3006), sudoers extended, .env with session-secret + reused Resend key, libsql DB under shared/data for mail.
- nginx vhosts for both hosts with .at→.ai 301, LE certs covering .ai + .at.
- First manual deploy already ran: both services active, https://mail.openape.ai/ and https://proxy.openape.ai/ return 200.
- Vercel git-disconnect on `openape-agent-mail` + `openape-agent-proxy`; domain-detach + project-delete in the dashboard still pending (operator action).

## Test plan
- [x] `pnpm --filter openape-agent-mail build` + `--filter openape-agent-proxy build` green locally.
- [x] Manual deploys land and both services serve 200 on the .ai canonical.
- [ ] After merge, auto-deploy runs and health-check passes.