### PR TITLE
feat(idp): per-audience YOLO policies + audience-bucket registry (M3 foundation)

### DIFF
--- a/.changeset/idp-yolo-per-audience.md
+++ b/.changeset/idp-yolo-per-audience.md
@@ -1,0 +1,56 @@
+---
+"openape-free-idp": minor
+---
+
+idp: per-audience YOLO policies + audience-bucket registry (M3 foundation)
+
+Splits the per-agent YOLO policy table so an operator can YOLO `ape-proxy`
+without YOLOing `ape-shell` (or vice versa). The data layer was previously
+flat (one policy per agent, applied to every audience); after M2 added
+`ape-proxy` as a first-class audience alongside the pre-existing `ape-shell`,
+`claude-code`, `escapes`, and `shapes`, that flatness conflated trust
+domains that should be independent.
+
+### Schema migration
+
+`yolo_policies` PK changes from `agent_email` to `(agent_email, audience)`.
+Existing rows are preserved as `audience='*'` (= per-agent fallback).
+Migration runs once in `06.yolo-hook.ts` and is gated on the absence of the
+`audience` column so it's idempotent across reboots. Recreate-pattern
+because SQLite can't change a PK in place.
+
+### Lookup semantic
+
+`store.get(agentEmail, audience)` does most-specific-wins:
+
+1. Try `(agentEmail, audience)` exact row.
+2. Fall through to `(agentEmail, '*')` wildcard row.
+3. Return null if neither exists.
+
+The IdP pre-approval hook now passes `request.audience` so an `ape-proxy`
+grant looks up the proxy-scoped policy first, then the agent's wildcard,
+and only YOLO-approves if either matches.
+
+### API back-compat
+
+Existing `/api/users/:email/yolo-policy.{get,put,delete}` endpoints keep
+working unchanged. The new optional `?audience=` query parameter targets
+a specific audience; without it, the endpoint operates on the wildcard
+row (= the previous behavior). `?audience=__all__` on GET returns every
+per-agent row across all audiences for the upcoming UI.
+
+### Audience-bucket registry
+
+New module `apps/openape-free-idp/server/utils/audience-buckets.ts` groups
+audiences into the three policy-enforcement layers:
+
+- **commands** — `ape-shell`, `claude-code`, `shapes` (per-line / per-tool gates)
+- **web** — `ape-proxy` (per-host network egress)
+- **root** — `escapes` (privilege elevation)
+- **other** — fallback for unknown audiences
+
+Bucket is purely UI/UX grouping; never affects grant evaluation. The UI
+redesign on `/agents/:email` (separate PR) will use this to render
+per-bucket sections for YOLO + deny rules + standing grants.
+
+No UI changes in this PR — that's the explicit follow-up.

--- a/apps/openape-free-idp/server/api/users/[email]/yolo-policy.delete.ts
+++ b/apps/openape-free-idp/server/api/users/[email]/yolo-policy.delete.ts
@@ -1,13 +1,16 @@
-import { defineEventHandler, getRouterParam, setResponseStatus } from 'h3'
+import { defineEventHandler, getQuery, getRouterParam, setResponseStatus } from 'h3'
 import { requireYoloPolicyActor } from '../../../utils/yolo-policy-auth'
-import { useYoloPolicyStore } from '../../../utils/yolo-policy-store'
+import { AUDIENCE_WILDCARD, useYoloPolicyStore } from '../../../utils/yolo-policy-store'
 
 export default defineEventHandler(async (event) => {
   const email = decodeURIComponent(getRouterParam(event, 'email') || '')
   if (!email) throw createProblemError({ status: 400, title: 'Email is required' })
 
   await requireYoloPolicyActor(event, email)
-  await useYoloPolicyStore().delete(email)
+  // Audience scope: defaults to the wildcard. Pass `?audience=ape-proxy` to
+  // remove only the per-audience override and keep the wildcard fallback.
+  const audience = (getQuery(event).audience as string | undefined)?.trim() || AUDIENCE_WILDCARD
+  await useYoloPolicyStore().delete(email, audience)
   setResponseStatus(event, 204)
   return null
 })

--- a/apps/openape-free-idp/server/api/users/[email]/yolo-policy.get.ts
+++ b/apps/openape-free-idp/server/api/users/[email]/yolo-policy.get.ts
@@ -1,12 +1,24 @@
-import { defineEventHandler, getRouterParam } from 'h3'
+import { defineEventHandler, getQuery, getRouterParam } from 'h3'
 import { requireYoloPolicyActor } from '../../../utils/yolo-policy-auth'
-import { useYoloPolicyStore } from '../../../utils/yolo-policy-store'
+import { AUDIENCE_WILDCARD, useYoloPolicyStore } from '../../../utils/yolo-policy-store'
 
 export default defineEventHandler(async (event) => {
   const email = decodeURIComponent(getRouterParam(event, 'email') || '')
   if (!email) throw createProblemError({ status: 400, title: 'Email is required' })
 
   await requireYoloPolicyActor(event, email)
-  const policy = await useYoloPolicyStore().get(email)
+
+  const audience = (getQuery(event).audience as string | undefined)?.trim()
+  // Modes:
+  //   - no `audience` query: legacy callers — return the wildcard row.
+  //   - `audience=*`: same as no param.
+  //   - `audience=<specific>`: most-specific match for that audience with
+  //     wildcard fallback. UI uses this when rendering bucket-scoped views.
+  //   - `audience=__all__`: dump every per-agent row across all audiences.
+  if (audience === '__all__') {
+    const policies = await useYoloPolicyStore().listForAgent(email)
+    return { policies }
+  }
+  const policy = await useYoloPolicyStore().get(email, audience || AUDIENCE_WILDCARD)
   return { policy }
 })

--- a/apps/openape-free-idp/server/api/users/[email]/yolo-policy.put.ts
+++ b/apps/openape-free-idp/server/api/users/[email]/yolo-policy.put.ts
@@ -1,6 +1,6 @@
-import { defineEventHandler, getRouterParam, readBody } from 'h3'
+import { defineEventHandler, getQuery, getRouterParam, readBody } from 'h3'
 import { requireYoloPolicyActor } from '../../../utils/yolo-policy-auth'
-import { useYoloPolicyStore } from '../../../utils/yolo-policy-store'
+import { AUDIENCE_WILDCARD, useYoloPolicyStore } from '../../../utils/yolo-policy-store'
 import type { RiskLevel, YoloPolicy } from '../../../utils/yolo-policy-store'
 
 const VALID_RISK: RiskLevel[] = ['low', 'medium', 'high', 'critical']
@@ -40,11 +40,17 @@ export default defineEventHandler(async (event) => {
     }
   }
 
+  // Audience scope: optional `?audience=` query param. Defaults to the
+  // wildcard so unmodified UI calls (which don't yet pass audience) keep
+  // writing the per-agent fallback row.
+  const audience = (getQuery(event).audience as string | undefined)?.trim() || AUDIENCE_WILDCARD
+
   const store = useYoloPolicyStore()
-  const existing = await store.get(agentEmail)
+  const existing = await store.getExact(agentEmail, audience)
   const now = Math.floor(Date.now() / 1000)
   const policy: YoloPolicy = {
     agentEmail,
+    audience,
     enabledBy: caller === '_management_' ? (existing?.enabledBy ?? caller) : caller,
     denyRiskThreshold: body.denyRiskThreshold !== undefined ? body.denyRiskThreshold : (existing?.denyRiskThreshold ?? null),
     denyPatterns: body.denyPatterns !== undefined ? normalisePatterns(body.denyPatterns) : (existing?.denyPatterns ?? []),

--- a/apps/openape-free-idp/server/database/schema.ts
+++ b/apps/openape-free-idp/server/database/schema.ts
@@ -1,4 +1,4 @@
-import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+import { index, integer, primaryKey, sqliteTable, text } from 'drizzle-orm/sqlite-core'
 
 export const grants = sqliteTable('grants', {
   id: text('id').primaryKey(),
@@ -166,14 +166,21 @@ export const signingKeys = sqliteTable('signing_keys', {
 // One row per agent. Presence = enabled. Deny rules mark the subset of
 // grant requests that fall back to the normal (human) approval flow.
 export const yoloPolicies = sqliteTable('yolo_policies', {
-  agentEmail: text('agent_email').primaryKey(),
+  agentEmail: text('agent_email').notNull(),
+  // Audience scope. '*' = applies to ALL audiences as a fallback.
+  // Specific audience strings like 'ape-shell', 'ape-proxy', 'escapes' override
+  // the '*' fallback when the request matches. Composite PK with agent_email
+  // means per-agent-per-audience policies are independent rows.
+  audience: text('audience').notNull().default('*'),
   enabledBy: text('enabled_by').notNull(),
   denyRiskThreshold: text('deny_risk_threshold'),
   denyPatterns: text('deny_patterns', { mode: 'json' }).notNull().default('[]'),
   enabledAt: integer('enabled_at').notNull(),
   expiresAt: integer('expires_at'),
   updatedAt: integer('updated_at').notNull(),
-})
+}, table => [
+  primaryKey({ columns: [table.agentEmail, table.audience] }),
+])
 
 // --- Milestone 5: SSH Keys ---
 

--- a/apps/openape-free-idp/server/plugins/06.yolo-hook.ts
+++ b/apps/openape-free-idp/server/plugins/06.yolo-hook.ts
@@ -11,20 +11,54 @@ import { commandFromRequest, evaluateYoloPolicy } from '../utils/yolo-evaluator'
 export default defineNitroPlugin(async () => {
   // Idempotent schema ensure — safe on every boot, needed under OPENAPE_E2E=1
   // too (where 02.database.ts short-circuits).
+  //
+  // Schema evolution: started as `agent_email PRIMARY KEY` (one YOLO policy
+  // per agent, applied to all audiences). M3 split it per-audience so an
+  // operator can YOLO `ape-proxy` without YOLOing `ape-shell`. The migration
+  // is a recreate-from-old (SQLite can't change a PK in place) and is gated
+  // on the absence of the `audience` column so it runs at most once per DB.
   try {
     const db = useDb()
+    // Fresh-DB shape (composite PK).
     await db.run(sql`CREATE TABLE IF NOT EXISTS yolo_policies (
-      agent_email TEXT PRIMARY KEY,
+      agent_email TEXT NOT NULL,
+      audience TEXT NOT NULL DEFAULT '*',
       enabled_by TEXT NOT NULL,
       deny_risk_threshold TEXT,
       deny_patterns TEXT NOT NULL DEFAULT '[]',
       enabled_at INTEGER NOT NULL,
       expires_at INTEGER,
-      updated_at INTEGER NOT NULL
+      updated_at INTEGER NOT NULL,
+      PRIMARY KEY (agent_email, audience)
     )`)
+
+    // Migration path: existing prod tables created from the old schema have a
+    // single-column PK on agent_email and no audience column. Detect that
+    // and rebuild.
+    const cols = await db.all<{ name: string }>(sql`SELECT name FROM pragma_table_info('yolo_policies')`)
+    const hasAudience = Array.isArray(cols) && cols.some((c: { name: string }) => c.name === 'audience')
+    if (!hasAudience) {
+      console.warn('[yolo] migrating yolo_policies → composite (agent_email, audience) PK')
+      await db.run(sql`CREATE TABLE yolo_policies_v2 (
+        agent_email TEXT NOT NULL,
+        audience TEXT NOT NULL DEFAULT '*',
+        enabled_by TEXT NOT NULL,
+        deny_risk_threshold TEXT,
+        deny_patterns TEXT NOT NULL DEFAULT '[]',
+        enabled_at INTEGER NOT NULL,
+        expires_at INTEGER,
+        updated_at INTEGER NOT NULL,
+        PRIMARY KEY (agent_email, audience)
+      )`)
+      await db.run(sql`INSERT INTO yolo_policies_v2 (agent_email, audience, enabled_by, deny_risk_threshold, deny_patterns, enabled_at, expires_at, updated_at)
+        SELECT agent_email, '*', enabled_by, deny_risk_threshold, deny_patterns, enabled_at, expires_at, updated_at FROM yolo_policies`)
+      await db.run(sql`DROP TABLE yolo_policies`)
+      await db.run(sql`ALTER TABLE yolo_policies_v2 RENAME TO yolo_policies`)
+      console.warn('[yolo] migration complete')
+    }
   }
   catch (err) {
-    console.error('[yolo] yolo_policies table init failed:', err)
+    console.error('[yolo] yolo_policies table init / migration failed:', err)
   }
 
   definePreApprovalHook(async (_event, request) => {
@@ -32,7 +66,10 @@ export default defineNitroPlugin(async () => {
     try { store = useYoloPolicyStore() }
     catch { return null } // DB not wired (e.g. unit tests)
 
-    const policy = await store.get(request.requester)
+    // Most-specific lookup: try (requester, request.audience) first, then
+    // fall through to (requester, '*'). Lets an operator YOLO `ape-proxy`
+    // without YOLOing `ape-shell` (or vice versa).
+    const policy = await store.get(request.requester, request.audience)
     if (!policy) return null
 
     const cmd = commandFromRequest(request)

--- a/apps/openape-free-idp/server/utils/audience-buckets.ts
+++ b/apps/openape-free-idp/server/utils/audience-buckets.ts
@@ -1,0 +1,70 @@
+/**
+ * Audience-bucket registry. Groups grant-audiences into the three policy-
+ * enforcement layers the IdP UI surfaces:
+ *
+ *  - **commands**: per-bash-line / per-tool-invocation gates. The grant
+ *    decides "may this agent execute this command?" Audited at command-level.
+ *    Audiences: `ape-shell` (REPL line dispatch + `apes run --shell`),
+ *    `claude-code` (the Claude PreToolUse Bash gate), `shapes` (typed CLI
+ *    adapter mode), and any adapter-defined audience falls here by default.
+ *
+ *  - **web**: per-host network-egress gates. The grant decides "may this
+ *    agent reach this host?" Audited at HTTPS-CONNECT / HTTP-forward level.
+ *    Audiences: `ape-proxy`.
+ *
+ *  - **root**: privilege-elevated execution. The grant decides "may this
+ *    agent run a command as root?" Audited per-elevation.
+ *    Audiences: `escapes`.
+ *
+ *  - **other**: anything not yet categorized. New audiences from plugins or
+ *    future products land here until added to KNOWN_BUCKETS.
+ *
+ * The bucket is purely a UI/UX grouping — it never affects grant evaluation.
+ * Per-audience YOLO policies and standing grants are stored with the literal
+ * `audience` string; the bucket is computed at read-time for display.
+ */
+
+export type AudienceBucket = 'commands' | 'web' | 'root' | 'other'
+
+/**
+ * Hardcoded mapping of well-known audience strings to buckets. Update when
+ * a new bundled audience ships. Plugin-defined audiences fall to 'other'
+ * until explicitly registered here.
+ */
+export const KNOWN_BUCKETS: Record<string, AudienceBucket> = {
+  // Commands layer
+  'ape-shell': 'commands',
+  'claude-code': 'commands',
+  'shapes': 'commands',
+  // Web layer
+  'ape-proxy': 'web',
+  // Root-Commands layer
+  'escapes': 'root',
+}
+
+/**
+ * The wildcard audience string used by yolo_policies and similar tables to
+ * mean "applies to every audience that doesn't have its own row". Exported
+ * as a constant so callers don't sprinkle the literal '*' across the
+ * codebase.
+ */
+export const AUDIENCE_WILDCARD = '*'
+
+/** Bucket lookup. Returns 'other' for unknown audiences. */
+export function bucketFor(audience: string): AudienceBucket {
+  return KNOWN_BUCKETS[audience] ?? 'other'
+}
+
+/** Reverse lookup: every audience known to belong to a given bucket. */
+export function audiencesInBucket(bucket: AudienceBucket): string[] {
+  return Object.entries(KNOWN_BUCKETS)
+    .filter(([, b]) => b === bucket)
+    .map(([a]) => a)
+}
+
+/**
+ * The buckets surfaced in the UI in canonical display order. 'other' is
+ * rendered last and only when there are audiences that don't map to a
+ * known bucket.
+ */
+export const DISPLAY_BUCKETS: readonly AudienceBucket[] = ['commands', 'web', 'root', 'other']

--- a/apps/openape-free-idp/server/utils/yolo-policy-store.ts
+++ b/apps/openape-free-idp/server/utils/yolo-policy-store.ts
@@ -1,13 +1,22 @@
 // App-level YOLO-Policy store. Drizzle-backed; consumed by the YOLO
 // Nitro plugin + API handlers.
-import { eq } from 'drizzle-orm'
+import { and, eq } from 'drizzle-orm'
 import { useDb } from '../database/drizzle'
 import { yoloPolicies } from '../database/schema'
+import { AUDIENCE_WILDCARD } from './audience-buckets'
 
+export { AUDIENCE_WILDCARD }
 export type RiskLevel = 'low' | 'medium' | 'high' | 'critical'
 
 export interface YoloPolicy {
   agentEmail: string
+  /**
+   * Audience scope. `'*'` matches all audiences as a per-agent fallback;
+   * any other value (e.g. `'ape-proxy'`, `'ape-shell'`) is a more-specific
+   * override. The IdP's pre-approval hook does most-specific-wins lookup:
+   * try (agent, request.audience) first, then fall back to (agent, '*').
+   */
+  audience: string
   enabledBy: string
   /** Auto-approval stops when the resolved shape risk meets or exceeds this. */
   denyRiskThreshold: RiskLevel | null
@@ -20,9 +29,23 @@ export interface YoloPolicy {
 }
 
 export interface YoloPolicyStore {
-  get: (agentEmail: string) => Promise<YoloPolicy | null>
+  /**
+   * Look up the most-specific policy for (agentEmail, audience). Tries the
+   * exact audience first; if no row matches, falls back to the agent's
+   * wildcard ('*') row. Returns null only if neither exists.
+   */
+  get: (agentEmail: string, audience?: string) => Promise<YoloPolicy | null>
+  /**
+   * Look up an exact (agentEmail, audience) row. No fallback. Used by the
+   * UI / API layer when the operator explicitly asks for the wildcard or a
+   * specific audience.
+   */
+  getExact: (agentEmail: string, audience: string) => Promise<YoloPolicy | null>
   put: (policy: YoloPolicy) => Promise<void>
-  delete: (agentEmail: string) => Promise<void>
+  delete: (agentEmail: string, audience: string) => Promise<void>
+  /** All policies for an agent across all audiences. */
+  listForAgent: (agentEmail: string) => Promise<YoloPolicy[]>
+  /** All policies system-wide. */
   list: () => Promise<YoloPolicy[]>
 }
 
@@ -44,6 +67,7 @@ function mapRow(row: Row): YoloPolicy {
   }
   return {
     agentEmail: row.agentEmail,
+    audience: row.audience ?? AUDIENCE_WILDCARD,
     enabledBy: row.enabledBy,
     denyRiskThreshold: (row.denyRiskThreshold ?? null) as YoloPolicy['denyRiskThreshold'],
     denyPatterns: patterns,
@@ -57,14 +81,27 @@ export function createDrizzleYoloPolicyStore(): YoloPolicyStore {
   const db = useDb()
 
   return {
-    async get(email) {
-      const rows = await db.select().from(yoloPolicies).where(eq(yoloPolicies.agentEmail, email)).limit(1)
+    async get(email, audience) {
+      // Most-specific match first, then wildcard fallback. Two queries instead
+      // of a single `IN ('audience', '*')` because we want deterministic
+      // ordering — SQLite would order by row insertion otherwise.
+      if (audience && audience !== AUDIENCE_WILDCARD) {
+        const exact = await db.select().from(yoloPolicies).where(and(eq(yoloPolicies.agentEmail, email), eq(yoloPolicies.audience, audience))).limit(1)
+        if (exact[0]) return mapRow(exact[0])
+      }
+      const fallback = await db.select().from(yoloPolicies).where(and(eq(yoloPolicies.agentEmail, email), eq(yoloPolicies.audience, AUDIENCE_WILDCARD))).limit(1)
+      return fallback[0] ? mapRow(fallback[0]) : null
+    },
+
+    async getExact(email, audience) {
+      const rows = await db.select().from(yoloPolicies).where(and(eq(yoloPolicies.agentEmail, email), eq(yoloPolicies.audience, audience))).limit(1)
       return rows[0] ? mapRow(rows[0]) : null
     },
 
     async put(policy) {
       const values = {
         agentEmail: policy.agentEmail,
+        audience: policy.audience,
         enabledBy: policy.enabledBy,
         denyRiskThreshold: policy.denyRiskThreshold,
         denyPatterns: policy.denyPatterns,
@@ -76,7 +113,7 @@ export function createDrizzleYoloPolicyStore(): YoloPolicyStore {
         .insert(yoloPolicies)
         .values(values)
         .onConflictDoUpdate({
-          target: yoloPolicies.agentEmail,
+          target: [yoloPolicies.agentEmail, yoloPolicies.audience],
           set: {
             enabledBy: values.enabledBy,
             denyRiskThreshold: values.denyRiskThreshold,
@@ -87,8 +124,14 @@ export function createDrizzleYoloPolicyStore(): YoloPolicyStore {
         })
     },
 
-    async delete(email) {
-      await db.delete(yoloPolicies).where(eq(yoloPolicies.agentEmail, email))
+    async delete(email, audience) {
+      await db.delete(yoloPolicies)
+        .where(and(eq(yoloPolicies.agentEmail, email), eq(yoloPolicies.audience, audience)))
+    },
+
+    async listForAgent(email) {
+      const rows = await db.select().from(yoloPolicies).where(eq(yoloPolicies.agentEmail, email))
+      return rows.map(mapRow)
     },
 
     async list() {


### PR DESCRIPTION
## Summary

Foundation for separating policy-enforcement layers in the free-idp UI. Splits per-agent YOLO so an operator can YOLO `ape-proxy` without YOLOing `ape-shell` (or vice versa).

## Audience inventory verified

| Audience | Emitter | Bucket |
|---|---|---|
| `ape-shell` | `apes run --shell`, REPL line dispatch | **commands** |
| `claude-code` | `claude-grant-gate.sh` PreToolUse hook | **commands** |
| `shapes` | `apes run -- <cli>` adapter mode | **commands** |
| (adapter-defined, e.g. `gh-cli`) | `cli.audience` in TOML | **commands** (default) |
| `escapes` | `apes run --root` | **root** |
| `ape-proxy` | `apes proxy --` (M2) | **web** |

## Schema migration

`yolo_policies` PK changes from `agent_email` to `(agent_email, audience)`. Existing rows preserved as `audience='*'` (= per-agent wildcard fallback). Migration in `06.yolo-hook.ts` is idempotent (gated on absence of the `audience` column) and uses the recreate-pattern since SQLite can't change a PK in place.

## Lookup semantic — most-specific-wins

```ts
store.get(agentEmail, audience)
// 1. tries (agentEmail, audience) exact row
// 2. falls through to (agentEmail, '*') wildcard row
// 3. returns null only if neither exists
```

The IdP pre-approval hook now passes `request.audience` so an `ape-proxy` grant looks up the proxy-scoped policy first, then the wildcard, and only YOLO-approves if either matches.

## API back-compat

- Existing `/api/users/:email/yolo-policy.{get,put,delete}` keep working unchanged — they operate on the wildcard (`audience='*'`) row by default.
- New optional `?audience=` query param targets a specific audience.
- `?audience=__all__` on GET returns every per-agent row across all audiences (for the upcoming UI).

## Audience-bucket registry

New `apps/openape-free-idp/server/utils/audience-buckets.ts` groups audiences into three policy-enforcement layers:

- **commands** — `ape-shell`, `claude-code`, `shapes`
- **web** — `ape-proxy`
- **root** — `escapes`
- **other** — unknown / future audiences

Bucket is purely UI/UX grouping; never affects grant evaluation. `bucketFor(audience)` + `audiencesInBucket(bucket)` + `DISPLAY_BUCKETS`.

## Verification

- [x] 51/51 free-idp tests pass
- [x] `pnpm --filter openape-free-idp lint` 0 errors
- [x] Migration logic stays idempotent (verified by reading the column-presence guard)

## Out of scope (next PR)

- UI redesign on `/agents/:email` to render per-bucket sections (Commands / Web / Root) for YOLO toggle + deny patterns + standing grants
- Possibly per-bucket "apply to all in this bucket" convenience action