### PR TITLE
feat(apes): broaden proxy env-vars set by 'apes proxy --'

### DIFF
--- a/.changeset/apes-proxy-broaden-env-vars.md
+++ b/.changeset/apes-proxy-broaden-env-vars.md
@@ -1,0 +1,20 @@
+---
+"@openape/apes": patch
+---
+
+apes: `apes proxy --` now sets all common proxy env-var variants
+
+Wider tool coverage for the env-var-based egress mediation. Previously
+only `HTTPS_PROXY`, `HTTP_PROXY`, and `NO_PROXY` (uppercase) were set.
+Now also: `https_proxy` / `http_proxy` / `no_proxy` (lowercase, libcurl
++ many Python tools), `ALL_PROXY` / `all_proxy` (curl, rsync, ftp), and
+`NODE_USE_ENV_PROXY=1` (Node 24+ native `fetch` via undici).
+
+Net effect: a wrapped command's child Node code (e.g. Claude Code's
+WebFetch tool calling out via undici) now routes through the proxy
+without per-app ProxyAgent wiring, and lowercase-only tools that
+previously bypassed (some Python `urllib`, older curl distro builds)
+are now covered.
+
+No CLI-flag change. Hard kernel-level enforcement (block direct
+sockets) remains a separate opt-in milestone.

--- a/packages/apes/src/commands/proxy.ts
+++ b/packages/apes/src/commands/proxy.ts
@@ -61,11 +61,29 @@ export const proxyCommand = defineCommand({
 
     // Forward SIGINT/SIGTERM so the user's Ctrl-C stops the wrapped command
     // gracefully (which then triggers our finally-block cleanup of the proxy).
+    //
+    // We set every common variant of the proxy env-vars because tools differ:
+    // - libcurl / curl honors lowercase `https_proxy` and uppercase
+    //   `HTTPS_PROXY` (and security advisories caused some distros to ignore
+    //   uppercase `HTTP_PROXY` for HTTP requests; setting both is safest).
+    // - Many Go / Rust / Python tools read uppercase only.
+    // - `ALL_PROXY` is honored by curl, rsync, ftp, and others as a fallback
+    //   when the per-scheme variant is absent.
+    // - Node 24+ native `fetch` (undici) honors `NODE_USE_ENV_PROXY=1`. Setting
+    //   it here means the wrapped command's Node code routes through the proxy
+    //   without per-app ProxyAgent wiring.
+    const noProxy = process.env.NO_PROXY ?? process.env.no_proxy ?? '127.0.0.1,localhost'
     const childEnv: NodeJS.ProcessEnv = {
       ...process.env,
       HTTPS_PROXY: proxyUrl,
+      https_proxy: proxyUrl,
       HTTP_PROXY: proxyUrl,
-      NO_PROXY: process.env.NO_PROXY ?? '127.0.0.1,localhost',
+      http_proxy: proxyUrl,
+      ALL_PROXY: proxyUrl,
+      all_proxy: proxyUrl,
+      NO_PROXY: noProxy,
+      no_proxy: noProxy,
+      NODE_USE_ENV_PROXY: '1',
     }
 
     const exitCode = await new Promise<number>((resolveExit) => {


### PR DESCRIPTION
## Summary

Small follow-up to M1a. `apes proxy -- <cmd>` now sets every common variant of the proxy env-vars instead of only `HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` (uppercase).

## Why

Tools differ in which variant they honor:

- **libcurl / curl:** lowercase `https_proxy` (case-sensitive on Linux/macOS) AND uppercase `HTTPS_PROXY`. Some distro-patched curls also ignore uppercase `HTTP_PROXY` for HTTP-scheme requests due to CVE-2016-5420.
- **Many Go / Rust / Python tools:** uppercase only.
- **`ALL_PROXY`:** curl, rsync, ftp fallback when per-scheme variant is absent.
- **`NODE_USE_ENV_PROXY=1`:** Node 24+ native `fetch` (undici) honors this.

## What changes

```diff
+ HTTPS_PROXY: proxyUrl, https_proxy: proxyUrl,
+ HTTP_PROXY:  proxyUrl, http_proxy:  proxyUrl,
+ ALL_PROXY:   proxyUrl, all_proxy:   proxyUrl,
+ NO_PROXY:    noProxy,  no_proxy:    noProxy,
+ NODE_USE_ENV_PROXY: '1',
```

## Net effect for `apes proxy -- claude`

Claude Code's WebFetch tool (Node `fetch` via undici) now routes through `openape-proxy` automatically, and any `bash -c "curl …"` it triggers via the Bash tool inherits the same env — libcurl picks up either variant.

## Verification

- [x] `apes proxy -- bash -c 'for v in HTTPS_PROXY https_proxy HTTP_PROXY http_proxy ALL_PROXY all_proxy NO_PROXY no_proxy NODE_USE_ENV_PROXY; do echo "$v=${!v}"; done'` → all 9 variants set
- [x] `pnpm --filter @openape/apes lint` → 0 errors
- [x] `pnpm --filter @openape/apes typecheck` → clean
- [x] `pnpm --filter @openape/apes build` → clean

## Out of scope

Hard kernel-level enforcement (block direct sockets even when tools ignore env-vars) tracked as separate opt-in M7 in the [plan](https://plans.openape.ai/teams/01KPV1XN2S4FEGHFVPR3ZZ7VN1/plans/01KQ6QY6R67STKSK1D2G90YHX4) — `apes proxy --strict --` via `sandbox-exec` (macOS) / `unshare`+`iptables` (Linux).