### PR TITLE
feat(idp): add rp_id column to credentials + webauthn_challenges

### DIFF
--- a/apps/openape-free-idp/server/database/schema.ts
+++ b/apps/openape-free-idp/server/database/schema.ts
@@ -124,8 +124,15 @@ export const credentials = sqliteTable('credentials', {
   backedUp: integer('backed_up', { mode: 'boolean' }).notNull(),
   createdAt: integer('created_at').notNull(),
   name: text('name'),
+  // WebAuthn RP ID this credential was registered against. Nullable only
+  // because the column was added after the credentials table existed; every
+  // new insert MUST populate it. Reads should filter by rp_id matching the
+  // current request host so browsers and server stay in sync about which
+  // passkey belongs to which origin.
+  rpId: text('rp_id'),
 }, table => [
   index('idx_credentials_user_email').on(table.userEmail),
+  index('idx_credentials_rp_id').on(table.rpId),
 ])
 
 export const webauthnChallenges = sqliteTable('webauthn_challenges', {
@@ -134,6 +141,9 @@ export const webauthnChallenges = sqliteTable('webauthn_challenges', {
   userEmail: text('user_email'),
   type: text('type').notNull(),
   expiresAt: integer('expires_at').notNull(),
+  // RP ID this challenge was minted for. A challenge minted on id.openape.ai
+  // must never be verifiable against an assertion from id.openape.at.
+  rpId: text('rp_id'),
 })
 
 export const registrationUrls = sqliteTable('registration_urls', {

--- a/apps/openape-free-idp/server/plugins/02.database.ts
+++ b/apps/openape-free-idp/server/plugins/02.database.ts
@@ -100,6 +100,29 @@ export default defineNitroPlugin(async () => {
       kid TEXT PRIMARY KEY, private_key_jwk TEXT NOT NULL, public_key_jwk TEXT NOT NULL,
       is_active INTEGER NOT NULL DEFAULT 1, created_at INTEGER NOT NULL
     )`)
+
+    // WebAuthn RP isolation: credentials + challenges track the RP ID they
+    // belong to so a single IdP instance can host multiple origins without
+    // cross-origin passkey confusion. Idempotent ALTER on existing rows;
+    // backfill treats everything already there as the canonical primary
+    // origin (OPENAPE_DEFAULT_RP_ID env, fallback to issuer host).
+    try { await db.run(sql`ALTER TABLE credentials ADD COLUMN rp_id TEXT`) }
+    catch { /* already present */ }
+    try { await db.run(sql`ALTER TABLE webauthn_challenges ADD COLUMN rp_id TEXT`) }
+    catch { /* already present */ }
+    await db.run(sql`CREATE INDEX IF NOT EXISTS idx_credentials_rp_id ON credentials(rp_id)`)
+
+    // Backfill any pre-rp_id credentials to the default RP — conservative
+    // default so existing users aren't orphaned when the tenant filter
+    // lands. The default comes from OPENAPE_DEFAULT_RP_ID, else parsed from
+    // OPENAPE_ISSUER, else 'id.openape.ai' (the canonical prod host).
+    let defaultRp = process.env.OPENAPE_DEFAULT_RP_ID?.trim() || ''
+    if (!defaultRp && process.env.OPENAPE_ISSUER) {
+      try { defaultRp = new URL(process.env.OPENAPE_ISSUER).hostname }
+      catch { /* invalid URL, fall through */ }
+    }
+    if (!defaultRp) defaultRp = 'id.openape.ai'
+    await db.run(sql`UPDATE credentials SET rp_id = ${defaultRp} WHERE rp_id IS NULL`)
   }
   catch (err) {
     console.error('[database] Table creation failed (tables may already exist):', err)


### PR DESCRIPTION
Purely additive schema change — first of several small PRs on the road to hosting id.openape.ai AND id.openape.at from a single Nitro instance with a shared DB.

See plan: https://plans.openape.ai/teams/01KPV1XN2S4FEGHFVPR3ZZ7VN1/plans/01KPWRV8KZTAK8YYYAH60KTJD7

## What this PR does

- Adds nullable `rp_id TEXT` column on `credentials` and `webauthn_challenges` via schema.ts.
- Idempotent `ALTER TABLE ... ADD COLUMN` on existing prod DBs (same pattern as the users/shapes rollout).
- Backfill: every pre-migration credential gets `rp_id = OPENAPE_DEFAULT_RP_ID || parseHost(OPENAPE_ISSUER) || 'id.openape.ai'`. Chatty's current DB was only ever `.ai`, so the canonical backfill is correct.

## What this PR does not do

- No handler reads or writes rp_id yet. Behavior is identical on chatty after deploy.
- No credential filter per host yet — that lands in the follow-up PR that adds the tenant middleware + threads rp_id through `drizzle-credential-store`, `drizzle-challenge-store`, and every `modules/nuxt-auth-idp/.../api/webauthn/**` handler.

## Test plan

- [x] Lint + typecheck green on `openape-free-idp`.
- [x] Manual: `sqlite3 idp.db '.schema credentials'` on a local dev DB shows `rp_id TEXT`.
- [ ] After deploy, `SELECT rp_id, COUNT(*) FROM credentials GROUP BY rp_id` returns `id.openape.ai = N, NULL = 0` on chatty.