### PR TITLE
feat(proxy): Node-runnable build, depended on by apes (M0)

### DIFF
--- a/.changeset/apes-proxy-m0-node-build.md
+++ b/.changeset/apes-proxy-m0-node-build.md
@@ -1,0 +1,20 @@
+---
+"@openape/proxy": patch
+"@openape/apes": patch
+---
+
+proxy + apes: Node-runnable build for `@openape/proxy`, depended on by `@openape/apes`
+
+`@openape/proxy` is now distributed as a Node-runnable bundle (`dist/index.js` with
+`#!/usr/bin/env node` shebang, exec bit set, target node22) instead of a Bun-only
+TypeScript source. The package's `bin` entry now points at `dist/index.js`, the
+package ships `dist/`, `config.example.toml`, and `README.md`.
+
+`@openape/apes` adds `@openape/proxy` as a `workspace:*` dependency. This is
+foundation work for the upcoming `apes proxy -- <cmd>` subcommand: a global
+`npm i -g @openape/apes` install will from now on also install the proxy
+binary, and `apes` can locate it via
+`require.resolve('@openape/proxy/package.json')` plus the `bin` field — no
+`bun` runtime required on the user's machine.
+
+No CLI behavior change today. `apes proxy --` lands in the next milestone.

--- a/packages/apes/package.json
+++ b/packages/apes/package.json
@@ -34,6 +34,7 @@
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@openape/core": "workspace:*",
     "@openape/grants": "workspace:*",
+    "@openape/proxy": "workspace:*",
     "citty": "^0.1.6",
     "consola": "^3.4.2",
     "giget": "^2.0.0",

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -11,8 +11,13 @@
   "author": "Patrick Hofmann",
   "license": "MIT",
   "bin": {
-    "openape-proxy": "./src/index.ts"
+    "openape-proxy": "./dist/index.js"
   },
+  "files": [
+    "dist",
+    "config.example.toml",
+    "README.md"
+  ],
   "scripts": {
     "start": "bun run src/index.ts",
     "dev": "bun run --watch src/index.ts",

--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env bun
+#!/usr/bin/env node
 import { createServer } from 'node:http'
 import { parseArgs } from 'node:util'
 import { loadMultiAgentConfig } from './config.js'

--- a/packages/proxy/tsup.config.ts
+++ b/packages/proxy/tsup.config.ts
@@ -1,9 +1,17 @@
+import { chmodSync } from 'node:fs'
 import { defineConfig } from 'tsup'
 
 export default defineConfig({
   entry: ['src/index.ts'],
   format: ['esm', 'cjs'],
+  target: 'node22',
   dts: false,
   clean: true,
   sourcemap: true,
+  // Make the binary directly executable so the bin entry works without an
+  // explicit `node` prefix (npm-installed bin links rely on the +x bit).
+  onSuccess: async () => {
+    chmodSync('dist/index.js', 0o755)
+    chmodSync('dist/index.cjs', 0o755)
+  },
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -470,6 +470,9 @@ importers:
       '@openape/grants':
         specifier: workspace:*
         version: link:../grants
+      '@openape/proxy':
+        specifier: workspace:*
+        version: link:../proxy
       citty:
         specifier: ^0.1.6
         version: 0.1.6


### PR DESCRIPTION
## Summary

M0 of the [ape-shell proxy-mediated egress plan](https://plans.openape.ai/teams/01KPV1XN2S4FEGHFVPR3ZZ7VN1/plans/01KQ6QY6R67STKSK1D2G90YHX4). Foundation work for the upcoming `apes proxy -- <cmd>` subcommand.

## What changes

**`@openape/proxy`** is now a Node-runnable package:
- `src/index.ts` shebang switched `bun → node` (`bun run` still runs node-shebang files, so the existing dev script keeps working)
- tsup `target: 'node22'`, postbuild chmod +x on `dist/index.js` + `dist/index.cjs`
- `bin["openape-proxy"]` points at `./dist/index.js` (was: `./src/index.ts`)
- `package.json` gains a `files` allowlist so `dist/`, `config.example.toml`, `README.md` ship on npm publish

**`@openape/apes`** declares `@openape/proxy` as a `workspace:*` runtime dep so a global `npm i -g @openape/apes` install will from now on also pull the proxy binary, and `apes` can locate it via `require.resolve('@openape/proxy/package.json')` plus the `bin` field — no `bun` runtime required on the user's machine.

## Verification

- [x] `pnpm --filter @openape/proxy build` clean (`dist/index.js` has `#!/usr/bin/env node` shebang + exec bit)
- [x] `node packages/proxy/dist/index.js -c <config>` starts and listens; live `curl -x http://127.0.0.1:<port> https://api.github.com/zen` returns 200
- [x] In `packages/apes`, `node -e "console.log(require.resolve('@openape/proxy/package.json'))"` returns the workspace path; `bin['openape-proxy']` resolves to `dist/index.js`
- [x] `pnpm --filter @openape/apes typecheck` clean
- [x] Pre-commit hook ran lint + typecheck on the touched packages

## Out of scope

No CLI behavior change. The user-facing `apes proxy --` subcommand lands in M1a.