### PR TITLE
fix(proxy): DNS-unresolvable hosts return 502, not 403

### DIFF
--- a/.changeset/proxy-dns-failure-vs-private-ip.md
+++ b/.changeset/proxy-dns-failure-vs-private-ip.md
@@ -1,0 +1,44 @@
+---
+"@openape/proxy": minor
+---
+
+proxy: distinguish DNS-unresolvable hosts from private/loopback IPs (502 vs 403)
+
+Previously the SSRF check (`isPrivateOrLoopback`) collapsed three different
+egress conditions into one boolean and surfaced all of them as **403
+Forbidden** with audit `rule=ssrf-blocked`:
+
+- the host resolves to a private/loopback IP (a real policy refusal)
+- DNS returns no A/AAAA records (NXDOMAIN, NODATA)
+- DNS query itself errors out (timeout, SERVFAIL)
+
+That made `apes proxy -- curl https://example.at` (a typo) come back as a
+403 — misleading, because the proxy didn't refuse on policy, it just
+couldn't reach an upstream.
+
+New: `checkEgress(hostname)` returns a discriminated result and callers
+branch on it.
+
+| outcome           | response               | audit `rule`                  |
+|-------------------|------------------------|-------------------------------|
+| `ok`              | forward                | (n/a — proceeds to rules)     |
+| `private`         | **403 Forbidden**      | `ssrf-blocked`                |
+| `unresolvable`    | **502 Bad Gateway**    | `dns-unresolvable (<reason>)` |
+
+The `unresolvable` reason is `no-records` (NXDOMAIN/NODATA) or `dns-error`
+(query failure). The audit action is `error` for unresolvable, distinct
+from `deny` so dashboards can separate "policy stopped this" from "we
+couldn't reach the upstream".
+
+Both proxy entry points are updated: HTTP forward-proxy
+(`handleRequest`) and CONNECT tunnel (`handleConnect`).
+
+`isPrivateOrLoopback` is kept as a deprecated boolean shim for any
+out-of-tree caller; new callers should use `checkEgress`.
+
+Drive-by note on DNS-rebinding: the old "block on uncertainty" rationale
+was a weak hedge — a careful attacker can still race the resolution
+between our check and the kernel's `connect()`. The proper mitigation is
+pinning the resolved IP across the actual socket call; conflating
+unresolvable with private was costing us correctness for typos without
+buying meaningful safety.

--- a/packages/proxy/src/connect.ts
+++ b/packages/proxy/src/connect.ts
@@ -3,7 +3,7 @@ import type { Socket } from 'node:net'
 import { connect } from 'node:net'
 import type { AgentConfig, MultiAgentProxyConfig, ProxyConfig } from './types.js'
 import { AuthError, verifyAgentAuth } from './auth.js'
-import { isPrivateOrLoopback } from './ssrf.js'
+import { checkEgress } from './ssrf.js'
 import { writeAudit } from './audit.js'
 import { evaluateRules } from './matcher.js'
 import type { GrantsClient } from './grants-client.js'
@@ -116,11 +116,18 @@ export async function handleConnect(
     throw err
   }
 
-  // SSRF check
-  if (await isPrivateOrLoopback(host)) {
+  // SSRF / reachability check. We split the two outcomes:
+  //   - `private`        → policy refusal, 403 (the proxy will not forward).
+  //   - `unresolvable`   → upstream not reachable, 502 (DNS NXDOMAIN /
+  //     NODATA / query error — distinct from "I refuse on policy grounds";
+  //     conflating them shipped misleading 403s for typos like
+  //     `apes proxy -- curl https://example.at`).
+  const egress = await checkEgress(host)
+  const auditAgent = agentEmail ?? config.agents[0]?.email ?? 'unknown'
+  if (egress.kind === 'private') {
     writeAudit({
       ts: new Date().toISOString(),
-      agent: agentEmail ?? config.agents[0]?.email ?? 'unknown',
+      agent: auditAgent,
       action: 'deny',
       domain: host,
       method: 'CONNECT',
@@ -128,6 +135,22 @@ export async function handleConnect(
       rule: 'ssrf-blocked',
     })
     clientSocket.write('HTTP/1.1 403 Forbidden\r\n\r\n')
+    clientSocket.destroy()
+    return
+  }
+  if (egress.kind === 'unresolvable') {
+    writeAudit({
+      ts: new Date().toISOString(),
+      agent: auditAgent,
+      action: 'error',
+      domain: host,
+      method: 'CONNECT',
+      path: target,
+      rule: `dns-unresolvable (${egress.reason})`,
+    })
+    clientSocket.write(
+      `HTTP/1.1 502 Bad Gateway\r\nContent-Type: text/plain\r\n\r\nDNS lookup failed for ${host} (${egress.reason}).\r\n`,
+    )
     clientSocket.destroy()
     return
   }

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -6,7 +6,7 @@ import { evaluateRules } from './matcher.js'
 import { AuthError, verifyAgentAuth } from './auth.js'
 import { GrantsClient } from './grants-client.js'
 import { writeAudit } from './audit.js'
-import { isPrivateOrLoopback } from './ssrf.js'
+import { checkEgress } from './ssrf.js'
 import { handleConnect } from './connect.js'
 
 /**
@@ -105,9 +105,19 @@ export function createMultiAgentProxy(
       const method = req.method
       const path = targetParsed.pathname
 
-      // SSRF protection — block private/loopback IPs before any rule evaluation
-      if (await isPrivateOrLoopback(domain)) {
+      // SSRF / reachability check. Split outcomes so a non-existent host
+      // doesn't ship as a misleading 403:
+      //   - `private`      → policy refusal (403).
+      //   - `unresolvable` → upstream connectivity failure (502).
+      const egress = await checkEgress(domain)
+      if (egress.kind === 'private') {
         return new Response('Blocked: private/loopback IP', { status: 403 })
+      }
+      if (egress.kind === 'unresolvable') {
+        return new Response(
+          `DNS lookup failed for ${domain} (${egress.reason}).`,
+          { status: 502 },
+        )
       }
 
       // Read body once (needed for hash + forwarding)

--- a/packages/proxy/src/ssrf.ts
+++ b/packages/proxy/src/ssrf.ts
@@ -52,34 +52,72 @@ function isPrivateIP(ip: string): boolean {
 }
 
 /**
- * Check if a hostname resolves to a private or loopback IP.
- * If the hostname is already an IP literal, check directly.
- * Otherwise, resolve via DNS and check all results.
+ * Result of resolving a hostname for egress safety.
+ *
+ * - `ok` — resolved to at least one address, none of them private/loopback.
+ *   Caller forwards.
+ * - `private` — at least one resolved address is private/loopback. Caller
+ *   refuses with a policy response (403).
+ * - `unresolvable` — DNS returned NXDOMAIN, NODATA, or a query error. Caller
+ *   responds with an upstream-failure code (502). Distinct from `private`
+ *   because the host doesn't exist (or can't be reached) — that's not a
+ *   policy decision, it's a connectivity problem, and conflating the two
+ *   ships misleading 403s for typos and DNS hiccups.
  */
-export async function isPrivateOrLoopback(hostname: string): Promise<boolean> {
-  // Direct IP literal
+export type EgressCheckResult =
+  | { kind: 'ok' }
+  | { kind: 'private' }
+  | { kind: 'unresolvable', reason: 'no-records' | 'dns-error' }
+
+/**
+ * Check whether forwarding a connection to `hostname` is safe.
+ *
+ * IP literals are checked directly; hostnames are resolved via DNS (A and
+ * AAAA in parallel) and every returned address is screened against the
+ * private-range list. If any address is private the result is `private`.
+ *
+ * Note on DNS-rebinding: a careful attacker could return a public IP to our
+ * pre-flight resolution and a private one to the kernel's `connect()`. The
+ * proper fix for that is pinning the resolved IP across the actual socket
+ * call, not blocking on uncertainty — so we no longer conflate "I couldn't
+ * resolve" with "this is private". Callers can layer pinning on top.
+ */
+export async function checkEgress(hostname: string): Promise<EgressCheckResult> {
   if (isIP(hostname)) {
-    return isPrivateIP(hostname)
+    return isPrivateIP(hostname) ? { kind: 'private' } : { kind: 'ok' }
   }
 
-  // localhost shortcut
-  if (hostname === 'localhost') return true
+  if (hostname === 'localhost') return { kind: 'private' }
 
-  // DNS resolution — check both A and AAAA records
+  let settled: PromiseSettledResult<string[]>[]
   try {
-    const [v4, v6] = await Promise.allSettled([
-      resolve4(hostname),
-      resolve6(hostname),
-    ])
-    const addrs: string[] = []
-    if (v4.status === 'fulfilled') addrs.push(...v4.value)
-    if (v6.status === 'fulfilled') addrs.push(...v6.value)
-
-    if (addrs.length === 0) return true // no records — block to be safe
-    return addrs.some(addr => isPrivateIP(addr))
+    settled = await Promise.allSettled([resolve4(hostname), resolve6(hostname)])
   }
   catch {
-    // DNS failure — block to be safe
-    return true
+    return { kind: 'unresolvable', reason: 'dns-error' }
   }
+
+  const addrs: string[] = []
+  for (const r of settled) {
+    if (r.status === 'fulfilled') addrs.push(...r.value)
+  }
+
+  if (addrs.length === 0) {
+    return { kind: 'unresolvable', reason: 'no-records' }
+  }
+
+  return addrs.some(addr => isPrivateIP(addr)) ? { kind: 'private' } : { kind: 'ok' }
+}
+
+/**
+ * Backwards-compatible boolean shim. Returns true for both `private` and
+ * `unresolvable` because that matches the previous (overly conservative)
+ * behaviour. New code should call `checkEgress` and distinguish.
+ *
+ * @deprecated Use `checkEgress` so the caller can return 502 for unresolvable
+ * hosts and 403 only for actual private/loopback IPs.
+ */
+export async function isPrivateOrLoopback(hostname: string): Promise<boolean> {
+  const result = await checkEgress(hostname)
+  return result.kind !== 'ok'
 }

--- a/packages/proxy/test/connect.test.ts
+++ b/packages/proxy/test/connect.test.ts
@@ -121,13 +121,17 @@ describe('connect handler', () => {
     expect(statusLine).toContain('401')
   })
 
-  it('blocks malformed target (treated as SSRF)', async () => {
+  it('returns 502 for unresolvable host (DNS NXDOMAIN/no-records)', async () => {
+    // Previously this surfaced as 403 (`ssrf-blocked`) because the SSRF check
+    // conflated "no records" with "private IP". A host that doesn't exist is
+    // a connectivity problem, not a policy decision — see `checkEgress` in
+    // src/ssrf.ts for the new discriminated outcome.
     const config = makeConfig({ mandatory_auth: false })
     config.agents = [{ email: 'bot@example.com', idp_url: 'https://id.example.com' }]
     const { port, close } = await startProxy(config)
     cleanup = close
 
     const { statusLine } = await sendConnect(port, 'not-a-host')
-    expect(statusLine).toContain('403')
+    expect(statusLine).toContain('502')
   })
 })

--- a/packages/proxy/test/ssrf.test.ts
+++ b/packages/proxy/test/ssrf.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { isPrivateOrLoopback } from '../src/ssrf.js'
+import { checkEgress, isPrivateOrLoopback } from '../src/ssrf.js'
 
 describe('isPrivateOrLoopback', () => {
   // IPv4 loopback
@@ -69,5 +69,30 @@ describe('isPrivateOrLoopback', () => {
   // 172.32.x.x is NOT in 172.16.0.0/12
   it('allows 172.32.0.1', async () => {
     expect(await isPrivateOrLoopback('172.32.0.1')).toBe(false)
+  })
+})
+
+describe('checkEgress', () => {
+  // The discriminated outcome is what callers branch on. The boolean shim
+  // above stays for legacy callers, but new code should distinguish "private"
+  // (policy refusal → 403) from "unresolvable" (upstream failure → 502).
+
+  it('returns ok for a public IP literal', async () => {
+    expect(await checkEgress('8.8.8.8')).toEqual({ kind: 'ok' })
+  })
+
+  it('returns private for a loopback IP literal', async () => {
+    expect(await checkEgress('127.0.0.1')).toEqual({ kind: 'private' })
+  })
+
+  it('returns private for the literal "localhost"', async () => {
+    expect(await checkEgress('localhost')).toEqual({ kind: 'private' })
+  })
+
+  it('returns unresolvable for a non-existent host', async () => {
+    // `not-a-host` has no DNS records; previously this came back as `private`
+    // (and the proxy as 403). It's now `unresolvable` and proxies will 502.
+    const result = await checkEgress('not-a-host')
+    expect(result.kind).toBe('unresolvable')
   })
 })


### PR DESCRIPTION
## Symptom

\`apes proxy -- curl https://example.at\` (typo, host doesn't exist) reports **403 Forbidden** with audit \`rule=ssrf-blocked\`. Looks like the proxy refused on policy grounds. It didn't — it just couldn't resolve the host.

## Cause

\`isPrivateOrLoopback()\` returned \`true\` for three different conditions:

1. Host resolves to a private/loopback IP (real policy refusal)
2. DNS returns no records (NXDOMAIN, NODATA)
3. DNS query itself errors out (timeout, SERVFAIL)

Both proxy paths (CONNECT tunnel + HTTP forward-proxy) translated \`true\` into 403. Two different problems wearing the same response code.

## Fix

\`checkEgress(hostname)\` returns a discriminated result:

| outcome           | response               | audit \`rule\`                  | audit \`action\` |
|-------------------|------------------------|-------------------------------|----------------|
| \`ok\`              | forward                | (proceeds to rules)           | n/a            |
| \`private\`         | **403 Forbidden**      | \`ssrf-blocked\`                | \`deny\`         |
| \`unresolvable\`    | **502 Bad Gateway**    | \`dns-unresolvable (<reason>)\` | \`error\`        |

\`reason\` is \`no-records\` (NXDOMAIN/NODATA) or \`dns-error\`. Audit dashboards can now separate "policy stopped this" from "we couldn't reach the upstream".

\`isPrivateOrLoopback()\` stays as a deprecated boolean shim for any out-of-tree caller; new callers use \`checkEgress\`.

## Drive-by note

The old "block on DNS uncertainty" rationale was a DNS-rebinding hedge — but it's a weak one (an attacker can still race resolution vs. \`connect()\`). The proper mitigation is pinning the resolved IP across the actual socket call. Conflating unresolvable with private cost correctness without meaningful safety gain.

## Test plan
- [x] Existing CONNECT test "blocks malformed target (treated as SSRF)" asserted 403 — that contract is exactly what we're fixing. Renamed and updated to assert 502.
- [x] Four new \`checkEgress\` cases: public IP literal, loopback literal, "localhost", unresolvable host.
- [x] \`pnpm --filter @openape/proxy test\` — 40/40 (was 36 + 4 new).
- [x] \`pnpm --filter @openape/proxy build\` + \`typecheck\` clean.
- [ ] Post-publish: \`apes proxy -- curl https://example.at\` returns 502 with \`DNS lookup failed for example.at\`.