### PR TITLE
fix(apes): apes proxy requires apes login (no transparent fallback)

### DIFF
--- a/.changeset/apes-proxy-require-login.md
+++ b/.changeset/apes-proxy-require-login.md
@@ -1,0 +1,30 @@
+---
+"@openape/apes": patch
+---
+
+apes: `apes proxy --` requires `apes login` first
+
+Removes the silent fallback to transparent mode when no `~/.config/apes/auth.json`
+is present. That fallback shipped in the same minor that introduced
+IdP-mediation (M3) and was UX-dishonest: the UI on `id.openape.ai/agents/<email>`
+suggests YOLO + Allow/Deny rules apply, but a not-logged-in proxy ignored
+them all and just transparently let everything through. Worst kind of bug
+for a security-relevant feature — looks like it works, doesn't.
+
+Now `apes proxy --` exits with code **77** (EX_NOPERM) and a clear message:
+
+```
+apes proxy requires `apes login` first.
+
+Without a login the proxy has no agent identity to attribute grant
+requests to, so the YOLO / Allow / Deny policy on id.openape.ai cannot
+apply. Run:
+
+  apes login
+
+and re-run `apes proxy -- ...`.
+```
+
+Tightening: anyone scripting around `apes proxy --` who relied on the silent
+transparent fallback now gets a hard fail. That's intentional — the security
+posture promised by the UI requires identity.

--- a/packages/apes/src/commands/proxy.ts
+++ b/packages/apes/src/commands/proxy.ts
@@ -9,25 +9,31 @@ import { startEphemeralProxy } from '../proxy/local-proxy.js'
 import { extractWrappedCommand } from '../shapes/index.js'
 
 /**
- * Decide between IdP-mediated and transparent proxy modes based on whether
- * the user is logged in via `apes login`. When logged in: take agent email +
- * IdP URL from the cached auth file so grant requests are attributed to the
- * real user. When not logged in: fall back to transparent (default-allow)
- * mode with a synthetic identity — the honest default rather than locking
- * everything down.
+ * Pull the agent email + IdP URL from the cached `apes login` session and
+ * return options for an IdP-mediated proxy. Throws if no valid session is on
+ * disk: the proxy needs the user's identity to attribute grant requests
+ * (`requester` field) and to find the right YOLO policy row keyed on
+ * `(agent_email, audience='ape-proxy')`. Without that we'd silently fall
+ * back to permissive transparent mode, which lies to the user about the
+ * UI-side YOLO config having an effect — better to fail loudly.
  */
 function resolveProxyConfigOptions(): ProxyConfigOptions {
   const auth = loadAuth()
-  if (auth?.email && auth?.idp) {
-    consola.info(`[apes proxy] IdP-mediated mode — agent=${auth.email}, idp=${auth.idp}`)
-    return { agentEmail: auth.email, idpUrl: auth.idp, mediated: true }
+  if (!auth?.email || !auth?.idp) {
+    throw new CliError(
+      'apes proxy requires `apes login` first.\n\n'
+      + 'Without a login the proxy has no agent identity to attribute grant\n'
+      + 'requests to, so the YOLO / Allow / Deny policy on id.openape.ai cannot\n'
+      + 'apply. Run:\n\n'
+      + '  apes login\n\n'
+      + 'and re-run `apes proxy -- ...`.',
+      // 77 = EX_NOPERM from sysexits.h ("permission denied"); fits "user has\n'
+      // not authenticated to use this command" better than the default 1.
+      77,
+    )
   }
-  consola.warn('[apes proxy] not logged in — transparent mode (default-allow + audit). Run `apes login` to enable IdP-mediated egress + per-user YOLO policy.')
-  return {
-    agentEmail: 'ephemeral@apes-proxy.local',
-    idpUrl: 'https://id.openape.ai',
-    mediated: false,
-  }
+  consola.info(`[apes proxy] IdP-mediated mode — agent=${auth.email}, idp=${auth.idp}`)
+  return { agentEmail: auth.email, idpUrl: auth.idp, mediated: true }
 }
 
 /**


### PR DESCRIPTION
Removes the silent transparent-mode fallback shipped in M3 (#186). UX-dishonest: UI suggests YOLO/Allow/Deny applies, transparent proxy ignored all of it.

`apes proxy --` now exits 77 (EX_NOPERM) with:

```
apes proxy requires `apes login` first.

Without a login the proxy has no agent identity to attribute grant
requests to, so the YOLO / Allow / Deny policy on id.openape.ai cannot
apply. Run:

  apes login

and re-run `apes proxy -- ...`.
```

Tightens the contract: `apes proxy --` callers either have an identity (and YOLO applies) or fail loudly. No more 'looks like it works'.

533/533 tests pass. Lint + typecheck clean.