### PR TITLE
feat(idp): Web-YOLO evaluation + per-bucket tabs UI

### DIFF
--- a/.changeset/idp-yolo-host-patterns-and-tabs.md
+++ b/.changeset/idp-yolo-host-patterns-and-tabs.md
@@ -1,0 +1,33 @@
+---
+"openape-free-idp": minor
+---
+
+idp: web-YOLO actually evaluates + per-bucket UI tabs
+
+**Web YOLO was inert.** The `yolo-evaluator` early-returned `null` whenever
+the grant request had no `command` array. Web grants (audience `ape-proxy`)
+arrive with `target_host` and no command, so every Web YOLO attempt fell
+through to human approval — the UI lied.
+
+Evaluator now accepts a generic `target` string (joined command for
+Commands/Root, `target_host` for Web) and globs deny-patterns against it
+the same way for both shapes. New `targetFromRequest()` helper picks the
+right field; the pre-approval hook calls it. 4 new tests cover Web/host
+patterns + host fallback to wildcard.
+
+UI changes on `/agents/:email`:
+
+- **Tabs instead of stacked cards** — Commands / Web / Root / Default each
+  in its own tab. Compact at any viewport.
+- **Per-bucket placeholders + helper text.** Web no longer suggests
+  `rm -rf *`; it shows `*.openai.com\nstripe.com`. Commands shows
+  bash-shaped patterns. Root shows root-command examples. Default is
+  the catch-all.
+- **Web tab carries an inline notice** that today only host-globs are
+  enforceable (TLS-opaque CONNECT). Method+Path patterns for cleartext-HTTP
+  are flagged as future work — no surprise lying.
+- **"Erlaubte Commands" (Standing Grants list)** moved into the Commands
+  tab only. Web/Root will get their own surfaces in a follow-up.
+- **Authentifizierung** is no longer an accordion taking page space; it's
+  a small `?`-icon popover next to the section title with the same
+  `apes login` command + DDISA hint.

--- a/.claude/plans/ape-shell-proxy-mediated-egress.md
+++ b/.claude/plans/ape-shell-proxy-mediated-egress.md
@@ -1,0 +1,430 @@
+# Plan: `apes proxy --` foundation + ape-shell egress mediation
+
+> Dieser Plan ist **self-contained**: ein Agent oder Mensch ohne Vorwissen muss ihn von
+> oben nach unten lesen und ein funktionierendes Ergebnis produzieren können. Alle
+> Pfade sind repo-relativ zu `openape-monorepo/`.
+
+## Purpose / Big Picture
+
+**Ziel:** Zwei aufeinander aufbauende user-sichtbare Capabilities.
+
+1. **`apes proxy -- <cmd>`** als general-purpose Subcommand: jeder Skript/Agent/User
+   kann beliebige Commands "durch den OpenApe-Proxy" laufen lassen. Per-Invocation
+   Lifecycle: Proxy startet, `HTTPS_PROXY` wird gesetzt, command läuft,
+   Proxy wird beim Exit gestoppt. Allow/Deny/Grant-Required-Regeln entscheiden ob
+   Egress-Calls rausgehen, Audit-Trail JSONL.
+2. **`ape-shell` opt-in via `OPENAPE_PROXY_URL`**: ape-shell startet **keinen**
+   Proxy automatisch. Wenn der User vor dem ape-shell-Start `OPENAPE_PROXY_URL`
+   in seinem Shell-Env gesetzt hat (z.B. `openape-proxy &` plus `export
+   OPENAPE_PROXY_URL=http://127.0.0.1:9090`), injiziert ape-shell `HTTPS_PROXY`
+   passend ins Bash-env. Ohne gesetzte env-var verhält sich ape-shell exakt wie heute
+   — keine Verhaltensänderung, keine implizite Mediation. `apes proxy --` honoriert
+   `OPENAPE_PROXY_URL` analog: gesetzt → kein eigenes Spawn, einfach existing reusen.
+
+Kein MITM, kein Token-Swap, kein neues Trust-Boundary-Theater. Nur **Host-basiertes
+Policy-Gating + Audit** auf der Egress-Schicht — als zusätzliche Verteidigungslinie
+zum existierenden Per-Line-Grant-Flow auf der Bash-Schicht.
+
+**Kontext:** OneCLI-Diskussion 2026-04-26. Patrick wollte Trust-Boundary für
+Agent-Outbound härten ohne MITM/CA-Inject. `@openape/proxy` (v0.2.14, `packages/proxy/`)
+ist bereits ein Forward-Proxy mit Grant-Integration zum eigenen IdP. Architektur-
+Vorschlag von Patrick (2026-04-27): `apes proxy --` analog zu `apes run --root → escapes`,
+also ein eigenständiges Tool das per-Invocation aufgerufen werden kann — nicht ein
+für-immer-an-`ape-shell`-gekettetes Embedding. Stack bleibt TS/Node/Bun.
+
+**Scope (drin):**
+- `@openape/apes` bekommt neues Subcommand `apes proxy -- <cmd>`.
+- `@openape/proxy` bekommt Node-runnable `dist/cli.js` (tsup build), wird runtime-dep
+  von `@openape/apes`.
+- Default + Per-User TOML-Config (`~/.config/openape/proxy.toml`).
+- Auth zwischen apes und Proxy: ephemeral agent-JWT via `@openape/cli-auth`
+  (RFC8693 Token-Exchange).
+- ape-shell-Integration via `OPENAPE_PROXY_URL`-Env-Discovery (daemon reuse).
+- Per-Line Env-Overlay für Grant-IDs (Patrick's "manchen Commands env erzwingen").
+- Audit-Surfacing in ape-shell-REPL.
+
+**Scope (nicht drin):**
+- MITM/TLS-Termination, URL-Path-/Header-/Body-Inspection.
+- Token-Swap (Placeholder → echter Upstream-Key) à la OneCLI.
+- OS-Level Egress-Firewall (Agent kann Proxy umgehen wenn er env-vars löscht).
+- Capability-Sandboxing per `sandbox-exec` / `bwrap`.
+
+## Repo-Orientierung
+
+- **Projekt:** openape-monorepo, branch off latest `origin/main`.
+- **Relevante Pakete + Pfade:**
+  - `packages/apes/` — `@openape/apes` v0.12.6+.
+    - `src/cli.ts` — citty entry inkl. `ape-shell`-rewrite-pfad.
+    - `src/commands/` — Subcommand-Files. `apes proxy --` neu in `src/commands/proxy.ts`.
+    - `src/commands/run.ts` — Vorbild-Pattern (`execFileSync escapes --grant ... -- ...`).
+    - `src/shell/orchestrator.ts` — REPL-Entry, hier wird Daemon hochgezogen.
+    - `src/shell/pty-bridge.ts` — wrapt persistent bash, Marker-PS1.
+    - `src/shell/repl-dispatch.ts` / `oneshot-dispatch.ts` — Per-Line-Pipeline.
+  - `packages/proxy/` — `@openape/proxy` v0.2.14.
+    - `src/index.ts` — bun-shebang Entry, `parseArgs` + `createServer`. Muss zu
+      Node-runnable `dist/cli.js` gebaut werden (tsup).
+    - `src/proxy.ts` — `createNodeHandler(config)`, exportiert.
+    - `src/connect.ts` — CONNECT-Tunneling für HTTPS.
+    - `src/auth.ts` — `verifyAgentAuth(authHeader, idpUrl, mandatory)`.
+    - `src/config.ts` — `loadMultiAgentConfig(path)`.
+    - `src/audit.ts` — `initAudit(path)`, JSONL-Append.
+    - `config.example.toml` — Schema-Beispiel.
+  - `packages/cli-auth/` — `@openape/cli-auth`, Token-Cache + RFC8693-Exchange.
+  - `packages/grants/`, `packages/core/` — bereits Deps des Proxy.
+- **Tech-Stack:** Node 22+ (apes), TypeScript, PNPM workspaces, turbo, tsup, vitest, citty.
+  Stack-Entscheidung 2026-04-27: bewusst TS/Node/Bun — kein Sprachwechsel für Proxy.
+- **Dev-Setup:**
+  - `pnpm install` im Repo-Root.
+  - `pnpm --filter @openape/apes build` — apes bundle.
+  - `pnpm --filter @openape/apes dev` für Watch.
+  - `pnpm --filter @openape/proxy build` — proxy bundle (Node-target).
+  - Proxy lokal probieren: `bun packages/proxy/src/index.ts -c packages/proxy/config.example.toml`.
+  - Tests: `pnpm --filter @openape/apes test` (vitest, 533+ Tests).
+  - Lint/typecheck: `pnpm check` (root, oxlint + tsc).
+
+## Open Questions / Discovery vor M0
+
+1. **`@openape/proxy` Build-Target.** Aktueller bin: `src/index.ts` mit
+   `#!/usr/bin/env bun`. Für npm-Install global brauchen wir einen Node-runnable
+   Bundle in `dist/cli.js`. tsup-config prüfen, ggf. `--platform=node --target=node22`
+   ergänzen + bin-shebang umstellen.
+2. **Cross-package bin-resolution.** `apes proxy --` muss `openape-proxy`-binary
+   finden ohne PATH-Annahmen. Lösung: `require.resolve('@openape/proxy/package.json')`
+   → `bin`-Eintrag aus dem JSON lesen → absoluter Pfad → `execFileSync(absPath, ...)`.
+3. **Daemon-Discovery via env.** `OPENAPE_PROXY_URL` ist die Konvention. Wenn gesetzt
+   und via TCP erreichbar → reuse, sonst spawn. Plus `OPENAPE_PROXY_PID` damit der
+   Cleanup-Mechanismus weiß was er killen muss.
+4. **Auth-Modus.** Erste Iteration: `mandatoryAuth: false`, JWT optional. Härten
+   in M3.
+5. **Feature-Flag.** `OPENAPE_SHELL_PROXY=0` deaktiviert die ape-shell-Integration
+   für Power-User-Debug. `apes proxy --` als Subcommand funktioniert immer.
+
+## Milestones
+
+Jeder Milestone ist unabhängig testbar. Pro Session max. einer.
+
+### Milestone 0: `@openape/proxy` Node-runnable + Wiring
+
+**Ziel:** Nach `pnpm install` + `pnpm build` existiert ein `node`-startbares
+`packages/proxy/dist/cli.js`. `@openape/proxy` ist als runtime-dep in `packages/apes/package.json`.
+
+**Schritte:**
+1. `packages/proxy/tsup.config.ts` (oder package.json `tsup` block) so konfigurieren dass
+   ein `dist/cli.js` rauskommt mit:
+   - shebang `#!/usr/bin/env node`
+   - target node22
+   - format esm (oder cjs, je nach was im monorepo Standard ist)
+   - external: keine — alle deps inline (smol-toml, jose, @openape/core, @openape/grants)
+2. `packages/proxy/package.json` `bin` umstellen: `"openape-proxy": "./dist/cli.js"`.
+3. `packages/proxy/package.json` `files` enthält `dist`.
+4. `packages/apes/package.json` `dependencies` ergänzen: `"@openape/proxy": "workspace:*"`.
+5. `pnpm install && pnpm --filter @openape/proxy build && pnpm --filter @openape/apes build`
+   muss clean durchlaufen.
+
+**Akzeptanzkriterien:**
+- [ ] `node packages/proxy/dist/cli.js -c packages/proxy/config.example.toml` startet
+      und logged `[openape-proxy] Listening on http://127.0.0.1:9090`.
+- [ ] `node -e "console.log(require.resolve('@openape/proxy/package.json'))"`
+      ausgeführt im `packages/apes`-Cwd liefert einen Pfad.
+- [ ] `pnpm --filter @openape/apes typecheck` clean.
+
+**Rollback:** Trivial — Edits revertieren, dependency-eintrag entfernen.
+
+### Milestone 1a: `apes proxy -- <cmd>` Subcommand (foundation)
+
+**Ziel:** General-purpose Subcommand. Spiegelt das Pattern von `apes run --root → escapes`.
+Per-Invocation Lifecycle: Proxy spawnt, command läuft, Proxy stirbt.
+
+**Schritte:**
+1. Neue Datei `packages/apes/src/commands/proxy.ts` als citty-Subcommand:
+   ```ts
+   export const proxyCommand = defineCommand({
+     meta: { name: 'proxy', description: 'Run a command through the OpenApe egress proxy.' },
+     args: {
+       /* nicht-`--` args sind via `args._` der wrapped command;
+          additional flags: --grant <name>, --config <path>, --no-auth */
+     },
+     async run(ctx) {
+       // 1. Resolve config (default + ~/.config/openape/proxy.toml overlay)
+       // 2. Spawn openape-proxy as child, wait for it to listen
+       // 3. Mint agent-JWT via @openape/cli-auth (token-exchange)
+       // 4. Build env: HTTPS_PROXY=http://127.0.0.1:<port>, HTTP_PROXY=...
+       //    Optional: NO_PROXY=127.0.0.1,localhost
+       // 5. execFileSync(wrapped[0], wrapped.slice(1), { stdio:'inherit', env })
+       // 6. on exit: SIGTERM proxy child, wait, force-kill if needed
+     },
+   })
+   ```
+2. Implementiere `startEphemeralProxy(config)`:
+   - `child_process.spawn('node', [resolvedProxyBin, '-c', tempConfigPath])`
+   - liest stdout zeile für zeile bis `[openape-proxy] Listening on http://127.0.0.1:<port>`
+   - extrahiert Port → return `{ proc, port, url, close: ... }`
+3. Implementiere `findProxyBin(): string`:
+   - `dirname(require.resolve('@openape/proxy/package.json'))` + bin-Eintrag
+4. Default-Config-Builder `buildDefaultProxyConfig({ port: 0 })`:
+   - `default_action: "allow"` für M1a, hardening in M3
+   - Deny-Liste: `169.254.169.254`, `metadata.google.internal`, `*.internal`
+   - Allow-Liste: `registry.npmjs.org`, `*.openape.ai`, `*.openape.at`,
+     `api.github.com`, `objects.githubusercontent.com`
+   - Audit-Log: `${XDG_STATE_HOME:-$HOME/.local/state}/openape/proxy-audit.jsonl`
+5. CLI-Wiring in `src/cli.ts`: `apes proxy --` als citty subcommand registrieren.
+
+**Akzeptanzkriterien:**
+- [ ] `apes proxy -- echo PROXY=$HTTPS_PROXY` → Output enthält
+      `PROXY=http://127.0.0.1:` gefolgt von einer Port-Zahl > 0.
+- [ ] `apes proxy -- curl -sS -o /dev/null -w '%{http_code}' https://api.github.com/zen`
+      liefert `200`. Im Audit-File neue Zeile `{"event":"connect","host":"api.github.com",...}`.
+- [ ] Nach `apes proxy -- sleep 1`-Exit: `lsof -nP -iTCP -sTCP:LISTEN | grep openape-proxy`
+      liefert nichts (Proxy gestorben).
+- [ ] `apes proxy -- bash -c 'curl http://169.254.169.254/'` → curl exit nicht-null
+      (vom Proxy geblockt).
+
+**Rollback:** Subcommand registrieren rückgängig, Datei `proxy.ts` löschen.
+
+### Milestone 1b: ape-shell respektiert `OPENAPE_PROXY_URL` (opt-in, kein Autostart)
+
+**Ziel:** Wenn der User vor `ape-shell`-Start `OPENAPE_PROXY_URL` gesetzt hat,
+injiziert ape-shell `HTTPS_PROXY` aus dieser URL ins Bash-env. Ohne gesetzte
+env-var: kein Verhaltens-Diff zum Status-quo. Kein Autostart, kein Daemon-
+Lifecycle in ape-shell.
+
+**Why no autostart:** Patrick (2026-04-27): User soll explizit selbst entscheiden ob
+ein Proxy läuft (`openape-proxy &` plus `export OPENAPE_PROXY_URL=...`). ape-shell
+ist nur Konsument, kein Lifecycle-Owner.
+
+**Schritte:**
+1. PtyBridge `extraEnv: Record<string, string>`-Parameter ergänzen (auch M4 braucht das).
+2. In `src/shell/orchestrator.ts` (`runInteractiveShell`):
+   - Lese `process.env.OPENAPE_PROXY_URL`.
+   - Wenn gesetzt: PtyBridge-extraEnv enthält
+     ```ts
+     {
+       HTTPS_PROXY: process.env.OPENAPE_PROXY_URL,
+       HTTP_PROXY: process.env.OPENAPE_PROXY_URL,
+       NO_PROXY: process.env.NO_PROXY ?? '127.0.0.1,localhost',
+     }
+     ```
+     Dazu einmalig auf stderr: `[ape-shell] using egress proxy at <url>`.
+   - Wenn nicht gesetzt: extraEnv leer, keine Logzeile, alles unverändert.
+3. `apes proxy --` (M1a) detection-pfad ergänzen:
+   - Wenn `process.env.OPENAPE_PROXY_URL` gesetzt:
+     - **Skip spawn**, nur `HTTPS_PROXY=$OPENAPE_PROXY_URL` ins env des wrapped cmd.
+   - Sonst: full ephemeral spawn (M1a default).
+4. **Kein** Daemon-Spawn in ape-shell, **kein** `OPENAPE_SHELL_PROXY`-Feature-Flag
+   nötig (env nicht gesetzt = kein Proxy = entspricht Flag-aus).
+
+**Akzeptanzkriterien:**
+- [ ] **Ohne** `OPENAPE_PROXY_URL`: `apes ape-shell -c "echo HTTPS_PROXY=$HTTPS_PROXY"`
+      → leere Variable. Kein Process von `openape-proxy` gestartet.
+- [ ] **Mit** `OPENAPE_PROXY_URL=http://127.0.0.1:9090`:
+      `OPENAPE_PROXY_URL=http://127.0.0.1:9090 apes ape-shell -c "echo HTTPS_PROXY=$HTTPS_PROXY"`
+      → druckt die URL.
+- [ ] Mit gesetzter URL und einem davor manuell gestarteten `openape-proxy &`:
+      `apes ape-shell -c "curl https://api.github.com/zen"` → 200, Audit-File des
+      manuell gestarteten Proxy enthält den Eintrag.
+- [ ] `apes proxy -- curl ...` ohne env-var: spawnt eigenen ephemeren Proxy,
+      stirbt mit Command. **Mit** env-var: re-uset existing, kein Spawn (PID-Count
+      von openape-proxy unverändert).
+- [ ] Nach ape-shell-Exit ohne env-var-Pfad: keine zurückgelassenen Proxy-Prozesse
+      (war ja nie einer).
+
+**Rollback:** orchestrator-Patch revertieren — Bash-env unverändert.
+
+### Milestone 2: Default-Config + Per-User-Overlay
+
+**Ziel:** Sinnvolle, konservative Default-Regeln. User kann via TOML überschreiben.
+
+**Schritte:**
+1. `packages/apes/src/proxy/config.ts`:
+   - `DEFAULT_PROXY_CONFIG` als typed Konstante.
+   - `loadProxyConfig()`: liest `${XDG_CONFIG_HOME:-$HOME/.config}/openape/proxy.toml`
+     falls vorhanden, sonst Default. Logged `[apes-proxy] using <default|user> config`.
+2. `apes proxy --` und ape-shell-Daemon nutzen beide `loadProxyConfig()`.
+3. `docs/cli/apes-proxy.md` (NEW): User-Doku — Defaults, wie überschreiben, wie
+   Feature-Flag.
+
+**Akzeptanzkriterien:**
+- [ ] User-Override-File mit `default_action = "deny"` setzen → erneutes
+      `apes proxy -- curl https://example.com` schlägt fehl (vom Proxy geblockt).
+- [ ] User-File löschen → curl auf api.github.com geht wieder durch (Allowlist).
+
+**Rollback:** User-File löschen oder `OPENAPE_SHELL_PROXY=0`.
+
+### Milestone 3: Auth — Ephemeral Agent-JWT für Proxy
+
+**Ziel:** Jeder Outbound-Call hat ein verifiziertes Agent-Identity-JWT (`act:'agent'`,
+`sub:<email>`). Proxy schreibt `agent_email` ins Audit, kann später per-agent-Regeln.
+
+**Schritte:**
+1. Bei `apes proxy --` und ape-shell-Daemon-Start: `await mintAgentToken({ aud:'openape-proxy' })`
+   via `@openape/cli-auth` (RFC8693 Exchange, kurze TTL).
+2. Token in `HTTPS_PROXY`-URL als userinfo: `http://x:<token>@127.0.0.1:<port>`.
+   Proxy decodiert `password` als Bearer (fallback auf `Proxy-Authorization`-Header).
+3. Default-Config auf `mandatory_auth = true`.
+4. Token-Refresh: TTL großzügig (60min) für M3, daemon-side Refresh als TODO M5+.
+
+**Akzeptanzkriterien:**
+- [ ] Audit-Log enthält `agent_email` für jeden Eintrag.
+- [ ] Manueller `curl -x http://127.0.0.1:<port> https://api.github.com/zen` ohne
+      embedded creds → `407 Proxy Authentication Required`.
+
+**Rollback:** Defaults zurück auf `mandatory_auth = false`.
+
+### Milestone 4: Per-Line Env-Overlay & Grant-Header
+
+**Ziel:** Pro Bash-Zeile in ape-shell: zusätzliche env-vars setzen. Wenn ein Grant
+für die Zeile approved wurde, geht dessen ID als `X-Openape-Grant-Id` durch den
+Proxy ins Audit.
+
+**Schritte:**
+1. In `src/shell/repl-dispatch.ts`: `wrapLineWithEnv(line, overlay)` Helfer der
+   in `env A=1 B=2 -- bash -c '<line>'` rewriten kann (oder subshell-Prefix).
+2. Approved Grant pro Zeile → `OPENAPE_GRANT_ID=<id>` im overlay,
+   `OPENAPE_PROXY_EXTRA_HEADERS='X-Openape-Grant-Id: <id>'`.
+3. `packages/proxy/src/audit.ts` erweitern um optional `extra` object.
+4. `packages/proxy`-Config: `audit_extra_headers = ["X-Openape-Grant-Id"]`.
+
+**Akzeptanzkriterien:**
+- [ ] In ape-shell: nach Grant-Approval einer Zeile, Audit-JSONL enthält
+      `X-Openape-Grant-Id` mit der korrekten Grant-ID.
+- [ ] Tests in `packages/apes/src/shell/__tests__/wrap-line-env.test.ts`
+      decken Quoting-Edge-Cases ab.
+
+**Rollback:** Overlay-Helper zur identity-Funktion machen.
+
+### Milestone 5: Audit-Surfacing in REPL
+
+**Ziel:** User sieht direkt im REPL welche Egress-Calls geblockt wurden.
+
+**Schritte:**
+1. Audit-Stream-Mode im Proxy: zusätzlich zu File-Append einen ND-JSON-Output
+   auf stdout (Flag `--audit-stdout`). ape-shell-Daemon liest stream.
+2. orchestrator subscribed, formatiert als Inline-Status `[ape-shell] 🛡️ blocked CONNECT metadata.google.internal:443`.
+3. `--quiet` respektieren (default: nur deny/grant_required surface'n, nicht plain allow).
+
+**Akzeptanzkriterien:**
+- [ ] `apes ape-shell -c "curl http://169.254.169.254/"` → user sieht `[ape-shell] 🛡️ blocked …`
+      und curl-exit nicht-null.
+- [ ] Allow-listed call: keine Zusatzzeile, normaler Output.
+
+**Rollback:** Subscriber-Hook entfernen, Audit-File bleibt.
+
+### Milestone 7 (optional, opt-in): Hard egress-enforcement via OS sandbox
+
+**Ziel:** `apes proxy --strict -- <cmd>` zwingt das wrapped command auf
+Kernel-Level — TCP-Egress nur zum lokalen Proxy-Port erlaubt, alles andere
+(direct-socket-tools, raw curl mit ignoriertem env, ssh-protocol etc.) bekommt
+ein hartes `connection-refused`. Wer nicht durch den Proxy will, kann nicht.
+
+Ohne `--strict` bleibt M1a's "opt-in via env" Standard — 95% der CLI-Tools
+respektieren ja `HTTPS_PROXY`/`ALL_PROXY` (M1a + Level-1-Followup), und das
+ist meistens genug.
+
+**Schritte:**
+1. Plattform-Detection: macOS / Linux / Windows.
+2. macOS: `sandbox-exec` mit Profile:
+   ```scheme
+   (version 1)
+   (allow default)
+   (deny network-outbound)
+   (allow network-outbound (remote tcp "localhost:<proxy-port>"))
+   (allow network-outbound (remote unix-socket))   ;; for syslog etc.
+   ```
+3. Linux: `unshare -n` + zwei `iptables`-Regeln im neuen Netzwerk-Namespace
+   (DNAT zum Proxy oder REJECT alles außer Loopback). Heavier Setup, evtl.
+   erst in M7b nachschieben.
+4. Windows: aktuell nicht supported, klar dokumentieren.
+5. `apes proxy --strict --` Flag in `commands/proxy.ts`. Default off.
+
+**Akzeptanzkriterien:**
+- [ ] macOS: `apes proxy --strict -- bash -c 'echo open ssh; ssh -o ConnectTimeout=2 github.com 2>&1'`
+      → ssh schlägt mit "connection refused" fehl (statt sich zu verbinden), während
+      `apes proxy --strict -- curl https://api.github.com/zen` weiter funktioniert.
+- [ ] macOS: ohne `--strict` (M1a) funktionieren beide.
+
+**Rollback:** Flag entfernen.
+
+### Milestone 6: Tests, CI, Doku, Changeset
+
+**Ziel:** Production-ready: green, dokumentiert, releasable.
+
+**Schritte:**
+1. Test-Coverage M1a-M5 prüfen, fehlende Kanten ergänzen (port-collision,
+   proxy-crash-mid-session, slow shutdown, NO_PROXY-respektieren, daemon-reuse).
+2. `packages/apes/README.md`-Section "Egress Mediation" mit Architektur-Diagramm.
+3. `docs/cli/apes-proxy.md` final.
+4. `.changeset/<name>.md`: `@openape/apes` patch + `@openape/proxy` patch.
+5. `pnpm check` + `pnpm test` grün.
+6. PR.
+
+**Akzeptanzkriterien:**
+- [ ] CI grün.
+- [ ] Changeset korrekt.
+- [ ] `npm view @openape/apes@<new-ver>` zeigt `@openape/proxy` als Dep.
+
+**Rollback:** Revert-PR.
+
+## Progress
+
+> Laufend aktualisieren. Diese Section ist das Übergabedokument zwischen Sessions.
+
+- [x] `[2026-04-27 21:40]` M0: `@openape/proxy` Node-build + dep-wiring (merged)
+- [x] `[2026-04-27 22:10]` M1a: `apes proxy -- <cmd>` Subcommand (merged)
+  - [x] `[2026-04-27 22:35]` Level-1 Followup: alle Proxy-env-var-Varianten setzen (`HTTPS_PROXY`/`https_proxy`/`HTTP_PROXY`/`http_proxy`/`ALL_PROXY`/`all_proxy`/`NO_PROXY`/`no_proxy`/`NODE_USE_ENV_PROXY=1`). Deckt Tools die nur lowercase oder `ALL_PROXY` lesen + Node 24+ native fetch.
+- [x] `[2026-04-28 12:30]` M2: Host-based allow/deny/grant_required für HTTPS-CONNECT (merged) inkl. IdP-system-bypass + audience='ape-proxy' Rename + default_action='allow' Fix
+- [x] `[2026-04-28 12:45]` M3 Foundation: per-audience YOLO + audience-bucket-registry (merged). Schema migrated, API back-compat, hook nutzt request.audience.
+- [x] `[2026-04-28 13:00]` M3 UI: BucketYoloCard component + 4-Section layout auf `/agents/:email` (PR pending). Commands / Web / Root / Default jeweils eigene YOLO-Policy + Deny-Patterns.
+- [ ] `[ … ]` M1b: ape-shell shared-daemon integration
+- [x] `[2026-04-28 12:10]` M2: Host-based allow/deny/grant_required for HTTPS-CONNECT (PR pending)
+  - Side-fix: `default_action="allow"` was previously type-invalid AND ignored by matcher (fall-through to grant_required). Type extended + matcher honors 'allow' as a hard-pass. Without this fix M2 would have made the M1a default permissive config block all unmatched HTTPS hosts.
+- [ ] `[ … ]` M3: Ephemeral Agent-JWT für Proxy
+- [ ] `[ … ]` M4: Per-Line Env-Overlay + Grant-Header
+- [ ] `[ … ]` M5: Audit-Surfacing in REPL
+- [ ] `[ … ]` M6: Tests + CI + Doku + Changeset + Release
+- [ ] `[ … ]` M7 (opt-in): Hard egress-enforcement via OS sandbox (macOS sandbox-exec, Linux netns)
+
+## Surprises & Discoveries
+
+> Unerwartete Erkenntnisse während der Implementierung. Immer mit Evidenz.
+
+- **2026-04-27 (M0):** dist-file ist `dist/index.js` (nicht `dist/cli.js` wie im Plan-Entwurf), weil tsup-entry `src/index.ts` heißt. Plan-Akzeptanzkriterien-Pfade entsprechend lesen. Evidenz: `node -e "console.log(require.resolve('@openape/proxy/package.json'))"` → `.../packages/proxy/package.json`, `bin['openape-proxy']` → `./dist/index.js`.
+- **2026-04-27 (M0):** Audit-File schrieb keine Zeile bei einem allow-Request während Smoke-Test (`/tmp/openape-proxy-smoke-audit.jsonl` blieb leer trotz erfolgreichem `curl … api.github.com → HTTP 200`). Vermutung: Audit logged nur deny/grant_required, nicht plain allow. Außerhalb M0-Scope, beobachten in M5 (Audit-Surfacing).
+- **2026-04-27 (M0):** `listen = "127.0.0.1:0"` in der TOML-Config geht zwar (server bindet auf zufälligen Port), aber das Log-Statement gibt fälschlich `Listening on http://127.0.0.1:0` aus statt der echten Port-Nummer. ~~Klein, kann später separat fixen.~~ **Fixed in M1a** (`packages/proxy/src/index.ts`, lese `server.address()` im listen-callback statt der konfigurierten Port-Zahl).
+- **2026-04-27 (M1a):** Deny-Pfad gegen `169.254.169.254` blockt nicht aktiv mit fast-403 — curl läuft in den Timeout (28 connection-timed-out). Effekt-equivalent (Request kommt nicht durch), aber UX ist fuzzy. Vermutlich macht der Proxy keinen `early reject` auf CONNECT mit deny-host, sondern hängt die Verbindung. Beobachten in M2 (Config-Defaults) oder M3 (Auth + Härten); separater Followup-Issue möglich. Evidenz: `apes proxy -- curl http://169.254.169.254/...` → `curl: (28) Connection timed out after 3002 milliseconds`.
+
+## Decision Log
+
+| Datum | Entscheidung | Begründung | Alternativen verworfen |
+|---|---|---|---|
+| 2026-04-27 | Kein Subcommand `ape spawn` | Patrick: bestehende Bash-Wrapper-Architektur ist der natürliche Ort. | `ape spawn` als separates Subcommand. |
+| 2026-04-27 | Kein MITM/CA-Inject | Vermeidet Truststore-Eingriff, kein Cert-Pinning-Bruch. Trade-off: nur Host-granular. | OneCLI-Style MITM. |
+| 2026-04-27 | Default `default_action="allow"` in M1a, später härten in M3 | Schrittweises Rollout. | Direkt deny-by-default. |
+| 2026-04-27 | Env-Var-Routing statt OS-Sandbox | TS-only, plattformneutral. | OS-Egress-Firewall. |
+| 2026-04-27 | **`apes proxy -- <cmd>` als general-purpose Subcommand**, ape-shell nutzt es intern via shared daemon | Patrick (2026-04-27): spiegelt `apes run --root → escapes` Pattern, komponierbar außerhalb ape-shell, ssh-agent-style daemon-reuse. | In-process embedded proxy in ape-shell (verworfen weil weniger komponierbar + nicht analog zu existierender `escapes`-Architektur). |
+| 2026-04-27 | **Stack bleibt TS/Node/Bun** für Proxy-Implementierung | Patrick: Einfachheit. Existing `@openape/proxy` ist TS, kein Sprachwechsel-Aufwand. | Rust (à la OneCLI) — verworfen wegen Toolchain-Burden + zweite Sprache im Stack. |
+| 2026-04-27 | Daemon-Discovery via `OPENAPE_PROXY_URL`-env | ssh-agent / gpg-agent-Pattern, etabliert + verständlich. | Unix-domain-socket discovery; verworfen für M1, kann später nachrüsten. |
+| 2026-04-27 | **Kein Autostart eines Proxy-Daemons in ape-shell.** ape-shell respektiert nur `OPENAPE_PROXY_URL` wenn der User die Var explizit gesetzt hat. | Patrick: User soll Lifecycle bewusst kontrollieren (`openape-proxy &`); ape-shell ist Konsument, kein Lifecycle-Owner. Keine impliziten Behavior-Änderungen für bestehende Sessions. | Auto-Spawn eines Session-Daemons (verworfen weil zu opaque + cleanup-fehleranfällig). |
+
+## Session-Checkliste
+
+> Jede Session beginnt mit dieser Checkliste:
+
+1. Diesen Plan lesen, Progress + Surprises + Decision-Log durchgehen.
+2. `git fetch origin && git log origin/main --since="last session" --oneline`.
+3. `pnpm install` (lockfile-Drift fängt CI sonst spät).
+4. Baseline-Test: `pnpm --filter @openape/apes test` muss grün starten.
+5. Nächsten offenen Milestone identifizieren, Branch off main: `git checkout -b feat/apes-proxy-m<N>-<short>`.
+6. Implementieren, Pre-commit hook akzeptieren.
+7. E2E-Verifikation per Akzeptanzkriterien des Milestones (echter `apes proxy --`-Aufruf,
+   echter HTTP-Call, echtes Audit-File-Inspect).
+8. Progress-Section, Surprises (mit Evidenz), Decision-Log aktualisieren.
+9. PR aufmachen, CI abwarten, mergen, Changeset (M6) zuletzt zusammen.
+10. Bei Force-Push/`--admin` Bedarf: stop, frag Patrick.
+
+## Outcomes & Retrospective
+
+> Erst nach Abschluss aller Milestones ausfüllen.
+
+- **Ergebnis:** *(tbd)*
+- **Abweichungen vom Plan:** *(tbd)*
+- **Learnings:** *(tbd)*

--- a/apps/openape-free-idp/app/components/BucketYoloCard.vue
+++ b/apps/openape-free-idp/app/components/BucketYoloCard.vue
@@ -230,6 +230,14 @@ watch(() => props.agentEmail, () => { if (props.agentEmail) load() }, { immediat
       </div>
     </div>
 
+    <UAlert
+      v-if="bucket.notice"
+      color="info"
+      variant="subtle"
+      :title="bucket.notice"
+      icon="i-lucide-info"
+    />
+
     <UAlert v-if="error" color="error" :title="error" @close="error = ''" />
 
     <div v-if="loading" class="text-xs text-gray-400">
@@ -285,11 +293,11 @@ watch(() => props.agentEmail, () => { if (props.agentEmail) load() }, { immediat
       <UFormField label="Risiko-Schwelle" help="Requests mit diesem oder höherem Risiko werden weiter menschlich bestätigt.">
         <USelect v-model="form.denyRiskThreshold" :items="riskOptions" />
       </UFormField>
-      <UFormField label="Deny-Patterns (eine Zeile, Glob: * ?)">
+      <UFormField label="Deny-Patterns (eine pro Zeile, Glob: * ?)" :help="bucket.denyPatternHelp">
         <UTextarea
           v-model="form.denyPatterns"
-          :rows="3"
-          placeholder="rm -rf *&#10;sudo *"
+          :rows="4"
+          :placeholder="bucket.denyPatternPlaceholder"
         />
       </UFormField>
       <div class="flex gap-2">

--- a/apps/openape-free-idp/app/pages/agents/[id].vue
+++ b/apps/openape-free-idp/app/pages/agents/[id].vue
@@ -48,6 +48,20 @@ const wizardOpen = ref(false)
 // its own load/save lifecycle. The page just hands them the agent email and
 // lets them render.
 
+// Tab navigation for the bucket sections. Commands is the default landing
+// tab because Standing Grants currently only live there (Web/Root will get
+// their own surfaces in a follow-up PR).
+const activeBucketTab = ref('commands')
+const bucketTabItems = computed(() => BUCKET_DISPLAY.map(b => ({
+  label: b.label,
+  value: b.id,
+  icon: b.icon,
+  slot: b.id,
+})))
+function bucketByValue(value: string) {
+  return BUCKET_DISPLAY.find(b => b.id === value) ?? BUCKET_DISPLAY[0]!
+}
+
 useSeoMeta({ title: computed(() => agent.value ? `Agent: ${agent.value.name}` : 'Agent') })
 
 await fetchUser()
@@ -346,112 +360,120 @@ async function handleDelete() {
             </p>
           </div>
 
-          <details class="bg-gray-800/40 border border-gray-700 rounded-lg">
-            <summary class="cursor-pointer select-none px-3 py-2 text-sm text-gray-300 font-medium">
-              Authentifizierung
-            </summary>
-            <div class="px-3 pb-3 pt-1 text-sm text-gray-300 space-y-4">
-              <div class="space-y-2">
-                <h4 class="text-xs uppercase tracking-wide text-gray-500 font-semibold">
-                  1) Bei OpenApe anmelden — für Grant-Anfragen
-                </h4>
-                <p class="text-xs text-gray-400">
-                  Der Agent holt sich einen JWT über Ed25519-Challenge/Response mit seinem
-                  privaten Schlüssel. Danach kann er Grants anfordern und Kommandos ausführen
-                  (inkl. <span class="font-mono">apes run --as root</span> für privilegierte
-                  Commands — Details siehe
-                  <a
-                    href="https://docs.openape.ai/getting-started/quickstart-agent"
-                    target="_blank"
-                    rel="noopener"
-                    class="text-orange-400 underline"
-                  >Quickstart: Agent</a>).
-                </p>
-                <div class="relative">
-                  <pre class="bg-gray-800 border border-gray-700 rounded-lg p-3 pr-10 text-xs text-gray-200 font-mono overflow-x-auto">{{ apesLoginCmd }}</pre>
-                  <UButton
-                    color="neutral"
-                    variant="ghost"
-                    size="xs"
-                    :icon="copied === 'apesLogin' ? 'i-lucide-check' : 'i-lucide-copy'"
-                    class="absolute top-2 right-2"
-                    @click="copyField('apesLogin', apesLoginCmd)"
+          <!-- Per-Bucket Tabs: Authorization-Layer (Commands / Web / Root /
+               Default-Fallback). Standing-Grants-Liste für "Erlaubte Commands"
+               ist nur unter Commands sichtbar — Web und Root haben heute noch
+               keine eigene UI dafür, kommt in Folge-PRs. Auth-Details sind
+               jetzt ein Help-Popover statt eines Accordion-Blocks. -->
+          <div class="border border-gray-700 rounded-lg overflow-hidden">
+            <div class="flex items-center justify-between gap-2 px-3 py-2 border-b border-gray-700 bg-gray-800/40">
+              <h2 class="text-sm font-semibold text-gray-300 flex items-center gap-2">
+                <UIcon name="i-lucide-shield-check" class="w-4 h-4 text-gray-400" />
+                Auto-Approval (YOLO) + Standing Grants
+              </h2>
+              <UPopover :content="{ side: 'bottom', align: 'end' }">
+                <UButton
+                  icon="i-lucide-help-circle"
+                  color="neutral"
+                  variant="ghost"
+                  size="xs"
+                  aria-label="Authentifizierung erklärt"
+                />
+                <template #content>
+                  <div class="p-4 max-w-md text-sm text-gray-200 space-y-3">
+                    <h3 class="font-semibold text-gray-100">
+                      Authentifizierung
+                    </h3>
+                    <div class="space-y-1">
+                      <h4 class="text-xs uppercase tracking-wide text-gray-500 font-semibold">
+                        1) Bei OpenApe anmelden
+                      </h4>
+                      <p class="text-xs text-gray-400">
+                        Ed25519-Challenge/Response mit dem privaten Schlüssel. Danach kann der Agent Grants anfordern.
+                      </p>
+                      <div class="relative">
+                        <pre class="bg-gray-800 border border-gray-700 rounded p-2 pr-8 text-xs text-gray-200 font-mono overflow-x-auto">{{ apesLoginCmd }}</pre>
+                        <UButton
+                          color="neutral"
+                          variant="ghost"
+                          size="xs"
+                          :icon="copied === 'apesLogin' ? 'i-lucide-check' : 'i-lucide-copy'"
+                          class="absolute top-1.5 right-1.5"
+                          @click="copyField('apesLogin', apesLoginCmd)"
+                        />
+                      </div>
+                    </div>
+                    <div class="space-y-1">
+                      <h4 class="text-xs uppercase tracking-wide text-gray-500 font-semibold">
+                        2) DDISA-Login auf SPs
+                      </h4>
+                      <p class="text-xs text-gray-400">
+                        Jede DDISA-fähige Website löst <span class="font-mono">_ddisa.{{ ddisaDomain }}</span> per DNS auf und vertraut diesem IdP.
+                        <a
+                          href="https://docs.openape.ai/getting-started/how-it-works"
+                          target="_blank"
+                          rel="noopener"
+                          class="text-orange-400 underline"
+                        >Mehr</a>.
+                      </p>
+                    </div>
+                  </div>
+                </template>
+              </UPopover>
+            </div>
+            <UTabs
+              v-model="activeBucketTab"
+              :items="bucketTabItems"
+              :unmount-on-hide="false"
+              variant="link"
+              size="sm"
+              color="primary"
+            >
+              <template #commands>
+                <div class="space-y-3 p-3">
+                  <BucketYoloCard
+                    :agent-email="agent.email"
+                    :bucket="bucketByValue('commands')"
+                  />
+                  <div>
+                    <h3 class="text-sm font-semibold text-gray-300 mb-2 mt-2">
+                      Erlaubte Commands (Standing Grants)
+                    </h3>
+                    <AllowedCommandsList
+                      :agent-email="agent.email"
+                      :owner="agent.owner ?? user?.email ?? ''"
+                      :standing-grants="standingGrants"
+                      @refresh="loadStandingGrants"
+                      @add-scoped="openWizard"
+                    />
+                  </div>
+                </div>
+              </template>
+              <template #web>
+                <div class="p-3">
+                  <BucketYoloCard
+                    :agent-email="agent.email"
+                    :bucket="bucketByValue('web')"
                   />
                 </div>
-                <p class="text-xs text-gray-500">
-                  <span class="font-mono">apes</span> erledigt Challenge/Response + Token-Caching
-                  transparent. Rohe Endpunkte:
-                  <span class="font-mono">POST /api/agent/challenge</span> &rarr;
-                  <span class="font-mono">POST /api/agent/authenticate</span> (siehe
-                  <a
-                    href="https://docs.openape.ai/ecosystem/auth"
-                    target="_blank"
-                    rel="noopener"
-                    class="text-orange-400 underline"
-                  >Auth-Overview</a>).
-                </p>
-              </div>
-
-              <div class="space-y-2">
-                <h4 class="text-xs uppercase tracking-wide text-gray-500 font-semibold">
-                  2) Auf anderen Websites anmelden — via DDISA
-                </h4>
-                <p class="text-xs text-gray-400">
-                  Jede Website, die DDISA unterstützt, erkennt diesen Agent über seine
-                  Email-Domain
-                  <span class="font-mono text-gray-300">{{ ddisaDomain }}</span>. Der SP
-                  löst
-                  <span class="font-mono">_ddisa.{{ ddisaDomain }}</span> per DNS auf, folgt
-                  dem OAuth-Redirect hierher, und der Agent signt den Login mit demselben
-                  Schlüssel wie in (1). Kein separater Account, keine zusätzliche Registrierung.
-                  Flow-Details:
-                  <a
-                    href="https://docs.openape.ai/getting-started/how-it-works"
-                    target="_blank"
-                    rel="noopener"
-                    class="text-orange-400 underline"
-                  >How DDISA works</a>.
-                </p>
-              </div>
-            </div>
-          </details>
-
-          <details class="bg-gray-800/40 border border-gray-700 rounded-lg" open>
-            <summary class="cursor-pointer select-none px-3 py-2 text-sm text-gray-300 font-medium">
-              Erlaubte Commands
-            </summary>
-            <div class="px-3 pb-3">
-              <AllowedCommandsList
-                :agent-email="agent.email"
-                :owner="agent.owner ?? user?.email ?? ''"
-                :standing-grants="standingGrants"
-                @refresh="loadStandingGrants"
-                @add-scoped="openWizard"
-              />
-            </div>
-          </details>
-
-          <!-- Per-Bucket YOLO + Deny: ein Card pro Policy-Layer.
-               Commands / Web / Root-Commands sind die drei Audience-Buckets,
-               'Default' deckt alles ab was nicht zu einem Bucket gehört. -->
-          <div class="space-y-3">
-            <div class="flex items-center gap-2">
-              <UIcon name="i-lucide-shield-check" class="w-5 h-5 text-gray-400" />
-              <h2 class="text-lg font-semibold">
-                Auto-Approval (YOLO) + Deny-Patterns
-              </h2>
-            </div>
-            <p class="text-xs text-gray-500 -mt-1">
-              Pro Policy-Layer einzeln aktivieren. Eine Konfiguration für Bash-Commands
-              betrifft Network-Egress nicht und umgekehrt. Lookup ist most-specific-wins:
-              Bucket-spezifischer Eintrag &gt; Default-Fallback &gt; menschliche Bestätigung.
-            </p>
-            <BucketYoloCard
-              v-for="b in BUCKET_DISPLAY"
-              :key="b.id"
-              :agent-email="agent.email"
-              :bucket="b"
-            />
+              </template>
+              <template #root>
+                <div class="p-3">
+                  <BucketYoloCard
+                    :agent-email="agent.email"
+                    :bucket="bucketByValue('root')"
+                  />
+                </div>
+              </template>
+              <template #default>
+                <div class="p-3">
+                  <BucketYoloCard
+                    :agent-email="agent.email"
+                    :bucket="bucketByValue('default')"
+                  />
+                </div>
+              </template>
+            </UTabs>
           </div>
 
           <UAlert

--- a/apps/openape-free-idp/app/utils/audience-buckets.ts
+++ b/apps/openape-free-idp/app/utils/audience-buckets.ts
@@ -41,6 +41,19 @@ export interface BucketDisplay {
   audiences: string[]
   icon: string
   accent: 'blue' | 'orange' | 'purple' | 'gray'
+  /**
+   * Placeholder for the deny-patterns textarea. Bucket-specific so users see
+   * shape examples that fit the audience (bash for Commands, host glob for
+   * Web, etc.) instead of bash patterns under a Web tab.
+   */
+  denyPatternPlaceholder: string
+  /** Helper text displayed under the deny-patterns field. */
+  denyPatternHelp: string
+  /**
+   * Optional notice rendered above the form (e.g. limitations, future work).
+   *  Empty string = no banner.
+   */
+  notice?: string
 }
 
 export const BUCKET_DISPLAY: readonly BucketDisplay[] = [
@@ -51,6 +64,8 @@ export const BUCKET_DISPLAY: readonly BucketDisplay[] = [
     audiences: ['ape-shell', 'claude-code', 'shapes'],
     icon: 'i-lucide-terminal',
     accent: 'blue',
+    denyPatternPlaceholder: 'rm -rf *\nsudo *\ncurl * | sh\ngit push --force *',
+    denyPatternHelp: 'Bash-Glob-Pattern (eine pro Zeile). Match gegen den vollen Command-String. * = beliebige Zeichen, ? = ein Zeichen.',
   },
   {
     id: 'web',
@@ -59,21 +74,28 @@ export const BUCKET_DISPLAY: readonly BucketDisplay[] = [
     audiences: ['ape-proxy'],
     icon: 'i-lucide-globe',
     accent: 'orange',
+    denyPatternPlaceholder: '*.openai.com\nstripe.com\n169.254.169.254\n*.evil.com',
+    denyPatternHelp: 'Host-Glob (eine pro Zeile). Match gegen den Target-Host beim CONNECT. URL-Pfad + Methode sind heute nicht enforcebar (TLS-opaque). Method+Path-Patterns für cleartext-HTTP folgen in einer späteren Iteration.',
+    notice: 'Heute matcht der Evaluator nur Hostname-Globs. URL+Method-Patterns für cleartext-HTTP sind in Arbeit.',
   },
   {
     id: 'root',
-    label: 'Root-Commands',
+    label: 'Root',
     description: 'Privileg-Eskalation über escapes (sudo / root).',
     audiences: ['escapes'],
     icon: 'i-lucide-shield-alert',
     accent: 'purple',
+    denyPatternPlaceholder: 'apt-get install *\nsystemctl stop *\nuserdel *',
+    denyPatternHelp: 'Bash-Glob für root-Commands (eine pro Zeile). Wird nach escapes-Aufruf gegen den ausgeführten Command-String gematched.',
   },
   {
     id: 'default',
-    label: 'Default (Fallback)',
+    label: 'Default',
     description: 'Wirkt für alle Audiences die keinen eigenen Bucket-Eintrag haben.',
     audiences: [AUDIENCE_WILDCARD],
     icon: 'i-lucide-asterisk',
     accent: 'gray',
+    denyPatternPlaceholder: '*.openai.com\nrm -rf *',
+    denyPatternHelp: 'Catch-all für Audiences ohne eigenen Bucket. Pattern-Shape je nachdem, welche Audience matched.',
   },
 ]

--- a/apps/openape-free-idp/server/plugins/06.yolo-hook.ts
+++ b/apps/openape-free-idp/server/plugins/06.yolo-hook.ts
@@ -6,7 +6,7 @@ import { resolveServerShape } from '@openape/grants'
 import { useDb } from '../database/drizzle'
 import { useYoloPolicyStore  } from '../utils/yolo-policy-store'
 import type { RiskLevel } from '../utils/yolo-policy-store'
-import { commandFromRequest, evaluateYoloPolicy } from '../utils/yolo-evaluator'
+import { commandFromRequest, evaluateYoloPolicy, targetFromRequest } from '../utils/yolo-evaluator'
 
 export default defineNitroPlugin(async () => {
   // Idempotent schema ensure — safe on every boot, needed under OPENAPE_E2E=1
@@ -72,6 +72,9 @@ export default defineNitroPlugin(async () => {
     const policy = await store.get(request.requester, request.audience)
     if (!policy) return null
 
+    // Risk-threshold lookup needs an executable to score, which only exists
+    // for Commands/Root grants. Web grants (ape-proxy) carry no command —
+    // the evaluator just match-globs against target_host instead.
     const cmd = commandFromRequest(request)
     let resolvedRisk: RiskLevel | null = null
     if (policy.denyRiskThreshold && cmd && cmd.length > 0) {
@@ -85,7 +88,8 @@ export default defineNitroPlugin(async () => {
       }
     }
 
-    const result = evaluateYoloPolicy({ policy, command: cmd, resolvedRisk })
+    const target = targetFromRequest(request)
+    const result = evaluateYoloPolicy({ policy, target, resolvedRisk })
     return result ? { kind: result.kind, decidedBy: result.decidedBy } : null
   })
 })

--- a/apps/openape-free-idp/server/utils/yolo-evaluator.ts
+++ b/apps/openape-free-idp/server/utils/yolo-evaluator.ts
@@ -16,7 +16,22 @@ export interface YoloDecision {
 
 export interface YoloDecisionContext {
   policy: YoloPolicy | null
-  command: string[] | undefined
+  /**
+   * The string deny-patterns are matched against. Two shapes:
+   *
+   * - For Commands / Root grants this is the joined command line (e.g.
+   *   `"git push origin main"`). Operators write bash-style globs like
+   *   `"rm -rf *"` or `"sudo *"`.
+   *
+   * - For Web grants this is the `target_host[:port]` (e.g.
+   *   `"api.openai.com:443"`). Operators write host globs like
+   *   `"*.openai.com"` or `"169.254.169.254"`.
+   *
+   * The evaluator doesn't care which of the two shapes it gets — both go
+   * through the same glob matcher. The hook is responsible for picking the
+   * right field from the grant request via `targetFromRequest`.
+   */
+  target: string | undefined
   resolvedRisk: RiskLevel | null
   now?: number
 }
@@ -27,15 +42,15 @@ export function evaluateYoloPolicy(ctx: YoloDecisionContext): YoloDecision | nul
   if (!p) return null
   if (p.expiresAt != null && p.expiresAt <= now) return null
 
-  const cmd = ctx.command && ctx.command.length ? ctx.command.join(' ') : null
-  if (!cmd) return null
+  const target = ctx.target && ctx.target.length ? ctx.target : null
+  if (!target) return null
 
   if (ctx.resolvedRisk && p.denyRiskThreshold) {
     if (RISK_ORDER[ctx.resolvedRisk] >= RISK_ORDER[p.denyRiskThreshold]) return null
   }
 
   for (const pattern of p.denyPatterns || []) {
-    if (matchesGlob(cmd, pattern)) return null
+    if (matchesGlob(target, pattern)) return null
   }
 
   return { kind: 'yolo', decidedBy: p.enabledBy }
@@ -60,5 +75,26 @@ export function commandFromRequest(body: OpenApeGrantRequest): string[] | undefi
   if (body.command?.length) return body.command
   const argv = body.execution_context?.argv
   if (argv?.length) return [...argv]
+  return undefined
+}
+
+/**
+ * Extract the deny-pattern match-target from a grant request:
+ *
+ *   - Commands / Root grants (audience: ape-shell, claude-code, shapes,
+ *     escapes, …): joined `command` array.
+ *   - Web grants (audience: ape-proxy): the `target_host`. The proxy passes
+ *     it as `target_host: "api.openai.com"` (no port suffix today; the
+ *     evaluator and operator-written patterns must agree on that).
+ *
+ * The hook calls this at request time and feeds the result into
+ * `evaluateYoloPolicy` as `ctx.target`. Returns undefined when neither
+ * shape is present — evaluator interprets that as "no match data → no
+ * YOLO" and returns null (= human approval needed).
+ */
+export function targetFromRequest(body: OpenApeGrantRequest): string | undefined {
+  const cmd = commandFromRequest(body)
+  if (cmd && cmd.length > 0) return cmd.join(' ')
+  if (body.target_host) return body.target_host
   return undefined
 }

--- a/apps/openape-free-idp/tests/yolo-evaluator.test.ts
+++ b/apps/openape-free-idp/tests/yolo-evaluator.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 // Pure-logic tests — no server spawn needed.
-import { evaluateYoloPolicy, matchesGlob } from '../server/utils/yolo-evaluator'
+import { evaluateYoloPolicy, matchesGlob, targetFromRequest } from '../server/utils/yolo-evaluator'
 
 type Risk = 'low' | 'medium' | 'high' | 'critical'
 
@@ -44,43 +44,91 @@ describe('matchesGlob', () => {
 
 describe('evaluateYoloPolicy', () => {
   it('no policy → null', () => {
-    expect(evaluateYoloPolicy({ policy: null, command: ['ls'], resolvedRisk: null })).toBeNull()
+    expect(evaluateYoloPolicy({ policy: null, target: 'ls', resolvedRisk: null })).toBeNull()
   })
   it('expired policy → null', () => {
     const p = policy({ expiresAt: 1 })
-    const result = evaluateYoloPolicy({ policy: p, command: ['ls'], resolvedRisk: null, now: 100 })
+    const result = evaluateYoloPolicy({ policy: p, target: 'ls', resolvedRisk: null, now: 100 })
     expect(result).toBeNull()
   })
   it('empty command → null', () => {
     const p = policy()
-    expect(evaluateYoloPolicy({ policy: p, command: undefined, resolvedRisk: null })).toBeNull()
-    expect(evaluateYoloPolicy({ policy: p, command: [], resolvedRisk: null })).toBeNull()
+    expect(evaluateYoloPolicy({ policy: p, target: undefined, resolvedRisk: null })).toBeNull()
+    expect(evaluateYoloPolicy({ policy: p, target: '', resolvedRisk: null })).toBeNull()
   })
   it('match without any rules → approves with enabledBy', () => {
     const p = policy()
-    const result = evaluateYoloPolicy({ policy: p, command: ['ls', '-la'], resolvedRisk: null })
+    const result = evaluateYoloPolicy({ policy: p, target: 'ls -la', resolvedRisk: null })
     expect(result).toEqual({ kind: 'yolo', decidedBy: 'owner@x' })
   })
   it('deny-pattern drops the match', () => {
     const p = policy({ denyPatterns: ['rm *'] })
-    const result = evaluateYoloPolicy({ policy: p, command: ['rm', 'foo'], resolvedRisk: null })
+    const result = evaluateYoloPolicy({ policy: p, target: 'rm foo', resolvedRisk: null })
     expect(result).toBeNull()
   })
   it('risk at threshold blocks', () => {
     const p = policy({ denyRiskThreshold: 'high' })
-    expect(evaluateYoloPolicy({ policy: p, command: ['rm'], resolvedRisk: 'high' })).toBeNull()
-    expect(evaluateYoloPolicy({ policy: p, command: ['rm'], resolvedRisk: 'critical' })).toBeNull()
+    expect(evaluateYoloPolicy({ policy: p, target: 'rm', resolvedRisk: 'high' })).toBeNull()
+    expect(evaluateYoloPolicy({ policy: p, target: 'rm', resolvedRisk: 'critical' })).toBeNull()
   })
   it('risk below threshold passes', () => {
     const p = policy({ denyRiskThreshold: 'high' })
-    expect(evaluateYoloPolicy({ policy: p, command: ['ls'], resolvedRisk: 'medium' }))
+    expect(evaluateYoloPolicy({ policy: p, target: 'ls', resolvedRisk: 'medium' }))
       .toEqual({ kind: 'yolo', decidedBy: 'owner@x' })
-    expect(evaluateYoloPolicy({ policy: p, command: ['ls'], resolvedRisk: 'low' }))
+    expect(evaluateYoloPolicy({ policy: p, target: 'ls', resolvedRisk: 'low' }))
       .toEqual({ kind: 'yolo', decidedBy: 'owner@x' })
   })
   it('risk-threshold only applies when resolvedRisk is non-null', () => {
     const p = policy({ denyRiskThreshold: 'high' })
-    expect(evaluateYoloPolicy({ policy: p, command: ['ls'], resolvedRisk: null }))
+    expect(evaluateYoloPolicy({ policy: p, target: 'ls', resolvedRisk: null }))
       .toEqual({ kind: 'yolo', decidedBy: 'owner@x' })
+  })
+
+  // Web grants come in via target_host + audience='ape-proxy' and have no
+  // command. The evaluator should glob-match host patterns against the
+  // host-shaped target the same way it match-globs commands.
+  it('host-target matches host-glob deny pattern', () => {
+    const p = policy({ denyPatterns: ['*.openai.com'] })
+    expect(evaluateYoloPolicy({ policy: p, target: 'api.openai.com', resolvedRisk: null })).toBeNull()
+    expect(evaluateYoloPolicy({ policy: p, target: 'api.github.com', resolvedRisk: null }))
+      .toEqual({ kind: 'yolo', decidedBy: 'owner@x' })
+  })
+  it('host-target without deny patterns auto-approves', () => {
+    const p = policy()
+    expect(evaluateYoloPolicy({ policy: p, target: 'example.org', resolvedRisk: null }))
+      .toEqual({ kind: 'yolo', decidedBy: 'owner@x' })
+  })
+})
+
+describe('targetFromRequest', () => {
+  it('prefers command over target_host', () => {
+    expect(targetFromRequest({
+      requester: 'a@x',
+      target_host: 'api.openai.com',
+      audience: 'ape-shell',
+      command: ['ls', '-la'],
+    } as never)).toBe('ls -la')
+  })
+  it('falls back to argv from execution_context when command missing', () => {
+    expect(targetFromRequest({
+      requester: 'a@x',
+      target_host: 'api.openai.com',
+      audience: 'ape-shell',
+      execution_context: { argv: ['rm', '-rf', '/'] },
+    } as never)).toBe('rm -rf /')
+  })
+  it('uses target_host for Web grants without a command', () => {
+    expect(targetFromRequest({
+      requester: 'a@x',
+      target_host: 'api.openai.com',
+      audience: 'ape-proxy',
+    } as never)).toBe('api.openai.com')
+  })
+  it('returns undefined when neither shape is present', () => {
+    expect(targetFromRequest({
+      requester: 'a@x',
+      target_host: '',
+      audience: 'ape-proxy',
+    } as never)).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Bug fix: Web-YOLO was inert

`yolo-evaluator` early-returned `null` whenever `grant.command` was empty. Web grants (audience `ape-proxy`) carry no command — only `target_host`. So **every Web YOLO attempt fell through to human approval**. The UI showed "YOLO aktiv", the server ignored it. PR #180 shipped a UI lying to the user.

Evaluator now accepts a generic `target` string. New `targetFromRequest()` helper picks the right shape:

- Commands / Root grants → joined `command` array (existing behavior)
- Web grants → `target_host`

Same glob matcher applies to both. Operators write `*.openai.com` for Web, `rm -rf *` for Commands, both work through the same code path.

## UI changes on `/agents/:email`

- **Tabs instead of stacked cards** — Commands / Web / Root / Default each in its own tab. Compact at any viewport.
- **Per-bucket placeholders + helper text.** Web shows `*.openai.com\nstripe.com`, Commands shows `rm -rf *\nsudo *`, Root shows `apt-get install *`, Default is the catch-all. No more bash patterns under a Web tab.
- **Web tab has an inline notice** flagging that only host globs are enforceable today (TLS-opaque CONNECT). Method+Path patterns for cleartext-HTTP are explicit future work.
- **"Erlaubte Commands" (Standing Grants list)** moved into the Commands tab only. Web/Root get their own surfaces in a follow-up.
- **Authentifizierung** is no longer an accordion taking page space — it's a `?`-icon popover next to the tabs header with the same `apes login` command + DDISA hint.

## Out of scope (next iterations)

- **Method+Path patterns for Web cleartext-HTTP**. Requires the proxy to forward `method` + `path` to the IdP grant request and a Web-specific pattern parser (`POST https://api.openai.com/v1/*`).
- **Web/Root standing-grants surfaces.** Currently only Commands has the AllowedCommandsList wizard.
- **Per-bucket "Apply to all" convenience action** for the Default card.

## Verification

- [x] 57/57 free-idp tests pass (6 new: host-target glob match, host-target without deny, 4× targetFromRequest variants)
- [x] `pnpm --filter openape-free-idp lint` 0 errors
- [x] `pnpm --filter openape-free-idp typecheck` clean