### PR TITLE
feat(idp): YOLO mode toggle (allow/deny) + per-row pattern editor

### DIFF
--- a/.changeset/idp-yolo-allow-deny-mode-and-row-editor.md
+++ b/.changeset/idp-yolo-allow-deny-mode-and-row-editor.md
@@ -1,0 +1,55 @@
+---
+"openape-free-idp": minor
+---
+
+idp: YOLO mode toggle (allow/deny) + per-row pattern editor + Method+URL shape
+
+Two structural changes to the YOLO model and a UI overhaul.
+
+### `mode: 'allow-list' | 'deny-list'`
+
+YOLO was always a single semantic: "auto-approve unless deny pattern matches".
+That works for blocklist-style policies but not for the inverse — "auto-approve
+ONLY for these specific things" — which is the right shape for tight Web/Root
+profiles where the operator wants to enumerate the safe set.
+
+Adds a `mode` column to `yolo_policies` (default `'deny-list'`,
+backwards-compatible). The evaluator branches on it:
+
+- **deny-list (legacy):** auto-approve UNLESS a pattern matches; risk
+  threshold also applies.
+- **allow-list (new):** require manual approval UNLESS a pattern matches.
+  Risk threshold is a no-op (operator already enumerated the safe set).
+
+Migration runs in `06.yolo-hook.ts` via idempotent `ALTER TABLE ADD COLUMN`.
+
+### Per-row pattern editor
+
+Replaces the multi-line textarea with one row per pattern + add/remove
+buttons. Per-bucket shape:
+
+- **Web:** `[Method ▼: ALL | GET | POST | PUT | …] [URL/Host glob] [🗑]`
+- **Commands / Root / Default:** `[Pattern field] [🗑]`
+
+Storage stays as a string array. Web rows serialize as `"<METHOD> <URL>"`
+when method ≠ `*`, or just `"<URL>"` when method = `*` so today's
+host-only matcher still fires for `ALL`-method rows. Method-specific rows
+are stored forward-compatibly for the upcoming proxy-side method+path
+enrichment (M3.5).
+
+### Honest "Web enforcement" notice
+
+Replaces the aspirational "in Arbeit" text with a concrete description of
+today's enforcement coverage: ALL-method rows match host globs at CONNECT
+time; method-specific rows are stored but only fire once M3.5 ships
+proxy-side method+path enrichment.
+
+### "Dauer" → "YOLO-Timer"
+
+Field rename per Patrick's spec. Same semantics (expiry timestamp).
+
+### Tests
+
+61/61 pass, including 4 new tests for allow-list mode (no patterns →
+null; matching pattern → approve; non-matching → null; risk threshold
+ignored in allow mode).

--- a/apps/openape-free-idp/app/components/BucketYoloCard.vue
+++ b/apps/openape-free-idp/app/components/BucketYoloCard.vue
@@ -1,10 +1,14 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
-import type { BucketDisplay } from '../utils/audience-buckets'
+import type { BucketDisplay, HttpMethodChoice } from '../utils/audience-buckets'
+import { HTTP_METHODS, parsePattern, serializePattern } from '../utils/audience-buckets'
+
+type YoloMode = 'deny-list' | 'allow-list'
 
 interface YoloPolicy {
   agentEmail: string
   audience: string
+  mode: YoloMode
   enabledBy: string
   denyRiskThreshold: 'low' | 'medium' | 'high' | 'critical' | null
   denyPatterns: string[]
@@ -18,17 +22,15 @@ const props = defineProps<{
   bucket: BucketDisplay
 }>()
 
-/**
- * Per-bucket YOLO state. We hold one YoloPolicy per audience in the bucket
- * (could be 1..N rows). Aggregate state:
- *
- *   - 'all'    — every audience in the bucket has a YOLO row → bucket is fully on
- *   - 'partial'— some audiences have YOLO, some don't → mixed state
- *   - 'none'   — no audience in the bucket has YOLO
- *
- * For multi-audience buckets (Commands has 3) "Enable" writes one row per
- * audience and "Disable" deletes them all. Single-audience buckets are 1:1.
- */
+interface PatternRow { method: HttpMethodChoice, value: string }
+
+interface FormState {
+  mode: YoloMode
+  denyRiskThreshold: 'low' | 'medium' | 'high' | 'critical' | ''
+  patterns: PatternRow[]
+  duration: string
+}
+
 const policiesByAudience = ref<Record<string, YoloPolicy | null>>({})
 const loading = ref(false)
 const submitting = ref(false)
@@ -43,10 +45,6 @@ const aggregate = computed<'all' | 'partial' | 'none'>(() => {
 })
 
 const representativePolicy = computed<YoloPolicy | null>(() => {
-  // For display purposes, surface the first existing policy in the bucket.
-  // When the bucket is partially active or inactive across audiences, we
-  // still need *some* policy fields to render the form — fall back to the
-  // last-known.
   for (const aud of props.bucket.audiences) {
     const p = policiesByAudience.value[aud]
     if (p) return p
@@ -60,20 +58,21 @@ const expiryLabel = computed(() => {
   return new Date(ts * 1000).toLocaleString()
 })
 
-// --- Form state -------------------------------------------------------------
+const form = ref<FormState>(emptyForm())
 
-interface FormState {
-  denyRiskThreshold: 'low' | 'medium' | 'high' | 'critical' | ''
-  denyPatterns: string
-  duration: string
+function emptyForm(): FormState {
+  return {
+    mode: 'deny-list',
+    denyRiskThreshold: '',
+    patterns: [],
+    duration: '3600',
+  }
 }
 
-const form = ref<FormState>({
-  denyRiskThreshold: 'high',
-  denyPatterns: '',
-  duration: '3600',
-})
-
+const modeOptions = [
+  { label: 'Deny-Liste — alles erlaubt außer …', value: 'deny-list' },
+  { label: 'Allow-Liste — nichts erlaubt außer …', value: 'allow-list' },
+]
 const riskOptions = [
   { label: 'Kein Schwellwert', value: '' },
   { label: 'Low', value: 'low' },
@@ -90,6 +89,7 @@ const durationOptions = [
   { label: '30 Tage', value: '2592000' },
   { label: 'Unbefristet', value: '' },
 ]
+const methodOptions = HTTP_METHODS.map(m => ({ label: m === '*' ? 'ALL' : m, value: m }))
 
 const accentClass = computed(() => {
   switch (props.bucket.accent) {
@@ -99,6 +99,14 @@ const accentClass = computed(() => {
     default: return 'border-gray-700 bg-gray-900/40'
   }
 })
+
+// Risk threshold is only meaningful in deny-list mode AND for buckets where
+// a shape resolver exists (Commands / Root). Web has no shape risk.
+const showRiskThreshold = computed(() => form.value.mode === 'deny-list' && props.bucket.id !== 'web')
+
+const patternsListLabel = computed(() =>
+  form.value.mode === 'allow-list' ? 'Allow-Patterns' : 'Deny-Patterns',
+)
 
 // --- Data flow --------------------------------------------------------------
 
@@ -111,10 +119,6 @@ async function load() {
       try {
         const url = `/api/users/${encodeURIComponent(props.agentEmail)}/yolo-policy?audience=${encodeURIComponent(aud)}`
         const res = await ($fetch as any)(url) as { policy: YoloPolicy | null }
-        // The GET endpoint falls back to wildcard ('*') when there's no
-        // exact row; we want exact-match here so the "this audience has its
-        // own row" signal isn't muddled by the bucket-default. Only count it
-        // if the returned policy.audience matches what we asked for.
         fetched[aud] = res?.policy && res.policy.audience === aud ? res.policy : null
       }
       catch {
@@ -126,10 +130,14 @@ async function load() {
     const rep = representativePolicy.value
     if (rep) {
       form.value = {
-        denyRiskThreshold: (rep.denyRiskThreshold ?? 'high') as FormState['denyRiskThreshold'],
-        denyPatterns: rep.denyPatterns.join('\n'),
+        mode: rep.mode ?? 'deny-list',
+        denyRiskThreshold: (rep.denyRiskThreshold ?? '') as FormState['denyRiskThreshold'],
+        patterns: (rep.denyPatterns ?? []).map(p => parsePattern(p, props.bucket.patternShape)),
         duration: rep.expiresAt ? '' : '3600',
       }
+    }
+    else {
+      form.value = emptyForm()
     }
   }
   catch (err: unknown) {
@@ -141,25 +149,33 @@ async function load() {
   }
 }
 
+function addPatternRow() {
+  form.value.patterns.push({ method: '*', value: '' })
+}
+
+function removePatternRow(i: number) {
+  form.value.patterns.splice(i, 1)
+}
+
 async function save() {
   submitting.value = true
   error.value = ''
   try {
-    const patterns = form.value.denyPatterns
-      .split(/\r?\n/)
-      .map(s => s.trim())
+    const patterns = form.value.patterns
+      .map(r => serializePattern(r.method, r.value, props.bucket.patternShape))
       .filter(Boolean)
     const durationSec = Number(form.value.duration)
     const expiresAt = Number.isFinite(durationSec) && durationSec > 0
       ? Math.floor(Date.now() / 1000) + durationSec
       : null
     const body = {
-      denyRiskThreshold: form.value.denyRiskThreshold || null,
+      mode: form.value.mode,
+      // Risk threshold only meaningful in deny-list mode + non-Web bucket.
+      // Server-side it's stored regardless; UI hides it where it has no effect.
+      denyRiskThreshold: showRiskThreshold.value ? (form.value.denyRiskThreshold || null) : null,
       denyPatterns: patterns,
       expiresAt,
     }
-    // Multi-audience buckets: write one row per audience. The server enforces
-    // (agent_email, audience) uniqueness so re-PUTs are upserts.
     await Promise.all(props.bucket.audiences.map(aud =>
       ($fetch as any)(
         `/api/users/${encodeURIComponent(props.agentEmail)}/yolo-policy?audience=${encodeURIComponent(aud)}`,
@@ -191,7 +207,7 @@ async function disable() {
     ))
     policiesByAudience.value = {}
     editing.value = false
-    form.value = { denyRiskThreshold: 'high', denyPatterns: '', duration: '3600' }
+    form.value = emptyForm()
   }
   catch (err: unknown) {
     const e = err as { data?: { title?: string } }
@@ -249,27 +265,33 @@ watch(() => props.agentEmail, () => { if (props.agentEmail) load() }, { immediat
         Inaktiv. Grant-Requests in dieser Schicht warten auf menschliche Bestätigung.
       </p>
       <UButton color="warning" size="sm" icon="i-lucide-zap" @click="editing = true">
-        YOLO aktivieren
+        YOLO konfigurieren
       </UButton>
     </div>
 
     <div v-else-if="!editing" class="space-y-2 text-sm">
       <div class="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1">
+        <span class="text-gray-400">Modus</span>
+        <span>
+          <code class="bg-gray-800 px-2 py-0.5 rounded text-xs">{{ representativePolicy?.mode ?? 'deny-list' }}</code>
+        </span>
         <span class="text-gray-400">Aktiviert von</span>
         <span class="font-mono text-xs">{{ representativePolicy?.enabledBy ?? '-' }}</span>
-        <span class="text-gray-400">Risiko-Schwelle</span>
-        <span>
-          <span v-if="representativePolicy?.denyRiskThreshold" class="font-mono">{{ representativePolicy.denyRiskThreshold }}</span>
-          <span v-else class="italic text-gray-500">keine</span>
-        </span>
-        <span class="text-gray-400">Deny-Patterns</span>
+        <template v-if="representativePolicy?.mode !== 'allow-list'">
+          <span class="text-gray-400">Risiko-Schwelle</span>
+          <span>
+            <span v-if="representativePolicy?.denyRiskThreshold" class="font-mono">{{ representativePolicy.denyRiskThreshold }}</span>
+            <span v-else class="italic text-gray-500">keine</span>
+          </span>
+        </template>
+        <span class="text-gray-400">{{ representativePolicy?.mode === 'allow-list' ? 'Allow-Patterns' : 'Deny-Patterns' }}</span>
         <span>
           <span v-if="!representativePolicy?.denyPatterns?.length" class="italic text-gray-500">keine</span>
           <span v-else class="flex flex-wrap gap-1">
             <code v-for="p in representativePolicy.denyPatterns" :key="p" class="bg-gray-800 px-2 py-0.5 rounded text-xs">{{ p }}</code>
           </span>
         </span>
-        <span class="text-gray-400">Ablauf</span>
+        <span class="text-gray-400">YOLO-Timer</span>
         <span>{{ expiryLabel }}</span>
       </div>
       <p v-if="aggregate === 'partial'" class="text-xs text-amber-400 italic">
@@ -287,24 +309,67 @@ watch(() => props.agentEmail, () => { if (props.agentEmail) load() }, { immediat
     </div>
 
     <div v-else class="space-y-3">
-      <UFormField label="Dauer" help="Nach Ablauf wird wieder jeder Request manuell bestätigt.">
+      <UFormField label="Modus" help="Deny: alles erlaubt, Pattern blockt. Allow: nur Patterns erlauben.">
+        <USelect v-model="form.mode" :items="modeOptions" />
+      </UFormField>
+      <UFormField label="YOLO-Timer" help="Nach Ablauf wird wieder jeder Request manuell bestätigt.">
         <USelect v-model="form.duration" :items="durationOptions" />
       </UFormField>
-      <UFormField label="Risiko-Schwelle" help="Requests mit diesem oder höherem Risiko werden weiter menschlich bestätigt.">
+      <UFormField
+        v-if="showRiskThreshold"
+        label="Risiko-Schwelle"
+        help="Requests mit diesem oder höherem Risiko werden weiter menschlich bestätigt (nur bei Deny-Liste)."
+      >
         <USelect v-model="form.denyRiskThreshold" :items="riskOptions" />
       </UFormField>
-      <UFormField label="Deny-Patterns (eine pro Zeile, Glob: * ?)" :help="bucket.denyPatternHelp">
-        <UTextarea
-          v-model="form.denyPatterns"
-          :rows="4"
-          :placeholder="bucket.denyPatternPlaceholder"
-        />
-      </UFormField>
-      <div class="flex gap-2">
+
+      <div>
+        <div class="flex items-center justify-between mb-1">
+          <label class="text-sm font-medium text-gray-300">{{ patternsListLabel }}</label>
+          <UButton size="xs" variant="ghost" icon="i-lucide-plus" @click="addPatternRow">
+            Hinzufügen
+          </UButton>
+        </div>
+        <p class="text-xs text-gray-500 mb-2">
+          {{ bucket.patternHelp }}
+        </p>
+        <div v-if="form.patterns.length === 0" class="text-xs italic text-gray-500 py-2">
+          Keine Patterns. <span v-if="form.mode === 'allow-list'">Im Allow-Modus ohne Patterns wird nichts auto-approved.</span>
+        </div>
+        <div v-else class="space-y-2">
+          <div
+            v-for="(row, i) in form.patterns"
+            :key="i"
+            class="flex items-center gap-2"
+          >
+            <USelect
+              v-if="bucket.patternShape === 'method-url'"
+              v-model="row.method"
+              :items="methodOptions"
+              class="w-28 shrink-0"
+            />
+            <UInput
+              v-model="row.value"
+              :placeholder="bucket.patternPlaceholder"
+              class="flex-1"
+              :class="{ 'font-mono text-xs': bucket.patternShape === 'method-url' }"
+            />
+            <UButton
+              size="xs"
+              color="error"
+              variant="ghost"
+              icon="i-lucide-trash-2"
+              @click="removePatternRow(i)"
+            />
+          </div>
+        </div>
+      </div>
+
+      <div class="flex gap-2 pt-1">
         <UButton color="warning" size="sm" icon="i-lucide-save" :loading="submitting" @click="save">
           {{ aggregate === 'none' ? 'Aktivieren' : 'Speichern' }}
         </UButton>
-        <UButton variant="ghost" size="sm" :disabled="submitting" @click="editing = false">
+        <UButton variant="ghost" size="sm" :disabled="submitting" @click="editing = false; load()">
           Abbrechen
         </UButton>
       </div>

--- a/apps/openape-free-idp/app/utils/audience-buckets.ts
+++ b/apps/openape-free-idp/app/utils/audience-buckets.ts
@@ -32,6 +32,49 @@ export function audiencesInBucket(bucket: AudienceBucket): string[] {
  * The fourth `default` row covers the per-agent wildcard fallback (audience
  * `'*'`) — anything not matched by a bucket-specific row.
  */
+/**
+ * Per-row pattern shape:
+ *   - 'command' → a single text field. Pattern stored as plain string.
+ *   - 'method-url' → method dropdown + URL/host glob field. Pattern stored
+ *     as `"<METHOD> <URL>"` (or just `"<URL>"` when method='*'), so today's
+ *     host-only matcher still fires for method='*' rows. Method-specific
+ *     rows are stored forward-compatibly for the upcoming proxy-side
+ *     method+path enrichment (M3.5).
+ */
+export type BucketPatternShape = 'command' | 'method-url'
+
+/** HTTP methods offered in the per-row Method dropdown for `method-url` shape. */
+export const HTTP_METHODS = ['*', 'GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS', 'HEAD'] as const
+export type HttpMethodChoice = typeof HTTP_METHODS[number]
+
+/**
+ * Parse a stored pattern string into its UI representation.
+ *
+ * For `method-url` shape:
+ *   - `"POST https://api.openai.com/v1/*"` → `{ method: 'POST', value: 'https://api.openai.com/v1/*' }`
+ *   - `"api.openai.com"`                   → `{ method: '*',    value: 'api.openai.com' }`
+ *
+ * For `command` shape: always `{ method: '*', value: <whole string> }`.
+ */
+export function parsePattern(stored: string, shape: BucketPatternShape): { method: HttpMethodChoice, value: string } {
+  if (shape === 'command') return { method: '*', value: stored }
+  const m = stored.match(/^(GET|POST|PUT|PATCH|DELETE|OPTIONS|HEAD) (.*)$/)
+  if (m) return { method: m[1] as HttpMethodChoice, value: m[2]! }
+  return { method: '*', value: stored }
+}
+
+/**
+ * Serialize a UI row back to a stored string. Method `'*'` is dropped from
+ * the prefix so today's host-only matcher (which has no method-awareness)
+ * still fires on the URL portion alone. Method-specific rows preserve the
+ * `"METHOD URL"` shape forward-compat.
+ */
+export function serializePattern(method: HttpMethodChoice, value: string, shape: BucketPatternShape): string {
+  const trimmed = value.trim()
+  if (shape === 'command' || method === '*') return trimmed
+  return `${method} ${trimmed}`
+}
+
 export interface BucketDisplay {
   /** Internal id used for keying. `'default'` is the wildcard catch-all. */
   id: AudienceBucket | 'default'
@@ -41,18 +84,13 @@ export interface BucketDisplay {
   audiences: string[]
   icon: string
   accent: 'blue' | 'orange' | 'purple' | 'gray'
-  /**
-   * Placeholder for the deny-patterns textarea. Bucket-specific so users see
-   * shape examples that fit the audience (bash for Commands, host glob for
-   * Web, etc.) instead of bash patterns under a Web tab.
-   */
-  denyPatternPlaceholder: string
-  /** Helper text displayed under the deny-patterns field. */
-  denyPatternHelp: string
-  /**
-   * Optional notice rendered above the form (e.g. limitations, future work).
-   *  Empty string = no banner.
-   */
+  /** Determines the per-row editor: free-form command vs structured method+URL. */
+  patternShape: BucketPatternShape
+  /** Placeholder for the URL/pattern field in a row. */
+  patternPlaceholder: string
+  /** Helper text displayed under the pattern editor. */
+  patternHelp: string
+  /** Optional notice rendered above the form (enforcement-coverage limits). */
   notice?: string
 }
 
@@ -64,8 +102,9 @@ export const BUCKET_DISPLAY: readonly BucketDisplay[] = [
     audiences: ['ape-shell', 'claude-code', 'shapes'],
     icon: 'i-lucide-terminal',
     accent: 'blue',
-    denyPatternPlaceholder: 'rm -rf *\nsudo *\ncurl * | sh\ngit push --force *',
-    denyPatternHelp: 'Bash-Glob-Pattern (eine pro Zeile). Match gegen den vollen Command-String. * = beliebige Zeichen, ? = ein Zeichen.',
+    patternShape: 'command',
+    patternPlaceholder: 'rm -rf *',
+    patternHelp: 'Bash-Glob-Pattern. Match gegen den vollen Command-String. * = beliebige Zeichen, ? = ein Zeichen.',
   },
   {
     id: 'web',
@@ -74,9 +113,10 @@ export const BUCKET_DISPLAY: readonly BucketDisplay[] = [
     audiences: ['ape-proxy'],
     icon: 'i-lucide-globe',
     accent: 'orange',
-    denyPatternPlaceholder: '*.openai.com\nstripe.com\n169.254.169.254\n*.evil.com',
-    denyPatternHelp: 'Host-Glob (eine pro Zeile). Match gegen den Target-Host beim CONNECT. URL-Pfad + Methode sind heute nicht enforcebar (TLS-opaque). Method+Path-Patterns für cleartext-HTTP folgen in einer späteren Iteration.',
-    notice: 'Heute matcht der Evaluator nur Hostname-Globs. URL+Method-Patterns für cleartext-HTTP sind in Arbeit.',
+    patternShape: 'method-url',
+    patternPlaceholder: '*.openai.com',
+    patternHelp: 'Method + URL/Host-Glob pro Zeile. Method=ALL fügt nur den URL-Teil als Host-Glob ein und wirkt heute beim CONNECT. Spezifische Methoden (POST etc.) werden gespeichert, matchen aber erst sobald der Proxy bei cleartext-HTTP-Calls Method+Path mitgibt (geplant in M3.5).',
+    notice: 'Heute matcht nur ALL-Methode (Host-Glob beim CONNECT). Method-spezifische Rows werden gespeichert, aber erst durch M3.5 (proxy-side method+path enrichment) live.',
   },
   {
     id: 'root',
@@ -85,8 +125,9 @@ export const BUCKET_DISPLAY: readonly BucketDisplay[] = [
     audiences: ['escapes'],
     icon: 'i-lucide-shield-alert',
     accent: 'purple',
-    denyPatternPlaceholder: 'apt-get install *\nsystemctl stop *\nuserdel *',
-    denyPatternHelp: 'Bash-Glob für root-Commands (eine pro Zeile). Wird nach escapes-Aufruf gegen den ausgeführten Command-String gematched.',
+    patternShape: 'command',
+    patternPlaceholder: 'apt-get install *',
+    patternHelp: 'Bash-Glob für root-Commands. Match gegen den ausgeführten Command-String nach escapes-Aufruf.',
   },
   {
     id: 'default',
@@ -95,7 +136,8 @@ export const BUCKET_DISPLAY: readonly BucketDisplay[] = [
     audiences: [AUDIENCE_WILDCARD],
     icon: 'i-lucide-asterisk',
     accent: 'gray',
-    denyPatternPlaceholder: '*.openai.com\nrm -rf *',
-    denyPatternHelp: 'Catch-all für Audiences ohne eigenen Bucket. Pattern-Shape je nachdem, welche Audience matched.',
+    patternShape: 'command',
+    patternPlaceholder: '*.openai.com',
+    patternHelp: 'Catch-all-Pattern. Glob-Match gegen das jeweilige Target (Command-String oder Host).',
   },
 ]

--- a/apps/openape-free-idp/server/api/users/[email]/yolo-policy.put.ts
+++ b/apps/openape-free-idp/server/api/users/[email]/yolo-policy.put.ts
@@ -1,7 +1,12 @@
 import { defineEventHandler, getQuery, getRouterParam, readBody } from 'h3'
 import { requireYoloPolicyActor } from '../../../utils/yolo-policy-auth'
-import { AUDIENCE_WILDCARD, useYoloPolicyStore } from '../../../utils/yolo-policy-store'
-import type { RiskLevel, YoloPolicy } from '../../../utils/yolo-policy-store'
+import {
+  AUDIENCE_WILDCARD,
+  useYoloPolicyStore,
+  YOLO_MODES,
+
+} from '../../../utils/yolo-policy-store'
+import type { RiskLevel, YoloMode, YoloPolicy } from '../../../utils/yolo-policy-store'
 
 const VALID_RISK: RiskLevel[] = ['low', 'medium', 'high', 'critical']
 const MAX_PATTERNS = 64
@@ -13,10 +18,15 @@ export default defineEventHandler(async (event) => {
 
   const caller = await requireYoloPolicyActor(event, agentEmail)
   const body = await readBody<{
+    mode?: YoloMode
     denyRiskThreshold?: RiskLevel | null
     denyPatterns?: string[]
     expiresAt?: number | null
   }>(event)
+
+  if (body.mode !== undefined && !YOLO_MODES.includes(body.mode)) {
+    throw createProblemError({ status: 400, title: `mode must be one of: ${YOLO_MODES.join(', ')}` })
+  }
 
   if (body.denyRiskThreshold !== undefined && body.denyRiskThreshold !== null && !VALID_RISK.includes(body.denyRiskThreshold)) {
     throw createProblemError({ status: 400, title: `denyRiskThreshold must be one of: ${VALID_RISK.join(', ')}` })
@@ -51,6 +61,7 @@ export default defineEventHandler(async (event) => {
   const policy: YoloPolicy = {
     agentEmail,
     audience,
+    mode: body.mode ?? existing?.mode ?? 'deny-list',
     enabledBy: caller === '_management_' ? (existing?.enabledBy ?? caller) : caller,
     denyRiskThreshold: body.denyRiskThreshold !== undefined ? body.denyRiskThreshold : (existing?.denyRiskThreshold ?? null),
     denyPatterns: body.denyPatterns !== undefined ? normalisePatterns(body.denyPatterns) : (existing?.denyPatterns ?? []),

--- a/apps/openape-free-idp/server/database/schema.ts
+++ b/apps/openape-free-idp/server/database/schema.ts
@@ -172,8 +172,17 @@ export const yoloPolicies = sqliteTable('yolo_policies', {
   // the '*' fallback when the request matches. Composite PK with agent_email
   // means per-agent-per-audience policies are independent rows.
   audience: text('audience').notNull().default('*'),
+  // Pattern-list interpretation:
+  //   'deny-list' (default; backwards-compatible with pre-M3.5 rows): auto-
+  //     approve UNLESS a pattern matches. Risk-threshold also applies.
+  //   'allow-list': require manual approval UNLESS a pattern matches. Risk-
+  //     threshold does NOT apply (operator already enumerated the safe set).
+  mode: text('mode').notNull().default('deny-list'),
   enabledBy: text('enabled_by').notNull(),
   denyRiskThreshold: text('deny_risk_threshold'),
+  // Despite the column name, in `mode='allow-list'` these are read as
+  // ALLOW-patterns, not deny-patterns. Renaming the column would force a
+  // full table recreate; the semantic is documented in the evaluator.
   denyPatterns: text('deny_patterns', { mode: 'json' }).notNull().default('[]'),
   enabledAt: integer('enabled_at').notNull(),
   expiresAt: integer('expires_at'),

--- a/apps/openape-free-idp/server/plugins/06.yolo-hook.ts
+++ b/apps/openape-free-idp/server/plugins/06.yolo-hook.ts
@@ -19,10 +19,11 @@ export default defineNitroPlugin(async () => {
   // on the absence of the `audience` column so it runs at most once per DB.
   try {
     const db = useDb()
-    // Fresh-DB shape (composite PK).
+    // Fresh-DB shape (composite PK + mode).
     await db.run(sql`CREATE TABLE IF NOT EXISTS yolo_policies (
       agent_email TEXT NOT NULL,
       audience TEXT NOT NULL DEFAULT '*',
+      mode TEXT NOT NULL DEFAULT 'deny-list',
       enabled_by TEXT NOT NULL,
       deny_risk_threshold TEXT,
       deny_patterns TEXT NOT NULL DEFAULT '[]',
@@ -36,7 +37,9 @@ export default defineNitroPlugin(async () => {
     // single-column PK on agent_email and no audience column. Detect that
     // and rebuild.
     const cols = await db.all<{ name: string }>(sql`SELECT name FROM pragma_table_info('yolo_policies')`)
-    const hasAudience = Array.isArray(cols) && cols.some((c: { name: string }) => c.name === 'audience')
+    const colNames = Array.isArray(cols) ? cols.map((c: { name: string }) => c.name) : []
+    const hasAudience = colNames.includes('audience')
+    const hasMode = colNames.includes('mode')
     if (!hasAudience) {
       console.warn('[yolo] migrating yolo_policies → composite (agent_email, audience) PK')
       await db.run(sql`CREATE TABLE yolo_policies_v2 (
@@ -55,6 +58,24 @@ export default defineNitroPlugin(async () => {
       await db.run(sql`DROP TABLE yolo_policies`)
       await db.run(sql`ALTER TABLE yolo_policies_v2 RENAME TO yolo_policies`)
       console.warn('[yolo] migration complete')
+    }
+
+    // M3.5: add `mode` column (allow-list vs deny-list) to existing tables.
+    // ALTER TABLE ADD COLUMN with NOT NULL + DEFAULT works in SQLite for
+    // existing rows; new rows pick up the default. Idempotent via try/catch
+    // when the column is already present.
+    if (!hasMode) {
+      try {
+        await db.run(sql`ALTER TABLE yolo_policies ADD COLUMN mode TEXT NOT NULL DEFAULT 'deny-list'`)
+        console.warn('[yolo] added `mode` column (default deny-list)')
+      }
+      catch (err) {
+        // Could already be there if the migration block above just ran (it
+        // creates the table with `mode`). Tolerate silently.
+        if (!String(err).includes('duplicate column')) {
+          console.error('[yolo] mode-column migration failed:', err)
+        }
+      }
     }
   }
   catch (err) {

--- a/apps/openape-free-idp/server/utils/yolo-evaluator.ts
+++ b/apps/openape-free-idp/server/utils/yolo-evaluator.ts
@@ -45,14 +45,25 @@ export function evaluateYoloPolicy(ctx: YoloDecisionContext): YoloDecision | nul
   const target = ctx.target && ctx.target.length ? ctx.target : null
   if (!target) return null
 
+  // Allow-list mode: operator enumerated the safe set explicitly. Match →
+  // approve, no match → null (= human approval). Risk-threshold doesn't
+  // apply: by listing a specific pattern the operator has already accepted
+  // that risk for the matched targets.
+  if (p.mode === 'allow-list') {
+    for (const pattern of p.denyPatterns || []) {
+      if (matchesGlob(target, pattern)) return { kind: 'yolo', decidedBy: p.enabledBy }
+    }
+    return null
+  }
+
+  // Deny-list mode (legacy default): auto-approve unless a pattern matches
+  // or the resolved risk meets/exceeds the configured threshold.
   if (ctx.resolvedRisk && p.denyRiskThreshold) {
     if (RISK_ORDER[ctx.resolvedRisk] >= RISK_ORDER[p.denyRiskThreshold]) return null
   }
-
   for (const pattern of p.denyPatterns || []) {
     if (matchesGlob(target, pattern)) return null
   }
-
   return { kind: 'yolo', decidedBy: p.enabledBy }
 }
 

--- a/apps/openape-free-idp/server/utils/yolo-policy-store.ts
+++ b/apps/openape-free-idp/server/utils/yolo-policy-store.ts
@@ -8,6 +8,17 @@ import { AUDIENCE_WILDCARD } from './audience-buckets'
 export { AUDIENCE_WILDCARD }
 export type RiskLevel = 'low' | 'medium' | 'high' | 'critical'
 
+/**
+ * YOLO pattern-list interpretation:
+ *
+ * - `'deny-list'` (legacy default): auto-approve UNLESS a pattern matches.
+ *   The historical YOLO behavior. Risk-threshold also applies.
+ * - `'allow-list'`: require manual approval UNLESS a pattern matches. Operator
+ *   has enumerated the safe set explicitly. Risk-threshold is a no-op here.
+ */
+export type YoloMode = 'deny-list' | 'allow-list'
+export const YOLO_MODES: YoloMode[] = ['deny-list', 'allow-list']
+
 export interface YoloPolicy {
   agentEmail: string
   /**
@@ -17,6 +28,8 @@ export interface YoloPolicy {
    * try (agent, request.audience) first, then fall back to (agent, '*').
    */
   audience: string
+  /** See YoloMode docs. Defaults to 'deny-list' for backwards compat. */
+  mode: YoloMode
   enabledBy: string
   /** Auto-approval stops when the resolved shape risk meets or exceeds this. */
   denyRiskThreshold: RiskLevel | null
@@ -65,9 +78,11 @@ function mapRow(row: Row): YoloPolicy {
     }
     catch { /* leave empty */ }
   }
+  const mode = (row.mode === 'allow-list' ? 'allow-list' : 'deny-list') as YoloMode
   return {
     agentEmail: row.agentEmail,
     audience: row.audience ?? AUDIENCE_WILDCARD,
+    mode,
     enabledBy: row.enabledBy,
     denyRiskThreshold: (row.denyRiskThreshold ?? null) as YoloPolicy['denyRiskThreshold'],
     denyPatterns: patterns,
@@ -102,6 +117,7 @@ export function createDrizzleYoloPolicyStore(): YoloPolicyStore {
       const values = {
         agentEmail: policy.agentEmail,
         audience: policy.audience,
+        mode: policy.mode,
         enabledBy: policy.enabledBy,
         denyRiskThreshold: policy.denyRiskThreshold,
         denyPatterns: policy.denyPatterns,
@@ -115,6 +131,7 @@ export function createDrizzleYoloPolicyStore(): YoloPolicyStore {
         .onConflictDoUpdate({
           target: [yoloPolicies.agentEmail, yoloPolicies.audience],
           set: {
+            mode: values.mode,
             enabledBy: values.enabledBy,
             denyRiskThreshold: values.denyRiskThreshold,
             denyPatterns: values.denyPatterns,

--- a/apps/openape-free-idp/tests/yolo-evaluator.test.ts
+++ b/apps/openape-free-idp/tests/yolo-evaluator.test.ts
@@ -6,12 +6,15 @@ import { evaluateYoloPolicy, matchesGlob, targetFromRequest } from '../server/ut
 type Risk = 'low' | 'medium' | 'high' | 'critical'
 
 function policy(overrides: Partial<{
+  mode: 'deny-list' | 'allow-list'
   denyRiskThreshold: Risk | null
   denyPatterns: string[]
   expiresAt: number | null
 }> = {}) {
   return {
     agentEmail: 'a@x',
+    audience: '*',
+    mode: overrides.mode ?? 'deny-list',
     enabledBy: 'owner@x',
     denyRiskThreshold: overrides.denyRiskThreshold ?? null,
     denyPatterns: overrides.denyPatterns ?? [],
@@ -97,6 +100,27 @@ describe('evaluateYoloPolicy', () => {
     const p = policy()
     expect(evaluateYoloPolicy({ policy: p, target: 'example.org', resolvedRisk: null }))
       .toEqual({ kind: 'yolo', decidedBy: 'owner@x' })
+  })
+
+  describe('allow-list mode', () => {
+    it('no patterns → no match → null (= human approval)', () => {
+      const p = policy({ mode: 'allow-list' })
+      expect(evaluateYoloPolicy({ policy: p, target: 'api.openai.com', resolvedRisk: null })).toBeNull()
+    })
+    it('matching pattern → approve', () => {
+      const p = policy({ mode: 'allow-list', denyPatterns: ['*.openai.com'] })
+      expect(evaluateYoloPolicy({ policy: p, target: 'api.openai.com', resolvedRisk: null }))
+        .toEqual({ kind: 'yolo', decidedBy: 'owner@x' })
+    })
+    it('non-matching target → null even with patterns', () => {
+      const p = policy({ mode: 'allow-list', denyPatterns: ['*.openai.com'] })
+      expect(evaluateYoloPolicy({ policy: p, target: 'api.github.com', resolvedRisk: null })).toBeNull()
+    })
+    it('risk threshold is ignored in allow-list mode (operator already enumerated safe set)', () => {
+      const p = policy({ mode: 'allow-list', denyRiskThreshold: 'low', denyPatterns: ['rm *'] })
+      expect(evaluateYoloPolicy({ policy: p, target: 'rm -rf foo', resolvedRisk: 'critical' }))
+        .toEqual({ kind: 'yolo', decidedBy: 'owner@x' })
+    })
   })
 })
 


### PR DESCRIPTION
## Summary

Two structural changes to the YOLO model and a UI overhaul on `/agents/:email`.

## `mode: 'allow-list' | 'deny-list'`

YOLO was always "auto-approve unless deny pattern matches" — blocklist semantics. The inverse — "auto-approve ONLY for these specific things" — is the right shape for tight Web/Root profiles where the operator enumerates the safe set explicitly.

Adds a `mode` column to `yolo_policies` (default `'deny-list'`, backwards-compatible). Evaluator branches:

- **deny-list (legacy):** approve UNLESS pattern matches; risk threshold applies.
- **allow-list (new):** require human approval UNLESS pattern matches. Risk threshold is a no-op (operator already enumerated the safe set).

Migration in `06.yolo-hook.ts` via idempotent `ALTER TABLE ADD COLUMN`.

## Per-row pattern editor

Replaces the multi-line textarea with one row per pattern + add/remove buttons:

| Bucket | Row UI |
|---|---|
| **Web** | `[Method ▼: ALL/GET/POST/PUT/PATCH/DELETE/OPTIONS/HEAD] [URL/Host glob] [🗑]` |
| **Commands / Root / Default** | `[Pattern field] [🗑]` |

Storage stays as a string array. Web rows serialize as `"METHOD URL"` when method ≠ `*`, or just `"URL"` when method = `*` so today's host-only matcher still fires for ALL-method rows.

## Method+URL enforcement coverage (Web tab notice)

Replaces the aspirational "in Arbeit" text with a concrete statement: today the matcher only sees `target_host` (CONNECT-time), so ALL-method rows enforce as host globs. Method-specific rows are stored forward-compatibly for M3.5 (proxy-side method+path enrichment for cleartext-HTTP) but inert until then.

## "Dauer" → "YOLO-Timer"

Field rename per Patrick's spec. Same semantics (expiry timestamp).

## Verification

- [x] 61/61 tests pass (4 new for allow-list mode: no patterns / matching / non-matching / risk-threshold-ignored)
- [x] `pnpm --filter openape-free-idp lint` 0 errors
- [x] `pnpm --filter openape-free-idp typecheck` clean

## Out of scope (next)

- M3.5: proxy-side method+path enrichment + IdP-evaluator method-aware match (so method-specific rows actually fire on cleartext-HTTP)