### PR TITLE
fix(idp): self-serve passkey re-registration for existing users

### DIFF
--- a/.changeset/idp-passkey-relogin-flow.md
+++ b/.changeset/idp-passkey-relogin-flow.md
@@ -1,0 +1,33 @@
+---
+"@openape/nuxt-auth-idp": patch
+---
+
+idp: existing users can self-serve passkey re-registration after passkey loss
+
+Previously `POST /api/register` returned a silent `{ok:true}` for any email
+that already had a user record, while only sending the registration mail for
+unknown emails. The intent was email-enumeration protection. The side effect
+was that users who lost their passkey (lost device, ditched browser profile,
+or — in our case — got migrated to a new RP-domain so their existing passkey
+no longer matched) were locked out without any self-service path.
+
+`POST /api/register` now always issues a registration token and sends the
+mail, regardless of whether the user record exists. The verify endpoint
+(`webauthn/register/verify.post.ts`) already handled the existing-user case
+idempotently: it skips user creation and just appends the new credential.
+
+Email-enumeration protection is preserved at the response/timing layer —
+both unknown and known emails get the same `{ok:true}` response and the
+same mail-send latency. The mail content is identical for both, so an
+attacker who already controls the victim's mailbox can't differentiate
+"known" vs "unknown" any more easily than via any normal mail-based
+recovery flow on any other product.
+
+Frontend changes:
+- `useWebAuthn` composable now reads `error.data.title` (h3 ProblemDetails)
+  in addition to `statusMessage`, so users see "No passkeys found for this
+  email" instead of the raw FetchError string `[POST] "...": 404`.
+- Login page detects the "no passkeys" case and shows an actionable CTA
+  pointing at `/register-email?email=…` to trigger the recovery flow.
+- `/register-email` pre-fills from the `?email=` query param so users
+  don't retype their address.

--- a/apps/openape-free-idp/app/pages/login.vue
+++ b/apps/openape-free-idp/app/pages/login.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onUnmounted, ref } from 'vue'
+import { computed, onUnmounted, ref } from 'vue'
 
 useSeoMeta({ title: 'Login' })
 
@@ -22,17 +22,28 @@ let countdownTimer: ReturnType<typeof setInterval> | null = null
 const { login, error: webauthnError, loading } = useWebAuthn()
 const { fetchUser } = useIdpAuth()
 
+const noPasskeyForDomain = computed(() =>
+  /no passkeys?/i.test(webauthnError.value ?? ''),
+)
+
 async function handlePasskeyLogin() {
-  const success = await login(email.value || undefined)
-  if (success) {
-    await fetchUser()
-    const returnTo = route.query.returnTo as string
-    if (returnTo) {
-      await navigateTo(returnTo, { external: true })
+  try {
+    const success = await login(email.value || undefined)
+    if (success) {
+      await fetchUser()
+      const returnTo = route.query.returnTo as string
+      if (returnTo) {
+        await navigateTo(returnTo, { external: true })
+      }
+      else {
+        await navigateTo('/')
+      }
     }
-    else {
-      await navigateTo('/')
-    }
+  }
+  catch {
+    // Composable already populated webauthnError; the template offers the
+    // re-register CTA when the message indicates "no passkeys for this domain"
+    // (typical after a passkey loss or RP-domain migration like .at → .ai).
   }
 }
 
@@ -250,6 +261,17 @@ onUnmounted(() => {
       <p v-if="webauthnError || challengeError" class="mt-3 text-sm text-red-400 text-center">
         {{ webauthnError || challengeError }}
       </p>
+
+      <!-- Actionable recovery: triggered when the server says "no passkeys for
+           this email" (for current RP domain). Sends the user to the email-
+           based registration flow which adds a new passkey to the existing
+           account without touching whatever credentials they already have. -->
+      <div v-if="noPasskeyForDomain && email" class="mt-3 text-sm text-gray-400 text-center">
+        Kein Passkey für diese Domain hinterlegt.
+        <NuxtLink :to="`/register-email?email=${encodeURIComponent(email)}`" class="text-primary hover:underline">
+          Registrierungslink anfordern
+        </NuxtLink>
+      </div>
 
       <button
         class="mt-4 text-sm text-gray-500 hover:text-gray-300 transition-colors"

--- a/apps/openape-free-idp/app/pages/register-email.vue
+++ b/apps/openape-free-idp/app/pages/register-email.vue
@@ -3,7 +3,10 @@ import { ref } from 'vue'
 
 useSeoMeta({ title: 'Account erstellen' })
 
-const email = ref('')
+// Pre-fill from query param so the login page's "no passkey for this domain"
+// recovery flow lands here without making the user retype their address.
+const route = useRoute()
+const email = ref((route.query.email as string) ?? '')
 const loading = ref(false)
 const sent = ref(false)
 const error = ref('')

--- a/apps/openape-free-idp/server/api/register.post.ts
+++ b/apps/openape-free-idp/server/api/register.post.ts
@@ -14,14 +14,20 @@ export default defineEventHandler(async (event) => {
   const ip = getRequestIP(event, { xForwardedFor: true }) || 'unknown'
   await checkRateLimit(email, ip)
 
-  const { userStore, registrationUrlStore } = useIdpStores()
+  const { registrationUrlStore } = useIdpStores()
 
-  // Silent return if user already exists (prevent email enumeration)
-  const existing = await userStore.findByEmail(email)
-  if (existing) {
-    return { ok: true }
-  }
-
+  // We always issue a registration token + send a mail, even for existing
+  // users. The verify endpoint (`webauthn/register/verify.post.ts`) already
+  // handles both new-user and existing-user cases idempotently: it only
+  // creates the user record if missing and otherwise just appends the new
+  // credential. This makes "lost passkey / new device / new RP-domain" a
+  // self-service recovery flow instead of an admin-only ticket.
+  //
+  // Email-enumeration protection is preserved at the response layer: both
+  // unknown and known emails get the same `{ok:true}` response and the same
+  // mail-send latency. The mail content is identical for both cases, so an
+  // attacker who controls a victim's mailbox can't infer "this email is
+  // registered" any more easily than via any normal mail-based recovery flow.
   const token = randomUUID()
   const now = Date.now()
   const twentyFourHours = 24 * 60 * 60 * 1000

--- a/modules/nuxt-auth-idp/src/runtime/composables/useWebAuthn.ts
+++ b/modules/nuxt-auth-idp/src/runtime/composables/useWebAuthn.ts
@@ -27,8 +27,8 @@ export function useWebAuthn() {
       return result
     }
     catch (err: unknown) {
-      const e = err as { data?: { statusMessage?: string }, message?: string }
-      error.value = e.data?.statusMessage ?? e.message ?? 'Registration failed'
+      const e = err as { data?: { statusMessage?: string, title?: string }, message?: string }
+      error.value = e.data?.title ?? e.data?.statusMessage ?? e.message ?? 'Registration failed'
       throw err
     }
     finally {
@@ -58,8 +58,8 @@ export function useWebAuthn() {
       return result
     }
     catch (err: unknown) {
-      const e = err as { data?: { statusMessage?: string }, message?: string }
-      error.value = e.data?.statusMessage ?? e.message ?? 'Login failed'
+      const e = err as { data?: { statusMessage?: string, title?: string }, message?: string, statusCode?: number }
+      error.value = e.data?.title ?? e.data?.statusMessage ?? e.message ?? 'Login failed'
       throw err
     }
     finally {
@@ -89,8 +89,8 @@ export function useWebAuthn() {
       return result
     }
     catch (err: unknown) {
-      const e = err as { data?: { statusMessage?: string }, message?: string }
-      error.value = e.data?.statusMessage ?? e.message ?? 'Failed to add device'
+      const e = err as { data?: { statusMessage?: string, title?: string }, message?: string }
+      error.value = e.data?.title ?? e.data?.statusMessage ?? e.message ?? 'Failed to add device'
       throw err
     }
     finally {


### PR DESCRIPTION
## Summary

Fixes the lockout case where any user who loses a passkey (device gone, browser profile reset, RP-domain migration like `.at → .ai`) had no self-service recovery path.

## Why

`POST /api/register` previously returned a silent `{ok:true}` for any email that already had a user record, while only sending the registration mail for unknown emails. The pre-existing branch was meant to protect against email enumeration. The side effect was a permanent lockout for existing users in any of these realistic scenarios:

- Passkey deleted from the authenticator
- Switched to a new device + iCloud Keychain didn't sync the credential
- RP-domain migrated (their existing passkey is bound to the old RP)

## Fix

Server: `POST /api/register` now always issues a registration token and calls `sendRegistrationEmail`. The verify endpoint (`webauthn/register/verify.post.ts:42-46`) already handles the existing-user case idempotently: skips user creation, appends new credential to the existing user record, leaving any pre-existing credentials untouched.

Email-enumeration protection is preserved at the **response + timing** layer:

- Both unknown and known emails return identical `{ok:true}`
- Same mail-send latency for both
- Identical mail content for both

So an attacker who already controls the victim's mailbox can't differentiate via this endpoint any more easily than via any other product's mail-based recovery flow.

Frontend follow-ups bundled in the same PR:

- `useWebAuthn` composable reads `error.data.title` (h3 ProblemDetails) in addition to `statusMessage`, so the UI shows `"No passkeys found for this email"` instead of the raw FetchError `[POST] "/api/webauthn/login/options": 404`.
- Login page detects the "no passkeys" case (regex on the surfaced message) and shows an actionable CTA → `/register-email?email=…` to trigger the recovery flow.
- `/register-email` pre-fills email from `?email=` query param so users don't retype their address.

## Verification

- [x] Pre-commit lint + typecheck green on the touched packages.
- [ ] Post-merge: real iPhone Mobile-Safari login attempt for `phofmann@delta-mind.at` → 404 → see CTA → click → registration mail arrives → register new `.ai` passkey → login succeeds.
- [ ] Existing `.at` passkey still works on `id.openape.at` (DB shared, credential row untouched).

## Risks

- Email-enumeration: argued above as not-worse-than-before. If we want to harden it further later, we can add a constant-time `setTimeout(0..N ms)` to equalize Resend-API latency between cases, but that's belt-and-braces for a threat we've already neutralized at the response layer.
- Slight increase in Resend cost: existing users who hit `/register` now consume one mail credit instead of zero. Negligible at current volumes.