### PR TITLE
fix(nuxt-auth-sp): explicit maxAge on logged-in session cookie

### DIFF
--- a/.changeset/fix-sp-session-max-age.md
+++ b/.changeset/fix-sp-session-max-age.md
@@ -1,0 +1,9 @@
+---
+'@openape/nuxt-auth-sp': minor
+---
+
+Explicit `maxAge` on the logged-in session cookie (`openape-sp`) so iOS Safari keeps the session across tab-close / backgrounding.
+
+- New `openapeSp.sessionMaxAge` module option (default: 604800 seconds = 7 days). Env: `NUXT_OPENAPE_SP_SESSION_MAX_AGE`.
+- `getSpSession` now sets `cookie.maxAge` + `cookie.httpOnly` + `cookie.secure` + `cookie.sameSite: 'lax'` explicitly. Previous behaviour relied on h3's default (session cookie without explicit expiry), which iOS aggressively evicts.
+- Backwards compatible: existing apps inherit the 7-day default without any config change.

--- a/modules/nuxt-auth-sp/src/module.ts
+++ b/modules/nuxt-auth-sp/src/module.ts
@@ -45,6 +45,13 @@ export interface ModuleOptions {
   clientId: string
   spName: string
   sessionSecret: string
+  /**
+   * Logged-in session cookie lifetime in seconds. Default: 7 days.
+   * iOS Safari aggressively evicts session cookies (no explicit expiry),
+   * so an explicit `maxAge` is what keeps users signed in on mobile.
+   * Env: `NUXT_OPENAPE_SP_SESSION_MAX_AGE`.
+   */
+  sessionMaxAge: number
   openapeUrl: string
   fallbackIdpUrl: string
   routes: boolean
@@ -62,6 +69,7 @@ export default defineNuxtModule<ModuleOptions>({
     clientId: '',
     spName: 'OpenApe Service Provider',
     sessionSecret: 'change-me-sp-secret-at-least-32-chars-long',
+    sessionMaxAge: 60 * 60 * 24 * 7, // 7 days
     openapeUrl: '',
     fallbackIdpUrl: 'https://id.openape.at',
     routes: true,

--- a/modules/nuxt-auth-sp/src/runtime/server/utils/sp-session.ts
+++ b/modules/nuxt-auth-sp/src/runtime/server/utils/sp-session.ts
@@ -2,10 +2,22 @@ import type { H3Event } from 'h3'
 import { useSession } from 'h3'
 import { useRuntimeConfig } from 'nitropack/runtime'
 
+const DEFAULT_SESSION_MAX_AGE = 60 * 60 * 24 * 7 // 7 days
+
 export async function getSpSession(event: H3Event) {
   const config = useRuntimeConfig()
+  const maxAge = Number(config.openapeSp.sessionMaxAge) || DEFAULT_SESSION_MAX_AGE
   return await useSession(event, {
     name: 'openape-sp',
     password: config.openapeSp.sessionSecret,
+    // Explicit max-age so iOS Safari doesn't evict this as a session cookie.
+    maxAge,
+    cookie: {
+      httpOnly: true,
+      secure: true,
+      sameSite: 'lax',
+      path: '/',
+      maxAge,
+    },
   })
 }


### PR DESCRIPTION
## Problem

iOS Safari aggressively evicts cookies that don't carry an explicit `expires` or `max-age` attribute. The logged-in `openape-sp` session cookie was falling back to h3's default (session-only, no `Expires`), so mobile users on plans.openape.ai were getting logged out every time the tab was backgrounded or the browser was closed.

## Fix

- New `openapeSp.sessionMaxAge` module option (default **604800 seconds = 7 days**). Env-overridable via `NUXT_OPENAPE_SP_SESSION_MAX_AGE`.
- `getSpSession` now passes `cookie.maxAge`, `cookie.httpOnly`, `cookie.secure`, and `cookie.sameSite: 'lax'` explicitly.

## Compatibility

Backwards compatible: existing apps inherit the 7-day default with no config change. Apps that want different lifetimes set `openapeSp.sessionMaxAge` in their `nuxt.config.ts`.

## Test plan
- [x] `pnpm --filter @openape/nuxt-auth-sp build` passes
- [x] `pnpm --filter @openape/nuxt-auth-sp test` passes
- [ ] Manual: sign into plans.openape.ai on iPhone, close tab, reopen after a few minutes — session still active.