### PR TITLE
test(free-idp): integration test for SSH-key human login (#140)

### DIFF
--- a/apps/openape-free-idp/tests/ssh-key-human-login.test.ts
+++ b/apps/openape-free-idp/tests/ssh-key-human-login.test.ts
@@ -1,0 +1,172 @@
+import { Buffer } from 'node:buffer'
+import { spawn } from 'node:child_process'
+import { generateKeyPairSync, sign } from 'node:crypto'
+import { dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+const appDir = dirname(dirname(fileURLToPath(import.meta.url)))
+
+const MANAGEMENT_TOKEN = 'openape-ssh-key-test-management-token'
+const SESSION_SECRET = 'openape-ssh-key-test-session-secret-123456'
+const USER_EMAIL = 'ssh-key-test@example.com'
+const USER_NAME = 'SSH Key Test User'
+
+function wait(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function waitForServer(url: string, timeoutMs = 30_000) {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url)
+      if (res.ok) return
+    }
+    catch {}
+    await wait(250)
+  }
+  throw new Error(`Timed out waiting for server: ${url}`)
+}
+
+function sshEd25519Line(rawPublicKey: Buffer, comment: string): string {
+  const keyType = Buffer.from('ssh-ed25519')
+  const lenBuf = (n: number) => {
+    const b = Buffer.alloc(4); b.writeUInt32BE(n, 0); return b
+  }
+  const wire = Buffer.concat([lenBuf(keyType.length), keyType, lenBuf(rawPublicKey.length), rawPublicKey])
+  return `ssh-ed25519 ${wire.toString('base64')} ${comment}`
+}
+
+describe('SSH-key login for humans', () => {
+  const port = 3401 + Math.floor(Math.random() * 200)
+  const baseUrl = `http://127.0.0.1:${port}`
+  let server: ReturnType<typeof spawn> | null = null
+  let serverLogs = ''
+
+  beforeAll(async () => {
+    server = spawn('pnpm', ['exec', 'nuxt', 'dev', '--port', String(port), '--host', '127.0.0.1'], {
+      cwd: appDir,
+      env: {
+        ...process.env,
+        OPENAPE_E2E: '1',
+        OPENAPE_ISSUER: baseUrl,
+        OPENAPE_RP_ORIGIN: baseUrl,
+        OPENAPE_RP_ID: '127.0.0.1',
+        OPENAPE_RP_HOST_ALLOWLIST: '127.0.0.1',
+        OPENAPE_SESSION_SECRET: SESSION_SECRET,
+        OPENAPE_MANAGEMENT_TOKEN: MANAGEMENT_TOKEN,
+        OPENAPE_ADMIN_EMAILS: USER_EMAIL,
+        NUXT_TURSO_URL: 'file::memory:',
+        NUXT_TURSO_AUTH_TOKEN: '',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    server.stdout?.on('data', chunk => { serverLogs += chunk.toString() })
+    server.stderr?.on('data', chunk => { serverLogs += chunk.toString() })
+
+    try {
+      await waitForServer(`${baseUrl}/.well-known/openid-configuration`, 60_000)
+    }
+    catch (err) {
+      console.error('Server failed to start. Last logs:\n', serverLogs.slice(-4000))
+      throw err
+    }
+  }, 90_000)
+
+  afterAll(() => {
+    if (server) { server.kill('SIGTERM'); server = null }
+  })
+
+  it('issues a JWT with act:"human" after a successful SSH-key challenge/response', async () => {
+    // Generate an ed25519 keypair.
+    const { privateKey, publicKey } = generateKeyPairSync('ed25519')
+    const spki = publicKey.export({ format: 'der', type: 'spki' })
+    const rawPub = spki.subarray(spki.length - 32)
+    const sshPubKey = sshEd25519Line(rawPub, USER_EMAIL)
+
+    // Create the user.
+    const createUserRes = await fetch(`${baseUrl}/api/admin/users`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${MANAGEMENT_TOKEN}` },
+      body: JSON.stringify({ email: USER_EMAIL, name: USER_NAME }),
+    })
+    expect([200, 201, 409]).toContain(createUserRes.status)
+
+    // Register the SSH public key.
+    const regKeyRes = await fetch(
+      `${baseUrl}/api/admin/users/${encodeURIComponent(USER_EMAIL)}/ssh-keys`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${MANAGEMENT_TOKEN}` },
+        body: JSON.stringify({ publicKey: sshPubKey, name: 'test-key' }),
+      },
+    )
+    expect([200, 201]).toContain(regKeyRes.status)
+
+    // Request a challenge.
+    const chRes = await fetch(`${baseUrl}/api/auth/challenge`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: USER_EMAIL }),
+    })
+    expect(chRes.status).toBe(200)
+    const { challenge } = await chRes.json() as { challenge: string }
+    expect(challenge).toMatch(/^[a-f0-9]{32,}$/)
+
+    // Sign the challenge bytes with the Ed25519 private key.
+    const signature = sign(null, Buffer.from(challenge), privateKey).toString('base64')
+
+    // Authenticate.
+    const authRes = await fetch(`${baseUrl}/api/auth/authenticate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: USER_EMAIL, challenge, signature, public_key: sshPubKey }),
+    })
+    expect(authRes.status).toBe(200)
+
+    const authBody = await authRes.json() as {
+      token: string
+      id: string
+      email: string
+      name: string
+      act: 'human' | 'agent'
+      expires_in: number
+    }
+    expect(authBody.act).toBe('human')
+    expect(authBody.sub ?? authBody.id).toBe(USER_EMAIL)
+    expect(authBody.email).toBe(USER_EMAIL)
+    expect(authBody.token.split('.').length).toBe(3)
+
+    // Decode JWT claims (signature already checked implicitly by the endpoint roundtrip).
+    const [, payloadB64] = authBody.token.split('.')
+    const payload = JSON.parse(Buffer.from(payloadB64, 'base64url').toString()) as {
+      sub: string; act: string; iss: string; iat: number; exp: number
+    }
+    expect(payload.sub).toBe(USER_EMAIL)
+    expect(payload.act).toBe('human')
+    expect(payload.exp).toBeGreaterThan(Math.floor(Date.now() / 1000))
+    expect(payload.iss).toContain('127.0.0.1')
+  }, 90_000)
+
+  it('rejects a forged signature', async () => {
+    const chRes = await fetch(`${baseUrl}/api/auth/challenge`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: USER_EMAIL }),
+    })
+    expect(chRes.status).toBe(200)
+    const { challenge } = await chRes.json() as { challenge: string }
+
+    // Sign with a FRESH key (not the one registered for this user).
+    const { privateKey: forged } = generateKeyPairSync('ed25519')
+    const signature = sign(null, Buffer.from(challenge), forged).toString('base64')
+
+    const authRes = await fetch(`${baseUrl}/api/auth/authenticate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: USER_EMAIL, challenge, signature }),
+    })
+    expect(authRes.status).toBe(401)
+  }, 30_000)
+})

--- a/apps/openape-free-idp/tests/ssh-key-human-login.test.ts
+++ b/apps/openape-free-idp/tests/ssh-key-human-login.test.ts
@@ -62,8 +62,8 @@ describe('SSH-key login for humans', () => {
       },
       stdio: ['ignore', 'pipe', 'pipe'],
     })
-    server.stdout?.on('data', chunk => { serverLogs += chunk.toString() })
-    server.stderr?.on('data', chunk => { serverLogs += chunk.toString() })
+    server.stdout?.on('data', (chunk) => { serverLogs += chunk.toString() })
+    server.stderr?.on('data', (chunk) => { serverLogs += chunk.toString() })
 
     try {
       await waitForServer(`${baseUrl}/.well-known/openid-configuration`, 60_000)


### PR DESCRIPTION
## Summary

Audit of #140 against current code shows the feature is already implemented (PRs #41 + #119, merged 2026-04-16). This PR adds the missing verification discipline so #140 can close with evidence:

- `apps/openape-free-idp/tests/ssh-key-human-login.test.ts` — integration test that spins up the IdP on an ephemeral port with `OPENAPE_E2E=1`, creates a user via the admin API, registers an ed25519 SSH public key, runs the full `/api/auth/challenge` → sign → `/api/auth/authenticate` round trip, and asserts the returned JWT carries `act: "human"` + `sub` + future `exp`.
- A forged-signature test asserts the endpoint returns 401 when the signature is made with an unregistered key.

Regression detection verified by temporarily forcing `act = 'agent'` in `authenticate.post.ts` — the assertion fails as expected.

## Why only a test

Everything on the original 7-phase plan of #140 is already in the tree:

| Phase | Status |
|---|---|
| 1. SSH Key Store | `modules/nuxt-auth-idp/…/utils/ssh-key-store.ts` + `defineSshKeyStore()` |
| 2. Generalized token helpers | `issueAuthToken` / `verifyAuthToken` / `tryBearerAuth` |
| 3. Unified `/api/auth/*` endpoints | IdP decides `act` via UserStore lookup at `authenticate.post.ts:65` |
| 3. `/api/agent/*` aliases | still registered, backwards-compatible |
| 4. Admin + self-service key mgmt | `/api/admin/users/:email/ssh-keys` + `/api/session/ssh-keys` |
| 5. Drizzle backend | `server/utils/drizzle-ssh-key-store.ts` + `ssh_keys` table in schema |
| 6. OIDC Discovery | `ddisa_auth_{challenge,authenticate}_endpoint` + `ddisa_auth_methods_supported: [..., 'ssh-key']` |
| 7. E2E helper | `examples/e2e/helpers/key-auth.ts` + rewritten `tests/login-flow.test.ts` |

The `examples/e2e` suite is independently broken locally — it hardcodes ports 3000/3001 with no EADDRINUSE handling. That's orthogonal to #140 (and doesn't affect CI), so it stays for a follow-up issue.

## Test plan
- [x] `pnpm --filter openape-free-idp test tests/ssh-key-human-login.test.ts` passes (2 tests, ~5s)
- [x] Confirmed regression detection by temporarily flipping `act` → `'agent'` (test fails)
- [x] Smoke-tested end-to-end against the real `openape-free-idp` dev server

Closes #140.