### PR TITLE
feat(idp): domain-agnostic runtime — per-request RP config from Host header

### DIFF
--- a/apps/openape-free-idp/nuxt.config.ts
+++ b/apps/openape-free-idp/nuxt.config.ts
@@ -17,6 +17,7 @@ export default defineNuxtConfig({
     rpName: process.env.OPENAPE_RP_NAME || 'OpenApe Free IdP',
     rpID: process.env.OPENAPE_RP_ID || new URL(localIssuer).hostname,
     rpOrigin: process.env.OPENAPE_RP_ORIGIN || localIssuer,
+    rpHostAllowList: process.env.OPENAPE_RP_HOST_ALLOWLIST || 'id.openape.ai,id.openape.at',
     grants: { enablePages: true, storageKey: 'grants' },
     routes: { admin: e2e },
   },

--- a/apps/openape-free-idp/server/database/schema.ts
+++ b/apps/openape-free-idp/server/database/schema.ts
@@ -124,11 +124,6 @@ export const credentials = sqliteTable('credentials', {
   backedUp: integer('backed_up', { mode: 'boolean' }).notNull(),
   createdAt: integer('created_at').notNull(),
   name: text('name'),
-  // WebAuthn RP ID this credential was registered against. Nullable only
-  // because the column was added after the credentials table existed; every
-  // new insert MUST populate it. Reads should filter by rp_id matching the
-  // current request host so browsers and server stay in sync about which
-  // passkey belongs to which origin.
   rpId: text('rp_id'),
 }, table => [
   index('idx_credentials_user_email').on(table.userEmail),
@@ -141,8 +136,6 @@ export const webauthnChallenges = sqliteTable('webauthn_challenges', {
   userEmail: text('user_email'),
   type: text('type').notNull(),
   expiresAt: integer('expires_at').notNull(),
-  // RP ID this challenge was minted for. A challenge minted on id.openape.ai
-  // must never be verifiable against an assertion from id.openape.at.
   rpId: text('rp_id'),
 })
 

--- a/apps/openape-free-idp/server/middleware/00.rp-tenant.ts
+++ b/apps/openape-free-idp/server/middleware/00.rp-tenant.ts
@@ -1,0 +1,25 @@
+import { getRequestHost } from 'h3'
+import { useRuntimeConfig } from '#imports'
+
+// Derives per-request WebAuthn RP config from Host header so one instance
+// can serve multiple origins (id.openape.ai + id.openape.at). Unknown hosts
+// are ignored and fall through to the static rpID; this prevents a rogue
+// Host header from binding credentials to an attacker-chosen RP.
+export default defineEventHandler((event) => {
+  const config = useRuntimeConfig()
+  const idpCfg = (config.openapeIdp || {}) as Record<string, unknown>
+  const raw = (idpCfg.rpHostAllowList as string | undefined) || 'id.openape.ai,id.openape.at'
+  const allow = raw.split(',').map(s => s.trim()).filter(Boolean)
+
+  const host = getRequestHost(event, { xForwardedHost: true })?.split(':')[0]
+  if (!host || !allow.includes(host)) return
+
+  event.context.openapeRpConfig = {
+    rpName: (idpCfg.rpName as string | undefined) || 'OpenApe Identity Server',
+    rpID: host,
+    origin: `https://${host}`,
+    requireUserVerification: idpCfg.requireUserVerification ?? false,
+    residentKey: idpCfg.residentKey ?? 'preferred',
+    attestationType: idpCfg.attestationType ?? 'none',
+  }
+})

--- a/apps/openape-free-idp/server/plugins/02.database.ts
+++ b/apps/openape-free-idp/server/plugins/02.database.ts
@@ -101,21 +101,14 @@ export default defineNitroPlugin(async () => {
       is_active INTEGER NOT NULL DEFAULT 1, created_at INTEGER NOT NULL
     )`)
 
-    // WebAuthn RP isolation: credentials + challenges track the RP ID they
-    // belong to so a single IdP instance can host multiple origins without
-    // cross-origin passkey confusion. Idempotent ALTER on existing rows;
-    // backfill treats everything already there as the canonical primary
-    // origin (OPENAPE_DEFAULT_RP_ID env, fallback to issuer host).
     try { await db.run(sql`ALTER TABLE credentials ADD COLUMN rp_id TEXT`) }
     catch { /* already present */ }
     try { await db.run(sql`ALTER TABLE webauthn_challenges ADD COLUMN rp_id TEXT`) }
     catch { /* already present */ }
     await db.run(sql`CREATE INDEX IF NOT EXISTS idx_credentials_rp_id ON credentials(rp_id)`)
 
-    // Backfill any pre-rp_id credentials to the default RP — conservative
-    // default so existing users aren't orphaned when the tenant filter
-    // lands. The default comes from OPENAPE_DEFAULT_RP_ID, else parsed from
-    // OPENAPE_ISSUER, else 'id.openape.ai' (the canonical prod host).
+    // Pre-rp_id rows are backfilled to the canonical primary RP, otherwise
+    // the upcoming tenant filter would orphan existing users.
     let defaultRp = process.env.OPENAPE_DEFAULT_RP_ID?.trim() || ''
     if (!defaultRp && process.env.OPENAPE_ISSUER) {
       try { defaultRp = new URL(process.env.OPENAPE_ISSUER).hostname }

--- a/apps/openape-free-idp/server/utils/drizzle-challenge-store.ts
+++ b/apps/openape-free-idp/server/utils/drizzle-challenge-store.ts
@@ -3,6 +3,16 @@ import { eq } from 'drizzle-orm'
 import { useDb } from '../database/drizzle'
 import { webauthnChallenges } from '../database/schema'
 
+function rowToChallenge(row: typeof webauthnChallenges.$inferSelect): WebAuthnChallenge {
+  return {
+    challenge: row.challenge,
+    userEmail: row.userEmail ?? undefined,
+    type: row.type as WebAuthnChallenge['type'],
+    expiresAt: row.expiresAt,
+    rpId: row.rpId ?? undefined,
+  }
+}
+
 export function createDrizzleChallengeStore(): ChallengeStore {
   const db = useDb()
 
@@ -14,6 +24,7 @@ export function createDrizzleChallengeStore(): ChallengeStore {
         userEmail: challenge.userEmail ?? null,
         type: challenge.type,
         expiresAt: challenge.expiresAt,
+        rpId: challenge.rpId ?? null,
       }).onConflictDoUpdate({
         target: webauthnChallenges.token,
         set: {
@@ -21,6 +32,7 @@ export function createDrizzleChallengeStore(): ChallengeStore {
           userEmail: challenge.userEmail ?? null,
           type: challenge.type,
           expiresAt: challenge.expiresAt,
+          rpId: challenge.rpId ?? null,
         },
       })
     },
@@ -32,12 +44,7 @@ export function createDrizzleChallengeStore(): ChallengeStore {
         await db.delete(webauthnChallenges).where(eq(webauthnChallenges.token, token))
         return null
       }
-      return {
-        challenge: row.challenge,
-        userEmail: row.userEmail ?? undefined,
-        type: row.type as WebAuthnChallenge['type'],
-        expiresAt: row.expiresAt,
-      }
+      return rowToChallenge(row)
     },
 
     async consume(token) {
@@ -48,12 +55,7 @@ export function createDrizzleChallengeStore(): ChallengeStore {
         return null
       }
       await db.delete(webauthnChallenges).where(eq(webauthnChallenges.token, token))
-      return {
-        challenge: row.challenge,
-        userEmail: row.userEmail ?? undefined,
-        type: row.type as WebAuthnChallenge['type'],
-        expiresAt: row.expiresAt,
-      }
+      return rowToChallenge(row)
     },
   }
 }

--- a/apps/openape-free-idp/server/utils/drizzle-credential-store.ts
+++ b/apps/openape-free-idp/server/utils/drizzle-credential-store.ts
@@ -1,5 +1,5 @@
 import type { CredentialStore, WebAuthnCredential } from '@openape/auth'
-import { eq } from 'drizzle-orm'
+import { and, eq } from 'drizzle-orm'
 import { useDb } from '../database/drizzle'
 import { credentials } from '../database/schema'
 
@@ -16,6 +16,7 @@ function rowToCredential(row: CredentialRow): WebAuthnCredential {
     backedUp: row.backedUp,
     createdAt: row.createdAt,
     name: row.name ?? undefined,
+    rpId: row.rpId ?? undefined,
   }
 }
 
@@ -34,6 +35,7 @@ export function createDrizzleCredentialStore(): CredentialStore {
         backedUp: credential.backedUp,
         createdAt: credential.createdAt,
         name: credential.name ?? null,
+        rpId: credential.rpId ?? null,
       }).onConflictDoUpdate({
         target: credentials.credentialId,
         set: {
@@ -50,6 +52,14 @@ export function createDrizzleCredentialStore(): CredentialStore {
 
     async findByUser(email) {
       const rows = await db.select().from(credentials).where(eq(credentials.userEmail, email))
+      return rows.map(rowToCredential)
+    },
+
+    async findByUserAndRp(email, rpId) {
+      const rows = await db
+        .select()
+        .from(credentials)
+        .where(and(eq(credentials.userEmail, email), eq(credentials.rpId, rpId)))
       return rows.map(rowToCredential)
     },
 

--- a/modules/nuxt-auth-idp/src/module.ts
+++ b/modules/nuxt-auth-idp/src/module.ts
@@ -25,6 +25,7 @@ export interface ModuleOptions {
   rpName: string
   rpID: string
   rpOrigin: string
+  rpHostAllowList: string
   requireUserVerification: boolean
   residentKey: 'preferred' | 'required' | 'discouraged'
   attestationType: 'none' | 'indirect' | 'direct' | 'enterprise'
@@ -75,6 +76,7 @@ export default defineNuxtModule<ModuleOptions>({
     rpName: '',
     rpID: '',
     rpOrigin: '',
+    rpHostAllowList: '',
     requireUserVerification: false,
     residentKey: 'preferred',
     attestationType: 'none',

--- a/modules/nuxt-auth-idp/src/runtime/server/api/webauthn/credentials.get.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/api/webauthn/credentials.get.ts
@@ -1,12 +1,16 @@
 import { defineEventHandler } from 'h3'
 import { requireAuth } from '../../utils/admin'
+import { getRPConfig } from '../../utils/rp-config'
 import { useIdpStores } from '../../utils/stores'
 
 export default defineEventHandler(async (event) => {
   const userId = await requireAuth(event)
   const { credentialStore } = useIdpStores()
+  const rpConfig = getRPConfig()
 
-  const credentials = await credentialStore.findByUser(userId)
+  const credentials = credentialStore.findByUserAndRp
+    ? await credentialStore.findByUserAndRp(userId, rpConfig.rpID)
+    : (await credentialStore.findByUser(userId)).filter(c => !c.rpId || c.rpId === rpConfig.rpID)
 
   return credentials.map(c => ({
     credentialId: c.credentialId,
@@ -15,5 +19,6 @@ export default defineEventHandler(async (event) => {
     backedUp: c.backedUp,
     createdAt: c.createdAt,
     transports: c.transports,
+    rpId: c.rpId,
   }))
 })

--- a/modules/nuxt-auth-idp/src/runtime/server/api/webauthn/credentials/add/options.post.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/api/webauthn/credentials/add/options.post.ts
@@ -15,7 +15,9 @@ export default defineEventHandler(async (event) => {
     throw createProblemError({ status: 404, title: 'User not found' })
   }
 
-  const existingCredentials = await credentialStore.findByUser(userId)
+  const existingCredentials = credentialStore.findByUserAndRp
+    ? await credentialStore.findByUserAndRp(userId, rpConfig.rpID)
+    : (await credentialStore.findByUser(userId)).filter(c => !c.rpId || c.rpId === rpConfig.rpID)
   const { options, challenge } = await createRegistrationOptions(rpConfig, userId, user.name, existingCredentials)
 
   const challengeToken = crypto.randomUUID()
@@ -24,6 +26,7 @@ export default defineEventHandler(async (event) => {
     userEmail: userId,
     type: 'registration',
     expiresAt: Date.now() + 5 * 60 * 1000,
+    rpId: rpConfig.rpID,
   })
 
   return { options, challengeToken }

--- a/modules/nuxt-auth-idp/src/runtime/server/api/webauthn/credentials/add/verify.post.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/api/webauthn/credentials/add/verify.post.ts
@@ -19,12 +19,16 @@ export default defineEventHandler(async (event) => {
   if (!challenge || challenge.userEmail !== userId) {
     throw createProblemError({ status: 400, title: 'Invalid or expired challenge' })
   }
+  if (challenge.rpId && challenge.rpId !== rpConfig.rpID) {
+    throw createProblemError({ status: 400, title: 'Challenge was issued for a different RP' })
+  }
 
   const { verified, credential } = await verifyRegistration(body.response, challenge.challenge, rpConfig, userId)
   if (!verified || !credential) {
     throw createProblemError({ status: 400, title: 'Registration verification failed' })
   }
 
+  credential.rpId = rpConfig.rpID
   if (body.deviceName) {
     credential.name = body.deviceName
   }

--- a/modules/nuxt-auth-idp/src/runtime/server/api/webauthn/login/options.post.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/api/webauthn/login/options.post.ts
@@ -12,7 +12,9 @@ export default defineEventHandler(async (event) => {
 
   let credentials
   if (body.email) {
-    credentials = await credentialStore.findByUser(body.email)
+    credentials = credentialStore.findByUserAndRp
+      ? await credentialStore.findByUserAndRp(body.email, rpConfig.rpID)
+      : (await credentialStore.findByUser(body.email)).filter(c => !c.rpId || c.rpId === rpConfig.rpID)
     if (credentials.length === 0) {
       throw createProblemError({ status: 404, title: 'No passkeys found for this email' })
     }
@@ -26,6 +28,7 @@ export default defineEventHandler(async (event) => {
     userEmail: body.email,
     type: 'authentication',
     expiresAt: Date.now() + 5 * 60 * 1000,
+    rpId: rpConfig.rpID,
   })
 
   return { options, challengeToken }

--- a/modules/nuxt-auth-idp/src/runtime/server/api/webauthn/login/verify.post.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/api/webauthn/login/verify.post.ts
@@ -18,15 +18,19 @@ export default defineEventHandler(async (event) => {
   if (!challenge) {
     throw createProblemError({ status: 400, title: 'Invalid or expired challenge' })
   }
+  if (challenge.rpId && challenge.rpId !== rpConfig.rpID) {
+    throw createProblemError({ status: 400, title: 'Challenge was issued for a different RP' })
+  }
 
-  // Find the credential that was used
   const credentialId = body.response.id
   const credential = await credentialStore.findById(credentialId)
   if (!credential) {
     throw createProblemError({ status: 400, title: 'Unknown credential' })
   }
+  if (credential.rpId && credential.rpId !== rpConfig.rpID) {
+    throw createProblemError({ status: 400, title: 'Credential belongs to a different RP' })
+  }
 
-  // If email was specified during options, verify it matches
   if (challenge.userEmail && credential.userEmail !== challenge.userEmail) {
     throw createProblemError({ status: 400, title: 'Credential does not belong to specified user' })
   }

--- a/modules/nuxt-auth-idp/src/runtime/server/api/webauthn/register/options.post.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/api/webauthn/register/options.post.ts
@@ -18,7 +18,9 @@ export default defineEventHandler(async (event) => {
     throw createProblemError({ status: 404, title: 'Invalid or expired registration URL' })
   }
 
-  const existingCredentials = await credentialStore.findByUser(regUrl.email)
+  const existingCredentials = credentialStore.findByUserAndRp
+    ? await credentialStore.findByUserAndRp(regUrl.email, rpConfig.rpID)
+    : (await credentialStore.findByUser(regUrl.email)).filter(c => !c.rpId || c.rpId === rpConfig.rpID)
   const { options, challenge } = await createRegistrationOptions(rpConfig, regUrl.email, regUrl.name, existingCredentials)
 
   const challengeToken = crypto.randomUUID()
@@ -27,6 +29,7 @@ export default defineEventHandler(async (event) => {
     userEmail: regUrl.email,
     type: 'registration',
     expiresAt: Date.now() + 5 * 60 * 1000,
+    rpId: rpConfig.rpID,
   })
 
   return { options, challengeToken }

--- a/modules/nuxt-auth-idp/src/runtime/server/api/webauthn/register/verify.post.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/api/webauthn/register/verify.post.ts
@@ -23,12 +23,16 @@ export default defineEventHandler(async (event) => {
   if (!challenge) {
     throw createProblemError({ status: 400, title: 'Invalid or expired challenge' })
   }
+  if (challenge.rpId && challenge.rpId !== rpConfig.rpID) {
+    throw createProblemError({ status: 400, title: 'Challenge was issued for a different RP' })
+  }
 
   const { verified, credential } = await verifyRegistration(body.response, challenge.challenge, rpConfig, regUrl.email)
   if (!verified || !credential) {
     throw createProblemError({ status: 400, title: 'Registration verification failed' })
   }
 
+  credential.rpId = rpConfig.rpID
   if (body.deviceName) {
     credential.name = body.deviceName
   }

--- a/packages/auth/src/idp/webauthn/types.ts
+++ b/packages/auth/src/idp/webauthn/types.ts
@@ -10,6 +10,7 @@ export interface WebAuthnCredential {
   backedUp: boolean
   createdAt: number
   name?: string
+  rpId?: string
 }
 
 export interface WebAuthnChallenge {
@@ -17,6 +18,7 @@ export interface WebAuthnChallenge {
   userEmail?: string
   type: 'registration' | 'authentication'
   expiresAt: number
+  rpId?: string
 }
 
 export interface RegistrationUrl {
@@ -33,6 +35,7 @@ export interface CredentialStore {
   save: (credential: WebAuthnCredential) => Promise<void>
   findById: (credentialId: string) => Promise<WebAuthnCredential | null>
   findByUser: (email: string) => Promise<WebAuthnCredential[]>
+  findByUserAndRp?: (email: string, rpId: string) => Promise<WebAuthnCredential[]>
   delete: (credentialId: string) => Promise<void>
   deleteAllForUser: (email: string) => Promise<void>
   updateCounter: (credentialId: string, counter: number) => Promise<void>


### PR DESCRIPTION
Follow-up to #143 (rp_id column). Threads rp_id through every WebAuthn handler and adds a per-request tenant middleware so one IdP instance can serve multiple origins (id.openape.ai + id.openape.at) from a single DB — passkeys registered on .at stay on .at and vice versa, all keyed by the same email account.

See plan: https://plans.openape.ai/teams/01KPV1XN2S4FEGHFVPR3ZZ7VN1/plans/01KPWRV8KZTAK8YYYAH60KTJD7

## What changes

**Runtime**
- `apps/openape-free-idp/server/middleware/00.rp-tenant.ts`: reads the request Host and populates `event.context.openapeRpConfig`. `getRPConfig()` (existing) already reads this seam first, so handlers need no other plumbing for RP config.
- Host allow-list (`rpHostAllowList` option, `NUXT_OPENAPE_IDP_RP_HOST_ALLOW_LIST` env) guards against rogue Host headers binding credentials to unexpected RPs.

**Types**
- `@openape/auth`: `WebAuthnCredential.rpId?` + `WebAuthnChallenge.rpId?`. New optional `CredentialStore.findByUserAndRp(email, rpId)` for origin-scoped lookups.

**Stores** (`apps/openape-free-idp/server/utils/`)
- `drizzle-credential-store.ts` persists `rpId` on save, returns it on rows, implements `findByUserAndRp`.
- `drizzle-challenge-store.ts` persists `rpId` on save, returns it on rows.

**Handlers** (`modules/nuxt-auth-idp/src/runtime/server/api/webauthn/`)
- register/options.post, register/verify.post, login/options.post, login/verify.post, credentials/add/options.post, credentials/add/verify.post — all stamp `rpId` on writes, filter reads by the current rpID, and reject assertions whose challenge/credential was issued for a different RP.
- credentials.get.ts returns only credentials matching the request's RP so account UIs on .ai don't list .at passkeys (browser can't use them anyway).

## Behavior on chatty today

- Middleware allow-list matches `id.openape.ai` → same tenant RP ID the static config would have picked. Zero behavior change for existing users.
- Once PR-D (M3 vhost + DNS flip + cert for .at) lands, the same service transparently starts handling `id.openape.at` requests with their own rpID.

## Test plan

- [x] Lint + typecheck + build green on `@openape/auth`, `@openape/nuxt-auth-idp`, and `openape-free-idp`.
- [ ] After deploy: existing `.ai` user logs in with their existing passkey — no regression. `SELECT rp_id, COUNT(*) FROM credentials` shows all rows on `id.openape.ai` (backfilled by #143).
- [ ] With `--resolve id.openape.at:443:chatty-ip`, ceremonies run against `rpID='id.openape.at'` end-to-end (verifiable via registration options JSON).