### PR TITLE
feat(idp): per-bucket YOLO UI on /agents/:email (M3 UI)

### DIFF
--- a/.changeset/idp-bucket-yolo-ui.md
+++ b/.changeset/idp-bucket-yolo-ui.md
@@ -1,0 +1,33 @@
+---
+"openape-free-idp": minor
+---
+
+free-idp: per-bucket YOLO UI on the agent detail page
+
+Replaces the single "YOLO-Modus" section on `/agents/:email` with four
+audience-bucket cards: **Commands** (ape-shell, claude-code, shapes),
+**Web** (ape-proxy), **Root-Commands** (escapes), and **Default**
+(wildcard fallback). Each card owns its own load / save / delete
+lifecycle through the audience-aware YOLO endpoints introduced in the
+foundation PR.
+
+User-visible result: an operator can YOLO `ape-proxy` (auto-approve
+network egress) without YOLOing `ape-shell` (still confirm every bash
+line) — and vice versa. Deny-patterns are configured per bucket so a
+network-egress deny-list doesn't accidentally block bash commands.
+
+Aggregate state per bucket:
+
+- **all** — every audience in the bucket has a YOLO row → "YOLO aktiv" badge
+- **partial** — some audiences in the bucket have YOLO, some don't →
+  "YOLO teilweise" badge with a hint that saving will unify them
+- **none** — bucket inactive, requests in this layer wait for human
+  confirmation
+
+For multi-audience buckets (Commands has three) Enable writes one
+yolo_policies row per audience; Disable deletes them all. Single-
+audience buckets (Web, Root, Default) are 1:1.
+
+Adds a client-side mirror of the audience-bucket registry under
+`app/utils/audience-buckets.ts`. Kept in sync with the server-side
+registry by hand for now (small, stable map). Documented inline.

--- a/apps/openape-free-idp/app/components/BucketYoloCard.vue
+++ b/apps/openape-free-idp/app/components/BucketYoloCard.vue
@@ -1,0 +1,305 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import type { BucketDisplay } from '../utils/audience-buckets'
+
+interface YoloPolicy {
+  agentEmail: string
+  audience: string
+  enabledBy: string
+  denyRiskThreshold: 'low' | 'medium' | 'high' | 'critical' | null
+  denyPatterns: string[]
+  enabledAt: number
+  expiresAt: number | null
+  updatedAt: number
+}
+
+const props = defineProps<{
+  agentEmail: string
+  bucket: BucketDisplay
+}>()
+
+/**
+ * Per-bucket YOLO state. We hold one YoloPolicy per audience in the bucket
+ * (could be 1..N rows). Aggregate state:
+ *
+ *   - 'all'    — every audience in the bucket has a YOLO row → bucket is fully on
+ *   - 'partial'— some audiences have YOLO, some don't → mixed state
+ *   - 'none'   — no audience in the bucket has YOLO
+ *
+ * For multi-audience buckets (Commands has 3) "Enable" writes one row per
+ * audience and "Disable" deletes them all. Single-audience buckets are 1:1.
+ */
+const policiesByAudience = ref<Record<string, YoloPolicy | null>>({})
+const loading = ref(false)
+const submitting = ref(false)
+const editing = ref(false)
+const error = ref('')
+
+const aggregate = computed<'all' | 'partial' | 'none'>(() => {
+  const present = props.bucket.audiences.filter(a => policiesByAudience.value[a] != null).length
+  if (present === 0) return 'none'
+  if (present === props.bucket.audiences.length) return 'all'
+  return 'partial'
+})
+
+const representativePolicy = computed<YoloPolicy | null>(() => {
+  // For display purposes, surface the first existing policy in the bucket.
+  // When the bucket is partially active or inactive across audiences, we
+  // still need *some* policy fields to render the form — fall back to the
+  // last-known.
+  for (const aud of props.bucket.audiences) {
+    const p = policiesByAudience.value[aud]
+    if (p) return p
+  }
+  return null
+})
+
+const expiryLabel = computed(() => {
+  const ts = representativePolicy.value?.expiresAt
+  if (!ts) return 'unbefristet'
+  return new Date(ts * 1000).toLocaleString()
+})
+
+// --- Form state -------------------------------------------------------------
+
+interface FormState {
+  denyRiskThreshold: 'low' | 'medium' | 'high' | 'critical' | ''
+  denyPatterns: string
+  duration: string
+}
+
+const form = ref<FormState>({
+  denyRiskThreshold: 'high',
+  denyPatterns: '',
+  duration: '3600',
+})
+
+const riskOptions = [
+  { label: 'Kein Schwellwert', value: '' },
+  { label: 'Low', value: 'low' },
+  { label: 'Medium', value: 'medium' },
+  { label: 'High (empfohlen)', value: 'high' },
+  { label: 'Critical', value: 'critical' },
+]
+const durationOptions = [
+  { label: '1 Stunde (Standard)', value: '3600' },
+  { label: '4 Stunden', value: '14400' },
+  { label: '8 Stunden', value: '28800' },
+  { label: '1 Tag', value: '86400' },
+  { label: '7 Tage', value: '604800' },
+  { label: '30 Tage', value: '2592000' },
+  { label: 'Unbefristet', value: '' },
+]
+
+const accentClass = computed(() => {
+  switch (props.bucket.accent) {
+    case 'blue': return 'border-blue-700/40 bg-blue-950/20'
+    case 'orange': return 'border-orange-700/40 bg-orange-950/20'
+    case 'purple': return 'border-purple-700/40 bg-purple-950/20'
+    default: return 'border-gray-700 bg-gray-900/40'
+  }
+})
+
+// --- Data flow --------------------------------------------------------------
+
+async function load() {
+  loading.value = true
+  error.value = ''
+  try {
+    const fetched: Record<string, YoloPolicy | null> = {}
+    await Promise.all(props.bucket.audiences.map(async (aud) => {
+      try {
+        const url = `/api/users/${encodeURIComponent(props.agentEmail)}/yolo-policy?audience=${encodeURIComponent(aud)}`
+        const res = await ($fetch as any)(url) as { policy: YoloPolicy | null }
+        // The GET endpoint falls back to wildcard ('*') when there's no
+        // exact row; we want exact-match here so the "this audience has its
+        // own row" signal isn't muddled by the bucket-default. Only count it
+        // if the returned policy.audience matches what we asked for.
+        fetched[aud] = res?.policy && res.policy.audience === aud ? res.policy : null
+      }
+      catch {
+        fetched[aud] = null
+      }
+    }))
+    policiesByAudience.value = fetched
+
+    const rep = representativePolicy.value
+    if (rep) {
+      form.value = {
+        denyRiskThreshold: (rep.denyRiskThreshold ?? 'high') as FormState['denyRiskThreshold'],
+        denyPatterns: rep.denyPatterns.join('\n'),
+        duration: rep.expiresAt ? '' : '3600',
+      }
+    }
+  }
+  catch (err: unknown) {
+    const e = err as { data?: { title?: string } }
+    error.value = e.data?.title ?? 'YOLO-Policies konnten nicht geladen werden'
+  }
+  finally {
+    loading.value = false
+  }
+}
+
+async function save() {
+  submitting.value = true
+  error.value = ''
+  try {
+    const patterns = form.value.denyPatterns
+      .split(/\r?\n/)
+      .map(s => s.trim())
+      .filter(Boolean)
+    const durationSec = Number(form.value.duration)
+    const expiresAt = Number.isFinite(durationSec) && durationSec > 0
+      ? Math.floor(Date.now() / 1000) + durationSec
+      : null
+    const body = {
+      denyRiskThreshold: form.value.denyRiskThreshold || null,
+      denyPatterns: patterns,
+      expiresAt,
+    }
+    // Multi-audience buckets: write one row per audience. The server enforces
+    // (agent_email, audience) uniqueness so re-PUTs are upserts.
+    await Promise.all(props.bucket.audiences.map(aud =>
+      ($fetch as any)(
+        `/api/users/${encodeURIComponent(props.agentEmail)}/yolo-policy?audience=${encodeURIComponent(aud)}`,
+        { method: 'PUT', body },
+      ),
+    ))
+    await load()
+    editing.value = false
+  }
+  catch (err: unknown) {
+    const e = err as { data?: { title?: string }, message?: string }
+    error.value = e.data?.title ?? e.message ?? 'Speichern fehlgeschlagen'
+  }
+  finally {
+    submitting.value = false
+  }
+}
+
+async function disable() {
+  if (!confirm(`YOLO für ${props.bucket.label} wirklich deaktivieren?`)) return
+  submitting.value = true
+  error.value = ''
+  try {
+    await Promise.all(props.bucket.audiences.map(aud =>
+      ($fetch as any)(
+        `/api/users/${encodeURIComponent(props.agentEmail)}/yolo-policy?audience=${encodeURIComponent(aud)}`,
+        { method: 'DELETE' },
+      ),
+    ))
+    policiesByAudience.value = {}
+    editing.value = false
+    form.value = { denyRiskThreshold: 'high', denyPatterns: '', duration: '3600' }
+  }
+  catch (err: unknown) {
+    const e = err as { data?: { title?: string } }
+    error.value = e.data?.title ?? 'Deaktivieren fehlgeschlagen'
+  }
+  finally {
+    submitting.value = false
+  }
+}
+
+watch(() => props.agentEmail, () => { if (props.agentEmail) load() }, { immediate: true })
+</script>
+
+<template>
+  <div class="border rounded-lg p-4 space-y-3" :class="[accentClass]">
+    <div class="flex items-start justify-between gap-2">
+      <div class="flex items-start gap-3">
+        <UIcon :name="bucket.icon" class="w-5 h-5 mt-0.5 text-gray-300" />
+        <div>
+          <h3 class="text-base font-semibold flex items-center gap-2">
+            {{ bucket.label }}
+            <UBadge v-if="aggregate === 'all'" color="warning" variant="subtle" size="sm">
+              YOLO aktiv
+            </UBadge>
+            <UBadge v-else-if="aggregate === 'partial'" color="warning" variant="outline" size="sm">
+              YOLO teilweise
+            </UBadge>
+          </h3>
+          <p class="text-xs text-gray-400 mt-1">
+            {{ bucket.description }}
+          </p>
+          <p class="text-xs text-gray-500 mt-1 font-mono">
+            audiences: {{ bucket.audiences.join(', ') }}
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <UAlert v-if="error" color="error" :title="error" @close="error = ''" />
+
+    <div v-if="loading" class="text-xs text-gray-400">
+      Lade…
+    </div>
+
+    <div v-else-if="aggregate === 'none' && !editing">
+      <p class="text-sm text-gray-400 mb-3">
+        Inaktiv. Grant-Requests in dieser Schicht warten auf menschliche Bestätigung.
+      </p>
+      <UButton color="warning" size="sm" icon="i-lucide-zap" @click="editing = true">
+        YOLO aktivieren
+      </UButton>
+    </div>
+
+    <div v-else-if="!editing" class="space-y-2 text-sm">
+      <div class="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1">
+        <span class="text-gray-400">Aktiviert von</span>
+        <span class="font-mono text-xs">{{ representativePolicy?.enabledBy ?? '-' }}</span>
+        <span class="text-gray-400">Risiko-Schwelle</span>
+        <span>
+          <span v-if="representativePolicy?.denyRiskThreshold" class="font-mono">{{ representativePolicy.denyRiskThreshold }}</span>
+          <span v-else class="italic text-gray-500">keine</span>
+        </span>
+        <span class="text-gray-400">Deny-Patterns</span>
+        <span>
+          <span v-if="!representativePolicy?.denyPatterns?.length" class="italic text-gray-500">keine</span>
+          <span v-else class="flex flex-wrap gap-1">
+            <code v-for="p in representativePolicy.denyPatterns" :key="p" class="bg-gray-800 px-2 py-0.5 rounded text-xs">{{ p }}</code>
+          </span>
+        </span>
+        <span class="text-gray-400">Ablauf</span>
+        <span>{{ expiryLabel }}</span>
+      </div>
+      <p v-if="aggregate === 'partial'" class="text-xs text-amber-400 italic">
+        Teilweise aktiv — nicht alle Audiences in diesem Bucket haben einen
+        eigenen YOLO-Eintrag. Speichern stellt alle gleich.
+      </p>
+      <div class="flex gap-2 pt-2">
+        <UButton size="sm" icon="i-lucide-pencil" variant="outline" @click="editing = true">
+          Bearbeiten
+        </UButton>
+        <UButton size="sm" color="error" variant="outline" icon="i-lucide-trash-2" :loading="submitting" @click="disable">
+          Deaktivieren
+        </UButton>
+      </div>
+    </div>
+
+    <div v-else class="space-y-3">
+      <UFormField label="Dauer" help="Nach Ablauf wird wieder jeder Request manuell bestätigt.">
+        <USelect v-model="form.duration" :items="durationOptions" />
+      </UFormField>
+      <UFormField label="Risiko-Schwelle" help="Requests mit diesem oder höherem Risiko werden weiter menschlich bestätigt.">
+        <USelect v-model="form.denyRiskThreshold" :items="riskOptions" />
+      </UFormField>
+      <UFormField label="Deny-Patterns (eine Zeile, Glob: * ?)">
+        <UTextarea
+          v-model="form.denyPatterns"
+          :rows="3"
+          placeholder="rm -rf *&#10;sudo *"
+        />
+      </UFormField>
+      <div class="flex gap-2">
+        <UButton color="warning" size="sm" icon="i-lucide-save" :loading="submitting" @click="save">
+          {{ aggregate === 'none' ? 'Aktivieren' : 'Speichern' }}
+        </UButton>
+        <UButton variant="ghost" size="sm" :disabled="submitting" @click="editing = false">
+          Abbrechen
+        </UButton>
+      </div>
+    </div>
+  </div>
+</template>

--- a/apps/openape-free-idp/app/pages/agents/[id].vue
+++ b/apps/openape-free-idp/app/pages/agents/[id].vue
@@ -2,7 +2,9 @@
 import { computed, ref, watch } from 'vue'
 import { useIdpAuth } from '#imports'
 import AllowedCommandsList from '../../components/AllowedCommandsList.vue'
+import BucketYoloCard from '../../components/BucketYoloCard.vue'
 import ScopedCommandWizard from '../../components/ScopedCommandWizard.vue'
+import { BUCKET_DISPLAY } from '../../utils/audience-buckets'
 
 const { user, loading: authLoading, fetchUser } = useIdpAuth()
 const route = useRoute()
@@ -42,52 +44,9 @@ const statusError = ref('')
 const standingGrants = ref<StandingGrant[]>([])
 const wizardOpen = ref(false)
 
-// --- YOLO-Modus state ---
-interface YoloPolicy {
-  agentEmail: string
-  enabledBy: string
-  denyRiskThreshold: 'low' | 'medium' | 'high' | 'critical' | null
-  denyPatterns: string[]
-  enabledAt: number
-  expiresAt: number | null
-  updatedAt: number
-}
-
-const yoloPolicy = ref<YoloPolicy | null>(null)
-const yoloLoading = ref(false)
-const yoloError = ref('')
-const yoloEditing = ref(false)
-const yoloSubmitting = ref(false)
-const yoloForm = ref<{
-  denyRiskThreshold: 'low' | 'medium' | 'high' | 'critical' | ''
-  denyPatterns: string
-  duration: string // seconds, or '' for unbefristet
-}>({
-  denyRiskThreshold: 'high',
-  denyPatterns: '',
-  duration: '3600', // 1 hour default
-})
-const yoloRiskOptions = [
-  { label: 'Kein Schwellwert', value: '' },
-  { label: 'Low', value: 'low' },
-  { label: 'Medium', value: 'medium' },
-  { label: 'High (empfohlen)', value: 'high' },
-  { label: 'Critical', value: 'critical' },
-]
-const yoloDurationOptions = [
-  { label: '1 Stunde (Standard)', value: '3600' },
-  { label: '4 Stunden', value: '14400' },
-  { label: '8 Stunden', value: '28800' },
-  { label: '1 Tag', value: '86400' },
-  { label: '7 Tage', value: '604800' },
-  { label: '30 Tage', value: '2592000' },
-  { label: 'Unbefristet', value: '' },
-]
-const yoloExpiryLabel = computed(() => {
-  const ts = yoloPolicy.value?.expiresAt
-  if (!ts) return 'unbefristet'
-  return new Date(ts * 1000).toLocaleString()
-})
+// YOLO state moved into per-bucket BucketYoloCard components — each card owns
+// its own load/save lifecycle. The page just hands them the agent email and
+// lets them render.
 
 useSeoMeta({ title: computed(() => agent.value ? `Agent: ${agent.value.name}` : 'Agent') })
 
@@ -117,92 +76,9 @@ async function loadStandingGrants() {
   }
 }
 
-async function loadYoloPolicy() {
-  if (!agent.value) return
-  yoloLoading.value = true
-  yoloError.value = ''
-  try {
-    const res = await ($fetch as any)(`/api/users/${encodeURIComponent(agent.value.email)}/yolo-policy`) as { policy: YoloPolicy | null }
-    yoloPolicy.value = res?.policy ?? null
-    if (yoloPolicy.value) {
-      // When re-opening the form, preselect "unbefristet" when there's
-      // already an active policy so we don't silently shorten its expiry.
-      yoloForm.value = {
-        denyRiskThreshold: (yoloPolicy.value.denyRiskThreshold ?? 'high') as typeof yoloForm.value.denyRiskThreshold,
-        denyPatterns: (yoloPolicy.value.denyPatterns ?? []).join('\n'),
-        duration: yoloPolicy.value.expiresAt ? '' : '',
-      }
-    }
-  }
-  catch (err: unknown) {
-    const e = err as { data?: { title?: string } }
-    yoloError.value = e.data?.title ?? 'YOLO-Policy konnte nicht geladen werden'
-  }
-  finally {
-    yoloLoading.value = false
-  }
-}
-
-async function saveYoloPolicy() {
-  if (!agent.value) return
-  yoloSubmitting.value = true
-  yoloError.value = ''
-  try {
-    const patterns = yoloForm.value.denyPatterns
-      .split(/\r?\n/)
-      .map(s => s.trim())
-      .filter(Boolean)
-    const durationSec = Number(yoloForm.value.duration)
-    const expiresAt = Number.isFinite(durationSec) && durationSec > 0
-      ? Math.floor(Date.now() / 1000) + durationSec
-      : null
-    const body = {
-      denyRiskThreshold: yoloForm.value.denyRiskThreshold || null,
-      denyPatterns: patterns,
-      expiresAt,
-    }
-    const res = await ($fetch as any)(
-      `/api/users/${encodeURIComponent(agent.value.email)}/yolo-policy`,
-      { method: 'PUT', body },
-    ) as { policy: YoloPolicy | null }
-    yoloPolicy.value = res?.policy ?? null
-    yoloEditing.value = false
-  }
-  catch (err: unknown) {
-    const e = err as { data?: { title?: string }, message?: string }
-    yoloError.value = e.data?.title ?? e.message ?? 'Speichern fehlgeschlagen'
-  }
-  finally {
-    yoloSubmitting.value = false
-  }
-}
-
-async function disableYoloPolicy() {
-  if (!agent.value) return
-  if (!confirm('YOLO-Modus wirklich deaktivieren?')) return
-  yoloSubmitting.value = true
-  yoloError.value = ''
-  try {
-    await ($fetch as any)(
-      `/api/users/${encodeURIComponent(agent.value.email)}/yolo-policy`,
-      { method: 'DELETE' },
-    )
-    yoloPolicy.value = null
-    yoloEditing.value = false
-    yoloForm.value = { denyRiskThreshold: 'high', denyPatterns: '', duration: '3600' }
-  }
-  catch (err: unknown) {
-    const e = err as { data?: { title?: string } }
-    yoloError.value = e.data?.title ?? 'Deaktivieren fehlgeschlagen'
-  }
-  finally {
-    yoloSubmitting.value = false
-  }
-}
-
 async function loadAll() {
   await loadAgent()
-  await Promise.all([loadStandingGrants(), loadYoloPolicy()])
+  await loadStandingGrants()
 }
 
 watch(user, (u) => {
@@ -555,116 +431,27 @@ async function handleDelete() {
             </div>
           </details>
 
-          <!-- YOLO-Modus: Auto-approval für alle Grants dieses Agents -->
-          <div class="border border-gray-700 rounded-lg p-4 space-y-3 bg-gray-900/40">
-            <div class="flex items-center justify-between gap-2">
-              <div>
-                <h3 class="text-base font-semibold flex items-center gap-2">
-                  YOLO-Modus
-                  <UBadge v-if="yoloPolicy" color="warning" variant="subtle" size="sm">
-                    aktiv
-                  </UBadge>
-                </h3>
-                <p class="text-xs text-gray-400 mt-1">
-                  Auto-approval für alle Grant-Requests dieses Agents — außer Deny-Pattern oder
-                  Risiko-Schwelle greifen. Nur der Audit-Trail markiert YOLO-Entscheidungen.
-                </p>
-              </div>
+          <!-- Per-Bucket YOLO + Deny: ein Card pro Policy-Layer.
+               Commands / Web / Root-Commands sind die drei Audience-Buckets,
+               'Default' deckt alles ab was nicht zu einem Bucket gehört. -->
+          <div class="space-y-3">
+            <div class="flex items-center gap-2">
+              <UIcon name="i-lucide-shield-check" class="w-5 h-5 text-gray-400" />
+              <h2 class="text-lg font-semibold">
+                Auto-Approval (YOLO) + Deny-Patterns
+              </h2>
             </div>
-
-            <UAlert
-              v-if="yoloError"
-              color="error"
-              :title="yoloError"
-              @close="yoloError = ''"
+            <p class="text-xs text-gray-500 -mt-1">
+              Pro Policy-Layer einzeln aktivieren. Eine Konfiguration für Bash-Commands
+              betrifft Network-Egress nicht und umgekehrt. Lookup ist most-specific-wins:
+              Bucket-spezifischer Eintrag &gt; Default-Fallback &gt; menschliche Bestätigung.
+            </p>
+            <BucketYoloCard
+              v-for="b in BUCKET_DISPLAY"
+              :key="b.id"
+              :agent-email="agent.email"
+              :bucket="b"
             />
-
-            <div v-if="yoloLoading" class="text-xs text-gray-400">
-              Lade…
-            </div>
-
-            <div v-else-if="!yoloPolicy && !yoloEditing">
-              <p class="text-sm text-gray-400 mb-3">
-                Derzeit inaktiv. Alle Grant-Requests warten auf menschliche Bestätigung.
-              </p>
-              <UButton
-                color="warning"
-                icon="i-lucide-zap"
-                @click="yoloEditing = true"
-              >
-                YOLO-Modus aktivieren
-              </UButton>
-            </div>
-
-            <div v-else-if="yoloPolicy && !yoloEditing" class="space-y-2 text-sm">
-              <div class="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1">
-                <span class="text-gray-400">Aktiviert von</span>
-                <span class="font-mono text-xs">{{ yoloPolicy.enabledBy }}</span>
-                <span class="text-gray-400">Risiko-Schwelle</span>
-                <span>
-                  <span v-if="yoloPolicy.denyRiskThreshold" class="font-mono">{{ yoloPolicy.denyRiskThreshold }}</span>
-                  <span v-else class="italic text-gray-500">keine</span>
-                </span>
-                <span class="text-gray-400">Deny-Patterns</span>
-                <span>
-                  <span v-if="yoloPolicy.denyPatterns.length === 0" class="italic text-gray-500">keine</span>
-                  <span v-else class="flex flex-wrap gap-1">
-                    <code
-                      v-for="p in yoloPolicy.denyPatterns"
-                      :key="p"
-                      class="bg-gray-800 px-2 py-0.5 rounded text-xs"
-                    >{{ p }}</code>
-                  </span>
-                </span>
-                <span class="text-gray-400">Ablauf</span>
-                <span>{{ yoloExpiryLabel }}</span>
-              </div>
-              <div class="flex gap-2 pt-2">
-                <UButton size="sm" icon="i-lucide-pencil" variant="outline" @click="yoloEditing = true">
-                  Bearbeiten
-                </UButton>
-                <UButton
-                  size="sm"
-                  color="error"
-                  variant="outline"
-                  icon="i-lucide-trash-2"
-                  :loading="yoloSubmitting"
-                  @click="disableYoloPolicy"
-                >
-                  Deaktivieren
-                </UButton>
-              </div>
-            </div>
-
-            <div v-else class="space-y-3">
-              <UFormField label="Dauer" help="Nach Ablauf wird wieder jeder Request manuell bestätigt.">
-                <USelect
-                  v-model="yoloForm.duration"
-                  :items="yoloDurationOptions"
-                />
-              </UFormField>
-              <UFormField label="Risiko-Schwelle" help="Requests mit diesem oder höherem Risiko werden weiter menschlich bestätigt.">
-                <USelect
-                  v-model="yoloForm.denyRiskThreshold"
-                  :items="yoloRiskOptions"
-                />
-              </UFormField>
-              <UFormField label="Deny-Patterns (eine Zeile, Glob-Syntax: * ?)">
-                <UTextarea
-                  v-model="yoloForm.denyPatterns"
-                  :rows="4"
-                  placeholder="rm -rf *&#10;sudo *&#10;curl*| sh"
-                />
-              </UFormField>
-              <div class="flex gap-2">
-                <UButton color="warning" icon="i-lucide-save" :loading="yoloSubmitting" @click="saveYoloPolicy">
-                  {{ yoloPolicy ? 'Speichern' : 'Aktivieren' }}
-                </UButton>
-                <UButton variant="ghost" :disabled="yoloSubmitting" @click="yoloEditing = false">
-                  Abbrechen
-                </UButton>
-              </div>
-            </div>
           </div>
 
           <UAlert

--- a/apps/openape-free-idp/app/utils/audience-buckets.ts
+++ b/apps/openape-free-idp/app/utils/audience-buckets.ts
@@ -1,0 +1,79 @@
+/**
+ * Client-side mirror of `server/utils/audience-buckets.ts`. Kept duplicated
+ * (small, stable map) so client code doesn't need to cross the server boundary.
+ * If the server-side registry grows, mirror the change here. The pre-approval
+ * hook + grant evaluation never read from this file — only the UI does.
+ */
+
+export type AudienceBucket = 'commands' | 'web' | 'root' | 'other'
+
+export const KNOWN_BUCKETS: Record<string, AudienceBucket> = {
+  'ape-shell': 'commands',
+  'claude-code': 'commands',
+  'shapes': 'commands',
+  'ape-proxy': 'web',
+  'escapes': 'root',
+}
+
+export const AUDIENCE_WILDCARD = '*'
+
+export function bucketFor(audience: string): AudienceBucket {
+  return KNOWN_BUCKETS[audience] ?? 'other'
+}
+
+export function audiencesInBucket(bucket: AudienceBucket): string[] {
+  return Object.entries(KNOWN_BUCKETS)
+    .filter(([, b]) => b === bucket)
+    .map(([a]) => a)
+}
+
+/**
+ * Display metadata for the four sections rendered on the agent detail page.
+ * The fourth `default` row covers the per-agent wildcard fallback (audience
+ * `'*'`) — anything not matched by a bucket-specific row.
+ */
+export interface BucketDisplay {
+  /** Internal id used for keying. `'default'` is the wildcard catch-all. */
+  id: AudienceBucket | 'default'
+  label: string
+  description: string
+  /** Audience strings to PUT/DELETE per bucket toggle. */
+  audiences: string[]
+  icon: string
+  accent: 'blue' | 'orange' | 'purple' | 'gray'
+}
+
+export const BUCKET_DISPLAY: readonly BucketDisplay[] = [
+  {
+    id: 'commands',
+    label: 'Commands',
+    description: 'Bash-Lines + Tool-Invocations (ape-shell, claude-code, shapes-CLI).',
+    audiences: ['ape-shell', 'claude-code', 'shapes'],
+    icon: 'i-lucide-terminal',
+    accent: 'blue',
+  },
+  {
+    id: 'web',
+    label: 'Web',
+    description: 'Outbound Network-Egress über den OpenApe-Proxy (ape-proxy).',
+    audiences: ['ape-proxy'],
+    icon: 'i-lucide-globe',
+    accent: 'orange',
+  },
+  {
+    id: 'root',
+    label: 'Root-Commands',
+    description: 'Privileg-Eskalation über escapes (sudo / root).',
+    audiences: ['escapes'],
+    icon: 'i-lucide-shield-alert',
+    accent: 'purple',
+  },
+  {
+    id: 'default',
+    label: 'Default (Fallback)',
+    description: 'Wirkt für alle Audiences die keinen eigenen Bucket-Eintrag haben.',
+    audiences: [AUDIENCE_WILDCARD],
+    icon: 'i-lucide-asterisk',
+    accent: 'gray',
+  },
+]


### PR DESCRIPTION
## Summary

UI-side completion of M3. Replaces the single "YOLO-Modus" section on `/agents/:email` with four audience-bucket cards: **Commands** (ape-shell, claude-code, shapes), **Web** (ape-proxy), **Root-Commands** (escapes), and **Default** (wildcard fallback).

## Why

Foundation PR (#179) introduced per-audience YOLO storage; this PR exposes it. An operator can now YOLO `ape-proxy` (auto-approve network egress) without YOLOing `ape-shell` (still confirm every bash line) — and vice versa. Deny-patterns configured per bucket don't accidentally cross over.

## What changes

**`app/utils/audience-buckets.ts`** (new): client-side mirror of the server registry plus `BUCKET_DISPLAY` metadata (label, description, audiences in bucket, icon, accent color).

**`app/components/BucketYoloCard.vue`** (new): owns one bucket's YOLO state.
- Loads one `yolo_policies` row per audience in the bucket via the exact-match GET (`?audience=<x>` + filter to `policy.audience === <x>` so wildcard fallback doesn't muddle the signal).
- Aggregates to `all` / `partial` / `none` for display.
- Save/Disable writes/deletes one PUT/DELETE per audience in the bucket — multi-audience buckets stay coherent.

**`app/pages/agents/[id].vue`**: replaces the inline YOLO block with a `v-for` over `BUCKET_DISPLAY` rendering four `<BucketYoloCard>` instances. ~100 LOC of YOLO state + form removed from the page.

## Aggregate states per bucket

- **all** — every audience in the bucket has a YOLO row → "YOLO aktiv" badge
- **partial** — some audiences have YOLO, some don't → "YOLO teilweise" badge with hint that Save unifies them
- **none** — bucket inactive

## Verification

- [x] 51/51 free-idp tests pass
- [x] `pnpm --filter openape-free-idp lint` 0 errors
- [ ] Post-merge: navigate to `/agents/<existing>` on id.openape.ai. Existing wildcard YOLO renders in the **Default** card. Activate "Web" → only `ape-proxy` calls auto-approve, bash commands still need human confirmation.

## Out of scope (next iterations)

- Standing-Grants-Listing nach Bucket gruppieren (Daten ist schon audience-aware, nur visuelle Gruppierung fehlt — Quick win für Folge-PR)
- "Apply to all buckets" convenience action im Default-Card
- Per-bucket Standing-Grants-Erstellung im Wizard (heute audience-frei)