### PR TITLE
docs: refresh content against current code (#81)

### DIFF
--- a/apps/docs/content/1.getting-started/5.installation.md
+++ b/apps/docs/content/1.getting-started/5.installation.md
@@ -20,24 +20,27 @@ The fastest way is a Nuxt app with the `@openape/nuxt-auth-idp` module:
 ```bash
 npx nuxi init my-idp
 cd my-idp
-pnpm add @openape/nuxt-auth-idp @openape/nuxt-grants
+pnpm add @openape/nuxt-auth-idp
 ```
 
 Configure `nuxt.config.ts`:
 
 ```ts
 export default defineNuxtConfig({
-  modules: ['@openape/nuxt-auth-idp', '@openape/nuxt-grants'],
+  modules: ['@openape/nuxt-auth-idp'],
   openapeIdp: {
     rpName: 'My Identity Provider',
     rpID: 'id.example.com',
     rpOrigin: 'https://id.example.com',
-    storageDriver: 's3', // or '' for local filesystem
+    issuer: 'https://id.example.com',
+    // sessionSecret: set NUXT_OPENAPE_IDP_SESSION_SECRET in production
   },
 })
 ```
 
 All routes are auto-registered: `/login`, `/register`, `/authorize`, `/token`, `/.well-known/jwks.json`, and the full admin API.
+
+For persistent storage, register a store backend from a Nitro plugin. See the [openape-free-idp reference app](https://github.com/openape-ai/openape/tree/main/apps/openape-free-idp) for a wired-up Drizzle + libsql/Turso example, or read the [Free-IdP Hosting Guide](/getting-started/free-idp-hosting).
 
 ## Deploy the SP
 
@@ -82,29 +85,33 @@ See the [nuxt-auth-sp docs](/ecosystem/nuxt-auth-sp) for full configuration refe
 
 ## Environment Variables
 
-All configuration can be set via `NUXT_OPENAPE_*` environment variables:
+Both modules follow Nuxt's runtimeConfig convention: `openapeIdp.*` options map to `NUXT_OPENAPE_IDP_*`, `openapeSp.*` options map to `NUXT_OPENAPE_SP_*`. Camel-case keys are upper-snake-case-ified.
 
-### IdP
+### IdP (common vars)
 
 | Variable | Description | Default |
 |---|---|---|
-| `NUXT_OPENAPE_RP_ID` | Relying Party ID (domain) | `localhost` |
-| `NUXT_OPENAPE_RP_ORIGIN` | Relying Party origin (URL) | `http://localhost:3000` |
-| `NUXT_OPENAPE_RP_NAME` | Display name | `OpenApe Identity` |
-| `NUXT_OPENAPE_STORAGE_DRIVER` | Storage driver (`s3` or empty for FS) | `` |
-| `NUXT_OPENAPE_ADMIN_EMAILS` | Comma-separated admin emails | |
-| `NUXT_OPENAPE_MANAGEMENT_TOKEN` | Bearer token for admin API | |
-| `NUXT_OPENAPE_SESSION_SECRET` | Session encryption secret (32+ chars) | |
-| `NUXT_OPENAPE_ISSUER` | JWT issuer URL | |
-| `NUXT_OPENAPE_S3_*` | S3 credentials (ACCESS_KEY, SECRET_KEY, BUCKET, ENDPOINT, REGION) | |
+| `NUXT_OPENAPE_IDP_RP_ID` | Relying Party ID (domain) | `''` (falls back to request host) |
+| `NUXT_OPENAPE_IDP_RP_ORIGIN` | Relying Party origin URL | `''` (falls back to request origin) |
+| `NUXT_OPENAPE_IDP_RP_NAME` | Display name | `''` |
+| `NUXT_OPENAPE_IDP_ISSUER` | JWT `iss` claim | `''` (falls back to request origin) |
+| `NUXT_OPENAPE_IDP_RP_HOST_ALLOW_LIST` | Comma-separated multi-tenant hostnames | `''` |
+| `NUXT_OPENAPE_IDP_SESSION_SECRET` | Session cookie secret (32+ chars) | `change-me…` (warn in prod) |
+| `NUXT_OPENAPE_IDP_ADMIN_EMAILS` | Comma-separated admin emails | `''` |
+| `NUXT_OPENAPE_IDP_MANAGEMENT_TOKEN` | Bearer for management API | `''` |
+| `NUXT_OPENAPE_IDP_ALLOWED_FRAME_ANCESTORS` | Space-separated origins allowed to embed the IdP in an iframe | `''` (frame-ancestors `'none'`) |
+
+The full option surface is documented in [nuxt-auth-idp](/ecosystem/nuxt-auth-idp).
 
 ### SP
 
 | Variable | Description | Default |
 |---|---|---|
-| `NUXT_OPENAPE_CLIENT_ID` | Service Provider ID | |
-| `NUXT_OPENAPE_URL` | IdP URL for discovery | |
-| `NUXT_OPENAPE_SP_SESSION_SECRET` | Session encryption secret (32+ chars) | |
+| `NUXT_OPENAPE_SP_CLIENT_ID` | Service Provider ID | `''` (dev: `localhost:{port}`) |
+| `NUXT_OPENAPE_SP_SP_NAME` | Display name | `OpenApe Service Provider` |
+| `NUXT_OPENAPE_SP_SESSION_SECRET` | Session encryption secret (32+ chars) | auto-generated in dev |
+| `NUXT_OPENAPE_SP_OPENAPE_URL` | Direct IdP URL (bypasses DDISA discovery) | `''` |
+| `NUXT_OPENAPE_SP_FALLBACK_IDP_URL` | Fallback when DNS has no DDISA record | `https://id.openape.at` |
 
 ## Create Your First User
 

--- a/apps/docs/content/1.getting-started/9.free-idp-hosting.md
+++ b/apps/docs/content/1.getting-started/9.free-idp-hosting.md
@@ -1,0 +1,186 @@
+---
+title: Free-IdP Hosting Guide
+description: Run your own persistent OpenApe IdP with Drizzle + libsql.
+---
+
+# Free-IdP Hosting Guide
+
+This guide walks through standing up a persistent, self-hosted OpenApe IdP using the reference [openape-free-idp](https://github.com/openape-ai/openape/tree/main/apps/openape-free-idp) app — a Nuxt 4 project that wires `@openape/nuxt-auth-idp` to a libsql database (either a local SQLite file or Turso).
+
+If you only need a dev sandbox or want to bring your own persistence layer, see [Quick Start](/getting-started/installation) for the minimal path.
+
+## What you get
+
+- Passkey login (WebAuthn) and SSH-key agent auth out of the box.
+- OAuth/OIDC endpoints (`/authorize`, `/token`, `/.well-known/openid-configuration`, `/userinfo`, JWKS).
+- Grant approval flows at `/grants`, `/grant-approval`, `/enroll`.
+- Admin UI at `/admin` for users, agents, sessions, and registration URLs.
+- Optional [multi-tenant hosting](/ecosystem/multi-tenant-idp) — one instance, many domains.
+- A working schema with migrations, backfills, and indexes you can iterate on.
+
+## Prerequisites
+
+- Node 22+
+- pnpm 10+
+- A libsql target. Either:
+  - **Local file** (recommended for development and single-node self-hosting) — any path on disk
+  - **Turso** (recommended for HA or multi-region) — a free-tier Turso DB works
+
+## Setup
+
+### 1. Clone the reference app
+
+```bash
+git clone https://github.com/openape-ai/openape
+cd openape
+pnpm install
+cd apps/openape-free-idp
+```
+
+### 2. Configure the database
+
+The database is accessed through `@libsql/client` → `drizzle-orm`. `useDb()` reads `tursoUrl` and `tursoAuthToken` from `runtimeConfig`:
+
+```ts
+// apps/openape-free-idp/server/database/drizzle.ts
+import { createClient } from '@libsql/client'
+import { drizzle } from 'drizzle-orm/libsql'
+
+export function useDb() {
+  const config = useRuntimeConfig()
+  const client = createClient({
+    url: config.tursoUrl as string,         // file:./data/idp.db  OR  libsql://...
+    authToken: config.tursoAuthToken as string, // empty for file:// URLs
+  })
+  return drizzle(client, { schema })
+}
+```
+
+#### Option A — local SQLite file
+
+```bash
+export NUXT_TURSO_URL="file:./data/idp.db"
+export NUXT_TURSO_AUTH_TOKEN=""
+```
+
+The DB file is created on first startup. The startup plugin `server/plugins/02.database.ts` runs idempotent `CREATE TABLE IF NOT EXISTS` statements for every table the module needs.
+
+#### Option B — Turso
+
+```bash
+turso db create my-idp
+turso db tokens create my-idp
+export NUXT_TURSO_URL="libsql://my-idp-YOURORG.turso.io"
+export NUXT_TURSO_AUTH_TOKEN="eyJhbGciOi…"
+```
+
+### 3. Configure the IdP module
+
+`apps/openape-free-idp/nuxt.config.ts` already includes the module. Set the runtime secrets:
+
+```bash
+export NUXT_OPENAPE_IDP_SESSION_SECRET=$(openssl rand -hex 32)
+export NUXT_OPENAPE_IDP_MANAGEMENT_TOKEN=$(openssl rand -hex 32)
+export NUXT_OPENAPE_IDP_ADMIN_EMAILS="you@example.com"
+```
+
+For a single-hostname deployment, also set:
+
+```bash
+export NUXT_OPENAPE_IDP_RP_ID=id.example.com
+export NUXT_OPENAPE_IDP_RP_ORIGIN=https://id.example.com
+export NUXT_OPENAPE_IDP_ISSUER=https://id.example.com
+```
+
+For [multi-tenant](/ecosystem/multi-tenant-idp), set `rpHostAllowList` instead and leave the static RP fields empty:
+
+```bash
+export NUXT_OPENAPE_IDP_RP_HOST_ALLOW_LIST="id.example.com,id.example.at"
+```
+
+### 4. Start it
+
+```bash
+pnpm dev    # http://localhost:3003
+```
+
+On first request the database tables and indexes are created. The login page is at `/login`; the admin UI at `/admin` (accessible to emails in `NUXT_OPENAPE_IDP_ADMIN_EMAILS`).
+
+### 5. Create your first user
+
+Use the management token to mint a registration URL:
+
+```bash
+curl -X POST http://localhost:3003/api/admin/registration-urls \
+  -H "Authorization: Bearer $NUXT_OPENAPE_IDP_MANAGEMENT_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"email":"you@example.com","name":"You"}'
+```
+
+Open the returned URL and register a passkey.
+
+## Production build
+
+```bash
+pnpm --filter openape-free-idp build
+node .output/server/index.mjs
+```
+
+Put nginx (or another reverse proxy) in front and terminate TLS there. A minimal vhost:
+
+```nginx
+server {
+  listen 443 ssl http2;
+  server_name id.example.com;
+
+  ssl_certificate     /etc/letsencrypt/live/id.example.com/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/id.example.com/privkey.pem;
+
+  location / {
+    proxy_pass http://127.0.0.1:3003;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_http_version 1.1;
+  }
+}
+```
+
+The runtime is Node 22+ — the same binary works under systemd, a container, or any Node-capable host.
+
+## Migrations
+
+The reference app ships two parallel mechanisms:
+
+- **Drizzle-kit migrations** under `server/database/migrations/` — used in dev to track schema history and generate DDL.
+- **Idempotent startup init** in `server/plugins/02.database.ts` — the authoritative path in production. `CREATE TABLE IF NOT EXISTS` + `ALTER TABLE ADD COLUMN` guarded by `PRAGMA table_info` lookups. Safe to run on every boot; handles new deploys and schema evolution without a separate migration step.
+
+When you add a schema change, update both: write the Drizzle migration for version control, and mirror the DDL in `02.database.ts` so fresh nodes come up cleanly.
+
+## Customizing
+
+Every store can be swapped by registering a different factory in `server/plugins/04.idp-stores.ts`:
+
+```ts
+import { defineUserStore, defineCredentialStore, … } from '#imports'
+
+export default defineNitroPlugin(() => {
+  defineUserStore(() => myPostgresUserStore)
+  defineCredentialStore(() => myPostgresCredentialStore)
+  // …
+})
+```
+
+Common reasons to replace stores:
+
+- Swap libsql for Postgres / DynamoDB / MongoDB.
+- Add caching in front of the credential lookup.
+- Plug into an existing identity provider during migration.
+
+The `CredentialStore`, `UserStore`, `CodeStore`, etc. interfaces are exported from `@openape/auth`; implementing each is a few methods per store.
+
+## Related
+
+- [nuxt-auth-idp](/ecosystem/nuxt-auth-idp) — Module options and route reference
+- [Multi-Tenant IdP](/ecosystem/multi-tenant-idp) — Host multiple domains from one instance
+- [Auth](/ecosystem/auth) — Authentication modes and flows

--- a/apps/docs/content/2.ecosystem/1.index.md
+++ b/apps/docs/content/2.ecosystem/1.index.md
@@ -12,7 +12,7 @@ OpenApe isn't a monolith — it's a set of small, focused packages you compose a
 ```
 ┌─────────────────────────────────────────────┐
 │            Framework Modules                │
-│  nuxt-auth-idp  nuxt-auth-sp  nuxt-grants  │
+│       nuxt-auth-idp      nuxt-auth-sp       │
 ├─────────────────────────────────────────────┤
 │            Protocol Packages                │
 │         @openape/auth    @openape/grants    │
@@ -29,20 +29,20 @@ OpenApe isn't a monolith — it's a set of small, focused packages you compose a
 | `@openape/core` | DNS discovery, crypto, PKCE, JWT utilities | None |
 | `@openape/auth` | OIDC login protocol — IdP and SP sides | None |
 | `@openape/grants` | Grant lifecycle, AuthZ-JWT issuance | None |
-| `@openape/nuxt-auth-idp` | Drop-in Nuxt module: run your own IdP | Nuxt |
+| `@openape/nuxt-auth-idp` | Drop-in Nuxt module: run your own IdP (includes grant routes + pages) | Nuxt |
 | `@openape/nuxt-auth-sp` | Drop-in Nuxt module: login via OpenApe | Nuxt |
-| `@openape/nuxt-grants` | Drop-in Nuxt module: grant management | Nuxt |
 | `openape-escapes` (`escapes`) | Rust binary for privilege elevation | OS-level |
+
+The older standalone `@openape/nuxt-grants` package has been consolidated into `nuxt-auth-idp` — see [Grants](/ecosystem/grants) for the migration note.
 
 ## Combinations
 
 | Use Case | Packages |
 |---|---|
 | App with OpenApe login | `nuxt-auth-sp` |
-| Run your own IdP | `nuxt-auth-idp` |
-| Agent permissions | `nuxt-grants` |
-| Full IdP + Grants | `nuxt-auth-idp` + `nuxt-grants` |
-| SP with grant requests | `nuxt-auth-sp` + `nuxt-grants` |
+| Run your own IdP (with grant flows) | `nuxt-auth-idp` |
+| One IdP, many domains | `nuxt-auth-idp` + the [multi-tenant pattern](/ecosystem/multi-tenant-idp) |
+| SP with grant requests | `nuxt-auth-sp` + IdP-side grant routes |
 | Non-Nuxt integration | `@openape/auth` + `@openape/grants` |
 | Local privilege elevation | `openape-escapes` (`escapes`) |
 

--- a/apps/docs/content/2.ecosystem/2.auth.md
+++ b/apps/docs/content/2.ecosystem/2.auth.md
@@ -41,6 +41,8 @@ Drop-in Nuxt module. Add it, configure it, you're an IdP.
 - `/authorize`, `/token` — OAuth endpoints
 - `/.well-known/jwks.json` — Public key discovery
 - `/api/webauthn/*` — Registration and login flows
+- `/api/session/ssh-keys` — SSH-key enrollment and listing (see below)
+- `/api/auth/*` — Unified challenge/authenticate for SSH-key auth (humans + agents)
 - `/api/admin/*` — User, agent, and registration URL management
 
 **Configuration via `openapeIdp` in `nuxt.config.ts`:**
@@ -55,6 +57,38 @@ openapeIdp: {
   attestationType: 'none',        // or 'direct' for enterprise
 }
 ```
+
+See the [dedicated nuxt-auth-idp docs](/ecosystem/nuxt-auth-idp) for the full module option surface, environment variables, and store interfaces.
+
+### SSH-key authentication
+
+Alongside passkeys, the IdP accepts Ed25519 SSH keys as a first-class credential for agents (and humans who prefer key-based auth, e.g. CI scripts). Keys are email-keyed — they are not bound to an RP, so the same SSH key authenticates against every hostname the IdP serves.
+
+**Manage keys on a logged-in user account:**
+
+| Route | Purpose |
+|---|---|
+| `GET /api/session/ssh-keys` | List keys registered to the caller's account |
+| `POST /api/session/ssh-keys` | Add a public key — body `{ publicKey: string, name?: string }` |
+| `DELETE /api/session/ssh-keys/:keyId` | Remove a key |
+
+The `publicKey` field accepts the standard OpenSSH one-line format (`ssh-ed25519 AAAA… comment`). The comment is captured as the key's display name if `name` is omitted.
+
+**Authenticate with an SSH key** (challenge/response, used by `@openape/apes` and `escapes`):
+
+```
+POST /api/auth/challenge   { email, publicKey }
+→  { challenge: "<random>", challengeId: "<id>" }
+
+(client signs the challenge with the matching private key)
+
+POST /api/auth/authenticate  { challengeId, signature }
+→  { token: "<JWT>" }
+```
+
+The returned JWT carries the same `act` claim discipline as passkey sessions (`human` or `agent`). SPs verifying the token do not need to distinguish the authentication method.
+
+**Admin-side key management** is available at `/api/admin/users/:email/ssh-keys` — `GET`, `POST`, `DELETE /:keyId` — for operators provisioning CI or agent keys on behalf of users.
 
 ## @openape/nuxt-auth-sp
 

--- a/apps/docs/content/2.ecosystem/3.grants.md
+++ b/apps/docs/content/2.ecosystem/3.grants.md
@@ -47,12 +47,12 @@ Key security features:
 - **`jti`** — replay protection
 - **Expiry** — all grants have a maximum lifetime
 
-## Grant Routes in `@openape/nuxt-auth-idp`
+## Grants live in `@openape/nuxt-auth-idp`
 
-Grant management is integrated into `@openape/nuxt-auth-idp`. Enable grant pages with `grants.enablePages: true` in your module config.
+Grant management is part of the IdP module. Enable grant pages with `grants.enablePages: true` in your module config.
 
 ::callout{type="warning"}
-`@openape/nuxt-grants` is **deprecated**. All grant functionality has been consolidated into `@openape/nuxt-auth-idp`.
+The older standalone `@openape/nuxt-grants` package (last release `0.1.10`, 2026-03-03) is **no longer maintained**. Uninstall it and use `@openape/nuxt-auth-idp` — the grant API and routes are identical and register automatically.
 ::
 
 **Auto-registered routes (via nuxt-auth-idp):**

--- a/apps/docs/content/2.ecosystem/4.nuxt-auth-sp.md
+++ b/apps/docs/content/2.ecosystem/4.nuxt-auth-sp.md
@@ -43,7 +43,7 @@ In development (`nuxt dev`), the module auto-configures:
 |---|---|
 | `sessionSecret` | Random UUID (regenerated each restart) |
 | `clientId` | `localhost:{port}` |
-| `fallbackIdpUrl` | `https://id.openape.ai` |
+| `fallbackIdpUrl` | `https://id.openape.at` |
 
 No `.env` file or `runtimeConfig` needed to start developing.
 
@@ -193,7 +193,7 @@ export default defineNuxtConfig({
     spName: 'My App',                  // Display name
     sessionSecret: '',                 // 32+ char secret (auto-generated in dev)
     openapeUrl: '',                    // Direct IdP URL (bypasses DNS discovery)
-    fallbackIdpUrl: 'https://id.openape.ai',  // Fallback when DNS has no record
+    fallbackIdpUrl: 'https://id.openape.at',  // Fallback when DNS has no record
   },
 })
 ```

--- a/apps/docs/content/2.ecosystem/6.nuxt-auth-idp.md
+++ b/apps/docs/content/2.ecosystem/6.nuxt-auth-idp.md
@@ -1,0 +1,239 @@
+---
+title: nuxt-auth-idp
+description: Build your own OpenApe Identity Provider as a Nuxt app.
+---
+
+# @openape/nuxt-auth-idp
+
+Drop-in Nuxt module that turns a Nuxt app into a full OpenApe IdP — WebAuthn passkey login, SSH-key agent auth, OAuth/OIDC endpoints, grant approval flows, federation, and admin UI. Counterpart to [`@openape/nuxt-auth-sp`](/ecosystem/nuxt-auth-sp) on the service-provider side.
+
+Pair it with a storage backend of your choice: the module ships with an in-memory store suitable for development, and the [openape-free-idp](https://github.com/openape-ai/openape/tree/main/apps/openape-free-idp) reference app wires it to Drizzle + libsql/Turso for persistent production hosting.
+
+## Quick Start
+
+### 1. Install
+
+```bash
+pnpm add @openape/nuxt-auth-idp
+```
+
+### 2. Add to `nuxt.config.ts`
+
+```ts
+export default defineNuxtConfig({
+  modules: ['@openape/nuxt-auth-idp'],
+  openapeIdp: {
+    issuer: 'https://id.example.com',
+    rpName: 'Example IdP',
+    sessionSecret: '', // set NUXT_OPENAPE_IDP_SESSION_SECRET in prod
+  },
+})
+```
+
+In dev the module auto-generates a `sessionSecret` and derives `rpID` from the request host. In production you must set `sessionSecret` and `adminEmails` explicitly.
+
+### 3. Register a storage backend
+
+The module is storage-agnostic. Register each store from a server plugin (`server/plugins/02.stores.ts`):
+
+```ts
+import {
+  defineUserStore,
+  defineCredentialStore,
+  defineKeyStore,
+  defineCodeStore,
+  defineRefreshTokenStore,
+  defineJtiStore,
+  defineWebAuthnChallengeStore,
+  defineRegistrationUrlStore,
+  defineGrantStore,
+  defineGrantChallengeStore,
+  defineSshKeyStore,
+  defineShapeStore,
+} from '#imports'
+
+export default defineNitroPlugin(() => {
+  defineUserStore(() => myUserStore)
+  defineCredentialStore(() => myCredentialStore)
+  // …register all stores
+})
+```
+
+For a complete wired-up example (Drizzle + libsql), see [`apps/openape-free-idp/server/plugins/03.stores.ts`](https://github.com/openape-ai/openape/blob/main/apps/openape-free-idp/server/plugins/03.stores.ts).
+
+## Module Options
+
+Full configuration surface in `nuxt.config.ts`:
+
+```ts
+openapeIdp: {
+  // Security
+  sessionSecret: '',            // 32+ char secret (required in prod)
+  sessionMaxAge: 604800,        // session cookie TTL in seconds (7 days)
+  managementToken: '',          // bearer for management endpoints
+  adminEmails: '',              // comma-separated list
+
+  // Identity
+  issuer: '',                   // OAuth `iss` claim; falls back to request origin
+  rpName: '',                   // WebAuthn RP display name
+  rpID: '',                     // WebAuthn RP ID; falls back to request host
+  rpOrigin: '',                 // WebAuthn origin; falls back to request origin
+  rpHostAllowList: '',          // comma-separated; see Multi-Tenant below
+
+  // WebAuthn policy
+  requireUserVerification: false,
+  residentKey: 'preferred',     // 'preferred' | 'required' | 'discouraged'
+  attestationType: 'none',      // 'none' | 'indirect' | 'direct' | 'enterprise'
+
+  // Routes (which groups to register)
+  routes: true,                 // or { auth, oauth, grants, admin, agent }
+  pages: true,                  // register /login, /register, /account, /admin etc.
+
+  // Grants
+  grants: {
+    enablePages: true,          // register /grants, /grant-approval, /enroll pages
+    storageKey: 'openape-grants',
+  },
+
+  // Federation
+  federationProviders: '',      // JSON string — see Federation below
+
+  // Embedding
+  allowedFrameAncestors: '',    // space-separated origins; defaults to frame-ancestors 'none'
+
+  // Storage namespace (used by the default in-memory store)
+  storageKey: 'openape-idp',
+}
+```
+
+All options are settable via environment variables following Nuxt's runtimeConfig convention (`NUXT_OPENAPE_IDP_*`):
+
+| Variable | Config key |
+|---|---|
+| `NUXT_OPENAPE_IDP_SESSION_SECRET` | `sessionSecret` |
+| `NUXT_OPENAPE_IDP_SESSION_MAX_AGE` | `sessionMaxAge` |
+| `NUXT_OPENAPE_IDP_MANAGEMENT_TOKEN` | `managementToken` |
+| `NUXT_OPENAPE_IDP_ADMIN_EMAILS` | `adminEmails` |
+| `NUXT_OPENAPE_IDP_ISSUER` | `issuer` |
+| `NUXT_OPENAPE_IDP_RP_NAME` | `rpName` |
+| `NUXT_OPENAPE_IDP_RP_ID` | `rpID` |
+| `NUXT_OPENAPE_IDP_RP_ORIGIN` | `rpOrigin` |
+| `NUXT_OPENAPE_IDP_RP_HOST_ALLOW_LIST` | `rpHostAllowList` |
+| `NUXT_OPENAPE_IDP_REQUIRE_USER_VERIFICATION` | `requireUserVerification` |
+| `NUXT_OPENAPE_IDP_RESIDENT_KEY` | `residentKey` |
+| `NUXT_OPENAPE_IDP_ATTESTATION_TYPE` | `attestationType` |
+| `NUXT_OPENAPE_IDP_FEDERATION_PROVIDERS` | `federationProviders` |
+| `NUXT_OPENAPE_IDP_ALLOWED_FRAME_ANCESTORS` | `allowedFrameAncestors` |
+
+## Server API Routes
+
+The module auto-registers the following routes (gated by the `routes` option):
+
+### Auth (`routes.auth`)
+- `POST /api/session/login` — cookie-session login
+- `POST /api/session/logout`
+- `GET /api/session/ssh-keys` — list caller's SSH keys
+- `POST /api/session/ssh-keys` — add an SSH key for the authenticated user
+- `DELETE /api/session/ssh-keys/:keyId`
+- `POST /api/logout`
+- `GET /api/me` — returns `{ email, name, isAdmin }` for the cookie session
+
+### WebAuthn (under `routes.auth`)
+- `POST /api/webauthn/register/options` · `POST /api/webauthn/register/verify`
+- `POST /api/webauthn/login/options` · `POST /api/webauthn/login/verify`
+- `GET /api/webauthn/credentials` — list the caller's registered credentials
+- `POST /api/webauthn/credentials/add/options` · `POST /api/webauthn/credentials/add/verify`
+- `DELETE /api/webauthn/credentials/:id`
+
+### OAuth / OIDC (`routes.oauth`)
+- `GET /authorize` — OAuth authorization endpoint
+- `POST /token` — token exchange
+- `POST /revoke`
+- `GET /userinfo`
+- `GET /.well-known/openid-configuration`
+- `GET /.well-known/jwks.json`
+
+### Grants (`routes.grants`)
+- `GET /api/grants` · `POST /api/grants` · `GET /api/grants/:id`
+- `POST /api/grants/:id/approve|deny|revoke|token|consume`
+- `POST /api/grants/verify` — verify an AuthZ-JWT
+- `POST /api/grants/batch`
+- `GET|POST /api/delegations` · `DELETE /api/delegations/:id` · `POST /api/delegations/:id/validate`
+- `GET /api/shapes` · `GET /api/shapes/:cliId` · `POST /api/shapes/resolve`
+- `GET|POST /api/standing-grants` · `DELETE /api/standing-grants/:id`
+- `GET /api/users/:email/agents`
+
+### Agents (`routes.agent`)
+- `POST /api/agent/challenge` · `POST /api/agent/authenticate` · `POST /api/agent/enroll`
+- `POST /api/auth/challenge` · `POST /api/auth/authenticate` · `POST /api/auth/enroll` — unified endpoints that work for agents and humans with SSH keys
+
+### Admin (`routes.admin`, requires `isAdmin`)
+- `/api/admin/users` · `/api/admin/users/:email` · `/api/admin/users/:email/credentials|ssh-keys`
+- `/api/admin/agents` · `/api/admin/agents/:id`
+- `/api/admin/sessions` · `/api/admin/sessions/:familyId` · `/api/admin/sessions/user/:email`
+- `/api/admin/registration-urls` · `/api/admin/registration-urls/:token`
+
+### Federation (if `federationProviders` is set)
+- `GET /auth/federated/:providerId` · `/auth/federated/:providerId/callback`
+- `GET /api/federation/providers`
+
+## Built-in Pages
+
+When `pages: true` (default), the module registers these Vue pages. A consuming app can override any by defining its own page with the same path:
+
+- `/login`, `/register`, `/account`, `/admin`
+- `/grants`, `/grant-approval`, `/enroll` (when `grants.enablePages: true`)
+- `/agents`, `/agents/:email`
+
+## Composables
+
+### `useIdpAuth()`
+
+```ts
+const { user, loading, fetchUser, logout } = useIdpAuth()
+```
+
+| Property | Type | Description |
+|---|---|---|
+| `user` | `Ref<{ email, name, isAdmin } \| null>` | Cookie-session claims for the current user |
+| `loading` | `Ref<boolean>` | Whether `fetchUser()` is in flight |
+| `fetchUser()` | `() => Promise<void>` | Hydrate `user` from `/api/me` |
+| `logout()` | `() => Promise<void>` | Destroy the cookie session |
+
+### `useWebAuthn()`
+
+Helper for browser-side passkey enrollment and login flows (wraps `@simplewebauthn/browser`). Used by the built-in pages; available for custom UIs.
+
+## Multi-Tenant (Host-Derived RP)
+
+The module supports hosting multiple IdP domains from a single deployment. RP config is resolved per request: if the incoming `Host` header is in `rpHostAllowList`, the module overrides the static `rpID`/`rpOrigin`/`issuer` for that request.
+
+```ts
+openapeIdp: {
+  rpHostAllowList: 'id.example.com,id.example.at',
+  // rpID / rpOrigin / issuer are vestigial when the allow-list covers every host
+}
+```
+
+The consuming app supplies a middleware that populates `event.context.openapeRpConfig` — all WebAuthn handlers read from that seam first before falling back to the static module config. See the full walkthrough in [Multi-Tenant IdP](/ecosystem/multi-tenant-idp).
+
+## Storage Backend Interfaces
+
+Each `define<Name>Store()` accepts a factory that receives the current `H3Event` and returns an instance of the matching interface from `@openape/auth` (user, credential, key, code, refresh-token, jti, webauthn-challenge, registration-url) or `@openape/grants` (shape). The IdP module only imports the shape — you control persistence.
+
+The reference [openape-free-idp](https://github.com/openape-ai/openape/tree/main/apps/openape-free-idp) implements each store against Drizzle + libsql (Turso or local SQLite); fork that pattern if you want a persistent IdP quickly, or ship your own backend (Postgres, DynamoDB, etc).
+
+## Security Headers
+
+The module installs these headers on every request:
+- `X-Content-Type-Options: nosniff`
+- `Referrer-Policy: strict-origin-when-cross-origin`
+- `X-Frame-Options: DENY` + `Content-Security-Policy: frame-ancestors 'none'` — unless `allowedFrameAncestors` is set, in which case X-Frame-Options is dropped and CSP carries `frame-ancestors 'self' <origins>`.
+
+Session, auth, and admin routes additionally receive `Cache-Control: no-store`.
+
+## Related
+
+- [`@openape/nuxt-auth-sp`](/ecosystem/nuxt-auth-sp) — Service-provider counterpart
+- [Grants](/ecosystem/grants) — Grant model and AuthZ-JWT structure
+- [Multi-Tenant IdP](/ecosystem/multi-tenant-idp) — Host-derived RP config

--- a/apps/docs/content/2.ecosystem/7.multi-tenant-idp.md
+++ b/apps/docs/content/2.ecosystem/7.multi-tenant-idp.md
@@ -1,0 +1,159 @@
+---
+title: Multi-Tenant IdP
+description: Serve multiple OpenApe IdP domains from a single Nuxt process.
+---
+
+# Multi-Tenant IdP
+
+`@openape/nuxt-auth-idp` can host more than one identity origin from a single deployment. A request to `id.acme.com` and a request to `id.acme.at` hit the same Nitro process, share the same database, and see the same users — but WebAuthn passkeys, OAuth issuers, and origin checks are scoped per request according to the incoming `Host` header.
+
+This is the pattern `id.openape.ai` and `id.openape.at` use today (one chatty instance, both hostnames). It also lets you bring up a new tenant with an nginx vhost and a DNS record, no redeploy.
+
+## Why
+
+WebAuthn passkeys are intrinsically bound to the Relying Party ID (`rp.id`) they were created against. A passkey registered at `https://id.acme.com/` cannot be used at `https://id.acme.at/` — browsers enforce that at the credential level. So "multi-tenant" here does **not** mean one passkey crosses hosts; it means:
+
+- One deployment, one DB, one user table.
+- The same email can own credentials on both `id.acme.com` (rp_id = `id.acme.com`) and `id.acme.at` (rp_id = `id.acme.at`), each usable only on its own origin.
+- Issued JWTs carry the `iss` claim of the hostname the user logged in through.
+- Adding a new hostname is a nginx/DNS task, not a code change.
+
+## How it works
+
+The module resolves Relying-Party config through a precedence chain:
+
+1. **Per-request tenant config** — `event.context.openapeRpConfig` (populated by your middleware).
+2. **Static module config** — `openapeIdp.rpID`, `rpOrigin`, `rpName`, `issuer` from `nuxt.config.ts`.
+3. **Dev fallback** — `rpID = 'localhost'`, `origin = http://localhost:3000`.
+
+Your middleware inspects each request, matches the `Host` header against an allow-list, and writes a typed tenant config on `event.context`. All WebAuthn endpoints and the OAuth `iss` minter read from that seam first.
+
+## Configuration
+
+### 1. Declare your allow-list
+
+In `nuxt.config.ts`:
+
+```ts
+export default defineNuxtConfig({
+  modules: ['@openape/nuxt-auth-idp'],
+  openapeIdp: {
+    rpHostAllowList: 'id.acme.com,id.acme.at',
+    rpName: 'Acme Identity',
+    // rpID/rpOrigin/issuer left empty — resolved per request
+  },
+})
+```
+
+Or via env:
+
+```bash
+NUXT_OPENAPE_IDP_RP_HOST_ALLOW_LIST=id.acme.com,id.acme.at
+```
+
+### 2. Add a tenant middleware
+
+Create `server/middleware/00.rp-tenant.ts` in your IdP app (the leading `00.` ensures it runs before any handler):
+
+```ts
+import { getRequestHost } from 'h3'
+import { useRuntimeConfig } from '#imports'
+
+export default defineEventHandler((event) => {
+  const config = useRuntimeConfig()
+  const idpCfg = (config.openapeIdp || {}) as Record<string, unknown>
+  const raw = (idpCfg.rpHostAllowList as string | undefined) || ''
+  const allow = raw.split(',').map(s => s.trim()).filter(Boolean)
+
+  const host = getRequestHost(event, { xForwardedHost: true })?.split(':')[0]
+  if (!host || !allow.includes(host)) return
+
+  const origin = `https://${host}`
+  event.context.openapeRpConfig = {
+    rpName: (idpCfg.rpName as string | undefined) || 'OpenApe Identity Server',
+    rpID: host,
+    origin,
+    requireUserVerification: idpCfg.requireUserVerification ?? false,
+    residentKey: idpCfg.residentKey ?? 'preferred',
+    attestationType: idpCfg.attestationType ?? 'none',
+  }
+  event.context.openapeIssuer = origin
+})
+```
+
+::callout{type="warning"}
+The allow-list is a **security boundary**. Without it, a malicious `Host: attacker.test` header could bind a freshly-created credential to an attacker-chosen RP. Only hostnames present in the allow-list are promoted; everything else falls through to the static module config.
+::
+
+### 3. Schema: scope credentials by `rp_id`
+
+The WebAuthn tables gain an `rp_id` column so the IdP can present only the credentials that match the current request's RP:
+
+```sql
+ALTER TABLE credentials            ADD COLUMN rp_id TEXT;
+ALTER TABLE webauthn_challenges    ADD COLUMN rp_id TEXT;
+CREATE INDEX idx_credentials_rp_id ON credentials(rp_id);
+```
+
+In the reference [openape-free-idp](https://github.com/openape-ai/openape/tree/main/apps/openape-free-idp), this is added idempotently at startup in `server/plugins/02.database.ts`. Existing rows are backfilled to a default RP (e.g. your canonical hostname) so pre-multi-tenant credentials keep working.
+
+The `CredentialStore` exposes an optional `findByUserAndRp(email, rpId)` that every WebAuthn handler calls before registration options, login options, and verification — making cross-RP credential leakage impossible at the data layer.
+
+### 4. nginx vhost per tenant
+
+Each tenant is a plain vhost that forwards `Host` to the shared Nitro port:
+
+```nginx
+server {
+  listen 443 ssl http2;
+  server_name id.acme.at;
+
+  ssl_certificate     /etc/letsencrypt/live/id.acme.com/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/id.acme.com/privkey.pem;
+
+  location / {
+    proxy_pass http://127.0.0.1:3003;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    # …plus standard proxy headers
+  }
+}
+```
+
+Use a single expanded Let's Encrypt cert for every tenant hostname — `certbot --nginx --expand -d id.acme.com -d id.acme.at` — or issue one per tenant.
+
+## Issuing tokens
+
+When `event.context.openapeIssuer` is set, the OAuth token minter uses that value as the `iss` claim instead of the static `openapeIdp.issuer`. A user who logs in at `https://id.acme.at/` therefore receives a JWT with `iss = "https://id.acme.at"` even though the process itself knows both hostnames.
+
+Consumers (service providers, grant verifiers) should either:
+- Accept a known allow-list of `iss` values, or
+- Use [DDISA discovery](/getting-started/how-it-works) to validate `iss` against the token subject's domain.
+
+`jose.jwtVerify()` accepts `issuer: string | string[]`, so adding multi-iss acceptance to a service provider is a one-line change.
+
+## Adding a new tenant
+
+Once the pattern is in place, onboarding a new hostname is:
+
+1. Add DNS record pointing to the deploy host.
+2. Add hostname to `rpHostAllowList` (env or `nuxt.config.ts`) and redeploy.
+3. Add nginx vhost + expand the LE cert to cover the new SAN.
+4. Done — users can now create passkeys scoped to the new RP.
+
+## Migrating data from an existing single-tenant IdP
+
+If you already run a separate IdP for a second hostname and want to collapse it into a multi-tenant deployment:
+
+1. Export the old DB.
+2. Import `users`, `credentials`, `ssh_keys`, `registration_urls`, `signing_keys`, `grants` into the multi-tenant DB, stamping `rp_id = <old-hostname>` on every `credentials` and `webauthn_challenges` row.
+3. On email collisions, keep the canonical row and attach the imported credentials to it (they're keyed by email in the FKs).
+4. Flip DNS for the old hostname at the new deploy host and expand the TLS cert.
+
+Users whose passkeys were registered against the old hostname keep using them — the rp_id scoping presents only the credentials valid for the request's RP. SSH keys work against both hostnames because they're email-keyed and have no RP binding.
+
+## Related
+
+- [nuxt-auth-idp](/ecosystem/nuxt-auth-idp) — Module options and store interfaces
+- [Auth Overview](/ecosystem/auth) — Authentication modes (WebAuthn, SSH, federated)

--- a/apps/openape-free-idp/server/middleware/00.rp-tenant.ts
+++ b/apps/openape-free-idp/server/middleware/00.rp-tenant.ts
@@ -14,12 +14,14 @@ export default defineEventHandler((event) => {
   const host = getRequestHost(event, { xForwardedHost: true })?.split(':')[0]
   if (!host || !allow.includes(host)) return
 
+  const origin = `https://${host}`
   event.context.openapeRpConfig = {
     rpName: (idpCfg.rpName as string | undefined) || 'OpenApe Identity Server',
     rpID: host,
-    origin: `https://${host}`,
+    origin,
     requireUserVerification: idpCfg.requireUserVerification ?? false,
     residentKey: idpCfg.residentKey ?? 'preferred',
     attestationType: idpCfg.attestationType ?? 'none',
   }
+  event.context.openapeIssuer = origin
 })


### PR DESCRIPTION
## Summary

Scoped refresh of `apps/docs/content/` to align with the current monorepo. Reality-checked against code before writing — the issue's 31-file scope was outdated (tree has 18 files) and most pages were actually fine.

### Fixes
- `2.ecosystem/4.nuxt-auth-sp.md` — correct fallback default `id.openape.ai` → `id.openape.at` (matches module default).
- `2.ecosystem/3.grants.md` — sharpen deprecation note for `@openape/nuxt-grants` (last release 0.1.10, 2026-03-03).
- `2.ecosystem/1.index.md` — drop dead `@openape/nuxt-grants` package from architecture diagram and package table; add multi-tenant combo.
- `1.getting-started/5.installation.md` — rewrite env-var tables with correct `NUXT_OPENAPE_IDP_*` / `NUXT_OPENAPE_SP_*` prefixes; remove obsolete `storageDriver`/S3 references.
- `2.ecosystem/2.auth.md` — add SSH-key enrollment section (`/api/session/ssh-keys`) and unified auth flow (`/api/auth/*`).

### New
- `2.ecosystem/6.nuxt-auth-idp.md` — counterpart to the SP doc: module options, full env var map, registered routes per group, store-registration pattern, composables, security headers.
- `2.ecosystem/7.multi-tenant-idp.md` — Host-header-driven RP config, `rpHostAllowList`, middleware pattern, `rp_id` credential scoping, nginx vhost example. References the recent `id.openape.ai + id.openape.at` collapse as the live example.
- `1.getting-started/9.free-idp-hosting.md` — persistent hosting with `openape-free-idp` as the reference app: Drizzle + libsql/Turso setup, env bootstrap, nginx, migrations.

### Out of scope (for follow-up)
- Federation providers doc (marginal usage).
- `6.operations/monorepo-contributing.md` (nice-to-have).
- `ape-shell.md` standalone page (current CLI doc has a working section).
- Desktop/iOS/Android docs (separate issue).

## Test plan
- [x] `pnpm turbo run build --filter=docs` passes
- [x] All three new pages prerender (`ecosystem/multi-tenant-idp`, `ecosystem/nuxt-auth-idp`, `getting-started/free-idp-hosting`)
- [x] All internal links target existing pages
- [ ] Reviewer eye on new docs for technical accuracy

Closes #81.