### PR TITLE
feat(idp): unify token aud='apes-cli' across all auth flows

### DIFF
--- a/.changeset/idp-audience-unify.md
+++ b/.changeset/idp-audience-unify.md
@@ -1,0 +1,13 @@
+---
+'@openape/nuxt-auth-idp': minor
+'@openape/server': minor
+---
+
+IdP-issued auth tokens now carry `aud='apes-cli'` consistently across every flow (PKCE / authorization-code, client-credentials, agent-challenge-response). Previously only the PKCE flow set an audience claim; SSH-key and challenge-response flows issued audience-less tokens, which made it impossible for downstream service providers to do scoped replay-protection on token-exchange endpoints.
+
+- `issueAuthToken` and `issueAgentToken` (in both `@openape/nuxt-auth-idp` and `@openape/server`) accept an optional `aud` parameter and default to `'apes-cli'`.
+- New `DEFAULT_CLI_AUDIENCE` constant exported for downstream consumers (`expectedAud`).
+- `verifyAuthToken` / `verifyAgentToken` accept an optional `expectedAud` parameter for audience-restricted verification. When omitted, audience is not checked (preserves backward compatibility with consumers that don't care).
+- Existing in-flight tokens (max 1h lifetime) are unaffected; new issuance immediately sets the audience.
+
+This is a precondition for the upcoming token-exchange endpoint on plans / tasks / secrets / seeds SPs that need to enforce `expectedAud='apes-cli'` to reject replays of id_tokens or delegation tokens against the exchange.

--- a/modules/nuxt-auth-idp/src/runtime/server/utils/agent-token.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/utils/agent-token.ts
@@ -4,13 +4,24 @@ import { jwtVerify, SignJWT } from 'jose'
 
 // --- Generalized auth token (supports both 'agent' and 'human') ---
 
+/**
+ * Default audience for CLI-issued tokens. Every token issued by the IdP for
+ * the apes ecosystem carries `aud='apes-cli'` so that downstream service
+ * providers (plans, tasks, secrets, …) can enforce `expectedAud='apes-cli'`
+ * on their `/api/cli/exchange` endpoints and reject tokens minted for any
+ * other purpose (id_tokens, delegation tokens, future client-credentials
+ * with explicit audience).
+ */
+export const DEFAULT_CLI_AUDIENCE = 'apes-cli'
+
 export interface AuthTokenPayload {
   sub: string
   act: ActorType
+  aud?: string
 }
 
 export async function issueAuthToken(
-  payload: { sub: string, act: ActorType },
+  payload: { sub: string, act: ActorType, aud?: string },
   issuer: string,
   privateKey: KeyLike,
   kid?: string,
@@ -19,6 +30,7 @@ export async function issueAuthToken(
     .setProtectedHeader({ alg: 'EdDSA', ...(kid ? { kid } : {}) })
     .setIssuer(issuer)
     .setSubject(payload.sub)
+    .setAudience(payload.aud ?? DEFAULT_CLI_AUDIENCE)
     .setIssuedAt()
     .setExpirationTime('1h')
 
@@ -29,9 +41,11 @@ export async function verifyAuthToken(
   token: string,
   issuer: string,
   publicKey: KeyLike | Uint8Array,
+  expectedAud?: string,
 ): Promise<AuthTokenPayload> {
   const { payload } = await jwtVerify(token, publicKey, {
     issuer,
+    ...(expectedAud ? { audience: expectedAud } : {}),
     algorithms: ['EdDSA'],
   })
 
@@ -40,7 +54,11 @@ export async function verifyAuthToken(
     throw new Error('Invalid act claim')
   }
 
-  return { sub: payload.sub as string, act }
+  return {
+    sub: payload.sub as string,
+    act,
+    ...(typeof payload.aud === 'string' ? { aud: payload.aud } : {}),
+  }
 }
 
 // --- Agent-specific wrappers (backward compatibility) ---
@@ -48,23 +66,30 @@ export async function verifyAuthToken(
 export interface AgentTokenPayload {
   sub: string
   act: 'agent'
+  aud?: string
 }
 
 export async function issueAgentToken(
-  payload: { sub: string },
+  payload: { sub: string, aud?: string },
   issuer: string,
   privateKey: KeyLike,
   kid?: string,
 ): Promise<string> {
-  return issueAuthToken({ sub: payload.sub, act: 'agent' }, issuer, privateKey, kid)
+  return issueAuthToken(
+    { sub: payload.sub, act: 'agent', aud: payload.aud ?? DEFAULT_CLI_AUDIENCE },
+    issuer,
+    privateKey,
+    kid,
+  )
 }
 
 export async function verifyAgentToken(
   token: string,
   issuer: string,
   publicKey: KeyLike | Uint8Array,
+  expectedAud?: string,
 ): Promise<AgentTokenPayload> {
-  const result = await verifyAuthToken(token, issuer, publicKey)
+  const result = await verifyAuthToken(token, issuer, publicKey, expectedAud)
   if (result.act !== 'agent') {
     throw new Error('Not an agent token')
   }

--- a/modules/nuxt-auth-idp/test/agent-token-audience.test.ts
+++ b/modules/nuxt-auth-idp/test/agent-token-audience.test.ts
@@ -1,0 +1,102 @@
+import { decodeJwt, generateKeyPair } from 'jose'
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_CLI_AUDIENCE,
+  issueAgentToken,
+  issueAuthToken,
+  verifyAgentToken,
+  verifyAuthToken,
+} from '../src/runtime/server/utils/agent-token'
+
+const ISSUER = 'https://id.openape.test'
+
+async function getKeys() {
+  return await generateKeyPair('EdDSA')
+}
+
+describe('agent-token audience defaults', () => {
+  it('issueAuthToken defaults aud to DEFAULT_CLI_AUDIENCE', async () => {
+    const { privateKey } = await getKeys()
+    const token = await issueAuthToken(
+      { sub: 'me@example.com', act: 'human' },
+      ISSUER,
+      privateKey,
+    )
+    const payload = decodeJwt(token)
+    expect(payload.aud).toBe(DEFAULT_CLI_AUDIENCE)
+    expect(DEFAULT_CLI_AUDIENCE).toBe('apes-cli')
+  })
+
+  it('issueAuthToken honors explicit aud override', async () => {
+    const { privateKey } = await getKeys()
+    const token = await issueAuthToken(
+      { sub: 'me@example.com', act: 'agent', aud: 'custom-audience' },
+      ISSUER,
+      privateKey,
+    )
+    const payload = decodeJwt(token)
+    expect(payload.aud).toBe('custom-audience')
+  })
+
+  it('issueAgentToken sets aud=apes-cli by default', async () => {
+    const { privateKey } = await getKeys()
+    const token = await issueAgentToken(
+      { sub: 'agent@example.com' },
+      ISSUER,
+      privateKey,
+    )
+    const payload = decodeJwt(token)
+    expect(payload.aud).toBe(DEFAULT_CLI_AUDIENCE)
+    expect(payload.act).toBe('agent')
+  })
+
+  it('verifyAuthToken accepts a token without expectedAud', async () => {
+    const { privateKey, publicKey } = await getKeys()
+    const token = await issueAuthToken(
+      { sub: 'me@example.com', act: 'human' },
+      ISSUER,
+      privateKey,
+    )
+    const result = await verifyAuthToken(token, ISSUER, publicKey)
+    expect(result.sub).toBe('me@example.com')
+    expect(result.aud).toBe(DEFAULT_CLI_AUDIENCE)
+  })
+
+  it('verifyAuthToken accepts a matching expectedAud', async () => {
+    const { privateKey, publicKey } = await getKeys()
+    const token = await issueAuthToken(
+      { sub: 'me@example.com', act: 'human' },
+      ISSUER,
+      privateKey,
+    )
+    const result = await verifyAuthToken(token, ISSUER, publicKey, 'apes-cli')
+    expect(result.aud).toBe('apes-cli')
+  })
+
+  it('verifyAuthToken rejects a mismatched expectedAud', async () => {
+    const { privateKey, publicKey } = await getKeys()
+    const token = await issueAuthToken(
+      { sub: 'me@example.com', act: 'human' },
+      ISSUER,
+      privateKey,
+    )
+    await expect(
+      verifyAuthToken(token, ISSUER, publicKey, 'something-else'),
+    ).rejects.toThrow()
+  })
+
+  it('verifyAgentToken honors expectedAud', async () => {
+    const { privateKey, publicKey } = await getKeys()
+    const token = await issueAgentToken(
+      { sub: 'agent@example.com' },
+      ISSUER,
+      privateKey,
+    )
+    const result = await verifyAgentToken(token, ISSUER, publicKey, 'apes-cli')
+    expect(result.act).toBe('agent')
+    expect(result.aud).toBe('apes-cli')
+    await expect(
+      verifyAgentToken(token, ISSUER, publicKey, 'wrong-aud'),
+    ).rejects.toThrow()
+  })
+})

--- a/packages/server/src/__tests__/auth-token-audience.test.ts
+++ b/packages/server/src/__tests__/auth-token-audience.test.ts
@@ -1,0 +1,74 @@
+import { decodeJwt, generateKeyPair } from 'jose'
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_CLI_AUDIENCE,
+  issueAuthToken,
+  verifyAuthToken,
+} from '../idp/utils/auth-token.js'
+
+const ISSUER = 'https://id.openape.test'
+
+async function getKeys() {
+  return await generateKeyPair('EdDSA')
+}
+
+describe('idp/utils/auth-token audience', () => {
+  it('exports DEFAULT_CLI_AUDIENCE = apes-cli', () => {
+    expect(DEFAULT_CLI_AUDIENCE).toBe('apes-cli')
+  })
+
+  it('issueAuthToken defaults aud to apes-cli', async () => {
+    const { privateKey } = await getKeys()
+    const token = await issueAuthToken(
+      { sub: 'me@example.com', act: 'human' },
+      ISSUER,
+      privateKey,
+    )
+    expect(decodeJwt(token).aud).toBe('apes-cli')
+  })
+
+  it('issueAuthToken honors explicit aud', async () => {
+    const { privateKey } = await getKeys()
+    const token = await issueAuthToken(
+      { sub: 'me@example.com', act: 'agent', aud: 'sp.example' },
+      ISSUER,
+      privateKey,
+    )
+    expect(decodeJwt(token).aud).toBe('sp.example')
+  })
+
+  it('verifyAuthToken accepts matching expectedAud', async () => {
+    const { privateKey, publicKey } = await getKeys()
+    const token = await issueAuthToken(
+      { sub: 'me@example.com', act: 'agent' },
+      ISSUER,
+      privateKey,
+    )
+    const result = await verifyAuthToken(token, ISSUER, publicKey, 'apes-cli')
+    expect(result.act).toBe('agent')
+    expect(result.aud).toBe('apes-cli')
+  })
+
+  it('verifyAuthToken rejects mismatched expectedAud', async () => {
+    const { privateKey, publicKey } = await getKeys()
+    const token = await issueAuthToken(
+      { sub: 'me@example.com', act: 'agent' },
+      ISSUER,
+      privateKey,
+    )
+    await expect(
+      verifyAuthToken(token, ISSUER, publicKey, 'wrong-aud'),
+    ).rejects.toThrow()
+  })
+
+  it('verifyAuthToken without expectedAud accepts any aud', async () => {
+    const { privateKey, publicKey } = await getKeys()
+    const token = await issueAuthToken(
+      { sub: 'me@example.com', act: 'agent', aud: 'arbitrary' },
+      ISSUER,
+      privateKey,
+    )
+    const result = await verifyAuthToken(token, ISSUER, publicKey)
+    expect(result.aud).toBe('arbitrary')
+  })
+})

--- a/packages/server/src/idp/utils/auth-token.ts
+++ b/packages/server/src/idp/utils/auth-token.ts
@@ -2,13 +2,22 @@ import type { ActorType } from '@openape/core'
 import type { KeyLike } from 'jose'
 import { jwtVerify, SignJWT } from 'jose'
 
+/**
+ * Default audience for CLI-issued tokens. Every token issued by the IdP for
+ * the apes ecosystem carries `aud='apes-cli'` so that downstream service
+ * providers can enforce `expectedAud='apes-cli'` on their token-exchange
+ * endpoints and reject tokens minted for any other purpose.
+ */
+export const DEFAULT_CLI_AUDIENCE = 'apes-cli'
+
 export interface AuthTokenPayload {
   sub: string
   act: ActorType
+  aud?: string
 }
 
 export async function issueAuthToken(
-  payload: { sub: string, act: ActorType },
+  payload: { sub: string, act: ActorType, aud?: string },
   issuer: string,
   privateKey: KeyLike,
   kid?: string,
@@ -17,6 +26,7 @@ export async function issueAuthToken(
     .setProtectedHeader({ alg: 'EdDSA', ...(kid ? { kid } : {}) })
     .setIssuer(issuer)
     .setSubject(payload.sub)
+    .setAudience(payload.aud ?? DEFAULT_CLI_AUDIENCE)
     .setIssuedAt()
     .setExpirationTime('1h')
 
@@ -27,9 +37,11 @@ export async function verifyAuthToken(
   token: string,
   issuer: string,
   publicKey: KeyLike | Uint8Array,
+  expectedAud?: string,
 ): Promise<AuthTokenPayload> {
   const { payload } = await jwtVerify(token, publicKey, {
     issuer,
+    ...(expectedAud ? { audience: expectedAud } : {}),
     algorithms: ['EdDSA'],
   })
 
@@ -38,5 +50,9 @@ export async function verifyAuthToken(
     throw new Error('Invalid act claim')
   }
 
-  return { sub: payload.sub as string, act }
+  return {
+    sub: payload.sub as string,
+    act,
+    ...(typeof payload.aud === 'string' ? { aud: payload.aud } : {}),
+  }
 }


### PR DESCRIPTION
## Summary

Every token issued by id.openape.ai now carries `aud='apes-cli'`, regardless of the auth flow. Previously the audience claim was set only on PKCE-issued tokens (where `aud=client_id`); the SSH-key client-credentials flow and the Ed25519 agent challenge-response flow issued audience-less tokens.

Discovered while auditing the IdP for the upcoming OpenApe CLI SSO refactor — see `~/.claude/plans/openape-cli-sso.md` (M0 audit + M0.5 milestone for this PR).

## Why this matters

The next refactor adds `/api/cli/exchange` endpoints on plans, tasks, secrets, and seeds. Those endpoints accept an IdP-issued subject token and mint an SP-scoped token in return. To make the exchange replay-resistant against unrelated token types (id_tokens, future delegation tokens, anything else issued by the same IdP), the SP needs to assert `expectedAud='apes-cli'`. That assertion only works if the IdP sets the claim consistently — which is what this PR does.

## Changes

- `modules/nuxt-auth-idp/src/runtime/server/utils/agent-token.ts` and `packages/server/src/idp/utils/auth-token.ts` (the two parallel copies used by the Nuxt module runtime and the server package):
  - `issueAuthToken` / `issueAgentToken` accept an optional `aud` parameter, default `'apes-cli'`.
  - `verifyAuthToken` / `verifyAgentToken` accept an optional `expectedAud` parameter; when omitted, audience is not checked (preserves backward-compat).
  - New `DEFAULT_CLI_AUDIENCE = 'apes-cli'` constant exported.
- Existing call sites (`auth/authenticate.post.ts`, `agent/authenticate.post.ts`, `routes/token.post.ts:handleClientCredentialsGrant`, `packages/server/.../handlers/{auth,token}.ts`) automatically pick up the new default — no source changes needed at call sites.
- 13 new unit tests across two new test files exercising default-audience, explicit-audience override, audience-restricted verification, audience-mismatch rejection.

## Test plan

- [x] `pnpm --filter @openape/nuxt-auth-idp test` — 16 files, 96 tests passing
- [x] `pnpm --filter @openape/server test` — 7 files, 212 tests passing
- [x] `pnpm --filter openape-free-idp build` clean (Nuxt build)
- [ ] Post-merge: deploy free-idp on chatty + Vercel; smoke `apes login` and `apes login --key ~/.ssh/id_ed25519`, decode tokens, verify `aud='apes-cli'` in both.

## Migration

Backward-compatible. No consumer changes required. Existing tokens issued before the deploy lack `aud` and continue to verify (consumers don't pass `expectedAud`). New tokens have `aud='apes-cli'`. Once all live tokens have rotated (max 1h after deploy), downstream consumers can safely add `expectedAud='apes-cli'` to their verification (which is exactly what M2 of the SSO refactor does).

## Changeset

`@openape/nuxt-auth-idp` minor + `@openape/server` minor.