### PR TITLE
feat(idp): mint tokens with per-request iss (origin from Host)

### DIFF
--- a/apps/openape-free-idp/server/middleware/00.rp-tenant.ts
+++ b/apps/openape-free-idp/server/middleware/00.rp-tenant.ts
@@ -14,12 +14,14 @@ export default defineEventHandler((event) => {
   const host = getRequestHost(event, { xForwardedHost: true })?.split(':')[0]
   if (!host || !allow.includes(host)) return
 
+  const origin = `https://${host}`
   event.context.openapeRpConfig = {
     rpName: (idpCfg.rpName as string | undefined) || 'OpenApe Identity Server',
     rpID: host,
-    origin: `https://${host}`,
+    origin,
     requireUserVerification: idpCfg.requireUserVerification ?? false,
     residentKey: idpCfg.residentKey ?? 'preferred',
     attestationType: idpCfg.attestationType ?? 'none',
   }
+  event.context.openapeIssuer = origin
 })


### PR DESCRIPTION
Tiny follow-up to #144.

`getIdpIssuer()` already reads `event.context.openapeIssuer` first. The tenant middleware now sets that context in the same place it sets `openapeRpConfig`, so:
- Request to `id.openape.ai` → tokens carry `iss=https://id.openape.ai`
- Request to `id.openape.at` → tokens carry `iss=https://id.openape.at`

SPs (plans, mail, proxy, any `@openape/nuxt-auth-sp` consumer) already validate tokens against `flowState.idpUrl` from DDISA discovery, not a hardcoded iss. Multi-iss is automatic, no SP code change.

Completes the domain-agnostic runtime path (M2). Next: M5 `.at` DB import, M6 DNS flip + cert --expand + Vercel retire.

Plan: https://plans.openape.ai/teams/01KPV1XN2S4FEGHFVPR3ZZ7VN1/plans/01KPWRV8KZTAK8YYYAH60KTJD7