### PR TITLE
fix(idp): add missing decided_by_standing_grant migration

### DIFF
--- a/apps/openape-free-idp/server/plugins/02.database.ts
+++ b/apps/openape-free-idp/server/plugins/02.database.ts
@@ -131,6 +131,12 @@ export default defineNitroPlugin(async () => {
     // auto_approval_kind column on grants — null = human, 'standing' or 'yolo'.
     try { await db.run(sql`ALTER TABLE grants ADD COLUMN auto_approval_kind TEXT`) }
     catch { /* already present */ }
+    // decided_by_standing_grant — id of the standing grant that auto-approved
+    // this grant, for audit. Nullable. Drizzle's `db.select().from(grants)`
+    // includes this column on every read, so a missing column means every
+    // /api/grants and /api/standing-grants call 500s on existing prod DBs.
+    try { await db.run(sql`ALTER TABLE grants ADD COLUMN decided_by_standing_grant TEXT`) }
+    catch { /* already present */ }
   }
   catch (err) {
     console.error('[database] Table creation failed (tables may already exist):', err)


### PR DESCRIPTION
## Summary

Drizzle's \`grants\` schema declares \`decided_by_standing_grant\` (nullable TEXT) but the IdP DB-init plugin never had a matching idempotent \`ALTER TABLE … ADD COLUMN\`. On every existing prod DB created before that column was added to the schema, \`SELECT * FROM grants\` (issued by Drizzle for \`/api/grants\` and \`/api/standing-grants\`) errored with:

\`\`\`
SQLITE_ERROR: no such column: decided_by_standing_grant
\`\`\`

…surfacing as **HTTP 500** on grants-list / standing-grants-list and breaking every apes-CLI flow that needed to request or reuse a grant (Nano sandbox running \`ape-shell -c "echo …"\`, the iPhone web UI on \`/agents/<id>\`, etc.).

## Fix

Adds the same self-healing \`ALTER TABLE … ADD COLUMN … TEXT\` pattern that already exists for \`auto_approval_kind\` two lines above. Idempotent — wrapped in try/catch so a re-run on a DB that already has the column is a no-op.

## Verification

- Hotfix applied on chatty's \`idp.db\`. Endpoints went from 500 → 401-when-unauth (correct).
- New self-healing migration covered locally: build + lint + typecheck green via pre-commit.
- Future restarts on any stale DB will silently ALTER (or no-op).

## Test plan

- [x] After deploy, \`curl https://id.openape.ai/api/standing-grants\` returns 401 (auth required), not 500.
- [x] Bot retries \`apes login\` / \`ape-shell -c "echo …"\` from a sandbox without compile toolchain — succeeds.