### PR TITLE
chore: replace version-PR ceremony with `pnpm release:local`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,16 +1,29 @@
 name: release
+
+# Versioning is local-only now: maintainers run `pnpm release:local` from
+# their machine, which bumps versions, commits, builds, publishes to npm, and
+# pushes the result. This workflow is the safety net only:
+#
+#   - If a push to main carries pending `.changeset/*.md` files, fail loudly
+#     so we don't silently fall back to a version-PR ceremony.
+#   - Otherwise run `publish-chain.mjs` — idempotent: it only publishes
+#     packages whose local version is newer than what's on npm. The common
+#     case (already published locally) is a no-op.
+
 on:
   workflow_run:
     workflows: [ci]
     types: [completed]
     branches: [main]
+
 concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
+
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
   id-token: write
+
 jobs:
   release:
     if: github.event.workflow_run.conclusion == 'success'
@@ -19,22 +32,42 @@ jobs:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
       - uses: pnpm/action-setup@v4
+
       - uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: pnpm
           registry-url: https://registry.npmjs.org
-      - run: pnpm install --frozen-lockfile
-      - name: Build publishable packages only
-        run: pnpm turbo run build --filter='./packages/*' --filter='./modules/*'
-      - uses: changesets/action@v1
-        with:
-          publish: pnpm release
-          version: pnpm version-packages
-          title: 'chore: version packages'
-          commit: 'chore: version packages'
+
+      - name: Detect pending changesets
+        id: pending
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CS_DIR: .changeset
+        run: |
+          count=$(ls "$CS_DIR"/*.md 2>/dev/null | grep -v 'README' | wc -l | tr -d ' ')
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+
+      - name: Refuse — versioning is local-only
+        if: steps.pending.outputs.count != '0'
+        env:
+          PENDING_COUNT: ${{ steps.pending.outputs.count }}
+        run: |
+          echo "::error::Found $PENDING_COUNT pending changeset(s) on main."
+          echo "::error::Versioning is local-only: run 'pnpm release:local' from your machine to bump, build, publish, and push in one shot."
+          echo "::error::See scripts/release-local.mjs for the why."
+          exit 1
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build publishable packages
+        run: pnpm turbo run build --filter='./packages/*' --filter='./modules/*'
+
+      - name: Publish (idempotent — only packages whose local version > npm)
+        run: node scripts/publish-chain.mjs
+        env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,9 +65,19 @@ gh pr create
 - CI must pass before merge
 - Add a changeset if publishable packages changed: `pnpm changeset`
 
-### 6. After Merge
+### 6. After Merge — Release
 
-Changesets bot creates a Release PR automatically. When merged, packages are published to npm.
+Versioning and publish are **local-only**. After your PR with a changeset lands on main, run from your machine:
+
+```bash
+git checkout main
+git pull
+pnpm release:local
+```
+
+This script (`scripts/release-local.mjs`) consumes pending changesets, bumps versions, builds, publishes to npm in dependency order, and pushes the version commit. It replaces what used to be three sequential CI cycles (version-PR + post-merge CI + publish) with a single local pass — usually faster, and you skip the surface area for CI flakes.
+
+The CI `release.yml` is the safety net: pushing a changeset to main without running `release:local` first will fail loudly instead of silently opening a version-PR.
 
 ## Branch Policy
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "version-packages": "changeset version",
     "release": "node scripts/publish-chain.mjs",
     "release:dry": "node scripts/publish-chain.mjs --dry-run",
+    "release:local": "node scripts/release-local.mjs",
     "sync:openclaw": "bash scripts/sync-openclaw-skills.sh",
     "seed:shapes": "tsx scripts/seed-shapes.ts",
     "prepare": "git config core.hooksPath .githooks || true"

--- a/scripts/release-local.mjs
+++ b/scripts/release-local.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+
+/**
+ * Local release orchestrator.
+ *
+ *   pnpm release:local
+ *
+ * Why this exists
+ * ---------------
+ * The default `changesets/action@v1` flow needs four sequential CI cycles for
+ * one publish (feature PR, post-merge main CI, version-PR, post-merge main CI
+ * again). For a small monorepo that's many minutes of waiting per patch and
+ * extra surface for flakes. This script runs the same steps locally, in one
+ * pass:
+ *
+ *   1. preflight         (clean tree, on main, in sync, npm logged in)
+ *   2. changeset version (consume `.changeset/*.md`, bump versions, write CHANGELOGs)
+ *   3. commit            ("chore: version packages")
+ *   4. build             (publishable packages only — same filter CI uses)
+ *   5. publish-chain     (publish whatever's not yet on npm, in dep order)
+ *   6. push              (so origin/main reflects the new versions)
+ *
+ * The CI-side `release.yml` is the safety net: if a contributor forgets to
+ * run this and pushes raw changesets to main, the workflow fails loudly
+ * instead of silently opening a version-PR. Versioning is local-only.
+ */
+
+import { execFileSync } from 'node:child_process'
+import { readdirSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const ROOT = new URL('..', import.meta.url).pathname
+
+const RED = '\x1b[31m'
+const GREEN = '\x1b[32m'
+const CYAN = '\x1b[36m'
+const DIM = '\x1b[2m'
+const RESET = '\x1b[0m'
+
+function run(cmd, args, opts = {}) {
+  console.log(`${DIM}$ ${cmd} ${args.join(' ')}${RESET}`)
+  return execFileSync(cmd, args, { stdio: 'inherit', cwd: ROOT, ...opts })
+}
+
+function capture(cmd, args, opts = {}) {
+  return execFileSync(cmd, args, { encoding: 'utf-8', cwd: ROOT, stdio: ['pipe', 'pipe', 'pipe'], ...opts }).trim()
+}
+
+function fail(msg) {
+  console.error(`\n${RED}✗ ${msg}${RESET}\n`)
+  process.exit(1)
+}
+
+function step(label) {
+  console.log(`\n${CYAN}▶ ${label}${RESET}`)
+}
+
+// --- 1. Preflight -----------------------------------------------------------
+
+step('Preflight')
+
+const branch = capture('git', ['rev-parse', '--abbrev-ref', 'HEAD'])
+if (branch !== 'main') fail(`Must be on main, currently on '${branch}'.`)
+
+const dirty = capture('git', ['status', '--porcelain'])
+if (dirty) fail(`Working tree not clean:\n${dirty}\n\nCommit or stash first.`)
+
+run('git', ['fetch', 'origin', 'main'])
+const behind = Number(capture('git', ['rev-list', '--count', 'HEAD..origin/main']))
+if (behind > 0) fail(`Local main is ${behind} commit(s) behind origin/main. Pull first.`)
+
+const ahead = Number(capture('git', ['rev-list', '--count', 'origin/main..HEAD']))
+if (ahead > 0) {
+  console.log(`${DIM}  ${ahead} local commit(s) ahead of origin/main — will be pushed after publish.${RESET}`)
+}
+
+try {
+  const who = capture('npm', ['whoami'])
+  console.log(`${DIM}  npm whoami: ${who}${RESET}`)
+}
+catch {
+  fail('npm whoami failed — run `npm login` first or set NPM_TOKEN in your shell.')
+}
+
+// --- 2. Detect pending changesets ------------------------------------------
+
+step('Detect pending changesets')
+
+const csDir = resolve(ROOT, '.changeset')
+const csFiles = readdirSync(csDir).filter(f => f.endsWith('.md') && f !== 'README.md')
+console.log(`${DIM}  found ${csFiles.length} pending changeset file(s)${RESET}`)
+
+if (csFiles.length > 0) {
+  step('changeset version')
+  run('pnpm', ['changeset', 'version'])
+
+  const newDirty = capture('git', ['status', '--porcelain'])
+  if (newDirty) {
+    step('Commit version bump')
+    run('git', ['add', '-A'])
+    run('git', ['commit', '-m', 'chore: version packages'])
+  }
+  else {
+    // All changesets target ignored packages → nothing to commit. publish-chain
+    // will still detect drift if any local version > npm.
+    console.log(`${DIM}  changeset version produced no changes (ignored packages?) — skipping commit.${RESET}`)
+  }
+}
+
+// --- 3. Build publishable packages -----------------------------------------
+
+step('Build publishable packages')
+run('pnpm', ['turbo', 'run', 'build', '--filter=./packages/*', '--filter=./modules/*'])
+
+// --- 4. Publish ------------------------------------------------------------
+
+step('Publish (only packages where local > npm)')
+run('node', ['scripts/publish-chain.mjs'])
+
+// --- 5. Push ---------------------------------------------------------------
+
+step('Push to origin/main')
+run('git', ['push', 'origin', 'main'])
+
+console.log(`\n${GREEN}✅ Release complete.${RESET}\n`)


### PR DESCRIPTION
## Why

The current \`changesets/action@v1\` flow needs **four sequential CI cycles** for one publish:

1. Feature PR validate
2. Post-merge main CI
3. Auto-generated version-PR validate (often needs a close+reopen to fire — bot-PRs don't auto-trigger workflows)
4. Post-merge main CI again, then publish

For a small monorepo that's many minutes per patch, and every extra CI run is another shot at a flake (we hit two unrelated test flakes on the most recent publish — see #189). The version-PR is also half-broken in our setup: stale changesets for ignored packages like \`openape-free-idp\` make the action take the version path, find nothing to bump, then error trying to create an empty PR ("No commits between main and changeset-release/main").

## New flow

Versioning + publish is local-only:

\`\`\`bash
git checkout main && git pull
pnpm release:local
\`\`\`

\`scripts/release-local.mjs\` does it all in one pass:

1. **Preflight** — on \`main\`, clean tree, in sync, \`npm whoami\` works.
2. **\`changeset version\`** — consume \`.changeset/*.md\`, bump versions, write CHANGELOGs.
3. **Commit** — \`chore: version packages\`.
4. **Build** — same filter CI uses (\`./packages/*\`, \`./modules/*\`).
5. **\`publish-chain.mjs\`** — publish packages whose local version > npm, in dep order.
6. **Push** — origin/main reflects the new versions.

## CI safety net

\`release.yml\` keeps running on every \`workflow_run\` of \`ci\` against main, but with a different shape:

- If pending \`.changeset/*.md\` files reach main (someone forgot \`release:local\`), it **fails loudly** with a pointer to the new flow. No more silent version-PR ceremony.
- Otherwise it runs \`publish-chain.mjs\` directly. That script is idempotent — only publishes packages whose local version is ahead of npm — so the common case (already published locally) is a no-op.

Removed: \`changesets/action@v1\`. \`pnpm version-packages\` (= \`changeset version\`) stays for ad-hoc use.

## Test plan
- [x] \`node --check scripts/release-local.mjs\` — syntax OK
- [x] \`pnpm release:local\` from a feature branch — preflight rejects with "Must be on main"
- [ ] On main with no pending changesets: script should run preflight + build + publish-chain (no-op) + push (no-op)
- [ ] On main with a pending changeset: script should bump, commit, build, publish, push
- [ ] CI safety net: push a raw changeset to main, expect the workflow to fail with the "versioning is local-only" message