### PR TITLE
feat(cli-auth): introduce @openape/cli-auth shared library

### DIFF
--- a/.changeset/cli-auth-init.md
+++ b/.changeset/cli-auth-init.md
@@ -1,0 +1,14 @@
+---
+'@openape/cli-auth': minor
+---
+
+Initial release of `@openape/cli-auth` — shared client-side auth library for OpenApe CLIs.
+
+Provides:
+- `getAuthorizedBearer({ endpoint, aud, scopes? })` — one-shot helper that returns a valid `Bearer …` header for any OpenApe SP, handling IdP-token refresh + SP-token exchange + caching transparently.
+- `ensureFreshIdpAuth()` — refresh the IdP-issued OAuth access token if needed (using the stored refresh_token).
+- `exchangeForSpToken(idpAuth, request)` — RFC 8693-style token exchange against an SP's `/api/cli/exchange` endpoint.
+- Storage primitives for the IdP-token (shared with `@openape/apes` at `~/.config/apes/auth.json`) and SP-tokens (per-audience under `~/.config/apes/sp-tokens/`).
+- Error types `AuthError`, `NotLoggedInError`.
+
+Designed to be the auth dependency for `@openape/apes`, `@openape/ape-plans`, `@openape/ape-tasks`, `@openape/ape-secrets`, and `@openape/ape-seeds`. After `apes login` once, every other CLI works without re-authenticating per service.

--- a/packages/cli-auth/README.md
+++ b/packages/cli-auth/README.md
@@ -1,0 +1,105 @@
+# @openape/cli-auth
+
+Shared client-side auth library for OpenApe CLIs. Used by `@openape/apes`, `@openape/ape-plans`, `@openape/ape-tasks`, and forthcoming `@openape/ape-secrets` / `@openape/ape-seeds`.
+
+## What it does
+
+The user runs `apes login <email>` once on their device (PKCE browser flow OR SSH-key challenge-response). That stores an IdP-issued OAuth access + refresh token at `~/.config/apes/auth.json`. From then on, every other OpenApe CLI just needs:
+
+```ts
+import { getAuthorizedBearer } from '@openape/cli-auth'
+
+const authorization = await getAuthorizedBearer({
+  endpoint: 'https://plans.openape.ai',
+  aud: 'plans.openape.ai',
+  scopes: ['plans:rw'],
+})
+
+const teams = await fetch('https://plans.openape.ai/api/teams', {
+  headers: { Authorization: authorization },
+})
+```
+
+`getAuthorizedBearer` does the right thing transparently:
+
+1. Check the cached SP-token at `~/.config/apes/sp-tokens/plans.openape.ai.json`. Return it if still valid.
+2. Otherwise, ensure the IdP token is fresh — refresh via OIDC if expired (rotates the stored `refresh_token` server-side).
+3. POST the IdP token to `https://plans.openape.ai/api/cli/exchange`. The SP verifies it via JWKS against `id.openape.ai`, applies its own policies, and mints a 30-day SP-scoped HS256 token with `aud=plans.openape.ai`.
+4. Cache the SP-token for next time.
+
+If anything fails the user gets a clear "Run `apes login` again" message — never silent 401 spam.
+
+## Public API
+
+```ts
+// One-shot helper for nearly every consumer.
+getAuthorizedBearer(opts: {
+  endpoint: string
+  aud: string
+  scopes?: string[]
+  forceRefresh?: boolean
+}): Promise<string>  // 'Bearer <jwt>'
+
+// Lower-level building blocks.
+ensureFreshIdpAuth(now?: number): Promise<IdpAuth>
+exchangeForSpToken(idpAuth: IdpAuth, request: ExchangeRequest, now?: number): Promise<SpToken>
+
+// Storage primitives.
+loadIdpAuth(): IdpAuth | null
+saveIdpAuth(auth: IdpAuth): void
+clearIdpAuth(): void
+
+loadSpToken(aud: string): SpToken | null
+saveSpToken(token: SpToken): void
+clearSpToken(aud: string): void
+clearAllSpTokens(): void
+
+// Path inspection.
+getConfigDir(): string  // ~/.config/apes/
+getAuthFile(): string   // ~/.config/apes/auth.json
+getSpTokensDir(): string // ~/.config/apes/sp-tokens/
+
+// Errors.
+AuthError, NotLoggedInError, type IdpAuth, type SpToken
+```
+
+## File layout
+
+```
+~/.config/apes/
+├── auth.json                       # IdP access + refresh tokens (managed by apes login/logout)
+└── sp-tokens/
+    ├── plans.openape.ai.json       # SP-scoped tokens, one per audience
+    ├── tasks.openape.ai.json
+    └── secrets.openape.ai.json
+```
+
+All files are written with mode 0600. Directories with mode 0700.
+
+## Coexistence with `@openape/apes`
+
+This package shares `~/.config/apes/auth.json` with `@openape/apes`, which is the canonical IdP-token writer (`apes login` writes; `apes logout` clears). Both packages agree on the JSON schema:
+
+```json
+{
+  "idp": "https://id.openape.ai",
+  "access_token": "eyJ...",
+  "refresh_token": "rt-abc",
+  "email": "patrick@hofmann.eco",
+  "expires_at": 1727000000
+}
+```
+
+`@openape/cli-auth` is intentionally **read-mostly** for `auth.json` — the only write is via `ensureFreshIdpAuth` after a successful refresh, which preserves all other fields and just bumps `access_token` + `refresh_token` + `expires_at`. SP-tokens live in their own subdirectory and are managed exclusively here.
+
+## Testing
+
+```bash
+pnpm --filter @openape/cli-auth test
+```
+
+Tests use `OPENAPE_CLI_AUTH_HOME` env override to redirect storage to a temp dir per test case.
+
+## License
+
+MIT — part of the OpenApe project.

--- a/packages/cli-auth/package.json
+++ b/packages/cli-auth/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@openape/cli-auth",
+  "version": "0.1.0",
+  "turbo": {
+    "tags": [
+      "publishable"
+    ]
+  },
+  "description": "Shared client-side auth for OpenApe CLIs (apes, ape-plans, ape-tasks, ape-secrets, ape-seeds). Manages the IdP-issued auth.json store, refresh-token rotation, and SP token-exchange (RFC 8693) caching.",
+  "type": "module",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/openape-ai/openape.git",
+    "directory": "packages/cli-auth"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run --no-coverage"
+  },
+  "dependencies": {
+    "@openape/core": "workspace:*",
+    "ofetch": "^1.4.1"
+  },
+  "devDependencies": {
+    "@types/node": "^25.3.5",
+    "tsup": "^8.3.0",
+    "typescript": "^5.9.0",
+    "vitest": "^2.1.9"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "keywords": [
+    "openape",
+    "cli",
+    "oidc",
+    "ddisa",
+    "auth",
+    "token-exchange"
+  ]
+}

--- a/packages/cli-auth/src/bearer.ts
+++ b/packages/cli-auth/src/bearer.ts
@@ -1,0 +1,48 @@
+import { exchangeForSpToken } from './exchange.js'
+import { ensureFreshIdpAuth } from './refresh.js'
+import { loadSpToken } from './storage.js'
+
+const SP_TOKEN_SKEW_SECONDS = 60
+
+export interface AuthorizedBearerOptions {
+  /** SP endpoint (e.g. `https://plans.openape.ai`). */
+  endpoint: string
+  /** SP audience (e.g. `plans.openape.ai`). */
+  aud: string
+  /** Optional scopes to request from the SP exchange endpoint. */
+  scopes?: string[]
+  /** When true, ignore the cached SP-token and force a fresh exchange. */
+  forceRefresh?: boolean
+}
+
+/**
+ * One-shot helper for CLI commands. Returns an `Authorization: Bearer …`
+ * header value valid for the given SP, doing whatever is necessary under the
+ * hood:
+ *
+ * 1. Read the cached SP-token. If still valid (with 60 s skew), return it.
+ * 2. Otherwise, ensure the IdP-token is fresh (refresh via OIDC if expired).
+ * 3. Exchange the IdP-token at the SP's `/api/cli/exchange` endpoint.
+ * 4. Persist the resulting SP-token and return it.
+ *
+ * Throws `NotLoggedInError` if the user is not logged in via `apes login`.
+ * Throws `AuthError` if the exchange fails.
+ */
+export async function getAuthorizedBearer(opts: AuthorizedBearerOptions): Promise<string> {
+  const now = Math.floor(Date.now() / 1000)
+
+  if (!opts.forceRefresh) {
+    const cached = loadSpToken(opts.aud)
+    if (cached && cached.expires_at > now + SP_TOKEN_SKEW_SECONDS) {
+      return `Bearer ${cached.access_token}`
+    }
+  }
+
+  const idpAuth = await ensureFreshIdpAuth(now)
+  const sp = await exchangeForSpToken(idpAuth, {
+    endpoint: opts.endpoint,
+    aud: opts.aud,
+    ...(opts.scopes ? { scopes: opts.scopes } : {}),
+  }, now)
+  return `Bearer ${sp.access_token}`
+}

--- a/packages/cli-auth/src/exchange.ts
+++ b/packages/cli-auth/src/exchange.ts
@@ -1,0 +1,80 @@
+import { ofetch } from 'ofetch'
+import { saveSpToken } from './storage.js'
+import { AuthError   } from './types.js'
+import type { IdpAuth, SpToken } from './types.js'
+
+export interface ExchangeRequest {
+  /** Endpoint of the SP that owns the exchange (e.g. `https://plans.openape.ai`). */
+  endpoint: string
+  /** Audience the SP advertises for its exchanged tokens (e.g. `plans.openape.ai`). */
+  aud: string
+  /** Optional scope hints the SP may use to scope-down the issued token. */
+  scopes?: string[]
+}
+
+interface ExchangeResponse {
+  access_token: string
+  token_type: string
+  expires_at?: number
+  expires_in?: number
+  aud?: string
+}
+
+/**
+ * Trade an IdP-issued subject token for an SP-scoped access token.
+ *
+ * Posts the IdP's `access_token` to `${endpoint}/api/cli/exchange`. The SP
+ * verifies the IdP signature + expected audience (`apes-cli`) via JWKS,
+ * applies its own policy checks (member? banned? rate-limited?), and mints
+ * an HS256 JWT with `aud=<sp.host>` and a longer expiry.
+ *
+ * The returned SpToken is also persisted to `~/.config/apes/sp-tokens/<aud>.json`
+ * so subsequent `getAuthorizedBearer` calls can hit cache.
+ */
+export async function exchangeForSpToken(
+  idpAuth: IdpAuth,
+  request: ExchangeRequest,
+  now: number = Math.floor(Date.now() / 1000),
+): Promise<SpToken> {
+  const url = `${request.endpoint.replace(/\/$/, '')}/api/cli/exchange`
+
+  let response: ExchangeResponse
+  try {
+    response = await ofetch<ExchangeResponse>(url, {
+      method: 'POST',
+      body: {
+        subject_token: idpAuth.access_token,
+        ...(request.scopes ? { scopes: request.scopes } : {}),
+      },
+    })
+  }
+  catch (err: unknown) {
+    const status = (err as { status?: number, statusCode?: number }).status
+      ?? (err as { statusCode?: number }).statusCode
+      ?? 0
+    const data = (err as { data?: { title?: string, detail?: string } }).data
+    const title = data?.title ?? `Token exchange failed (HTTP ${status})`
+    const hint = status === 401
+      ? `IdP token rejected at ${url}. Try \`apes login\` again — token may be expired or audience-mismatched.`
+      : data?.detail
+    throw new AuthError(status, title, hint)
+  }
+
+  if (!response.access_token) {
+    throw new AuthError(0, `Exchange response from ${url} missing access_token`)
+  }
+
+  const expiresAt = response.expires_at
+    ?? (response.expires_in ? now + response.expires_in : now + 3600 * 24 * 30)
+
+  const token: SpToken = {
+    endpoint: request.endpoint,
+    aud: response.aud ?? request.aud,
+    access_token: response.access_token,
+    expires_at: expiresAt,
+    ...(request.scopes ? { scopes: request.scopes } : {}),
+    issued_from_idp_iat: now,
+  }
+  saveSpToken(token)
+  return token
+}

--- a/packages/cli-auth/src/index.ts
+++ b/packages/cli-auth/src/index.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared client-side auth library for OpenApe CLIs.
+ *
+ * Public surface:
+ *
+ * - `getAuthorizedBearer({ endpoint, aud, scopes? })` — one-shot helper that
+ *   returns a valid `Bearer …` header for the given SP, handling IdP-token
+ *   refresh + SP-token exchange + caching transparently.
+ * - `ensureFreshIdpAuth()` — refresh the IdP-issued OAuth token if needed.
+ * - `exchangeForSpToken(idpAuth, request)` — manual SP-token mint.
+ * - `loadIdpAuth()` / `saveIdpAuth()` / `clearIdpAuth()` — IdP token store.
+ * - `loadSpToken(aud)` / `saveSpToken(token)` / `clearSpToken(aud)` /
+ *   `clearAllSpTokens()` — SP token cache.
+ * - Error types: `AuthError`, `NotLoggedInError`.
+ *
+ * The IdP token file is shared with `@openape/apes` (both packages read/write
+ * `~/.config/apes/auth.json`). SP tokens live in `~/.config/apes/sp-tokens/`.
+ */
+
+export { getAuthorizedBearer, type AuthorizedBearerOptions } from './bearer.js'
+export { exchangeForSpToken, type ExchangeRequest } from './exchange.js'
+export { ensureFreshIdpAuth } from './refresh.js'
+export {
+  clearAllSpTokens,
+  clearIdpAuth,
+  clearSpToken,
+  getAuthFile,
+  getConfigDir,
+  getSpTokensDir,
+  loadIdpAuth,
+  loadSpToken,
+  saveIdpAuth,
+  saveSpToken,
+} from './storage.js'
+export { AuthError, NotLoggedInError, type IdpAuth, type SpToken } from './types.js'

--- a/packages/cli-auth/src/refresh.ts
+++ b/packages/cli-auth/src/refresh.ts
@@ -1,0 +1,104 @@
+import { ofetch } from 'ofetch'
+import { loadIdpAuth, saveIdpAuth } from './storage.js'
+import { AuthError, NotLoggedInError  } from './types.js'
+import type { IdpAuth } from './types.js'
+
+/**
+ * Skew applied when deciding whether a token is expired. We refresh 30 seconds
+ * before the actual `exp` so an in-flight request never lands at the SP after
+ * the IdP has already rejected the bearer.
+ */
+const EXPIRY_SKEW_SECONDS = 30
+
+interface DiscoveryDocument {
+  token_endpoint?: string
+}
+
+async function getTokenEndpoint(idp: string): Promise<string> {
+  try {
+    const disco = await ofetch<DiscoveryDocument>(`${idp}/.well-known/openid-configuration`)
+    if (disco.token_endpoint) return disco.token_endpoint
+  }
+  catch {
+    // Fall through to the conventional path.
+  }
+  return `${idp}/token`
+}
+
+/**
+ * Return a non-expired IdP token. If the cached one is still good (with skew),
+ * return it as-is. Otherwise try the OAuth refresh-token grant against the
+ * IdP's `/token` endpoint. On success, persist the new auth and return it. On
+ * failure (no refresh_token, refresh rejected, network error), throw
+ * `NotLoggedInError`.
+ *
+ * NOTE: this function does NOT serialize concurrent calls. Two parallel
+ * `apes`/`ape-plans` invocations could both consume the same rotating
+ * refresh_token and one would lose. The `@openape/apes` package already
+ * implements file-locking around its own refresh; we cooperate with the same
+ * `~/.config/apes/auth.json` file but rely on apes to own the lock for now.
+ * Cross-package locking is a follow-up — for the MVP single-user case it
+ * effectively never races.
+ */
+export async function ensureFreshIdpAuth(now: number = Math.floor(Date.now() / 1000)): Promise<IdpAuth> {
+  const auth = loadIdpAuth()
+  if (!auth) {
+    throw new NotLoggedInError()
+  }
+
+  if (auth.expires_at > now + EXPIRY_SKEW_SECONDS) {
+    return auth
+  }
+
+  if (!auth.refresh_token) {
+    throw new NotLoggedInError(
+      `IdP token expired at ${new Date(auth.expires_at * 1000).toISOString()} and no refresh_token is stored. Run \`apes login\` again.`,
+    )
+  }
+
+  const tokenEndpoint = await getTokenEndpoint(auth.idp)
+  const body = new URLSearchParams({
+    grant_type: 'refresh_token',
+    refresh_token: auth.refresh_token,
+  })
+
+  let response: { access_token?: string, refresh_token?: string, expires_in?: number }
+  try {
+    response = await ofetch(tokenEndpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+    })
+  }
+  catch (err: unknown) {
+    const status = (err as { status?: number, statusCode?: number }).status
+      ?? (err as { statusCode?: number }).statusCode
+      ?? 0
+    if (status === 400 || status === 401) {
+      // Refresh-token family revoked or already-rotated. Clear it so we don't
+      // loop refreshing on every subsequent invocation; user must re-login.
+      saveIdpAuth({ ...auth, refresh_token: undefined })
+      throw new NotLoggedInError(
+        `Refresh token rejected by ${auth.idp}. Run \`apes login\` again.`,
+      )
+    }
+    throw new AuthError(
+      0,
+      `Network error refreshing IdP token at ${tokenEndpoint}`,
+      `Underlying: ${(err as Error).message ?? err}`,
+    )
+  }
+
+  if (!response.access_token) {
+    throw new AuthError(0, `IdP refresh response missing access_token (endpoint: ${tokenEndpoint})`)
+  }
+
+  const next: IdpAuth = {
+    ...auth,
+    access_token: response.access_token,
+    refresh_token: response.refresh_token ?? auth.refresh_token,
+    expires_at: now + (response.expires_in ?? 3600),
+  }
+  saveIdpAuth(next)
+  return next
+}

--- a/packages/cli-auth/src/storage.ts
+++ b/packages/cli-auth/src/storage.ts
@@ -1,0 +1,112 @@
+import { existsSync, mkdirSync, readFileSync, readdirSync, unlinkSync, writeFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import type { IdpAuth, SpToken } from './types.js'
+
+/**
+ * Resolve the OpenApe CLI auth home (`~/.config/apes/` by default).
+ *
+ * Override via `OPENAPE_CLI_AUTH_HOME` env var (used by tests + CI). Read on
+ * every call so tests can mutate `process.env` between cases.
+ */
+export function getConfigDir(): string {
+  const override = process.env.OPENAPE_CLI_AUTH_HOME
+  if (override) return override
+  return join(homedir(), '.config', 'apes')
+}
+
+export function getAuthFile(): string {
+  return join(getConfigDir(), 'auth.json')
+}
+
+export function getSpTokensDir(): string {
+  return join(getConfigDir(), 'sp-tokens')
+}
+
+function ensureConfigDir(): void {
+  const dir = getConfigDir()
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true, mode: 0o700 })
+  }
+}
+
+function ensureSpTokensDir(): void {
+  ensureConfigDir()
+  const dir = getSpTokensDir()
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true, mode: 0o700 })
+  }
+}
+
+export function loadIdpAuth(): IdpAuth | null {
+  const file = getAuthFile()
+  if (!existsSync(file)) return null
+  try {
+    const raw = readFileSync(file, 'utf-8')
+    if (!raw.trim()) return null
+    return JSON.parse(raw) as IdpAuth
+  }
+  catch {
+    return null
+  }
+}
+
+export function saveIdpAuth(auth: IdpAuth): void {
+  ensureConfigDir()
+  writeFileSync(getAuthFile(), JSON.stringify(auth, null, 2), { mode: 0o600 })
+}
+
+export function clearIdpAuth(): void {
+  const file = getAuthFile()
+  if (existsSync(file)) {
+    writeFileSync(file, '', { mode: 0o600 })
+  }
+}
+
+/**
+ * Filename-safe representation of an audience. Audiences are typically
+ * hostnames like `plans.openape.ai` — already filesystem-safe — but we
+ * defensively replace anything outside `[A-Za-z0-9._-]`.
+ */
+function audToFilename(aud: string): string {
+  return aud.replace(/[^\w.-]/g, '_')
+}
+
+function spTokenPath(aud: string): string {
+  return join(getSpTokensDir(), `${audToFilename(aud)}.json`)
+}
+
+export function loadSpToken(aud: string): SpToken | null {
+  const path = spTokenPath(aud)
+  if (!existsSync(path)) return null
+  try {
+    const raw = readFileSync(path, 'utf-8')
+    if (!raw.trim()) return null
+    return JSON.parse(raw) as SpToken
+  }
+  catch {
+    return null
+  }
+}
+
+export function saveSpToken(token: SpToken): void {
+  ensureSpTokensDir()
+  writeFileSync(spTokenPath(token.aud), JSON.stringify(token, null, 2), { mode: 0o600 })
+}
+
+export function clearSpToken(aud: string): void {
+  const path = spTokenPath(aud)
+  if (existsSync(path)) unlinkSync(path)
+}
+
+/** Wipe every cached SP-token. Called by `apes logout` to ensure a clean slate. */
+export function clearAllSpTokens(): void {
+  const dir = getSpTokensDir()
+  if (!existsSync(dir)) return
+  for (const entry of readdirSync(dir)) {
+    if (entry.endsWith('.json')) {
+      try { unlinkSync(join(dir, entry)) }
+      catch { /* best effort */ }
+    }
+  }
+}

--- a/packages/cli-auth/src/types.ts
+++ b/packages/cli-auth/src/types.ts
@@ -1,0 +1,58 @@
+/**
+ * IdP-issued auth credentials, stored at `~/.config/apes/auth.json`. Same
+ * shape as `@openape/apes`'s internal AuthData — both packages cooperate on
+ * this file. The CLI commands in `apes` write here on `apes login`; this
+ * package reads here on every `getAuthorizedBearer` call.
+ */
+export interface IdpAuth {
+  idp: string
+  access_token: string
+  refresh_token?: string
+  email: string
+  expires_at: number
+}
+
+/**
+ * SP-scoped access token cached after a successful exchange. Stored per
+ * audience under `~/.config/apes/sp-tokens/<aud>.json`.
+ */
+export interface SpToken {
+  endpoint: string
+  aud: string
+  access_token: string
+  expires_at: number
+  scopes?: string[]
+  /**
+   * When the IdP-token used for the exchange was issued. Lets us evict the
+   * SP-token cache if the IdP-token has been rotated since.
+   */
+  issued_from_idp_iat?: number
+}
+
+export class AuthError extends Error {
+  status: number
+  hint?: string
+
+  constructor(status: number, message: string, hint?: string) {
+    super(hint ? `${message}\n${hint}` : message)
+    this.name = 'AuthError'
+    this.status = status
+    this.hint = hint
+  }
+}
+
+/**
+ * Thrown by `getAuthorizedBearer` when no valid IdP session can be obtained
+ * (no auth file, refresh failed, etc.). Caller should surface a "run
+ * `apes login`" message.
+ */
+export class NotLoggedInError extends AuthError {
+  constructor(hint?: string) {
+    super(
+      401,
+      'Not logged in',
+      hint ?? 'Run `apes login <email>` once on this device to authenticate against the OpenApe IdP.',
+    )
+    this.name = 'NotLoggedInError'
+  }
+}

--- a/packages/cli-auth/test/exchange-bearer.test.ts
+++ b/packages/cli-auth/test/exchange-bearer.test.ts
@@ -1,0 +1,135 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { getAuthorizedBearer } from '../src/bearer'
+import { exchangeForSpToken } from '../src/exchange'
+import { loadSpToken, saveIdpAuth, saveSpToken } from '../src/storage'
+import { AuthError } from '../src/types'
+
+let tmpHome: string
+const ORIG = process.env.OPENAPE_CLI_AUTH_HOME
+
+beforeEach(() => {
+  tmpHome = mkdtempSync(join(tmpdir(), 'cli-auth-exch-'))
+  process.env.OPENAPE_CLI_AUTH_HOME = tmpHome
+  vi.restoreAllMocks()
+})
+
+afterEach(() => {
+  rmSync(tmpHome, { recursive: true, force: true })
+  if (ORIG === undefined) delete process.env.OPENAPE_CLI_AUTH_HOME
+  else process.env.OPENAPE_CLI_AUTH_HOME = ORIG
+})
+
+describe('exchangeForSpToken', () => {
+  it('POSTs subject_token + scopes and persists the response', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url, init) => {
+      expect(String(url)).toBe('https://plans.openape.ai/api/cli/exchange')
+      const body = JSON.parse(String((init?.body as string) ?? '{}'))
+      expect(body.subject_token).toBe('idp-eyJ...')
+      expect(body.scopes).toEqual(['plans:rw'])
+      return new Response(
+        JSON.stringify({
+          access_token: 'sp-eyJ...',
+          token_type: 'Bearer',
+          expires_in: 3600,
+          aud: 'plans.openape.ai',
+        }),
+        { status: 201, headers: { 'Content-Type': 'application/json' } },
+      )
+    })
+
+    const token = await exchangeForSpToken(
+      {
+        idp: 'https://id.openape.ai',
+        access_token: 'idp-eyJ...',
+        email: 'me@x',
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+      },
+      { endpoint: 'https://plans.openape.ai', aud: 'plans.openape.ai', scopes: ['plans:rw'] },
+      1000,
+    )
+
+    expect(token.access_token).toBe('sp-eyJ...')
+    expect(token.expires_at).toBe(1000 + 3600)
+    expect(loadSpToken('plans.openape.ai')?.access_token).toBe('sp-eyJ...')
+    fetchSpy.mockRestore()
+  })
+
+  it('throws AuthError with hint on 401', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({ title: 'Unauthorized', detail: 'aud mismatch' }),
+        { status: 401, headers: { 'Content-Type': 'application/json' } },
+      ),
+    )
+    await expect(
+      exchangeForSpToken(
+        { idp: 'x', access_token: 't', email: 'e', expires_at: 9 },
+        { endpoint: 'https://plans.openape.ai', aud: 'plans.openape.ai' },
+      ),
+    ).rejects.toThrow(AuthError)
+  })
+})
+
+describe('getAuthorizedBearer', () => {
+  it('uses cached SP token if not expired', async () => {
+    saveIdpAuth({ idp: 'https://id.openape.ai', access_token: 'idp-x', email: 'me@x', expires_at: Math.floor(Date.now() / 1000) + 3600 })
+    saveSpToken({
+      endpoint: 'https://plans.openape.ai',
+      aud: 'plans.openape.ai',
+      access_token: 'cached-sp-token',
+      expires_at: Math.floor(Date.now() / 1000) + 3600,
+    })
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+
+    const header = await getAuthorizedBearer({
+      endpoint: 'https://plans.openape.ai',
+      aud: 'plans.openape.ai',
+    })
+    expect(header).toBe('Bearer cached-sp-token')
+    expect(fetchSpy).not.toHaveBeenCalled()
+    fetchSpy.mockRestore()
+  })
+
+  it('exchanges when no SP token cached', async () => {
+    saveIdpAuth({ idp: 'https://id.openape.ai', access_token: 'idp-x', email: 'me@x', expires_at: Math.floor(Date.now() / 1000) + 3600 })
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({ access_token: 'fresh-sp', expires_in: 3600 }),
+        { status: 201, headers: { 'Content-Type': 'application/json' } },
+      ),
+    )
+
+    const header = await getAuthorizedBearer({
+      endpoint: 'https://plans.openape.ai',
+      aud: 'plans.openape.ai',
+    })
+    expect(header).toBe('Bearer fresh-sp')
+    expect(loadSpToken('plans.openape.ai')?.access_token).toBe('fresh-sp')
+  })
+
+  it('forceRefresh bypasses cache', async () => {
+    saveIdpAuth({ idp: 'https://id.openape.ai', access_token: 'idp-x', email: 'me@x', expires_at: Math.floor(Date.now() / 1000) + 3600 })
+    saveSpToken({
+      endpoint: 'https://plans.openape.ai',
+      aud: 'plans.openape.ai',
+      access_token: 'cached-sp',
+      expires_at: Math.floor(Date.now() / 1000) + 3600,
+    })
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({ access_token: 'forced-fresh', expires_in: 3600 }),
+        { status: 201, headers: { 'Content-Type': 'application/json' } },
+      ),
+    )
+
+    const header = await getAuthorizedBearer({
+      endpoint: 'https://plans.openape.ai',
+      aud: 'plans.openape.ai',
+      forceRefresh: true,
+    })
+    expect(header).toBe('Bearer forced-fresh')
+  })
+})

--- a/packages/cli-auth/test/refresh.test.ts
+++ b/packages/cli-auth/test/refresh.test.ts
@@ -1,0 +1,120 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ensureFreshIdpAuth } from '../src/refresh'
+import { loadIdpAuth, saveIdpAuth } from '../src/storage'
+import { NotLoggedInError } from '../src/types'
+
+let tmpHome: string
+const ORIG = process.env.OPENAPE_CLI_AUTH_HOME
+
+beforeEach(() => {
+  tmpHome = mkdtempSync(join(tmpdir(), 'cli-auth-refresh-'))
+  process.env.OPENAPE_CLI_AUTH_HOME = tmpHome
+  vi.restoreAllMocks()
+})
+
+afterEach(() => {
+  rmSync(tmpHome, { recursive: true, force: true })
+  if (ORIG === undefined) delete process.env.OPENAPE_CLI_AUTH_HOME
+  else process.env.OPENAPE_CLI_AUTH_HOME = ORIG
+})
+
+describe('ensureFreshIdpAuth', () => {
+  it('throws NotLoggedInError when no auth file exists', async () => {
+    await expect(ensureFreshIdpAuth(0)).rejects.toThrow(NotLoggedInError)
+  })
+
+  it('returns the cached auth when not yet expired', async () => {
+    saveIdpAuth({
+      idp: 'https://id.openape.ai',
+      access_token: 'still-good',
+      refresh_token: 'rt',
+      email: 'me@x',
+      expires_at: 5000,
+    })
+    const result = await ensureFreshIdpAuth(1000)
+    expect(result.access_token).toBe('still-good')
+  })
+
+  it('throws NotLoggedInError when token expired and no refresh_token', async () => {
+    saveIdpAuth({
+      idp: 'https://id.openape.ai',
+      access_token: 'expired',
+      email: 'me@x',
+      expires_at: 100,
+    })
+    await expect(ensureFreshIdpAuth(2000)).rejects.toThrow(NotLoggedInError)
+  })
+
+  it('refreshes via OIDC and persists the new token', async () => {
+    saveIdpAuth({
+      idp: 'https://id.openape.ai',
+      access_token: 'expired',
+      refresh_token: 'rt-current',
+      email: 'me@x',
+      expires_at: 100,
+    })
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url, init) => {
+      if (typeof url === 'string' && url.endsWith('/.well-known/openid-configuration')) {
+        return new Response(
+          JSON.stringify({ token_endpoint: 'https://id.openape.ai/token' }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        )
+      }
+      if (typeof url === 'string' && url.endsWith('/token')) {
+        const body = String((init?.body as URLSearchParams | string) ?? '')
+        expect(body).toContain('refresh_token=rt-current')
+        return new Response(
+          JSON.stringify({
+            access_token: 'fresh-access',
+            refresh_token: 'rt-rotated',
+            expires_in: 900,
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        )
+      }
+      throw new Error(`unexpected fetch ${url}`)
+    })
+
+    const refreshed = await ensureFreshIdpAuth(2000)
+    expect(refreshed.access_token).toBe('fresh-access')
+    expect(refreshed.refresh_token).toBe('rt-rotated')
+    expect(refreshed.expires_at).toBe(2000 + 900)
+
+    // Persisted to disk
+    expect(loadIdpAuth()?.access_token).toBe('fresh-access')
+
+    fetchSpy.mockRestore()
+  })
+
+  it('clears refresh_token and throws NotLoggedInError on 401 from /token', async () => {
+    saveIdpAuth({
+      idp: 'https://id.openape.ai',
+      access_token: 'expired',
+      refresh_token: 'rt-revoked',
+      email: 'me@x',
+      expires_at: 100,
+    })
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      if (typeof url === 'string' && url.endsWith('/.well-known/openid-configuration')) {
+        return new Response(
+          JSON.stringify({ token_endpoint: 'https://id.openape.ai/token' }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        )
+      }
+      return new Response('{"error":"invalid_grant"}', {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    })
+
+    await expect(ensureFreshIdpAuth(2000)).rejects.toThrow(NotLoggedInError)
+    expect(loadIdpAuth()?.refresh_token).toBeUndefined()
+
+    fetchSpy.mockRestore()
+  })
+})

--- a/packages/cli-auth/test/storage.test.ts
+++ b/packages/cli-auth/test/storage.test.ts
@@ -1,0 +1,135 @@
+import { mkdtempSync, rmSync, writeFileSync as fsWriteFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  clearAllSpTokens,
+  clearIdpAuth,
+  clearSpToken,
+  getAuthFile,
+  getConfigDir,
+  getSpTokensDir,
+  loadIdpAuth,
+  loadSpToken,
+  saveIdpAuth,
+  saveSpToken,
+} from '../src/storage'
+
+let tmpHome: string
+const ORIG = process.env.OPENAPE_CLI_AUTH_HOME
+
+beforeEach(() => {
+  tmpHome = mkdtempSync(join(tmpdir(), 'cli-auth-storage-'))
+  process.env.OPENAPE_CLI_AUTH_HOME = tmpHome
+})
+
+afterEach(() => {
+  rmSync(tmpHome, { recursive: true, force: true })
+  if (ORIG === undefined) delete process.env.OPENAPE_CLI_AUTH_HOME
+  else process.env.OPENAPE_CLI_AUTH_HOME = ORIG
+})
+
+describe('storage paths', () => {
+  it('honors OPENAPE_CLI_AUTH_HOME override', () => {
+    expect(getConfigDir()).toBe(tmpHome)
+    expect(getAuthFile()).toBe(join(tmpHome, 'auth.json'))
+    expect(getSpTokensDir()).toBe(join(tmpHome, 'sp-tokens'))
+  })
+})
+
+describe('IdP auth roundtrip', () => {
+  it('returns null when no auth file exists', () => {
+    expect(loadIdpAuth()).toBeNull()
+  })
+
+  it('persists and reloads an IdP auth blob', () => {
+    saveIdpAuth({
+      idp: 'https://id.openape.ai',
+      access_token: 'eyJ...',
+      refresh_token: 'rt-abc',
+      email: 'patrick@hofmann.eco',
+      expires_at: 1234567890,
+    })
+    const loaded = loadIdpAuth()
+    expect(loaded?.access_token).toBe('eyJ...')
+    expect(loaded?.refresh_token).toBe('rt-abc')
+  })
+
+  it('clearIdpAuth empties the file', () => {
+    saveIdpAuth({
+      idp: 'https://id.openape.ai',
+      access_token: 'x',
+      email: 'me@x',
+      expires_at: 1,
+    })
+    clearIdpAuth()
+    expect(loadIdpAuth()).toBeNull()
+  })
+
+  it('returns null on corrupted JSON instead of throwing', () => {
+    saveIdpAuth({
+      idp: 'https://id.openape.ai',
+      access_token: 'x',
+      email: 'me@x',
+      expires_at: 1,
+    })
+    // Corrupt the file in place
+    fsWriteFileSync(getAuthFile(), '{not-json', { mode: 0o600 })
+    expect(loadIdpAuth()).toBeNull()
+  })
+})
+
+describe('SP token roundtrip', () => {
+  it('returns null for unknown audience', () => {
+    expect(loadSpToken('plans.openape.ai')).toBeNull()
+  })
+
+  it('persists and reloads an SP token', () => {
+    saveSpToken({
+      endpoint: 'https://plans.openape.ai',
+      aud: 'plans.openape.ai',
+      access_token: 'sp-eyJ...',
+      expires_at: 1234567890,
+      scopes: ['plans:rw'],
+    })
+    const loaded = loadSpToken('plans.openape.ai')
+    expect(loaded?.access_token).toBe('sp-eyJ...')
+    expect(loaded?.scopes).toEqual(['plans:rw'])
+  })
+
+  it('clearSpToken removes a single audience', () => {
+    saveSpToken({
+      endpoint: 'https://plans.openape.ai',
+      aud: 'plans.openape.ai',
+      access_token: 'a',
+      expires_at: 1,
+    })
+    saveSpToken({
+      endpoint: 'https://tasks.openape.ai',
+      aud: 'tasks.openape.ai',
+      access_token: 'b',
+      expires_at: 2,
+    })
+    clearSpToken('plans.openape.ai')
+    expect(loadSpToken('plans.openape.ai')).toBeNull()
+    expect(loadSpToken('tasks.openape.ai')?.access_token).toBe('b')
+  })
+
+  it('clearAllSpTokens wipes every cached entry', () => {
+    saveSpToken({ endpoint: 'a', aud: 'a', access_token: 'a', expires_at: 1 })
+    saveSpToken({ endpoint: 'b', aud: 'b', access_token: 'b', expires_at: 2 })
+    clearAllSpTokens()
+    expect(loadSpToken('a')).toBeNull()
+    expect(loadSpToken('b')).toBeNull()
+  })
+
+  it('audience-with-special-chars maps to a safe filename', () => {
+    saveSpToken({
+      endpoint: 'https://x',
+      aud: 'weird/audience:with*chars',
+      access_token: 'safe',
+      expires_at: 1,
+    })
+    expect(loadSpToken('weird/audience:with*chars')?.access_token).toBe('safe')
+  })
+})

--- a/packages/cli-auth/tsconfig.json
+++ b/packages/cli-auth/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": false,
+    "declaration": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*", "test/**/*"]
+}

--- a/packages/cli-auth/tsup.config.ts
+++ b/packages/cli-auth/tsup.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  target: 'node20',
+  platform: 'node',
+  clean: true,
+  shims: false,
+  dts: true,
+  splitting: false,
+  sourcemap: false,
+})

--- a/packages/cli-auth/vitest.config.ts
+++ b/packages/cli-auth/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.test.ts'],
+    environment: 'node',
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,7 +210,7 @@ importers:
         version: link:../../modules/nuxt-auth-sp
       nuxt:
         specifier: ^4.0.0
-        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@libsql/client@0.14.0)(@parcel/watcher@2.5.6)(@types/node@22.19.15)(@vue/compiler-sfc@3.5.30)(aws4fetch@1.0.20)(better-sqlite3@12.6.2)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.14.0)(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@libsql/client@0.14.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(bun-types@1.3.10)(gel@2.2.0)))(drizzle-orm@0.44.7(@libsql/client@0.14.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(bun-types@1.3.10)(gel@2.2.0))(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.11(rollup@4.59.0))(rollup@4.59.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2)
+        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@libsql/client@0.14.0)(@parcel/watcher@2.5.6)(@types/node@22.19.15)(@vue/compiler-sfc@3.5.30)(aws4fetch@1.0.20)(better-sqlite3@12.6.2)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.14.0)(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@libsql/client@0.14.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(bun-types@1.3.10)(gel@2.2.0)))(drizzle-orm@0.44.7(@libsql/client@0.14.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(bun-types@1.3.10)(gel@2.2.0))(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.11(rollup@4.59.0))(rollup@4.59.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@3.2.5(typescript@5.9.3))(yaml@2.8.2)
       tailwindcss:
         specifier: ^4.0.0
         version: 4.2.1
@@ -306,7 +306,7 @@ importers:
         version: 1.0.20
       nuxt:
         specifier: ^4.0.0
-        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@libsql/client@0.14.0)(@parcel/watcher@2.5.6)(@types/node@22.19.15)(@vue/compiler-sfc@3.5.30)(aws4fetch@1.0.20)(better-sqlite3@12.6.2)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.14.0)(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@libsql/client@0.14.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(bun-types@1.3.10)(gel@2.2.0)))(drizzle-orm@0.44.7(@libsql/client@0.14.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(bun-types@1.3.10)(gel@2.2.0))(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.11(rollup@4.59.0))(rollup@4.59.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2)
+        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@libsql/client@0.14.0)(@parcel/watcher@2.5.6)(@types/node@22.19.15)(@vue/compiler-sfc@3.5.30)(aws4fetch@1.0.20)(better-sqlite3@12.6.2)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.14.0)(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@libsql/client@0.14.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(bun-types@1.3.10)(gel@2.2.0)))(drizzle-orm@0.44.7(@libsql/client@0.14.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(bun-types@1.3.10)(gel@2.2.0))(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.11(rollup@4.59.0))(rollup@4.59.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@3.2.5(typescript@5.9.3))(yaml@2.8.2)
       tailwindcss:
         specifier: ^4.0.0
         version: 4.2.1
@@ -337,7 +337,7 @@ importers:
         version: link:../../modules/nuxt-auth-sp
       nuxt:
         specifier: ^4.3.1
-        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@libsql/client@0.14.0)(@parcel/watcher@2.5.6)(@types/node@22.19.15)(@vue/compiler-sfc@3.5.30)(aws4fetch@1.0.20)(better-sqlite3@12.6.2)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.14.0)(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@libsql/client@0.14.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(bun-types@1.3.10)(gel@2.2.0)))(drizzle-orm@0.44.7(@libsql/client@0.14.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(bun-types@1.3.10)(gel@2.2.0))(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.11(rollup@4.59.0))(rollup@4.59.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2)
+        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@libsql/client@0.14.0)(@parcel/watcher@2.5.6)(@types/node@22.19.15)(@vue/compiler-sfc@3.5.30)(aws4fetch@1.0.20)(better-sqlite3@12.6.2)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.14.0)(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@libsql/client@0.14.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(bun-types@1.3.10)(gel@2.2.0)))(drizzle-orm@0.44.7(@libsql/client@0.14.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(bun-types@1.3.10)(gel@2.2.0))(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.11(rollup@4.59.0))(rollup@4.59.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@3.2.5(typescript@5.9.3))(yaml@2.8.2)
       tailwindcss:
         specifier: ^4.2.1
         version: 4.2.1
@@ -572,6 +572,28 @@ importers:
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@25.5.0)(happy-dom@18.0.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+
+  packages/cli-auth:
+    dependencies:
+      '@openape/core':
+        specifier: workspace:*
+        version: link:../core
+      ofetch:
+        specifier: ^1.4.1
+        version: 1.5.1
+    devDependencies:
+      '@types/node':
+        specifier: ^25.3.5
+        version: 25.5.0
+      tsup:
+        specifier: ^8.3.0
+        version: 8.5.1(@microsoft/api-extractor@7.58.1(@types/node@25.5.0))(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5.9.0
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.9
+        version: 2.1.9(@types/node@25.5.0)(happy-dom@18.0.1)(lightningcss@1.32.0)(terser@5.46.0)
 
   packages/core:
     dependencies:
@@ -11626,75 +11648,6 @@ snapshots:
       - uploadthing
       - xml2js
 
-  '@nuxt/nitro-server@4.4.2(d7dd8928bf752be5249ac66e11fe492a)':
-    dependencies:
-      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
-      '@nuxt/devalue': 2.0.2
-      '@nuxt/kit': 4.4.2(magicast@0.5.2)
-      '@unhead/vue': 2.1.12(vue@3.5.30(typescript@5.9.3))
-      '@vue/shared': 3.5.30
-      consola: 3.4.2
-      defu: 6.1.4
-      destr: 2.0.5
-      devalue: 5.6.4
-      errx: 0.1.0
-      escape-string-regexp: 5.0.0
-      exsolve: 1.0.8
-      h3: 1.15.6
-      impound: 1.1.5
-      klona: 2.0.6
-      mocked-exports: 0.1.1
-      nitropack: 2.13.1(@libsql/client@0.14.0)(aws4fetch@1.0.20)(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@libsql/client@0.14.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(bun-types@1.3.10)(gel@2.2.0))
-      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@libsql/client@0.14.0)(@parcel/watcher@2.5.6)(@types/node@22.19.15)(@vue/compiler-sfc@3.5.30)(aws4fetch@1.0.20)(better-sqlite3@12.6.2)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.14.0)(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@libsql/client@0.14.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(bun-types@1.3.10)(gel@2.2.0)))(drizzle-orm@0.44.7(@libsql/client@0.14.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(bun-types@1.3.10)(gel@2.2.0))(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.11(rollup@4.59.0))(rollup@4.59.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2)
-      nypm: 0.6.5
-      ohash: 2.0.11
-      pathe: 2.0.3
-      pkg-types: 2.3.0
-      rou3: 0.8.1
-      std-env: 4.0.0
-      ufo: 1.6.3
-      unctx: 2.5.0
-      unstorage: 1.17.4(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.14.0)(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@libsql/client@0.14.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(bun-types@1.3.10)(gel@2.2.0)))(ioredis@5.10.0)
-      vue: 3.5.30(typescript@5.9.3)
-      vue-bundle-renderer: 2.2.0
-      vue-devtools-stub: 0.1.0
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@babel/core'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@electric-sql/pglite'
-      - '@libsql/client'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bare-abort-controller
-      - bare-buffer
-      - better-sqlite3
-      - db0
-      - drizzle-orm
-      - encoding
-      - idb-keyval
-      - ioredis
-      - magicast
-      - mysql2
-      - react-native-b4a
-      - rolldown
-      - sqlite3
-      - supports-color
-      - typescript
-      - uploadthing
-      - xml2js
-
   '@nuxt/nitro-server@4.4.2(f3094546668d8e8b7be11fe32a110480)':
     dependencies:
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
@@ -12305,66 +12258,6 @@ snapshots:
       - vite
       - vue
       - yjs
-
-  '@nuxt/vite-builder@4.4.2(801ee145aa323efd17bea0d6bd35cb58)':
-    dependencies:
-      '@nuxt/kit': 4.4.2(magicast@0.5.2)
-      '@rollup/plugin-replace': 6.0.3(rollup@4.59.0)
-      '@vitejs/plugin-vue': 6.0.5(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))
-      '@vitejs/plugin-vue-jsx': 5.1.5(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))
-      autoprefixer: 10.4.27(postcss@8.5.8)
-      consola: 3.4.2
-      cssnano: 7.1.3(postcss@8.5.8)
-      defu: 6.1.4
-      escape-string-regexp: 5.0.0
-      exsolve: 1.0.8
-      get-port-please: 3.2.0
-      jiti: 2.6.1
-      knitwork: 1.3.0
-      magic-string: 0.30.21
-      mlly: 1.8.1
-      mocked-exports: 0.1.1
-      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@libsql/client@0.14.0)(@parcel/watcher@2.5.6)(@types/node@22.19.15)(@vue/compiler-sfc@3.5.30)(aws4fetch@1.0.20)(better-sqlite3@12.6.2)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.14.0)(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@libsql/client@0.14.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(bun-types@1.3.10)(gel@2.2.0)))(drizzle-orm@0.44.7(@libsql/client@0.14.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(bun-types@1.3.10)(gel@2.2.0))(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.11(rollup@4.59.0))(rollup@4.59.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2)
-      nypm: 0.6.5
-      pathe: 2.0.3
-      pkg-types: 2.3.0
-      postcss: 8.5.8
-      seroval: 1.5.1
-      std-env: 4.0.0
-      ufo: 1.6.3
-      unenv: 2.0.0-rc.24
-      vite: 7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
-      vite-node: 5.3.0(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
-      vite-plugin-checker: 0.12.0(eslint@9.39.4(jiti@2.6.1))(optionator@0.9.4)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
-      vue: 3.5.30(typescript@5.9.3)
-      vue-bundle-renderer: 2.2.0
-    optionalDependencies:
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
-      rollup-plugin-visualizer: 6.0.11(rollup@4.59.0)
-    transitivePeerDependencies:
-      - '@biomejs/biome'
-      - '@types/node'
-      - eslint
-      - less
-      - lightningcss
-      - magicast
-      - meow
-      - optionator
-      - oxlint
-      - rollup
-      - sass
-      - sass-embedded
-      - stylelint
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - typescript
-      - vls
-      - vti
-      - vue-tsc
-      - yaml
 
   '@nuxt/vite-builder@4.4.2(b591d07692890e47f47c7a5d1c311a94)':
     dependencies:
@@ -18678,136 +18571,6 @@ snapshots:
       - xml2js
       - yaml
 
-  nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@libsql/client@0.14.0)(@parcel/watcher@2.5.6)(@types/node@22.19.15)(@vue/compiler-sfc@3.5.30)(aws4fetch@1.0.20)(better-sqlite3@12.6.2)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.14.0)(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@libsql/client@0.14.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(bun-types@1.3.10)(gel@2.2.0)))(drizzle-orm@0.44.7(@libsql/client@0.14.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(bun-types@1.3.10)(gel@2.2.0))(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.11(rollup@4.59.0))(rollup@4.59.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2):
-    dependencies:
-      '@dxup/nuxt': 0.4.0(magicast@0.5.2)(typescript@5.9.3)
-      '@nuxt/cli': 3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.5.2)
-      '@nuxt/devtools': 3.2.3(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))
-      '@nuxt/kit': 4.4.2(magicast@0.5.2)
-      '@nuxt/nitro-server': 4.4.2(d7dd8928bf752be5249ac66e11fe492a)
-      '@nuxt/schema': 4.4.2
-      '@nuxt/telemetry': 2.7.0(@nuxt/kit@4.4.2(magicast@0.5.2))
-      '@nuxt/vite-builder': 4.4.2(801ee145aa323efd17bea0d6bd35cb58)
-      '@unhead/vue': 2.1.12(vue@3.5.30(typescript@5.9.3))
-      '@vue/shared': 3.5.30
-      c12: 3.3.3(magicast@0.5.2)
-      chokidar: 5.0.0
-      compatx: 0.2.0
-      consola: 3.4.2
-      cookie-es: 2.0.0
-      defu: 6.1.4
-      devalue: 5.6.4
-      errx: 0.1.0
-      escape-string-regexp: 5.0.0
-      exsolve: 1.0.8
-      hookable: 6.0.1
-      ignore: 7.0.5
-      impound: 1.1.5
-      jiti: 2.6.1
-      klona: 2.0.6
-      knitwork: 1.3.0
-      magic-string: 0.30.21
-      mlly: 1.8.1
-      nanotar: 0.3.0
-      nypm: 0.6.5
-      ofetch: 1.5.1
-      ohash: 2.0.11
-      on-change: 6.0.2
-      oxc-minify: 0.117.0
-      oxc-parser: 0.117.0
-      oxc-transform: 0.117.0
-      oxc-walker: 0.7.0(oxc-parser@0.117.0)
-      pathe: 2.0.3
-      perfect-debounce: 2.1.0
-      picomatch: 4.0.3
-      pkg-types: 2.3.0
-      rou3: 0.8.1
-      scule: 1.3.0
-      semver: 7.7.4
-      std-env: 4.0.0
-      tinyglobby: 0.2.15
-      ufo: 1.6.3
-      ultrahtml: 1.6.0
-      uncrypto: 0.1.3
-      unctx: 2.5.0
-      unimport: 6.0.1
-      unplugin: 3.0.0
-      unrouting: 0.1.5
-      untyped: 2.0.0
-      vue: 3.5.30(typescript@5.9.3)
-      vue-router: 5.0.3(@vue/compiler-sfc@3.5.30)(vue@3.5.30(typescript@5.9.3))
-    optionalDependencies:
-      '@parcel/watcher': 2.5.6
-      '@types/node': 22.19.15
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@babel/core'
-      - '@babel/plugin-proposal-decorators'
-      - '@babel/plugin-syntax-jsx'
-      - '@biomejs/biome'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@electric-sql/pglite'
-      - '@libsql/client'
-      - '@netlify/blobs'
-      - '@pinia/colada'
-      - '@planetscale/database'
-      - '@rollup/plugin-babel'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - '@vitejs/devtools'
-      - '@vue/compiler-sfc'
-      - aws4fetch
-      - bare-abort-controller
-      - bare-buffer
-      - better-sqlite3
-      - bufferutil
-      - cac
-      - commander
-      - db0
-      - drizzle-orm
-      - encoding
-      - eslint
-      - idb-keyval
-      - ioredis
-      - less
-      - lightningcss
-      - magicast
-      - meow
-      - mysql2
-      - optionator
-      - oxlint
-      - pinia
-      - react-native-b4a
-      - rolldown
-      - rollup
-      - rollup-plugin-visualizer
-      - sass
-      - sass-embedded
-      - sqlite3
-      - stylelint
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - vite
-      - vls
-      - vti
-      - vue-tsc
-      - xml2js
-      - yaml
-
   nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@libsql/client@0.14.0)(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.30)(aws4fetch@1.0.20)(better-sqlite3@12.6.2)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.14.0)(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@libsql/client@0.14.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(bun-types@1.3.10)(gel@2.2.0)))(drizzle-orm@0.44.7(@libsql/client@0.14.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(bun-types@1.3.10)(gel@2.2.0))(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.11(rollup@4.59.0))(rollup@4.59.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@3.2.5(typescript@5.9.3))(yaml@2.8.2):
     dependencies:
       '@dxup/nuxt': 0.4.0(magicast@0.5.2)(typescript@5.9.3)
@@ -21166,22 +20929,6 @@ snapshots:
       - terser
       - tsx
       - yaml
-
-  vite-plugin-checker@0.12.0(eslint@9.39.4(jiti@2.6.1))(optionator@0.9.4)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      chokidar: 4.0.3
-      npm-run-path: 6.0.0
-      picocolors: 1.1.1
-      picomatch: 4.0.3
-      tiny-invariant: 1.3.3
-      tinyglobby: 0.2.15
-      vite: 7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
-      vscode-uri: 3.1.0
-    optionalDependencies:
-      eslint: 9.39.4(jiti@2.6.1)
-      optionator: 0.9.4
-      typescript: 5.9.3
 
   vite-plugin-checker@0.12.0(eslint@9.39.4(jiti@2.6.1))(optionator@0.9.4)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@2.2.12(typescript@5.9.3)):
     dependencies:


### PR DESCRIPTION
## Summary

Adds `packages/cli-auth` — the shared auth lib for OpenApe CLIs. After `apes login` once on a device, every other CLI (ape-plans, ape-tasks, upcoming ape-secrets / ape-seeds) gets a valid bearer transparently. No per-service login. M1 of the OpenApe CLI SSO refactor (`~/.claude/plans/openape-cli-sso.md`).

## What it does

```ts
import { getAuthorizedBearer } from '@openape/cli-auth'

const authorization = await getAuthorizedBearer({
  endpoint: 'https://plans.openape.ai',
  aud: 'plans.openape.ai',
  scopes: ['plans:rw'],
})

await fetch('https://plans.openape.ai/api/teams', { headers: { Authorization: authorization } })
```

Under the hood:
1. Check `~/.config/apes/sp-tokens/plans.openape.ai.json`. Return cached if not expired (60s skew).
2. Otherwise, ensure the IdP token at `~/.config/apes/auth.json` is fresh. Refresh via OIDC if needed (rotates the stored refresh_token).
3. POST the IdP token to `${endpoint}/api/cli/exchange`. SP verifies it via JWKS against id.openape.ai, applies its policies, mints a 30d SP-scoped token with `aud=plans.openape.ai` (M2 will land that endpoint on plans + tasks).
4. Cache and return.

If anything fails, throws `NotLoggedInError` with a clear "Run `apes login`" hint.

## Public API

- `getAuthorizedBearer(opts)` — one-shot
- `ensureFreshIdpAuth(now?)` — refresh the IdP OAuth token if needed
- `exchangeForSpToken(idpAuth, request)` — manual exchange
- Storage: `loadIdpAuth` / `saveIdpAuth` / `clearIdpAuth` / `loadSpToken` / `saveSpToken` / `clearSpToken` / `clearAllSpTokens`
- `getConfigDir()` / `getAuthFile()` / `getSpTokensDir()`
- Error types: `AuthError`, `NotLoggedInError`

## Coexistence with @openape/apes

`auth.json` is shared — both packages agree on the JSON schema (idp / access_token / refresh_token / email / expires_at). apes is the canonical writer (`apes login` writes; `apes logout` clears). cli-auth is read-mostly, only writing back via `ensureFreshIdpAuth` after a successful refresh (preserves all other fields). SP-tokens live in their own `sp-tokens/` subdirectory and are managed exclusively by cli-auth.

## Storage path override

`OPENAPE_CLI_AUTH_HOME` env var redirects the storage root. Used by tests for isolation; could also be used by CI.

## Test plan

- [x] `pnpm --filter @openape/cli-auth test` — 3 files, 20 tests passing
- [x] `pnpm --filter @openape/cli-auth typecheck` clean
- [x] `pnpm --filter @openape/cli-auth lint` clean
- [x] `pnpm --filter @openape/cli-auth build` clean (6.7 KB ESM, 5.1 KB d.ts)
- [ ] Post-merge: M2 lands `/api/cli/exchange` on plans.openape.ai + tasks.openape.ai
- [ ] M3 then makes ape-plans/ape-tasks consumer of this lib

## Changeset

`@openape/cli-auth` minor (initial 0.1.0).