### PR TITLE
feat(idp): YOLO mode — per-agent opt-in auto-approval

### DIFF
--- a/.changeset/feat-yolo-mode.md
+++ b/.changeset/feat-yolo-mode.md
@@ -1,0 +1,13 @@
+---
+'@openape/nuxt-auth-idp': minor
+'@openape/core': patch
+---
+
+YOLO-Modus: per-Agent Opt-in Auto-Approval für Grant-Requests.
+
+- Neuer Abschnitt auf `/agents/:email` zum (De)Aktivieren plus Deny-Patterns (Glob: `*`/`?`) und optionale Risiko-Schwelle.
+- Admin-API: `GET|PUT|DELETE /api/users/:email/yolo-policy` (Session-Auth + Owner/Approver/Admin-Check).
+- Server-seitige Auto-Approval läuft nach dem Standing-Grant-Match; zuerst erfolgreicher Matcher gewinnt. Deny-Patterns und Risk-Threshold (Shape-Resolver, generic fallback → `risk='high'`) rollen den Request auf den normalen manuellen Flow zurück.
+- Audit-Marker: neue Spalte `grants.auto_approval_kind` (`'standing' | 'yolo' | null`). Grants-UI zeigt die Herkunft als Badge.
+- Agent + CLI-Consumer (apes, grants, escapes) unverändert. JWT-Shape bleibt identisch zu human-approved Grants; nur der Datenbank-Eintrag markiert den Auto-Pfad.
+- `OpenApeGrant.auto_approval_kind` als optionales Feld im Core-Typ ergänzt.

--- a/apps/openape-free-idp/server/database/schema.ts
+++ b/apps/openape-free-idp/server/database/schema.ts
@@ -18,6 +18,9 @@ export const grants = sqliteTable('grants', {
   // column records the standing grant's id for audit-trail purposes.
   // Null for grants decided via the normal manual approval path.
   decidedByStandingGrant: text('decided_by_standing_grant'),
+  // Which auto-approval path decided this grant. Null = human decision,
+  // 'standing' = standing-grant match, 'yolo' = per-agent YOLO policy.
+  autoApprovalKind: text('auto_approval_kind'),
 }, table => [
   index('idx_grants_status').on(table.status),
   index('idx_grants_requester').on(table.requester),
@@ -157,6 +160,19 @@ export const signingKeys = sqliteTable('signing_keys', {
   publicKeyJwk: text('public_key_jwk', { mode: 'json' }).notNull(),
   isActive: integer('is_active', { mode: 'boolean' }).notNull().default(true),
   createdAt: integer('created_at').notNull(),
+})
+
+// --- Milestone 6: YOLO auto-approval policies ---
+// One row per agent. Presence = enabled. Deny rules mark the subset of
+// grant requests that fall back to the normal (human) approval flow.
+export const yoloPolicies = sqliteTable('yolo_policies', {
+  agentEmail: text('agent_email').primaryKey(),
+  enabledBy: text('enabled_by').notNull(),
+  denyRiskThreshold: text('deny_risk_threshold'),
+  denyPatterns: text('deny_patterns', { mode: 'json' }).notNull().default('[]'),
+  enabledAt: integer('enabled_at').notNull(),
+  expiresAt: integer('expires_at'),
+  updatedAt: integer('updated_at').notNull(),
 })
 
 // --- Milestone 5: SSH Keys ---

--- a/apps/openape-free-idp/server/plugins/02.database.ts
+++ b/apps/openape-free-idp/server/plugins/02.database.ts
@@ -116,6 +116,21 @@ export default defineNitroPlugin(async () => {
     }
     if (!defaultRp) defaultRp = 'id.openape.ai'
     await db.run(sql`UPDATE credentials SET rp_id = ${defaultRp} WHERE rp_id IS NULL`)
+
+    // YOLO auto-approval policies (one per agent; presence = enabled).
+    await db.run(sql`CREATE TABLE IF NOT EXISTS yolo_policies (
+      agent_email TEXT PRIMARY KEY,
+      enabled_by TEXT NOT NULL,
+      deny_risk_threshold TEXT,
+      deny_patterns TEXT NOT NULL DEFAULT '[]',
+      enabled_at INTEGER NOT NULL,
+      expires_at INTEGER,
+      updated_at INTEGER NOT NULL
+    )`)
+
+    // auto_approval_kind column on grants — null = human, 'standing' or 'yolo'.
+    try { await db.run(sql`ALTER TABLE grants ADD COLUMN auto_approval_kind TEXT`) }
+    catch { /* already present */ }
   }
   catch (err) {
     console.error('[database] Table creation failed (tables may already exist):', err)

--- a/apps/openape-free-idp/server/plugins/04.idp-stores.ts
+++ b/apps/openape-free-idp/server/plugins/04.idp-stores.ts
@@ -7,6 +7,7 @@ import { createDrizzleChallengeStore } from '../utils/drizzle-challenge-store'
 import { createDrizzleRegistrationUrlStore } from '../utils/drizzle-registration-url-store'
 import { createDrizzleKeyStore } from '../utils/drizzle-key-store'
 import { createDrizzleSshKeyStore } from '../utils/drizzle-ssh-key-store'
+import { createDrizzleYoloPolicyStore } from '../utils/drizzle-yolo-store'
 
 export default defineNitroPlugin(() => {
   if (process.env.OPENAPE_E2E === '1') return
@@ -29,4 +30,7 @@ export default defineNitroPlugin(() => {
 
   // Milestone 5: SSH Keys
   defineSshKeyStore(() => createDrizzleSshKeyStore())
+
+  // Milestone 6: YOLO auto-approval policies
+  defineYoloPolicyStore(() => createDrizzleYoloPolicyStore())
 })

--- a/apps/openape-free-idp/server/utils/drizzle-grant-store.ts
+++ b/apps/openape-free-idp/server/utils/drizzle-grant-store.ts
@@ -27,6 +27,8 @@ function grantToRow(grant: OpenApeGrant) {
     decidedBy: grant.decided_by ?? null,
     expiresAt: grant.expires_at ?? null,
     usedAt: grant.used_at ?? null,
+    decidedByStandingGrant: grant.decided_by_standing_grant ?? null,
+    autoApprovalKind: grant.auto_approval_kind ?? null,
   }
 }
 
@@ -48,6 +50,8 @@ function rowToGrant(row: GrantRow): OpenApeGrant {
     decided_by: row.decidedBy ?? undefined,
     expires_at: row.expiresAt ?? undefined,
     used_at: row.usedAt ?? undefined,
+    decided_by_standing_grant: row.decidedByStandingGrant ?? undefined,
+    auto_approval_kind: (row.autoApprovalKind as OpenApeGrant['auto_approval_kind']) ?? undefined,
   }
 }
 
@@ -72,6 +76,8 @@ export function createDrizzleGrantStore(): ExtendedGrantStore {
           decidedBy: row.decidedBy,
           expiresAt: row.expiresAt,
           usedAt: row.usedAt,
+          decidedByStandingGrant: row.decidedByStandingGrant,
+          autoApprovalKind: row.autoApprovalKind,
         },
       })
     },
@@ -91,6 +97,12 @@ export function createDrizzleGrantStore(): ExtendedGrantStore {
       if (extra?.decided_at !== undefined) updates.decidedAt = extra.decided_at
       if (extra?.expires_at !== undefined) updates.expiresAt = extra.expires_at
       if (extra?.used_at !== undefined) updates.usedAt = extra.used_at
+      if ((extra as Record<string, unknown> | undefined)?.decided_by_standing_grant !== undefined) {
+        updates.decidedByStandingGrant = (extra as Record<string, unknown>).decided_by_standing_grant
+      }
+      if ((extra as Record<string, unknown> | undefined)?.auto_approval_kind !== undefined) {
+        updates.autoApprovalKind = (extra as Record<string, unknown>).auto_approval_kind
+      }
       if (extra?.request !== undefined) {
         updates.request = extra.request as unknown as Record<string, unknown>
         updates.grantType = (extra.request as OpenApeGrantRequest).grant_type ?? 'once'

--- a/apps/openape-free-idp/server/utils/drizzle-yolo-store.ts
+++ b/apps/openape-free-idp/server/utils/drizzle-yolo-store.ts
@@ -1,0 +1,77 @@
+// YoloPolicyStore + YoloPolicy are auto-imported from @openape/nuxt-auth-idp
+// via addServerImportsDir.
+import { eq } from 'drizzle-orm'
+import { useDb } from '../database/drizzle'
+import { yoloPolicies } from '../database/schema'
+
+type Row = typeof yoloPolicies.$inferSelect
+
+function mapRow(row: Row): YoloPolicy {
+  let patterns: string[] = []
+  if (Array.isArray(row.denyPatterns)) {
+    patterns = (row.denyPatterns as unknown[]).filter((p): p is string => typeof p === 'string')
+  }
+  else if (typeof row.denyPatterns === 'string') {
+    try {
+      const parsed = JSON.parse(row.denyPatterns)
+      if (Array.isArray(parsed)) {
+        patterns = parsed.filter((p): p is string => typeof p === 'string')
+      }
+    }
+    catch { /* leave empty */ }
+  }
+  return {
+    agentEmail: row.agentEmail,
+    enabledBy: row.enabledBy,
+    denyRiskThreshold: (row.denyRiskThreshold ?? null) as YoloPolicy['denyRiskThreshold'],
+    denyPatterns: patterns,
+    enabledAt: row.enabledAt,
+    expiresAt: row.expiresAt ?? null,
+    updatedAt: row.updatedAt,
+  }
+}
+
+export function createDrizzleYoloPolicyStore(): YoloPolicyStore {
+  const db = useDb()
+
+  return {
+    async get(email) {
+      const rows = await db.select().from(yoloPolicies).where(eq(yoloPolicies.agentEmail, email)).limit(1)
+      return rows[0] ? mapRow(rows[0]) : null
+    },
+
+    async put(policy) {
+      const values = {
+        agentEmail: policy.agentEmail,
+        enabledBy: policy.enabledBy,
+        denyRiskThreshold: policy.denyRiskThreshold,
+        denyPatterns: policy.denyPatterns,
+        enabledAt: policy.enabledAt,
+        expiresAt: policy.expiresAt,
+        updatedAt: policy.updatedAt,
+      }
+      await db
+        .insert(yoloPolicies)
+        .values(values)
+        .onConflictDoUpdate({
+          target: yoloPolicies.agentEmail,
+          set: {
+            enabledBy: values.enabledBy,
+            denyRiskThreshold: values.denyRiskThreshold,
+            denyPatterns: values.denyPatterns,
+            expiresAt: values.expiresAt,
+            updatedAt: values.updatedAt,
+          },
+        })
+    },
+
+    async delete(email) {
+      await db.delete(yoloPolicies).where(eq(yoloPolicies.agentEmail, email))
+    },
+
+    async list() {
+      const rows = await db.select().from(yoloPolicies)
+      return rows.map(mapRow)
+    },
+  }
+}

--- a/apps/openape-free-idp/tests/ssh-key-human-login.test.ts
+++ b/apps/openape-free-idp/tests/ssh-key-human-login.test.ts
@@ -47,6 +47,7 @@ describe('SSH-key login for humans', () => {
   beforeAll(async () => {
     server = spawn('pnpm', ['exec', 'nuxt', 'dev', '--port', String(port), '--host', '127.0.0.1'], {
       cwd: appDir,
+      detached: true,
       env: {
         ...process.env,
         OPENAPE_E2E: '1',
@@ -74,8 +75,14 @@ describe('SSH-key login for humans', () => {
     }
   }, 90_000)
 
-  afterAll(() => {
-    if (server) { server.kill('SIGTERM'); server = null }
+  afterAll(async () => {
+    if (server?.pid) {
+      // Kill the process group so the nuxt child dies with the pnpm wrapper
+      try { process.kill(-server.pid, 'SIGKILL') }
+      catch { /* already gone */ }
+    }
+    server = null
+    await wait(200)
   })
 
   it('issues a JWT with act:"human" after a successful SSH-key challenge/response', async () => {

--- a/apps/openape-free-idp/tests/yolo-evaluator.test.ts
+++ b/apps/openape-free-idp/tests/yolo-evaluator.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+
+// The evaluator lives in @openape/nuxt-auth-idp. Import via the workspace
+// src path; no need to spawn a server for these pure-logic tests.
+// eslint-disable-next-line ts/ban-ts-comment
+// @ts-expect-error — workspace import for unit test
+import { evaluateYoloPolicy, matchesGlob } from '../../../modules/nuxt-auth-idp/src/runtime/server/utils/grant-auto-approval'
+
+type Risk = 'low' | 'medium' | 'high' | 'critical'
+
+function policy(overrides: Partial<{
+  denyRiskThreshold: Risk | null
+  denyPatterns: string[]
+  expiresAt: number | null
+}> = {}) {
+  return {
+    agentEmail: 'a@x',
+    enabledBy: 'owner@x',
+    denyRiskThreshold: overrides.denyRiskThreshold ?? null,
+    denyPatterns: overrides.denyPatterns ?? [],
+    enabledAt: 0,
+    expiresAt: overrides.expiresAt ?? null,
+    updatedAt: 0,
+  }
+}
+
+describe('matchesGlob', () => {
+  it('literal match', () => {
+    expect(matchesGlob('ls', 'ls')).toBe(true)
+    expect(matchesGlob('ls', 'lsof')).toBe(false)
+  })
+  it('star covers any run', () => {
+    expect(matchesGlob('rm -rf /tmp', 'rm *')).toBe(true)
+    expect(matchesGlob('curl http://x | sh', 'curl*| sh')).toBe(true)
+    expect(matchesGlob('sudo rm', 'sudo *')).toBe(true)
+  })
+  it('question mark covers exactly one', () => {
+    expect(matchesGlob('rm', 'r?')).toBe(true)
+    expect(matchesGlob('rmm', 'r?')).toBe(false)
+  })
+  it('escape regex specials in the pattern', () => {
+    expect(matchesGlob('1+2', '1+2')).toBe(true)
+    expect(matchesGlob('a.b', 'a.b')).toBe(true)
+    expect(matchesGlob('a_b', 'a.b')).toBe(false)
+  })
+})
+
+describe('evaluateYoloPolicy', () => {
+  it('no policy → null', () => {
+    expect(evaluateYoloPolicy({ policy: null, command: ['ls'], resolvedRisk: null })).toBeNull()
+  })
+  it('expired policy → null', () => {
+    const p = policy({ expiresAt: 1 })
+    const result = evaluateYoloPolicy({ policy: p, command: ['ls'], resolvedRisk: null, now: 100 })
+    expect(result).toBeNull()
+  })
+  it('empty command → null', () => {
+    const p = policy()
+    expect(evaluateYoloPolicy({ policy: p, command: undefined, resolvedRisk: null })).toBeNull()
+    expect(evaluateYoloPolicy({ policy: p, command: [], resolvedRisk: null })).toBeNull()
+  })
+  it('match without any rules → approves with enabledBy', () => {
+    const p = policy()
+    const result = evaluateYoloPolicy({ policy: p, command: ['ls', '-la'], resolvedRisk: null })
+    expect(result).toEqual({ kind: 'yolo', decidedBy: 'owner@x' })
+  })
+  it('deny-pattern drops the match', () => {
+    const p = policy({ denyPatterns: ['rm *'] })
+    const result = evaluateYoloPolicy({ policy: p, command: ['rm', 'foo'], resolvedRisk: null })
+    expect(result).toBeNull()
+  })
+  it('risk at threshold blocks', () => {
+    const p = policy({ denyRiskThreshold: 'high' })
+    expect(evaluateYoloPolicy({ policy: p, command: ['rm'], resolvedRisk: 'high' })).toBeNull()
+    expect(evaluateYoloPolicy({ policy: p, command: ['rm'], resolvedRisk: 'critical' })).toBeNull()
+  })
+  it('risk below threshold passes', () => {
+    const p = policy({ denyRiskThreshold: 'high' })
+    expect(evaluateYoloPolicy({ policy: p, command: ['ls'], resolvedRisk: 'medium' }))
+      .toEqual({ kind: 'yolo', decidedBy: 'owner@x' })
+    expect(evaluateYoloPolicy({ policy: p, command: ['ls'], resolvedRisk: 'low' }))
+      .toEqual({ kind: 'yolo', decidedBy: 'owner@x' })
+  })
+  it('risk-threshold only applies when resolvedRisk is non-null', () => {
+    const p = policy({ denyRiskThreshold: 'high' })
+    expect(evaluateYoloPolicy({ policy: p, command: ['ls'], resolvedRisk: null }))
+      .toEqual({ kind: 'yolo', decidedBy: 'owner@x' })
+  })
+})

--- a/apps/openape-free-idp/tests/yolo-policy.test.ts
+++ b/apps/openape-free-idp/tests/yolo-policy.test.ts
@@ -1,0 +1,303 @@
+import { Buffer } from 'node:buffer'
+import { spawn } from 'node:child_process'
+import { generateKeyPairSync } from 'node:crypto'
+import { dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+function sshEd25519Line(rawPublicKey: Buffer, comment: string): string {
+  const keyType = Buffer.from('ssh-ed25519')
+  const lenBuf = (n: number) => {
+    const b = Buffer.alloc(4); b.writeUInt32BE(n, 0); return b
+  }
+  const wire = Buffer.concat([lenBuf(keyType.length), keyType, lenBuf(rawPublicKey.length), rawPublicKey])
+  return `ssh-ed25519 ${wire.toString('base64')} ${comment}`
+}
+
+function genSshPubKey(comment: string): string {
+  const { publicKey } = generateKeyPairSync('ed25519')
+  const spki = publicKey.export({ format: 'der', type: 'spki' })
+  return sshEd25519Line(spki.subarray(spki.length - 32), comment)
+}
+
+const appDir = dirname(dirname(fileURLToPath(import.meta.url)))
+
+const MANAGEMENT_TOKEN = 'openape-yolo-test-management-token'
+const SESSION_SECRET = 'openape-yolo-test-session-secret-1234567890'
+const OWNER_EMAIL = 'owner@example.com'
+const AGENT_EMAIL = 'yolo-agent@example.com'
+const OTHER_EMAIL = 'other@example.com'
+
+function wait(ms: number) { return new Promise(resolve => setTimeout(resolve, ms)) }
+
+async function waitForServer(url: string, timeoutMs = 30_000) {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url)
+      if (res.ok) return
+    }
+    catch {}
+    await wait(250)
+  }
+  throw new Error(`Timed out waiting for server: ${url}`)
+}
+
+const managementHeader = { Authorization: `Bearer ${MANAGEMENT_TOKEN}` }
+
+describe('YOLO policy admin API', () => {
+  const port = 3601 + Math.floor(Math.random() * 200)
+  const baseUrl = `http://127.0.0.1:${port}`
+  let server: ReturnType<typeof spawn> | null = null
+  let serverLogs = ''
+
+  beforeAll(async () => {
+    server = spawn('pnpm', ['exec', 'nuxt', 'dev', '--port', String(port), '--host', '127.0.0.1'], {
+      cwd: appDir,
+      detached: true,
+      env: {
+        ...process.env,
+        OPENAPE_E2E: '1',
+        OPENAPE_ISSUER: baseUrl,
+        OPENAPE_RP_ORIGIN: baseUrl,
+        OPENAPE_RP_ID: '127.0.0.1',
+        OPENAPE_RP_HOST_ALLOWLIST: '127.0.0.1',
+        OPENAPE_SESSION_SECRET: SESSION_SECRET,
+        OPENAPE_MANAGEMENT_TOKEN: MANAGEMENT_TOKEN,
+        OPENAPE_ADMIN_EMAILS: OWNER_EMAIL,
+        NUXT_TURSO_URL: 'file::memory:',
+        NUXT_TURSO_AUTH_TOKEN: '',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    server.stdout?.on('data', (chunk) => { serverLogs += chunk.toString() })
+    server.stderr?.on('data', (chunk) => { serverLogs += chunk.toString() })
+    try {
+      await waitForServer(`${baseUrl}/.well-known/openid-configuration`, 60_000)
+    }
+    catch (err) {
+      console.error('Server failed to start. Last logs:\n', serverLogs.slice(-4000))
+      throw err
+    }
+
+    // Seed: owner + agent (agent.owner = owner)
+    const r1 = await fetch(`${baseUrl}/api/admin/users`, {
+      method: 'POST', headers: { ...managementHeader, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: OWNER_EMAIL, name: 'Owner' }),
+    })
+    expect([200, 201, 409]).toContain(r1.status)
+    const r2 = await fetch(`${baseUrl}/api/admin/users`, {
+      method: 'POST', headers: { ...managementHeader, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: OTHER_EMAIL, name: 'Other' }),
+    })
+    expect([200, 201, 409]).toContain(r2.status)
+    const r3 = await fetch(`${baseUrl}/api/admin/agents`, {
+      method: 'POST', headers: { ...managementHeader, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: AGENT_EMAIL,
+        name: 'YOLO Agent',
+        owner: OWNER_EMAIL,
+        approver: OWNER_EMAIL,
+        publicKey: genSshPubKey(AGENT_EMAIL),
+      }),
+    })
+    if (![200, 201, 409].includes(r3.status)) {
+      console.error('admin/agents create failed', r3.status, await r3.text())
+    }
+    expect([200, 201, 409]).toContain(r3.status)
+  }, 90_000)
+
+  afterAll(async () => {
+    if (server?.pid) {
+      // Kill the whole process group (pnpm + nuxt child) so no orphans linger
+      try { process.kill(-server.pid, 'SIGKILL') }
+      catch { /* already gone */ }
+    }
+    server = null
+    // Give the kernel a moment to release the bound port
+    await wait(200)
+  })
+
+  it('GET returns null when no policy is set', async () => {
+    const res = await fetch(`${baseUrl}/api/users/${encodeURIComponent(AGENT_EMAIL)}/yolo-policy`, {
+      headers: managementHeader,
+    })
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toEqual({ policy: null })
+  })
+
+  it('PUT creates then GET returns the policy', async () => {
+    const put = await fetch(`${baseUrl}/api/users/${encodeURIComponent(AGENT_EMAIL)}/yolo-policy`, {
+      method: 'PUT',
+      headers: { ...managementHeader, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        denyRiskThreshold: 'high',
+        denyPatterns: ['rm -rf *', 'sudo *'],
+      }),
+    })
+    expect(put.status).toBe(200)
+    const putBody = await put.json()
+    expect(putBody.policy.agentEmail).toBe(AGENT_EMAIL)
+    expect(putBody.policy.denyRiskThreshold).toBe('high')
+    expect(putBody.policy.denyPatterns).toEqual(['rm -rf *', 'sudo *'])
+
+    const get = await fetch(`${baseUrl}/api/users/${encodeURIComponent(AGENT_EMAIL)}/yolo-policy`, {
+      headers: managementHeader,
+    })
+    const getBody = await get.json()
+    expect(getBody.policy.denyRiskThreshold).toBe('high')
+    expect(getBody.policy.denyPatterns).toEqual(['rm -rf *', 'sudo *'])
+    expect(getBody.policy.enabledAt).toBeTypeOf('number')
+  })
+
+  it('PUT partial update preserves fields', async () => {
+    const put = await fetch(`${baseUrl}/api/users/${encodeURIComponent(AGENT_EMAIL)}/yolo-policy`, {
+      method: 'PUT',
+      headers: { ...managementHeader, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ denyPatterns: ['docker *'] }),
+    })
+    expect(put.status).toBe(200)
+    const body = await put.json()
+    expect(body.policy.denyRiskThreshold).toBe('high')
+    expect(body.policy.denyPatterns).toEqual(['docker *'])
+  })
+
+  it('PUT rejects invalid risk threshold', async () => {
+    const put = await fetch(`${baseUrl}/api/users/${encodeURIComponent(AGENT_EMAIL)}/yolo-policy`, {
+      method: 'PUT',
+      headers: { ...managementHeader, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ denyRiskThreshold: 'extreme' }),
+    })
+    expect(put.status).toBe(400)
+  })
+
+  it('PUT rejects non-agent target', async () => {
+    const put = await fetch(`${baseUrl}/api/users/${encodeURIComponent(OWNER_EMAIL)}/yolo-policy`, {
+      method: 'PUT',
+      headers: { ...managementHeader, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ denyRiskThreshold: 'high' }),
+    })
+    expect(put.status).toBe(400)
+  })
+
+  it('auto-approves a grant request when YOLO policy is active', async () => {
+    // Fresh policy without deny-patterns or risk threshold → all commands auto-approve.
+    await fetch(`${baseUrl}/api/users/${encodeURIComponent(AGENT_EMAIL)}/yolo-policy`, {
+      method: 'PUT',
+      headers: { ...managementHeader, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ denyPatterns: [], denyRiskThreshold: null }),
+    })
+
+    const res = await fetch(`${baseUrl}/api/grants`, {
+      method: 'POST',
+      headers: { ...managementHeader, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        requester: AGENT_EMAIL,
+        target_host: '127.0.0.1',
+        audience: 'test',
+        grant_type: 'once',
+        command: ['ls', '-la'],
+      }),
+    })
+    expect(res.status).toBe(201)
+    const grant = await res.json()
+    expect(grant.status).toBe('approved')
+    expect(grant.auto_approval_kind).toBe('yolo')
+    // enabledBy reflects the actor who set the policy. When created via the
+    // management token there's no email context, so it's '_management_'.
+    // In the normal admin flow an owner/approver's email lands here.
+    expect(grant.decided_by).toBe('_management_')
+  })
+
+  it('risk-threshold drops the request when shape resolves to generic-fallback (high risk)', async () => {
+    await fetch(`${baseUrl}/api/users/${encodeURIComponent(AGENT_EMAIL)}/yolo-policy`, {
+      method: 'PUT',
+      headers: { ...managementHeader, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ denyRiskThreshold: 'high', denyPatterns: [] }),
+    })
+    // `some-random-cli` has no registered shape → generic fallback → risk='high'
+    // → >= threshold 'high' → drops to pending.
+    const res = await fetch(`${baseUrl}/api/grants`, {
+      method: 'POST',
+      headers: { ...managementHeader, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        requester: AGENT_EMAIL,
+        target_host: '127.0.0.1',
+        audience: 'test',
+        grant_type: 'once',
+        command: ['some-random-cli', 'whatever'],
+      }),
+    })
+    const grant = await res.json()
+    expect(grant.status).toBe('pending')
+    expect(grant.auto_approval_kind).toBeUndefined()
+  })
+
+  it('deny-pattern drops the request back to pending', async () => {
+    await fetch(`${baseUrl}/api/users/${encodeURIComponent(AGENT_EMAIL)}/yolo-policy`, {
+      method: 'PUT',
+      headers: { ...managementHeader, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ denyPatterns: ['rm *'] }),
+    })
+
+    const res = await fetch(`${baseUrl}/api/grants`, {
+      method: 'POST',
+      headers: { ...managementHeader, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        requester: AGENT_EMAIL,
+        target_host: '127.0.0.1',
+        audience: 'test',
+        grant_type: 'once',
+        command: ['rm', 'foo.txt'],
+      }),
+    })
+    expect(res.status).toBe(201)
+    const grant = await res.json()
+    expect(grant.status).toBe('pending')
+    expect(grant.auto_approval_kind).toBeUndefined()
+  })
+
+  it('expired YOLO policy does not auto-approve', async () => {
+    // Expired policies are enforced by the evaluator only; the API rejects
+    // past `expiresAt`, so seed the store directly via a far-future timestamp
+    // and then simulate expiry by updating it out-of-band isn't trivial —
+    // instead we disable the policy entirely and confirm the request pends.
+    await fetch(`${baseUrl}/api/users/${encodeURIComponent(AGENT_EMAIL)}/yolo-policy`, {
+      method: 'DELETE',
+      headers: managementHeader,
+    })
+    const res = await fetch(`${baseUrl}/api/grants`, {
+      method: 'POST',
+      headers: { ...managementHeader, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        requester: AGENT_EMAIL,
+        target_host: '127.0.0.1',
+        audience: 'test',
+        grant_type: 'once',
+        command: ['ls'],
+      }),
+    })
+    const grant = await res.json()
+    expect(grant.status).toBe('pending')
+    expect(grant.auto_approval_kind).toBeUndefined()
+  })
+
+  it('DELETE removes the policy', async () => {
+    await fetch(`${baseUrl}/api/users/${encodeURIComponent(AGENT_EMAIL)}/yolo-policy`, {
+      method: 'PUT',
+      headers: { ...managementHeader, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ denyRiskThreshold: 'high' }),
+    })
+    const del = await fetch(`${baseUrl}/api/users/${encodeURIComponent(AGENT_EMAIL)}/yolo-policy`, {
+      method: 'DELETE',
+      headers: managementHeader,
+    })
+    expect(del.status).toBe(204)
+    const get = await fetch(`${baseUrl}/api/users/${encodeURIComponent(AGENT_EMAIL)}/yolo-policy`, {
+      headers: managementHeader,
+    })
+    const body = await get.json()
+    expect(body).toEqual({ policy: null })
+  })
+})

--- a/apps/openape-free-idp/vitest.config.ts
+++ b/apps/openape-free-idp/vitest.config.ts
@@ -5,6 +5,10 @@ export default defineConfig({
     include: ['tests/**/*.test.ts'],
     globals: true,
     environment: 'node',
+    // Server-spawning suites (ssh-key-human-login, yolo-policy, shapes-e2e)
+    // bind ephemeral ports and collide under parallelism. Sequential run
+    // is still comfortable (~30-60s total).
+    fileParallelism: false,
   },
   esbuild: {
     tsconfigRaw: {

--- a/modules/nuxt-auth-idp/src/module.ts
+++ b/modules/nuxt-auth-idp/src/module.ts
@@ -317,6 +317,11 @@ export default defineNuxtModule<ModuleOptions>({
       // Agent-view aggregate (per-agent standing grants + recent activity).
       // Phase 1 Milestone 7. Self-service only (requireAuth + caller == email).
       addServerHandler({ route: '/api/users/:email/agents', handler: resolve('./runtime/server/api/users/[email]/agents.get') })
+
+      // YOLO auto-approval policy (per-agent)
+      addServerHandler({ route: '/api/users/:email/yolo-policy', handler: resolve('./runtime/server/api/users/[email]/yolo-policy.get') })
+      addServerHandler({ route: '/api/users/:email/yolo-policy', method: 'put', handler: resolve('./runtime/server/api/users/[email]/yolo-policy.put') })
+      addServerHandler({ route: '/api/users/:email/yolo-policy', method: 'delete', handler: resolve('./runtime/server/api/users/[email]/yolo-policy.delete') })
     }
 
     // Server route handlers — Agent

--- a/modules/nuxt-auth-idp/src/runtime/pages/agents/[email].vue
+++ b/modules/nuxt-auth-idp/src/runtime/pages/agents/[email].vue
@@ -12,16 +12,11 @@ import {
 const { user, loading: authLoading, fetchUser } = useIdpAuth()
 const route = useRoute()
 const targetEmail = computed(() => decodeURIComponent(route.params.email))
-
 const agent = ref(null)
 const loading = ref(true)
 const error = ref('')
 const success = ref('')
-
-// Shapes for CLI picker
 const shapes = ref([])
-
-// Add-SG form state
 const form = ref({
   cli_id: '',
   resource_chain_text: '',
@@ -32,44 +27,120 @@ const form = ref({
 })
 const formSubmitting = ref(false)
 const formError = ref('')
-
-// Revoke dialog state
-const revokeTarget = ref(null) // the SG object being revoked
+const revokeTarget = ref(null)
 const revoking = ref(false)
-
-// Safe Commands state
-const safeCommandsBusy = ref(null) // cli_id currently being toggled/added
+const safeCommandsBusy = ref(null)
 const customInput = ref('')
 const safeCommandError = ref('')
-
-// Partition standing grants: safe-commands vs. "rich" custom grants
-const safeCommandGrants = computed(() =>
-  agent.value ? agent.value.standing_grants.filter(isSafeCommandGrant) : [],
+// YOLO-Modus state
+const yoloPolicy = ref(null)
+const yoloLoading = ref(false)
+const yoloError = ref('')
+const yoloForm = ref({
+  denyRiskThreshold: 'high',
+  denyPatterns: '',
+})
+const yoloSubmitting = ref(false)
+const yoloEditing = ref(false)
+const yoloExpiryInfo = computed(() => {
+  const ts = yoloPolicy.value?.expiresAt
+  if (!ts) return null
+  const date = new Date(ts * 1000)
+  return date.toLocaleString()
+})
+const safeCommandGrants = computed(
+  () => agent.value ? agent.value.standing_grants.filter(isSafeCommandGrant) : [],
 )
-const richStandingGrants = computed(() =>
-  agent.value ? agent.value.standing_grants.filter(g => !isSafeCommandGrant(g)) : [],
+const richStandingGrants = computed(
+  () => agent.value ? agent.value.standing_grants.filter(g => !isSafeCommandGrant(g)) : [],
 )
 const safeCommandByCliId = computed(() => {
-  const map = new Map()
+  const map = /* @__PURE__ */ new Map()
   for (const g of safeCommandGrants.value) {
     const cliId = g.request?.cli_id
     if (typeof cliId === 'string') map.set(cliId, g)
   }
   return map
 })
-const customSafeCommands = computed(() =>
-  safeCommandGrants.value.filter(g => g.request?.reason === 'safe-command:custom'),
+const customSafeCommands = computed(
+  () => safeCommandGrants.value.filter(g => g.request?.reason === 'safe-command:custom'),
 )
-
 onMounted(async () => {
   await fetchUser()
   if (!user.value) {
     await navigateTo('/login')
     return
   }
-  await Promise.all([loadAgent(), loadShapes()])
+  await Promise.all([loadAgent(), loadShapes(), loadYoloPolicy()])
 })
-
+async function loadYoloPolicy() {
+  yoloLoading.value = true
+  yoloError.value = ''
+  try {
+    const res = await $fetch(`/api/users/${encodeURIComponent(targetEmail.value)}/yolo-policy`)
+    yoloPolicy.value = res?.policy ?? null
+    if (yoloPolicy.value) {
+      yoloForm.value = {
+        denyRiskThreshold: yoloPolicy.value.denyRiskThreshold ?? 'high',
+        denyPatterns: (yoloPolicy.value.denyPatterns ?? []).join('\n'),
+      }
+    }
+  }
+  catch (err) {
+    yoloError.value = err?.data?.title || 'Failed to load YOLO policy'
+  }
+  finally {
+    yoloLoading.value = false
+  }
+}
+async function saveYoloPolicy() {
+  yoloSubmitting.value = true
+  yoloError.value = ''
+  try {
+    const patterns = yoloForm.value.denyPatterns
+      .split(/\r?\n/)
+      .map(s => s.trim())
+      .filter(Boolean)
+    const body = {
+      denyRiskThreshold: yoloForm.value.denyRiskThreshold || null,
+      denyPatterns: patterns,
+    }
+    const res = await $fetch(`/api/users/${encodeURIComponent(targetEmail.value)}/yolo-policy`, {
+      method: 'PUT',
+      body,
+    })
+    yoloPolicy.value = res?.policy ?? null
+    yoloEditing.value = false
+    success.value = 'YOLO-Modus gespeichert'
+  }
+  catch (err) {
+    yoloError.value = err?.data?.title || err?.message || 'Speichern fehlgeschlagen'
+  }
+  finally {
+    yoloSubmitting.value = false
+  }
+}
+async function disableYoloPolicy() {
+  if (!confirm('YOLO-Modus wirklich deaktivieren?')) return
+  yoloSubmitting.value = true
+  yoloError.value = ''
+  try {
+    await $fetch(`/api/users/${encodeURIComponent(targetEmail.value)}/yolo-policy`, { method: 'DELETE' })
+    yoloPolicy.value = null
+    yoloEditing.value = false
+    yoloForm.value = { denyRiskThreshold: 'high', denyPatterns: '' }
+    success.value = 'YOLO-Modus deaktiviert'
+  }
+  catch (err) {
+    yoloError.value = err?.data?.title || 'Deaktivieren fehlgeschlagen'
+  }
+  finally {
+    yoloSubmitting.value = false
+  }
+}
+function startYoloEditing() {
+  yoloEditing.value = true
+}
 async function loadAgent() {
   loading.value = true
   error.value = ''
@@ -87,7 +158,6 @@ async function loadAgent() {
     loading.value = false
   }
 }
-
 async function loadShapes() {
   try {
     shapes.value = await $fetch('/api/shapes')
@@ -96,41 +166,39 @@ async function loadShapes() {
     shapes.value = []
   }
 }
-
 const cliOptions = computed(() => [
   { label: 'Any CLI (wildcard)', value: '' },
   ...shapes.value.map(s => ({ label: s.cli_id, value: s.cli_id })),
 ])
-
 const riskOptions = [
   { label: 'Low', value: 'low' },
   { label: 'Medium', value: 'medium' },
   { label: 'High', value: 'high' },
   { label: 'Critical', value: 'critical' },
 ]
-
 const grantTypeOptions = [
   { label: 'Always', value: 'always' },
   { label: 'Timed', value: 'timed' },
 ]
-
 function commandCell(g) {
   const cmd = g.request?.command
-  if (!cmd || cmd.length === 0) return '—'
+  if (!cmd || cmd.length === 0) return '\u2014'
   return cmd.join(' ')
 }
-
 function statusColor(status) {
   switch (status) {
-    case 'approved': return 'success'
-    case 'pending': return 'warning'
+    case 'approved':
+      return 'success'
+    case 'pending':
+      return 'warning'
     case 'denied':
     case 'revoked':
-    case 'expired': return 'error'
-    default: return 'neutral'
+    case 'expired':
+      return 'error'
+    default:
+      return 'neutral'
   }
 }
-
 async function handleAddSg() {
   formError.value = ''
   formSubmitting.value = true
@@ -142,9 +210,9 @@ async function handleAddSg() {
       resource_chain_template,
       max_risk: form.value.max_risk,
       grant_type: form.value.grant_type,
-      ...(form.value.cli_id ? { cli_id: form.value.cli_id } : {}),
-      ...(form.value.grant_type === 'timed' ? { duration: Number(form.value.duration) } : {}),
-      ...(form.value.reason ? { reason: form.value.reason } : {}),
+      ...form.value.cli_id ? { cli_id: form.value.cli_id } : {},
+      ...form.value.grant_type === 'timed' ? { duration: Number(form.value.duration) } : {},
+      ...form.value.reason ? { reason: form.value.reason } : {},
     }
     await $fetch('/api/standing-grants', { method: 'POST', body })
     success.value = 'Standing grant created'
@@ -158,7 +226,6 @@ async function handleAddSg() {
     formSubmitting.value = false
   }
 }
-
 function resetForm() {
   form.value = {
     cli_id: '',
@@ -169,11 +236,9 @@ function resetForm() {
     reason: '',
   }
 }
-
 function askRevoke(sg) {
   revokeTarget.value = sg
 }
-
 async function confirmRevoke() {
   if (!revokeTarget.value) return
   revoking.value = true
@@ -190,11 +255,9 @@ async function confirmRevoke() {
     revoking.value = false
   }
 }
-
 function cancelRevoke() {
   revokeTarget.value = null
 }
-
 async function toggleSafeCommand(cliId, action) {
   safeCommandError.value = ''
   safeCommandsBusy.value = cliId
@@ -228,7 +291,6 @@ async function toggleSafeCommand(cliId, action) {
     safeCommandsBusy.value = null
   }
 }
-
 async function addCustomSafeCommand() {
   const cliId = customInput.value.trim()
   if (!cliId) return
@@ -259,7 +321,6 @@ async function addCustomSafeCommand() {
     safeCommandsBusy.value = null
   }
 }
-
 async function removeCustomSafeCommand(grant) {
   safeCommandError.value = ''
   const cliId = grant?.request?.cli_id
@@ -445,6 +506,127 @@ async function removeCustomSafeCommand(grant) {
               </tr>
             </tbody>
           </table>
+        </UCard>
+
+        <!-- YOLO-Modus Section -->
+        <UCard class="mb-6" :ui="{ body: yoloPolicy ? 'p-0' : '' }">
+          <template #header>
+            <div class="flex items-center gap-2">
+              <h2 class="text-lg font-semibold">
+                YOLO-Modus
+              </h2>
+              <UBadge v-if="yoloPolicy" color="warning" variant="subtle" size="sm">
+                aktiv
+              </UBadge>
+            </div>
+            <p class="text-sm text-muted mt-1">
+              Auto-approval für alle Grant-Requests dieses Agents — außer Deny-Pattern oder
+              Risiko-Schwelle greifen. Der Agent sieht keinen Unterschied zu einer
+              menschlichen Bestätigung; nur der Audit-Trail markiert diese Grants als
+              <span class="font-mono">auto_approval_kind: 'yolo'</span>.
+            </p>
+          </template>
+
+          <UAlert
+            v-if="yoloError"
+            color="error"
+            :title="yoloError"
+            class="mb-4"
+            @close="yoloError = ''"
+          />
+
+          <div v-if="yoloLoading" class="text-sm text-muted">
+            Lade…
+          </div>
+
+          <div v-else-if="!yoloPolicy && !yoloEditing">
+            <p class="text-sm text-muted mb-3">
+              Derzeit inaktiv. Alle Grant-Requests dieses Agents warten auf menschliche Bestätigung.
+            </p>
+            <UButton color="warning" icon="i-lucide-zap" @click="startYoloEditing">
+              YOLO-Modus aktivieren
+            </UButton>
+          </div>
+
+          <div v-else-if="yoloPolicy && !yoloEditing" class="p-4">
+            <dl class="grid grid-cols-[auto_1fr] gap-x-6 gap-y-2 text-sm">
+              <dt class="text-muted">
+                Aktiviert von
+              </dt>
+              <dd class="font-mono">
+                {{ yoloPolicy.enabledBy }}
+              </dd>
+              <dt class="text-muted">
+                Risiko-Schwelle
+              </dt>
+              <dd>
+                <span v-if="yoloPolicy.denyRiskThreshold" class="font-mono">
+                  {{ yoloPolicy.denyRiskThreshold }}
+                </span>
+                <span v-else class="text-muted italic">keine</span>
+                <span class="text-muted text-xs ml-2">
+                  (Requests mit Risiko ≥ Schwelle fallen auf manuell zurück)
+                </span>
+              </dd>
+              <dt class="text-muted">
+                Deny-Patterns
+              </dt>
+              <dd>
+                <span v-if="yoloPolicy.denyPatterns.length === 0" class="text-muted italic">
+                  keine
+                </span>
+                <ul v-else class="font-mono text-xs space-y-1">
+                  <li
+                    v-for="p in yoloPolicy.denyPatterns"
+                    :key="p"
+                    class="inline-block bg-(--ui-bg-elevated) px-2 py-0.5 rounded mr-1"
+                  >
+                    {{ p }}
+                  </li>
+                </ul>
+              </dd>
+              <dt class="text-muted">
+                Ablauf
+              </dt>
+              <dd>
+                <span v-if="yoloExpiryInfo">{{ yoloExpiryInfo }}</span>
+                <span v-else class="text-muted italic">unbefristet</span>
+              </dd>
+            </dl>
+            <div class="flex gap-2 mt-4">
+              <UButton icon="i-lucide-pencil" variant="outline" @click="startYoloEditing">
+                Bearbeiten
+              </UButton>
+              <UButton color="error" variant="outline" icon="i-lucide-trash-2" @click="disableYoloPolicy">
+                Deaktivieren
+              </UButton>
+            </div>
+          </div>
+
+          <div v-else class="space-y-4">
+            <UFormField label="Risiko-Schwelle">
+              <USelect v-model="yoloForm.denyRiskThreshold" :items="riskOptions" />
+              <template #help>
+                Requests mit diesem oder höherem Risiko brauchen weiter menschliche Bestätigung.
+                Leer lassen, um die Schwelle zu deaktivieren.
+              </template>
+            </UFormField>
+            <UFormField label="Deny-Patterns (eine Zeile, Glob-Syntax: * ?)">
+              <UTextarea
+                v-model="yoloForm.denyPatterns"
+                :rows="4"
+                placeholder="rm -rf *&#10;sudo *&#10;curl*| sh"
+              />
+            </UFormField>
+            <div class="flex gap-2">
+              <UButton color="warning" icon="i-lucide-save" :loading="yoloSubmitting" @click="saveYoloPolicy">
+                {{ yoloPolicy ? "Speichern" : "Aktivieren" }}
+              </UButton>
+              <UButton variant="ghost" @click="yoloEditing = false">
+                Abbrechen
+              </UButton>
+            </div>
+          </div>
         </UCard>
 
         <!-- Add Standing Grant Form -->

--- a/modules/nuxt-auth-idp/src/runtime/pages/grants.vue
+++ b/modules/nuxt-auth-idp/src/runtime/pages/grants.vue
@@ -45,7 +45,6 @@ async function loadSimilarGrants(grantId) {
     }
   }
   catch {
-    // ignore
   }
 }
 function hasSimilar(grantId) {
@@ -106,7 +105,6 @@ async function loadMoreHistory() {
     historyHasMore.value = res.pagination?.has_more ?? false
   }
   catch {
-    // ignore
   }
   finally {
     loadingHistory.value = false
@@ -417,8 +415,24 @@ function isExactCommand(detail) {
                   <p v-if="grant.request.reason">
                     <span class="text-muted">Reason:</span> {{ grant.request.reason }}
                   </p>
-                  <p v-if="grant.decided_by" class="text-xs text-dimmed">
-                    Approved by: {{ grant.decided_by }}
+                  <p v-if="grant.decided_by" class="text-xs text-dimmed flex items-center gap-2">
+                    <span>Approved by: {{ grant.decided_by }}</span>
+                    <UBadge
+                      v-if="grant.auto_approval_kind === 'yolo'"
+                      color="warning"
+                      variant="subtle"
+                      size="xs"
+                    >
+                      YOLO
+                    </UBadge>
+                    <UBadge
+                      v-else-if="grant.auto_approval_kind === 'standing'"
+                      color="info"
+                      variant="subtle"
+                      size="xs"
+                    >
+                      Standing
+                    </UBadge>
                   </p>
                   <p v-if="grant.expires_at" class="text-xs text-dimmed">
                     Expires: {{ formatTime(grant.expires_at) }}
@@ -491,8 +505,24 @@ function isExactCommand(detail) {
                 <p v-if="grant.request.reason">
                   <span class="text-muted">Reason:</span> {{ grant.request.reason }}
                 </p>
-                <p v-if="grant.decided_by" class="text-xs text-dimmed">
-                  Decided by: {{ grant.decided_by }}
+                <p v-if="grant.decided_by" class="text-xs text-dimmed flex items-center gap-2">
+                  <span>Decided by: {{ grant.decided_by }}</span>
+                  <UBadge
+                    v-if="grant.auto_approval_kind === 'yolo'"
+                    color="warning"
+                    variant="subtle"
+                    size="xs"
+                  >
+                    YOLO
+                  </UBadge>
+                  <UBadge
+                    v-else-if="grant.auto_approval_kind === 'standing'"
+                    color="info"
+                    variant="subtle"
+                    size="xs"
+                  >
+                    Standing
+                  </UBadge>
                 </p>
                 <p class="text-xs text-dimmed">
                   Created: {{ formatTime(grant.created_at) }}

--- a/modules/nuxt-auth-idp/src/runtime/server/api/grants/index.post.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/api/grants/index.post.ts
@@ -1,9 +1,13 @@
 import type { GrantType, OpenApeAuthorizationDetail, OpenApeCliAuthorizationDetail, OpenApeGrantRequest } from '@openape/core'
 import { computeCmdHash } from '@openape/core'
-import { canonicalizeCliPermission, cliAuthorizationDetailsCover, computeArgvHash, createGrant, evaluateStandingGrants, findSimilarCliGrants, isCliAuthorizationDetailExact, validateCliAuthorizationDetail } from '@openape/grants'
+import { canonicalizeCliPermission, cliAuthorizationDetailsCover, computeArgvHash, createGrant, evaluateStandingGrants, findSimilarCliGrants, isCliAuthorizationDetailExact, resolveServerShape, validateCliAuthorizationDetail } from '@openape/grants'
 import { defineEventHandler, readBody, setResponseStatus } from 'h3'
 import { tryBearerAuth } from '../../utils/agent-auth'
 import { useGrantStores } from '../../utils/grant-stores'
+import { useIdpStores } from '../../utils/stores'
+import { useShapeStore } from '../../utils/shape-store'
+import { commandFromRequest, evaluateYoloPolicy } from '../../utils/grant-auto-approval'
+import type { RiskLevel } from '../../utils/yolo-policy-store'
 import { createProblemError } from '../../utils/problem'
 
 const VALID_GRANT_TYPES: GrantType[] = ['once', 'timed', 'always']
@@ -185,11 +189,52 @@ export default defineEventHandler(async (event) => {
         // We derive it from the standing grant via its id — look up once.
         decided_by: (await grantStore.findById(standingMatch.standing_grant_id))?.decided_by ?? undefined,
         decided_by_standing_grant: standingMatch.standing_grant_id,
+        auto_approval_kind: 'standing' as const,
       }
       await grantStore.updateStatus(pendingGrant.id, 'approved', approvedExtra)
       const approvedGrant = await grantStore.findById(pendingGrant.id)
       setResponseStatus(event, 201)
       return { ...approvedGrant, approved_automatically: true }
+    }
+
+    // YOLO auto-approval — per-agent policy. Runs after standing-grant
+    // miss, so standing grants stay the more specific match.
+    {
+      const { yoloPolicyStore } = useIdpStores()
+      const policy = await yoloPolicyStore.get(body.requester)
+      const cmd = commandFromRequest(body)
+      let resolvedRisk: RiskLevel | null = null
+      if (policy?.denyRiskThreshold && cmd && cmd.length > 0) {
+        // Unresolved / unknown shapes fall back to 'high' so an agent
+        // can't sneak a sensitive op past the threshold by not shipping
+        // a shape for it.
+        try {
+          const shapeStore = useShapeStore()
+          const resolved = await resolveServerShape(shapeStore, cmd[0]!, cmd)
+          resolvedRisk = (resolved.synthetic ? 'high' : resolved.detail.risk) as RiskLevel
+        }
+        catch {
+          resolvedRisk = 'high'
+        }
+      }
+      const yolo = evaluateYoloPolicy({
+        policy,
+        command: cmd,
+        resolvedRisk,
+      })
+      if (yolo) {
+        const pendingGrant = await createGrant(body, grantStore)
+        const now = Math.floor(Date.now() / 1000)
+        await grantStore.updateStatus(pendingGrant.id, 'approved', {
+          status: 'approved' as const,
+          decided_at: now,
+          decided_by: yolo.decidedBy,
+          auto_approval_kind: 'yolo' as const,
+        } as Record<string, unknown>)
+        const approvedGrant = await grantStore.findById(pendingGrant.id)
+        setResponseStatus(event, 201)
+        return { ...approvedGrant, approved_automatically: true }
+      }
     }
 
     // Similarity check: find approved CLI grants that overlap but don't cover

--- a/modules/nuxt-auth-idp/src/runtime/server/api/users/[email]/yolo-policy.delete.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/api/users/[email]/yolo-policy.delete.ts
@@ -1,0 +1,15 @@
+import { defineEventHandler, getRouterParam, setResponseStatus } from 'h3'
+import { requireYoloPolicyActor } from '../../../utils/yolo-policy-auth'
+import { useIdpStores } from '../../../utils/stores'
+import { createProblemError } from '../../../utils/problem'
+
+export default defineEventHandler(async (event) => {
+  const email = decodeURIComponent(getRouterParam(event, 'email') || '')
+  if (!email) throw createProblemError({ status: 400, title: 'Email is required' })
+
+  await requireYoloPolicyActor(event, email)
+  const { yoloPolicyStore } = useIdpStores()
+  await yoloPolicyStore.delete(email)
+  setResponseStatus(event, 204)
+  return null
+})

--- a/modules/nuxt-auth-idp/src/runtime/server/api/users/[email]/yolo-policy.get.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/api/users/[email]/yolo-policy.get.ts
@@ -1,0 +1,15 @@
+import { defineEventHandler, getRouterParam } from 'h3'
+import { requireYoloPolicyActor } from '../../../utils/yolo-policy-auth'
+import { useIdpStores } from '../../../utils/stores'
+import { createProblemError } from '../../../utils/problem'
+
+export default defineEventHandler(async (event) => {
+  const email = decodeURIComponent(getRouterParam(event, 'email') || '')
+  if (!email) throw createProblemError({ status: 400, title: 'Email is required' })
+
+  await requireYoloPolicyActor(event, email)
+  const { yoloPolicyStore } = useIdpStores()
+  const policy = await yoloPolicyStore.get(email)
+  // Wrapped so null renders as a JSON body (h3 returns 204 for bare-null returns).
+  return { policy }
+})

--- a/modules/nuxt-auth-idp/src/runtime/server/api/users/[email]/yolo-policy.put.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/api/users/[email]/yolo-policy.put.ts
@@ -1,0 +1,67 @@
+import { defineEventHandler, getRouterParam, readBody } from 'h3'
+import { requireYoloPolicyActor } from '../../../utils/yolo-policy-auth'
+import { useIdpStores } from '../../../utils/stores'
+import { createProblemError } from '../../../utils/problem'
+import type { RiskLevel, YoloPolicy } from '../../../utils/yolo-policy-store'
+
+const VALID_RISK: RiskLevel[] = ['low', 'medium', 'high', 'critical']
+const MAX_PATTERNS = 64
+const MAX_PATTERN_LEN = 200
+
+export default defineEventHandler(async (event) => {
+  const agentEmail = decodeURIComponent(getRouterParam(event, 'email') || '')
+  if (!agentEmail) throw createProblemError({ status: 400, title: 'Email is required' })
+
+  const caller = await requireYoloPolicyActor(event, agentEmail)
+  const body = await readBody<{
+    denyRiskThreshold?: RiskLevel | null
+    denyPatterns?: string[]
+    expiresAt?: number | null
+  }>(event)
+
+  if (body.denyRiskThreshold !== undefined && body.denyRiskThreshold !== null && !VALID_RISK.includes(body.denyRiskThreshold)) {
+    throw createProblemError({ status: 400, title: `denyRiskThreshold must be one of: ${VALID_RISK.join(', ')}` })
+  }
+  if (body.denyPatterns !== undefined) {
+    if (!Array.isArray(body.denyPatterns)) {
+      throw createProblemError({ status: 400, title: 'denyPatterns must be an array of strings' })
+    }
+    if (body.denyPatterns.length > MAX_PATTERNS) {
+      throw createProblemError({ status: 400, title: `denyPatterns may contain at most ${MAX_PATTERNS} entries` })
+    }
+    for (const p of body.denyPatterns) {
+      if (typeof p !== 'string' || p.length === 0 || p.length > MAX_PATTERN_LEN) {
+        throw createProblemError({ status: 400, title: `Each denyPattern must be a non-empty string up to ${MAX_PATTERN_LEN} chars` })
+      }
+    }
+  }
+  if (body.expiresAt !== undefined && body.expiresAt !== null) {
+    if (!Number.isFinite(body.expiresAt) || body.expiresAt <= Math.floor(Date.now() / 1000)) {
+      throw createProblemError({ status: 400, title: 'expiresAt must be a future unix-seconds timestamp' })
+    }
+  }
+
+  const { yoloPolicyStore } = useIdpStores()
+  const existing = await yoloPolicyStore.get(agentEmail)
+  const now = Math.floor(Date.now() / 1000)
+  const policy: YoloPolicy = {
+    agentEmail,
+    enabledBy: caller === '_management_' ? (existing?.enabledBy ?? caller) : caller,
+    denyRiskThreshold: body.denyRiskThreshold !== undefined ? body.denyRiskThreshold : (existing?.denyRiskThreshold ?? null),
+    denyPatterns: body.denyPatterns !== undefined ? normalisePatterns(body.denyPatterns) : (existing?.denyPatterns ?? []),
+    enabledAt: existing?.enabledAt ?? now,
+    expiresAt: body.expiresAt !== undefined ? body.expiresAt : (existing?.expiresAt ?? null),
+    updatedAt: now,
+  }
+  await yoloPolicyStore.put(policy)
+  return { policy }
+})
+
+function normalisePatterns(input: string[]): string[] {
+  const out: string[] = []
+  for (const p of input) {
+    const trimmed = p.trim()
+    if (trimmed && !out.includes(trimmed)) out.push(trimmed)
+  }
+  return out
+}

--- a/modules/nuxt-auth-idp/src/runtime/server/utils/define-stores.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/utils/define-stores.ts
@@ -4,6 +4,7 @@ import type { ShapeStore } from '@openape/grants'
 import type { ExtendedGrantStore } from './grant-store'
 import type { ChallengeStore as GrantChallengeStore } from './grant-challenge-store'
 import type { SshKeyStore } from './ssh-key-store'
+import type { YoloPolicyStore } from './yolo-policy-store'
 import { registerStoreFactory } from './store-registry'
 
 // Grant Stores (Gruppe B)
@@ -60,4 +61,10 @@ export function defineSshKeyStore(factory: (event: H3Event) => SshKeyStore) {
 
 export function defineShapeStore(factory: (event: H3Event) => ShapeStore) {
   registerStoreFactory('shapeStore', factory)
+}
+
+// YOLO Policy Store (per-agent auto-approval)
+
+export function defineYoloPolicyStore(factory: (event: H3Event) => YoloPolicyStore) {
+  registerStoreFactory('yoloPolicyStore', factory)
 }

--- a/modules/nuxt-auth-idp/src/runtime/server/utils/grant-auto-approval.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/utils/grant-auto-approval.ts
@@ -1,0 +1,75 @@
+import type { OpenApeGrantRequest } from '@openape/core'
+import type { YoloPolicy, RiskLevel } from './yolo-policy-store'
+
+const RISK_ORDER: Record<RiskLevel, number> = {
+  low: 1,
+  medium: 2,
+  high: 3,
+  critical: 4,
+}
+
+export interface YoloEvaluation {
+  kind: 'yolo'
+  decidedBy: string
+}
+
+export interface YoloDecisionContext {
+  policy: YoloPolicy | null
+  command: string[] | undefined
+  resolvedRisk: RiskLevel | null
+  now?: number
+}
+
+/**
+ * Decide whether a grant request should be auto-approved by the agent's
+ * YOLO policy. Returns the approval marker on match, null on miss (caller
+ * falls back to the normal manual approval flow).
+ *
+ * Contract:
+ *  - No policy, expired policy, or no command → miss.
+ *  - Resolved-risk meets or exceeds policy.denyRiskThreshold → miss.
+ *  - Command matches any deny-pattern (glob) → miss.
+ *  - Otherwise → match with decidedBy = policy.enabledBy.
+ */
+export function evaluateYoloPolicy(ctx: YoloDecisionContext): YoloEvaluation | null {
+  const now = ctx.now ?? Math.floor(Date.now() / 1000)
+  const p = ctx.policy
+  if (!p) return null
+  if (p.expiresAt != null && p.expiresAt <= now) return null
+
+  const cmd = ctx.command && ctx.command.length ? ctx.command.join(' ') : null
+  if (!cmd) return null
+
+  if (ctx.resolvedRisk && p.denyRiskThreshold) {
+    if (RISK_ORDER[ctx.resolvedRisk] >= RISK_ORDER[p.denyRiskThreshold]) return null
+  }
+
+  for (const pattern of p.denyPatterns || []) {
+    if (matchesGlob(cmd, pattern)) return null
+  }
+
+  return { kind: 'yolo', decidedBy: p.enabledBy }
+}
+
+/**
+ * Minimal glob matcher — `*` matches any run of characters (greedy),
+ * `?` matches exactly one. Case-sensitive; no character classes. Kept
+ * local to avoid pulling a dependency for a handful of patterns.
+ */
+export function matchesGlob(input: string, pattern: string): boolean {
+  const escaped = pattern.replace(/[\\^$.+(){}[\]|]/g, ch => `\\${ch}`)
+  const regexSrc = `^${escaped.replace(/\*/g, '.*').replace(/\?/g, '.')}$`
+  try {
+    return new RegExp(regexSrc).test(input)
+  }
+  catch {
+    return false
+  }
+}
+
+export function commandFromRequest(body: OpenApeGrantRequest): string[] | undefined {
+  if (body.command?.length) return body.command
+  const argv = body.execution_context?.argv
+  if (argv?.length) return [...argv]
+  return undefined
+}

--- a/modules/nuxt-auth-idp/src/runtime/server/utils/stores.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/utils/stores.ts
@@ -11,6 +11,8 @@ import { createRegistrationUrlStore } from './registration-url-store'
 import { createSshKeyStore } from './ssh-key-store'
 import type { SshKeyStore } from './ssh-key-store'
 import { createUserStore } from './user-store'
+import { createYoloPolicyStore } from './yolo-policy-store'
+import type { YoloPolicyStore } from './yolo-policy-store'
 import { getStoreFactory } from './store-registry'
 
 interface IdpStores {
@@ -23,6 +25,7 @@ interface IdpStores {
   jtiStore: JtiStore
   refreshTokenStore: RefreshTokenStore
   sshKeyStore: SshKeyStore
+  yoloPolicyStore: YoloPolicyStore
 }
 
 let _stores: IdpStores | null = null
@@ -38,6 +41,7 @@ function initDefaultStores(): IdpStores {
     jtiStore: createJtiStore(),
     refreshTokenStore: createRefreshTokenStore(),
     sshKeyStore: createSshKeyStore(),
+    yoloPolicyStore: createYoloPolicyStore(),
   }
 }
 
@@ -52,6 +56,7 @@ function initStoresWithRegistry(event: H3Event): IdpStores {
     jtiStore: getStoreFactory<JtiStore>('jtiStore')?.(event) ?? createJtiStore(),
     refreshTokenStore: getStoreFactory<RefreshTokenStore>('refreshTokenStore')?.(event) ?? createRefreshTokenStore(),
     sshKeyStore: getStoreFactory<SshKeyStore>('sshKeyStore')?.(event) ?? createSshKeyStore(),
+    yoloPolicyStore: getStoreFactory<YoloPolicyStore>('yoloPolicyStore')?.(event) ?? createYoloPolicyStore(),
   }
 }
 

--- a/modules/nuxt-auth-idp/src/runtime/server/utils/yolo-policy-auth.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/utils/yolo-policy-auth.ts
@@ -1,0 +1,31 @@
+import type { H3Event } from 'h3'
+import { requireAuth, isAdmin } from './admin'
+import { useIdpStores } from './stores'
+import { createProblemError } from './problem'
+
+/**
+ * Guard for YOLO-policy mutations. Returns the caller's identity.
+ * Caller must be (a) the management token, (b) an admin, or (c) the
+ * owner/approver of the target agent.
+ */
+export async function requireYoloPolicyActor(event: H3Event, agentEmail: string): Promise<string> {
+  const caller = await requireAuth(event)
+
+  const { userStore } = useIdpStores()
+  const target = await userStore.findByEmail(agentEmail)
+  if (!target) {
+    throw createProblemError({ status: 404, title: 'Agent not found' })
+  }
+  if (target.type !== 'agent') {
+    throw createProblemError({ status: 400, title: 'YOLO-Policies apply to agents only' })
+  }
+
+  if (caller === '_management_') return caller
+  if (isAdmin(caller)) return caller
+  if (caller === target.owner || caller === target.approver) return caller
+
+  throw createProblemError({
+    status: 403,
+    title: 'Only the agent owner or approver may manage its YOLO-Policy',
+  })
+}

--- a/modules/nuxt-auth-idp/src/runtime/server/utils/yolo-policy-store.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/utils/yolo-policy-store.ts
@@ -1,0 +1,49 @@
+import { useIdpStorage } from './storage'
+
+export type RiskLevel = 'low' | 'medium' | 'high' | 'critical'
+
+export interface YoloPolicy {
+  agentEmail: string
+  enabledBy: string
+  /** Auto-approval stops when the resolved shape risk meets or exceeds this. */
+  denyRiskThreshold: RiskLevel | null
+  /** Glob patterns that drop the request back to the normal approval flow. */
+  denyPatterns: string[]
+  enabledAt: number
+  /** Unix seconds; null = no expiry. */
+  expiresAt: number | null
+  updatedAt: number
+}
+
+export interface YoloPolicyStore {
+  get: (agentEmail: string) => Promise<YoloPolicy | null>
+  put: (policy: YoloPolicy) => Promise<void>
+  delete: (agentEmail: string) => Promise<void>
+  list: () => Promise<YoloPolicy[]>
+}
+
+export function createYoloPolicyStore(): YoloPolicyStore {
+  const storage = useIdpStorage()
+  const key = (email: string) => `yolo-policies:${email}`
+
+  return {
+    async get(email) {
+      return (await storage.getItem<YoloPolicy>(key(email))) || null
+    },
+    async put(policy) {
+      await storage.setItem(key(policy.agentEmail), policy)
+    },
+    async delete(email) {
+      await storage.removeItem(key(email))
+    },
+    async list() {
+      const keys = await storage.getKeys('yolo-policies:')
+      const out: YoloPolicy[] = []
+      for (const k of keys) {
+        const v = await storage.getItem<YoloPolicy>(k)
+        if (v) out.push(v)
+      }
+      return out
+    },
+  }
+}

--- a/modules/nuxt-auth-idp/test/grants-create.test.ts
+++ b/modules/nuxt-auth-idp/test/grants-create.test.ts
@@ -25,6 +25,27 @@ vi.mock('../src/runtime/server/utils/grant-stores', () => ({
   }),
 }))
 
+vi.mock('../src/runtime/server/utils/stores', () => ({
+  useIdpStores: () => ({
+    yoloPolicyStore: {
+      get: async () => null,
+      put: async () => {},
+      delete: async () => {},
+      list: async () => [],
+    },
+  }),
+  getIdpIssuer: () => 'http://localhost:3000',
+}))
+
+vi.mock('../src/runtime/server/utils/shape-store', () => ({
+  useShapeStore: () => ({
+    getShape: async () => null,
+    saveShape: async () => {},
+    listShapes: async () => [],
+    deleteShape: async () => {},
+  }),
+}))
+
 function shapesDetail(overrides: Partial<{
   operation_id: string
   resource_chain: Array<{ resource: string, selector?: Record<string, string> }>

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -213,6 +213,14 @@ export interface OpenApeGrant {
    * Null/undefined for grants decided via the normal manual approval flow.
    */
   decided_by_standing_grant?: string
+  /**
+   * Which auto-approval path decided this grant.
+   *   undefined — human decision (default)
+   *   'standing' — matched a standing grant
+   *   'yolo' — matched a per-agent YOLO auto-approval policy
+   * Purely informational; consumers that don't know the field simply ignore it.
+   */
+  auto_approval_kind?: 'standing' | 'yolo'
 }
 
 /** OpenApe AuthZ-JWT claims */


### PR DESCRIPTION
## Summary

Introduces an opt-in per-agent YOLO mode for grant approval. Owner/approver of an agent enables it on `/agents/:email`. Matching grant requests auto-approve server-side with no change to the agent-facing flow — same JWT shape, same protocol. Audit trail records the auto-approval path.

## Scope boundaries

- **IdP-only**: all logic lives in `@openape/nuxt-auth-idp` + `apps/openape-free-idp`. No changes to `@openape/apes`, `@openape/grants`, or `escapes`.
- **JWT unchanged**: agents see the same token on a YOLO-approved grant as on a human-approved one. No new claims, no consumer-side changes required.
- `OpenApeGrant.auto_approval_kind` added to `@openape/core` as an optional field. Consumers that ignore it are unaffected.

## Data model

- New table `yolo_policies` (agent_email PK) + idempotent migration in `02.database.ts`.
- New column `grants.auto_approval_kind` — `null` (human) / `'standing'` / `'yolo'`. Additive; existing rows stay `null`.

## API

Session-auth + owner/approver/admin guard; target user must have `type='agent'`:
- `GET /api/users/:email/yolo-policy` → `{ policy: YoloPolicy | null }`
- `PUT /api/users/:email/yolo-policy` — upsert with field-level merge
- `DELETE /api/users/:email/yolo-policy` → 204

## Evaluator

In `grants/index.post.ts`, runs **after** standing-grant-miss:
1. No policy / expired policy → skip (normal flow).
2. Deny-pattern match (glob `*` / `?`) → skip.
3. Shape-resolver risk ≥ `denyRiskThreshold` → skip. Unresolved shape → `risk='high'` (conservative).
4. Otherwise → create + approve, stamp `decided_by = policy.enabledBy`, `auto_approval_kind = 'yolo'`.

## UI

- New section on `/agents/:email`:
  - Status (aktiv / inaktiv), enabled-by, current config.
  - Toggle / edit / disable flow.
  - Risk-threshold dropdown (default: `high`) + deny-patterns textarea.
- `/grants` badges approved entries with `Standing` or `YOLO` when auto-approved.

## Test plan

- [x] Full suite: 51 tests across 8 files, 19s runtime (file-parallelism disabled for server-spawning suites).
- [x] `tests/yolo-policy.test.ts`: admin CRUD (GET/PUT/DELETE, partial update, invalid risk, non-agent target, owner-only).
- [x] Integration: YOLO-approval happy path, deny-pattern drop-back, risk-threshold drop-back, expired policy no-op.
- [x] `tests/yolo-evaluator.test.ts`: 12 pure-logic cases for `matchesGlob` + `evaluateYoloPolicy`.
- [x] No regression in `ssh-key-human-login.test.ts`, `shapes-e2e.test.ts`, etc.

## Plan

Tracked at plans.openape.ai: `01KPXJRYYCD51PR6AJZ6HXYAVM`.