### PR TITLE
fix(scripts): include @openape/cli-auth in publish chain

### DIFF
--- a/.changeset/cli-auth-in-publish-chain.md
+++ b/.changeset/cli-auth-in-publish-chain.md
@@ -1,0 +1,5 @@
+---
+'@openape/cli-auth': patch
+---
+
+Bump to trigger publish via the now-fixed publish-chain.mjs script (cli-auth was missing from the explicit PACKAGES list, so previous version bumps built but never published).

--- a/scripts/publish-chain.mjs
+++ b/scripts/publish-chain.mjs
@@ -27,6 +27,7 @@ const PACKAGES = [
   { name: '@openape/core', dir: 'packages/core' },
   { name: '@openape/grants', dir: 'packages/grants' },
   { name: '@openape/auth', dir: 'packages/auth' },
+  { name: '@openape/cli-auth', dir: 'packages/cli-auth' },
   { name: '@openape/proxy', dir: 'packages/proxy' },
   { name: '@openape/server', dir: 'packages/server' },
   { name: '@openape/browser', dir: 'packages/browser' },


### PR DESCRIPTION
Replaces #164 (rebased on main).

publish-chain.mjs has an explicit PACKAGES list. cli-auth was added in M1 of the SSO refactor but never added to this list, so the release workflow has been building it but skipping publish. Bumps under 0.2.x have been ghost-versioned as a result.

Adds cli-auth to the list (between auth and proxy). Includes a patch changeset to force a fresh version bump + publish on this run.