### PR TITLE
fix(apes): proxy no longer prints misleading stack trace on non-zero exit

### DIFF
--- a/.changeset/apes-proxy-clean-exit-code.md
+++ b/.changeset/apes-proxy-clean-exit-code.md
@@ -1,0 +1,23 @@
+---
+"@openape/apes": patch
+---
+
+apes: `apes proxy --` no longer prints a misleading stack trace when the wrapped command exits non-zero
+
+Previously, after a wrapped command failed (e.g. `curl: (56) CONNECT tunnel
+failed, response 403` on a denied grant), `apes proxy` printed a bare
+"ERROR" header followed by an internal stack trace ending in citty's
+`runMain` — even though the proxy itself worked correctly (it denied the
+request as policy required) and the wrapped command's exit code was the
+real signal.
+
+Cause: `proxy.ts` did `throw new CliExit(exitCode)` to propagate the wrapped
+exit code, intending the top-level handler in `cli.ts` to translate it into
+`process.exit(exitCode)`. But citty's `runMain` has its own try/catch that
+calls `consola.error(error, "\n")` before our handler ever runs. Combined
+with `CliExit`'s empty message, that surfaces as `ERROR\n  at Object.run …`.
+
+Fix: skip the CliExit hop and call `process.exit(exitCode)` directly from
+`proxy.ts` once cleanup has finished. The user sees only the wrapped
+command's stderr and gets the wrapped command's exit code — same outcome,
+no spurious "ERROR" framing on a working deny path.

--- a/packages/apes/src/commands/proxy.ts
+++ b/packages/apes/src/commands/proxy.ts
@@ -2,7 +2,7 @@ import { spawn } from 'node:child_process'
 import { defineCommand } from 'citty'
 import consola from 'consola'
 import { loadAuth } from '../config.js'
-import { CliError, CliExit } from '../errors.js'
+import { CliError } from '../errors.js'
 import { buildDefaultProxyConfigToml  } from '../proxy/config.js'
 import type { ProxyConfigOptions } from '../proxy/config.js'
 import { startEphemeralProxy } from '../proxy/local-proxy.js'
@@ -140,7 +140,15 @@ export const proxyCommand = defineCommand({
 
     if (close) await close()
 
-    if (exitCode !== 0) throw new CliExit(exitCode)
+    // Propagate the wrapped command's exit code without going through
+    // CliExit + citty's runMain. `runMain` catches everything inside its own
+    // try/catch and prints `consola.error(error, "\n")` before our top-level
+    // handler in cli.ts can intercept — and since CliExit has no message,
+    // that surfaces as a bare "ERROR" header followed by an internal stack
+    // trace, which is misleading on a *successful* deny path (curl exits 56,
+    // proxy did its job correctly). process.exit here means the user sees
+    // their wrapped command's exit code and nothing else.
+    if (exitCode !== 0) process.exit(exitCode)
   },
 })
 


### PR DESCRIPTION
## Symptom

After a wrapped command exits non-zero — e.g. \`curl: (56) CONNECT tunnel failed, response 403\` on a denied grant — \`apes proxy\` prints a bare "ERROR" header followed by an internal stack trace ending in citty's \`runMain\`:

\`\`\`
[audit] grant_denied CONNECT example.com:443 grant=…
curl: (56) CONNECT tunnel failed, response 403

 ERROR

    at Object.run (.../cli.js:2671:31)
    at process.processTicksAndRejections (...)
    at async runCommand (.../citty/dist/index.mjs:316:16)
    ...
\`\`\`

The proxy itself behaved correctly (denied per IdP policy) and curl's exit code was the real signal. The "ERROR" framing makes it look like an internal failure.

## Cause

\`proxy.ts\` did \`throw new CliExit(exitCode)\` to propagate the wrapped command's exit code, expecting the top-level handler in \`cli.ts\` to translate it into \`process.exit(exitCode)\`:

\`\`\`ts
runMain(main).catch((err) => {
  if (err instanceof CliExit) {
    process.exit(err.exitCode)
  }
  ...
})
\`\`\`

But citty's \`runMain\` has its own try/catch that runs first:

\`\`\`js
} catch (error) {
  const isCLIError = error instanceof CLIError;
  if (!isCLIError) {
    consola.error(error, "\\n");   // <-- prints the stack
  }
  ...
}
\`\`\`

Citty's \`CLIError\` (its own class) is the only thing it treats as "intentional"; our \`CliExit\` is a plain \`Error\` with an empty \`.message\`, so consola prints the stack trace. Our top-level handler never gets to see the error because citty \`process.exit(1)\`s first.

## Fix

Skip the CliExit hop and \`process.exit(exitCode)\` directly from \`proxy.ts\` after cleanup. Same propagation, no spurious framing.

## Test plan
- [x] \`pnpm --filter @openape/apes test\` — 533/533 pass
- [x] \`pnpm --filter @openape/apes build\` clean
- [ ] After publish: \`apes proxy -- curl https://example.com\` on a denied host shows curl's output and exits with curl's code, no stack trace