### PR TITLE
feat(proxy): host-based rules at HTTPS-CONNECT (M2) + default_action='allow' fix

### DIFF
--- a/.changeset/proxy-m2-connect-rules.md
+++ b/.changeset/proxy-m2-connect-rules.md
@@ -1,0 +1,40 @@
+---
+"@openape/proxy": minor
+---
+
+proxy: host-based allow/deny/grant_required rules now apply at HTTPS CONNECT time
+
+Until now `connect.ts` (the HTTPS-tunnel handler) only did SSRF protection +
+optional JWT-auth before piping bytes through. The `[[allow]]` / `[[deny]]` /
+`[[grant_required]]` lists in the TOML config were inert for HTTPS hosts —
+they only fired on the cleartext-HTTP forward-proxy path. In practice that
+meant any agent doing `curl https://...` got tunneled regardless of policy.
+
+Now CONNECT runs the same `evaluateRules(domain, 'CONNECT', '/')` pipeline
+the HTTP path uses:
+- `[[deny]]` host-match → 403 fast-reject + audit
+- `[[grant_required]]` → blocking grant request to the IdP, tunnel only on
+  approval, 403/504 on deny/timeout
+- `[[allow]]` host-match → tunnel + audit
+- unmatched → falls to `default_action`
+
+Rules with `methods` or `path` filters cannot be enforced at CONNECT time
+(the TLS payload is opaque), so only domain-only rules match for HTTPS.
+This is intentional and documented inline.
+
+### Side-fix: `default_action="allow"`
+
+Adds `'allow'` to the `default_action` union (was: `'block' | 'request' | 'request-async'`).
+Previously the matcher only special-cased `'block'` and fell through to
+`grant_required` for anything else, so a config saying `default_action="allow"`
+would silently route unmatched hosts to a once-grant request — which blocks
+or fails when no IdP/grant flow is set up. Matcher now handles `'allow'` as a
+hard pass, matching the intent of the config string.
+
+### Internals: shared `GrantsClient` map
+
+`createNodeHandler` now builds a single `Map<email, GrantsClient>` via the
+new public `buildGrantsClients(config)` and passes it to both the forward-
+proxy fetch path (`createMultiAgentProxy`) and the new CONNECT-side grant
+flow. `createMultiAgentProxy` accepts an optional pre-built map for back-
+compat; behavior unchanged when called without it.

--- a/packages/proxy/src/connect.ts
+++ b/packages/proxy/src/connect.ts
@@ -36,6 +36,41 @@ export async function handleConnect(
     return
   }
 
+  // SYSTEM BYPASS: outbound to any configured IdP host is unconditionally
+  // allowed. The proxy itself talks to the IdP for JWT verification + grant
+  // approval, and any process inside the proxy boundary may need to call the
+  // IdP for `apes login` / `apes whoami` / token-exchange BEFORE it can ever
+  // produce a valid Proxy-Authorization JWT. Blocking IdP traffic would
+  // either deadlock the grant flow or lock users out of authentication.
+  // We therefore skip auth (no JWT yet for first-login), SSRF (local-dev IdPs
+  // can live at 127.0.0.1), and policy rules (operator must not be able to
+  // override this system invariant).
+  const idpHosts = new Set(
+    config.agents
+      .map((a) => {
+        try {
+          return new URL(a.idp_url).hostname.toLowerCase()
+        }
+        catch {
+          return ''
+        }
+      })
+      .filter(h => h.length > 0),
+  )
+  if (idpHosts.has(host.toLowerCase())) {
+    writeAudit({
+      ts: new Date().toISOString(),
+      agent: 'system',
+      action: 'allow',
+      domain: host,
+      method: 'CONNECT',
+      path: target,
+      rule: 'idp-system-bypass',
+    })
+    tunnel(host, port, clientSocket)
+    return
+  }
+
   const mandatoryAuth = config.proxy.mandatory_auth ?? false
 
   // Auth check — CONNECT always requires auth in mandatory mode
@@ -162,7 +197,7 @@ export async function handleConnect(
       const grant = await grantsClient.requestGrant({
         requester: effectiveEmail,
         targetHost: host,
-        audience: 'proxy',
+        audience: 'ape-proxy',
         grantType: action.rule.grant_type,
         permissions: action.rule.permissions,
         reason: `CONNECT ${host}:${port}`,
@@ -194,11 +229,17 @@ export async function handleConnect(
     writeAudit({ ...baseAudit, action: 'allow', rule: 'allow-list' })
   }
 
-  // Connect to target
+  tunnel(host, port, clientSocket)
+}
+
+/**
+ * Open a TCP socket to host:port and bidirectionally pipe it with the client
+ * socket. Used by both the policy-pass path (auth + rules approved) and the
+ * IdP system-bypass path (no auth/policy involved).
+ */
+function tunnel(host: string, port: number, clientSocket: Socket): void {
   const targetSocket = connect(port, host, () => {
     clientSocket.write('HTTP/1.1 200 Connection Established\r\n\r\n')
-
-    // Bidirectional pipe
     targetSocket.pipe(clientSocket)
     clientSocket.pipe(targetSocket)
   })
@@ -212,7 +253,6 @@ export async function handleConnect(
     targetSocket.destroy()
   })
 
-  // Cleanup on close
   clientSocket.on('close', () => targetSocket.destroy())
   targetSocket.on('close', () => clientSocket.destroy())
 }

--- a/packages/proxy/src/connect.ts
+++ b/packages/proxy/src/connect.ts
@@ -1,17 +1,27 @@
 import type { IncomingMessage } from 'node:http'
 import type { Socket } from 'node:net'
 import { connect } from 'node:net'
-import type { MultiAgentProxyConfig } from './types.js'
+import type { AgentConfig, MultiAgentProxyConfig, ProxyConfig } from './types.js'
 import { AuthError, verifyAgentAuth } from './auth.js'
 import { isPrivateOrLoopback } from './ssrf.js'
 import { writeAudit } from './audit.js'
+import { evaluateRules } from './matcher.js'
+import type { GrantsClient } from './grants-client.js'
 
 /**
  * Handle HTTP CONNECT requests for tunneling (used by HTTP_PROXY clients).
- * Flow: Auth check → SSRF check → TCP connect → bidirectional pipe.
+ * Flow: Auth → SSRF → host-based rule evaluation (allow / deny / grant_required)
+ *  → TCP connect → bidirectional pipe.
+ *
+ * For HTTPS via CONNECT we only see the hostname (the TLS payload is opaque).
+ * Rules with `methods` or `path` filters cannot be enforced at CONNECT time and
+ * are skipped — they'd only match if the client also carried the same hostname
+ * over cleartext-HTTP forward-proxy. This is intentional: there's no honest way
+ * to gate a method we can't observe.
  */
 export async function handleConnect(
   config: MultiAgentProxyConfig,
+  grantsClients: Map<string, GrantsClient>,
   req: IncomingMessage,
   clientSocket: Socket,
   _head: Buffer,
@@ -85,6 +95,103 @@ export async function handleConnect(
     clientSocket.write('HTTP/1.1 403 Forbidden\r\n\r\n')
     clientSocket.destroy()
     return
+  }
+
+  // Host-based rule evaluation. Pick the agent's config: in single-agent or
+  // unauth mode this is just config.agents[0]; in multi-agent mode we use the
+  // identity established above.
+  const agentConf: AgentConfig | undefined = agentEmail
+    ? config.agents.find(a => a.email === agentEmail)
+    : config.agents[0]
+  if (!agentConf) {
+    clientSocket.write('HTTP/1.1 403 Forbidden\r\n\r\n')
+    clientSocket.destroy()
+    return
+  }
+  const effectiveEmail = agentEmail ?? agentConf.email
+
+  const rulesConfig: ProxyConfig = {
+    proxy: {
+      listen: config.proxy.listen,
+      idp_url: agentConf.idp_url,
+      agent_email: agentConf.email,
+      default_action: config.proxy.default_action,
+    },
+    allow: agentConf.allow ?? [],
+    deny: agentConf.deny ?? [],
+    grant_required: agentConf.grant_required ?? [],
+  }
+
+  // CONNECT carries no method/path beyond host:port. Pass 'CONNECT' as method
+  // and '/' as path so rules with method-filters (which we can't enforce here)
+  // simply don't match — operator must specify method-less rules to gate
+  // HTTPS hosts.
+  const action = evaluateRules(rulesConfig, host, 'CONNECT', '/')
+  const baseAudit = {
+    ts: new Date().toISOString(),
+    agent: effectiveEmail,
+    domain: host,
+    method: 'CONNECT',
+    path: target,
+  } as const
+
+  if (action.type === 'deny') {
+    writeAudit({ ...baseAudit, action: 'deny', rule: 'deny-list' })
+    const note = action.note ? ` ${action.note}` : ''
+    clientSocket.write(`HTTP/1.1 403 Forbidden\r\nContent-Type: text/plain\r\n\r\nBlocked:${note}\r\n`)
+    clientSocket.destroy()
+    return
+  }
+
+  if (action.type === 'grant_required') {
+    const grantsClient = grantsClients.get(agentConf.email)
+    if (!grantsClient) {
+      writeAudit({ ...baseAudit, action: 'deny', rule: 'grant_required (no client)' })
+      clientSocket.write('HTTP/1.1 500 Internal Server Error\r\n\r\nNo grants client for agent\r\n')
+      clientSocket.destroy()
+      return
+    }
+
+    // Async-mode (`request-async`) is meaningful for HTTP forward-proxy where
+    // the client can re-issue the request after approval. CONNECT clients
+    // (curl, gh, …) won't transparently retry on 407 mid-handshake, so we
+    // always block the tunnel until the grant resolves. Operator can shorten
+    // the wait via per-rule `duration` or via the IdP's grant TTL.
+    const startTs = Date.now()
+    try {
+      const grant = await grantsClient.requestGrant({
+        requester: effectiveEmail,
+        targetHost: host,
+        audience: 'proxy',
+        grantType: action.rule.grant_type,
+        permissions: action.rule.permissions,
+        reason: `CONNECT ${host}:${port}`,
+        duration: action.rule.duration,
+      })
+      const decided = await grantsClient.waitForApproval(grant.id)
+      const waitedMs = Date.now() - startTs
+      if (decided.status === 'approved') {
+        writeAudit({ ...baseAudit, action: 'grant_approved', rule: 'grant_required', grant_id: decided.id, waited_ms: waitedMs })
+        // Fall through to the TCP connect below.
+      }
+      else {
+        writeAudit({ ...baseAudit, action: 'grant_denied', rule: 'grant_required', grant_id: decided.id, waited_ms: waitedMs })
+        clientSocket.write(`HTTP/1.1 403 Forbidden\r\n\r\nGrant denied by ${decided.decided_by ?? 'policy'}\r\n`)
+        clientSocket.destroy()
+        return
+      }
+    }
+    catch (err) {
+      const msg = err instanceof Error ? err.message : 'Unknown error'
+      writeAudit({ ...baseAudit, action: 'grant_timeout', rule: 'grant_required', error: msg })
+      clientSocket.write(`HTTP/1.1 504 Gateway Timeout\r\n\r\nGrant request failed: ${msg}\r\n`)
+      clientSocket.destroy()
+      return
+    }
+  }
+  else {
+    // 'allow' — log and continue.
+    writeAudit({ ...baseAudit, action: 'allow', rule: 'allow-list' })
   }
 
   // Connect to target

--- a/packages/proxy/src/matcher.ts
+++ b/packages/proxy/src/matcher.ts
@@ -65,9 +65,28 @@ export function evaluateRules(
     }
   }
 
-  // 4. Default: treat as grant_required with 'once'
+  // 4. Default action for unmatched hosts. Conceptually the proxy-side
+  // counterpart of the IdP's per-agent YOLO policy — both decide what
+  // happens when no specific rule matches, both live server-side (proxy or
+  // IdP), neither leaks the decision to the agent. Differences:
+  //   - IdP YOLO is per-agent, evaluated at grant time, can have deny-patterns
+  //     and an expiry window.
+  //   - Proxy default_action is per-proxy-instance, evaluated at request time,
+  //     binary outcome (allow/deny/request-grant).
+  //
+  // Modes:
+  //   - 'block': hard deny — paranoid agent profile.
+  //   - 'allow': hard pass — transparent-audit profile (log every call,
+  //     enforce nothing). Equivalent role to a YOLO policy without a
+  //     deny-list.
+  //   - 'request' / 'request-async' (OpenApe-default): treat as
+  //     grant_required with a once-grant catch-all so every new host
+  //     surfaces an interactive grant decision.
   if (config.proxy.default_action === 'block') {
     return { type: 'deny', note: 'No matching rule (default: block)' }
+  }
+  if (config.proxy.default_action === 'allow') {
+    return { type: 'allow' }
   }
 
   return {

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -43,11 +43,32 @@ export function createProxy(config: ProxyConfig) {
   return createMultiAgentProxy(multiConfig)
 }
 
-/** Multi-agent proxy with SSRF protection and mandatory auth */
-export function createMultiAgentProxy(config: MultiAgentProxyConfig) {
+/**
+ * Build the per-agent GrantsClient map used by both the HTTP forward-proxy
+ * handler (in this file's `createMultiAgentProxy`) and the CONNECT handler
+ * (in `connect.ts`). Exposed so `createNodeHandler` can share a single map
+ * instead of letting each handler construct its own — keeps any future
+ * per-agent token state coherent.
+ */
+export function buildGrantsClients(config: MultiAgentProxyConfig): Map<string, GrantsClient> {
   const grantsClients = new Map<string, GrantsClient>()
   for (const agent of config.agents) {
     grantsClients.set(agent.email, new GrantsClient(agent.idp_url))
+  }
+  return grantsClients
+}
+
+/** Multi-agent proxy with SSRF protection and mandatory auth */
+export function createMultiAgentProxy(
+  config: MultiAgentProxyConfig,
+  grantsClients: Map<string, GrantsClient> = buildGrantsClients(config),
+) {
+  // Backwards-compat: if caller didn't pre-build the map, we build our own.
+  // createNodeHandler always passes one in so the CONNECT handler can share it.
+  for (const agent of config.agents) {
+    if (!grantsClients.has(agent.email)) {
+      grantsClients.set(agent.email, new GrantsClient(agent.idp_url))
+    }
   }
 
   const mandatoryAuth = config.proxy.mandatory_auth ?? false
@@ -300,7 +321,12 @@ export function createNodeHandler(config: MultiAgentProxyConfig): {
   handleRequest: (req: IncomingMessage, res: ServerResponse) => void
   handleConnect: (req: IncomingMessage, socket: Socket, head: Buffer) => void
 } {
-  const proxy = createMultiAgentProxy(config)
+  // Build grantsClients once; share with both forward-proxy fetch path
+  // (createMultiAgentProxy) and the CONNECT path (handleConnect). Without
+  // sharing, CONNECT-time grant_required rules couldn't reach the IdP in
+  // multi-agent mode without duplicating constructor work.
+  const grantsClients = buildGrantsClients(config)
+  const proxy = createMultiAgentProxy(config, grantsClients)
 
   return {
     handleRequest(req: IncomingMessage, res: ServerResponse) {
@@ -354,7 +380,7 @@ export function createNodeHandler(config: MultiAgentProxyConfig): {
     },
 
     handleConnect(req: IncomingMessage, socket: Socket, head: Buffer) {
-      handleConnect(config, req, socket, head)
+      handleConnect(config, grantsClients, req, socket, head)
     },
   }
 }

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -234,7 +234,7 @@ export function createMultiAgentProxy(
         const grant = await grantsClient.requestGrant({
           requester: effectiveEmail,
           targetHost: domain,
-          audience: 'proxy',
+          audience: 'ape-proxy',
           grantType: rule.grant_type,
           permissions,
           reason: `${method} ${targetUrl}`,
@@ -266,7 +266,7 @@ export function createMultiAgentProxy(
         const grant = await grantsClient.requestGrant({
           requester: effectiveEmail,
           targetHost: domain,
-          audience: 'proxy',
+          audience: 'ape-proxy',
           grantType: rule.grant_type,
           permissions,
           reason: `${method} ${targetUrl}`,

--- a/packages/proxy/src/types.ts
+++ b/packages/proxy/src/types.ts
@@ -4,7 +4,7 @@ export interface ProxyConfig {
     listen: string
     idp_url: string
     agent_email: string
-    default_action: 'block' | 'request' | 'request-async'
+    default_action: 'allow' | 'block' | 'request' | 'request-async'
     audit_log?: string
     mandatory_auth?: boolean
   }
@@ -17,7 +17,7 @@ export interface ProxyConfig {
 export interface MultiAgentProxyConfig {
   proxy: {
     listen: string
-    default_action: 'block' | 'request' | 'request-async'
+    default_action: 'allow' | 'block' | 'request' | 'request-async'
     audit_log?: string
     mandatory_auth?: boolean
   }

--- a/packages/proxy/test/connect.test.ts
+++ b/packages/proxy/test/connect.test.ts
@@ -3,6 +3,7 @@ import { connect } from 'node:net'
 import { describe, expect, it, afterEach } from 'vitest'
 import type { MultiAgentProxyConfig } from '../src/types.js'
 import { handleConnect } from '../src/connect.js'
+import { buildGrantsClients } from '../src/proxy.js'
 
 function makeConfig(overrides?: Partial<MultiAgentProxyConfig['proxy']>): MultiAgentProxyConfig {
   return {
@@ -25,8 +26,9 @@ function startProxy(config: MultiAgentProxyConfig): Promise<{ port: number, clos
       res.writeHead(200)
       res.end('ok')
     })
+    const grantsClients = buildGrantsClients(config)
     server.on('connect', (req, socket, head) => {
-      handleConnect(config, req, socket, head)
+      handleConnect(config, grantsClients, req, socket, head)
     })
     server.listen(0, '127.0.0.1', () => {
       const addr = server.address() as { port: number }


### PR DESCRIPTION
## Summary

M2 of the [ape-shell proxy-mediated egress plan](https://plans.openape.ai/teams/01KPV1XN2S4FEGHFVPR3ZZ7VN1/plans/01KQ6QY6R67STKSK1D2G90YHX4). Closes the gap where M1a's `[[allow]]` / `[[deny]]` / `[[grant_required]]` lists were inert for HTTPS hosts because `connect.ts` only did SSRF + optional auth before piping bytes through.

## What changes

`connect.ts` now runs the same `evaluateRules(domain, 'CONNECT', '/')` pipeline the HTTP forward-proxy path uses:

- `[[deny]]` host-match → 403 fast-reject + audit
- `[[grant_required]]` → blocking grant request to the IdP, tunnel only on approval, 403/504 on deny/timeout
- `[[allow]]` host-match → tunnel + audit
- unmatched → falls to `default_action`

Rules with `methods` or `path` filters cannot be enforced at CONNECT time (TLS payload opaque) and only match for HTTPS if domain-only.

## IdP-host system-bypass (3 user-raised invariants)

System invariant: outbound to any configured IdP host is unconditionally allowed by the CONNECT handler. Skips auth, SSRF, and policy rules — operator cannot override. Rationale:

1. **Proxy → IdP must always work.** The proxy itself talks to the IdP for JWT verification + grant approval. If a deny rule or `default_action='block'` caught the IdP host, the proxy's own grant-required flow would deadlock.
2. **`apes login` must work even when proxy is up.** A process inside the proxy boundary may need to hit the IdP for token-exchange BEFORE it can ever produce a valid `Proxy-Authorization` JWT. `mandatory_auth` for the IdP host itself would create a chicken-and-egg lockout.
3. **Local-dev IdPs at `127.0.0.1` must work.** Without the bypass, SSRF would block them.

Audit entry uses `agent='system'`, `rule='idp-system-bypass'` so the bypass is visible.

## `default_action='allow'` fix

Adds `'allow'` to the `default_action` union. The matcher previously only special-cased `'block'` and fell through to `grant_required` for anything else, so a config saying `default_action='allow'` would silently route unmatched hosts to a once-grant request — which blocks/fails without IdP grant flow.

Conceptually `default_action` is the proxy-side counterpart of the IdP's per-agent **YOLO policy** — both decide what happens when no specific rule matches, both server-side, neither leaks the decision to the agent. Inline comment in `matcher.ts` maps the parallel.

## Audience rename: `'proxy'` → `'ape-proxy'`

Aligns the grant `audience` string with the apes-CLI naming family (`apes-cli` for user-CLI tokens, `ape-proxy` for proxy-side grants). Generic `'proxy'` was easily collidable.

## Internals: shared GrantsClient map

`createNodeHandler` now builds a single `Map<email, GrantsClient>` via the new public `buildGrantsClients(config)` and passes it to both the forward-proxy fetch path (`createMultiAgentProxy`) and the new CONNECT-side grant flow.

## Verification (live smokes)

| URL | Config | curl result | Audit |
|---|---|---|---|
| api.github.com | explicit `[[allow]]` | HTTP 200 | `rule:allow-list` |
| api.openai.com | glob `[[deny]] *.openai.com` | curl 56 / CONNECT 403 | `rule:deny-list` |
| example.org | unmatched, `default_action='allow'` | HTTP 200 | `rule:allow-list` |
| id.openape.ai | `default_action='block'` AND `[[deny]] id.openape.ai` | **HTTP 200 (system-bypass wins)** | `agent:system rule:idp-system-bypass` |

- [x] `pnpm --filter @openape/proxy build` clean
- [x] `pnpm --filter @openape/proxy lint` 0 errors
- [x] `pnpm --filter @openape/proxy typecheck` clean

## Out of scope

- Per-user `~/.config/openape/proxy.toml` overlay → M3+
- Mandatory agent-JWT auth → still M3
- Hard kernel-level enforcement (M7 opt-in via sandbox-exec)