### PR TITLE
fix(proxy): accept standard HTTP_PROXY absolute-URL request line

### DIFF
--- a/.changeset/proxy-fix-absolute-url-form.md
+++ b/.changeset/proxy-fix-absolute-url-form.md
@@ -1,0 +1,22 @@
+---
+"@openape/proxy": patch
+---
+
+proxy: accept the standard `HTTP_PROXY` absolute-URL request line
+
+`createNodeHandler.handleRequest` previously only understood the legacy
+path-encoded form (`http://proxy:port/<full-target-url>`). Standard
+HTTP_PROXY clients — curl, gh, git, npm, undici — send the target as an
+absolute URL in the request line: `GET http://example.com/path HTTP/1.1`,
+which `node:http` surfaces as `req.url = "http://example.com/path"`. The
+old code concatenated this with the proxy's own host header, producing
+garbage like `http://proxy:portshttp://example.com/path` → "Invalid target
+URL" 400.
+
+Fix: detect when `req.url` is already absolute and prefix it with a slash
+so the existing `pathname.slice(1)` extraction recovers the same target
+string. Path-form clients (legacy) keep working unchanged.
+
+Net effect: `apes proxy -- curl http://example.com` returns HTTP 200
+instead of "Invalid target URL". HTTPS-via-CONNECT was unaffected (uses
+`handleConnect`, not `handleRequest`).

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -330,8 +330,20 @@ export function createNodeHandler(config: MultiAgentProxyConfig): {
 
   return {
     handleRequest(req: IncomingMessage, res: ServerResponse) {
-      // Convert IncomingMessage to Request and use existing fetch logic
-      const url = `http://${req.headers.host || 'localhost'}${req.url || '/'}`
+      // Standard HTTP_PROXY clients (curl, gh, git, npm) send the target as
+      // an absolute URL in the request line for cleartext forward-proxying:
+      //   `GET http://example.com/path HTTP/1.1`
+      // node:http surfaces that absolute URL via `req.url`. The legacy
+      // `proxy.fetch` extraction expects a path-encoded form
+      // (`/<full-target-url>`), so we adapt here: when `req.url` is
+      // absolute, prefix it with a slash so `pathname.slice(1)` recovers
+      // the same target string. Path-form clients (legacy) keep working.
+      const reqUrl = req.url || '/'
+      const isAbsolute = reqUrl.startsWith('http://') || reqUrl.startsWith('https://')
+      const proxyHost = req.headers.host || 'localhost'
+      const url = isAbsolute
+        ? `http://${proxyHost}/${reqUrl}`
+        : `http://${proxyHost}${reqUrl}`
       const chunks: Buffer[] = []
 
       req.on('data', (chunk: Buffer) => chunks.push(chunk))


### PR DESCRIPTION
Fixes `apes proxy -- curl http://example.com` returning 'Invalid target URL'.

createNodeHandler only understood the legacy path-encoded form. Standard HTTP_PROXY clients (curl/gh/git/npm/undici) send absolute URLs in the request line; node:http surfaces those via `req.url = 'http://target.com/path'`. The old code concat'd that with the proxy's host header → broken URL → 400.

Fix: detect absolute-form, prefix with slash, existing extraction works.

Verified live:
- `http://example.com/` → HTTP 200 (was 400)
- `https://api.github.com` via CONNECT → still HTTP 200
- Audit captures `method:GET path:/` for cleartext-HTTP

Bonus: makes Web-bucket method+URL deny/allow patterns enforceable for cleartext-HTTP. The CONNECT-side method enrichment isn't possible via TLS without MITM, so this practically closes the M3.5 gap for the current architecture.

36/36 proxy tests pass, lint clean.