### PR TITLE
fix(release-local): bypass main pre-commit hook for version-bump

### DIFF
--- a/scripts/release-local.mjs
+++ b/scripts/release-local.mjs
@@ -98,7 +98,15 @@ if (csFiles.length > 0) {
   if (newDirty) {
     step('Commit version bump')
     run('git', ['add', '-A'])
-    run('git', ['commit', '-m', 'chore: version packages'])
+    // The repo's pre-commit hook blocks source edits on `main` to keep humans
+    // off the branch (CONTRIBUTING.md "Branch Policy"). The version-bump
+    // commit produced by `changeset version` is mechanical — generated
+    // CHANGELOG entries plus a single `version` field per package.json — so
+    // it falls under the documented `SKIP_HOOKS=1` exception. The hook
+    // itself prints this exact bypass.
+    run('git', ['commit', '-m', 'chore: version packages'], {
+      env: { ...process.env, SKIP_HOOKS: '1' },
+    })
   }
   else {
     // All changesets target ignored packages → nothing to commit. publish-chain


### PR DESCRIPTION
## Symptom

First real run of \`pnpm release:local\` (after #191 merged) failed at the version-bump commit:

\`\`\`
▶ Commit version bump
$ git add -A
$ git commit -m chore: version packages
[pre-commit] BLOCKED — Source-Änderungen auf 'main' nicht erlaubt:
packages/apes/CHANGELOG.md
packages/apes/package.json
\`\`\`

## Cause

CONTRIBUTING.md "Branch Policy" blocks source edits on \`main\` via the pre-commit hook to keep humans on feature branches. The hook fires on \`packages/apes/CHANGELOG.md\` + \`packages/apes/package.json\` changes regardless of who's editing them.

But the changeset-generated "chore: version packages" commit is purely mechanical:
- new CHANGELOG entries
- a single \`version\` bump per touched package.json
- deletion of consumed \`.changeset/*.md\` files

The hook's own help text documents \`SKIP_HOOKS=1\` as the bypass for exactly this kind of automated commit.

## Fix

Pass \`SKIP_HOOKS=1\` on the version-bump commit only. All other git ops in the script (push, etc.) keep the hook active.

## Test plan
- [x] Manual: \`apes@0.14.2\` was published this morning by running the script + finishing the steps manually after the hook block. With this fix, the script will go end-to-end.
- [ ] Next release will exercise the new path.