### PR TITLE
fix(free-idp): YOLO toggle stores independent allow/deny lists (no more relabel-on-flip)

### DIFF
--- a/apps/openape-free-idp/app/components/BucketYoloCard.vue
+++ b/apps/openape-free-idp/app/components/BucketYoloCard.vue
@@ -12,6 +12,7 @@ interface YoloPolicy {
   enabledBy: string
   denyRiskThreshold: 'low' | 'medium' | 'high' | 'critical' | null
   denyPatterns: string[]
+  allowPatterns: string[]
   enabledAt: number
   expiresAt: number | null
   updatedAt: number
@@ -32,7 +33,13 @@ interface FormState {
    */
   yoloOn: boolean
   denyRiskThreshold: 'low' | 'medium' | 'high' | 'critical' | ''
-  patterns: PatternRow[]
+  /**
+   * Independent pattern lists per mode. The active list is shown/edited
+   * based on `yoloOn`; the inactive one is preserved so flipping the toggle
+   * doesn't lose work. Both lists go to the server on every save.
+   */
+  denyPatterns: PatternRow[]
+  allowPatterns: PatternRow[]
   duration: string
 }
 
@@ -69,13 +76,25 @@ const expiryLabel = computed(() => {
 
 const form = ref<FormState>(emptyForm())
 
+// The pattern list the user is currently editing — picked by the YOLO toggle.
+// Switching the toggle reveals the OTHER list rather than relabeling the same
+// one (the previous shape lost data on every flip).
+const activePatterns = computed<PatternRow[]>({
+  get: () => form.value.yoloOn ? form.value.denyPatterns : form.value.allowPatterns,
+  set: (v) => {
+    if (form.value.yoloOn) form.value.denyPatterns = v
+    else form.value.allowPatterns = v
+  },
+})
+
 function emptyForm(): FormState {
   return {
     // No row in DB yet → default OFF (= allow-list with 0 patterns =
     // every request needs human approval). This is the safer default.
     yoloOn: false,
     denyRiskThreshold: '',
-    patterns: [],
+    denyPatterns: [],
+    allowPatterns: [],
     duration: '',
   }
 }
@@ -145,7 +164,8 @@ async function load() {
       form.value = {
         yoloOn: rep.mode !== 'allow-list',
         denyRiskThreshold: (rep.denyRiskThreshold ?? '') as FormState['denyRiskThreshold'],
-        patterns: (rep.denyPatterns ?? []).map(p => parsePattern(p, props.bucket.patternShape)),
+        denyPatterns: (rep.denyPatterns ?? []).map(p => parsePattern(p, props.bucket.patternShape)),
+        allowPatterns: (rep.allowPatterns ?? []).map(p => parsePattern(p, props.bucket.patternShape)),
         duration: rep.expiresAt ? '' : '',
       }
     }
@@ -163,28 +183,38 @@ async function load() {
 }
 
 function addPatternRow() {
-  form.value.patterns.push({ method: '*', value: '' })
+  activePatterns.value = [...activePatterns.value, { method: '*', value: '' }]
 }
 
 function removePatternRow(i: number) {
-  form.value.patterns.splice(i, 1)
+  const next = activePatterns.value.slice()
+  next.splice(i, 1)
+  activePatterns.value = next
+}
+
+function serializeRows(rows: PatternRow[]): string[] {
+  return rows
+    .map(r => serializePattern(r.method, r.value, props.bucket.patternShape))
+    .filter(Boolean)
 }
 
 async function save() {
   submitting.value = true
   error.value = ''
   try {
-    const patterns = form.value.patterns
-      .map(r => serializePattern(r.method, r.value, props.bucket.patternShape))
-      .filter(Boolean)
     const durationSec = Number(form.value.duration)
     const expiresAt = Number.isFinite(durationSec) && durationSec > 0
       ? Math.floor(Date.now() / 1000) + durationSec
       : null
+    // Send BOTH lists every save so the inactive one is preserved across mode
+    // flips. The server treats the unspecified list as "keep current" only
+    // when the field is absent — we always include both, so what the user
+    // sees is what they get.
     const body = {
       mode: modeFromToggle(form.value.yoloOn),
       denyRiskThreshold: showRiskThreshold.value ? (form.value.denyRiskThreshold || null) : null,
-      denyPatterns: patterns,
+      denyPatterns: serializeRows(form.value.denyPatterns),
+      allowPatterns: serializeRows(form.value.allowPatterns),
       expiresAt,
     }
     await Promise.all(props.bucket.audiences.map(aud =>
@@ -303,12 +333,12 @@ watch(() => props.agentEmail, () => { if (props.agentEmail) load() }, { immediat
         <p class="text-xs text-gray-500 mb-2">
           {{ bucket.patternHelp }}
         </p>
-        <div v-if="form.patterns.length === 0" class="text-xs italic text-gray-500 py-2">
+        <div v-if="activePatterns.length === 0" class="text-xs italic text-gray-500 py-2">
           {{ listEmptyHint }}
         </div>
         <div v-else class="space-y-2">
           <div
-            v-for="(row, i) in form.patterns"
+            v-for="(row, i) in activePatterns"
             :key="i"
             class="flex items-center gap-2"
           >

--- a/apps/openape-free-idp/server/api/users/[email]/yolo-policy.put.ts
+++ b/apps/openape-free-idp/server/api/users/[email]/yolo-policy.put.ts
@@ -21,6 +21,7 @@ export default defineEventHandler(async (event) => {
     mode?: YoloMode
     denyRiskThreshold?: RiskLevel | null
     denyPatterns?: string[]
+    allowPatterns?: string[]
     expiresAt?: number | null
   }>(event)
 
@@ -31,19 +32,8 @@ export default defineEventHandler(async (event) => {
   if (body.denyRiskThreshold !== undefined && body.denyRiskThreshold !== null && !VALID_RISK.includes(body.denyRiskThreshold)) {
     throw createProblemError({ status: 400, title: `denyRiskThreshold must be one of: ${VALID_RISK.join(', ')}` })
   }
-  if (body.denyPatterns !== undefined) {
-    if (!Array.isArray(body.denyPatterns)) {
-      throw createProblemError({ status: 400, title: 'denyPatterns must be an array of strings' })
-    }
-    if (body.denyPatterns.length > MAX_PATTERNS) {
-      throw createProblemError({ status: 400, title: `denyPatterns may contain at most ${MAX_PATTERNS} entries` })
-    }
-    for (const p of body.denyPatterns) {
-      if (typeof p !== 'string' || p.length === 0 || p.length > MAX_PATTERN_LEN) {
-        throw createProblemError({ status: 400, title: `Each denyPattern must be a non-empty string up to ${MAX_PATTERN_LEN} chars` })
-      }
-    }
-  }
+  validatePatternList(body.denyPatterns, 'denyPatterns')
+  validatePatternList(body.allowPatterns, 'allowPatterns')
   if (body.expiresAt !== undefined && body.expiresAt !== null) {
     if (!Number.isFinite(body.expiresAt) || body.expiresAt <= Math.floor(Date.now() / 1000)) {
       throw createProblemError({ status: 400, title: 'expiresAt must be a future unix-seconds timestamp' })
@@ -65,6 +55,7 @@ export default defineEventHandler(async (event) => {
     enabledBy: caller === '_management_' ? (existing?.enabledBy ?? caller) : caller,
     denyRiskThreshold: body.denyRiskThreshold !== undefined ? body.denyRiskThreshold : (existing?.denyRiskThreshold ?? null),
     denyPatterns: body.denyPatterns !== undefined ? normalisePatterns(body.denyPatterns) : (existing?.denyPatterns ?? []),
+    allowPatterns: body.allowPatterns !== undefined ? normalisePatterns(body.allowPatterns) : (existing?.allowPatterns ?? []),
     enabledAt: existing?.enabledAt ?? now,
     expiresAt: body.expiresAt !== undefined ? body.expiresAt : (existing?.expiresAt ?? null),
     updatedAt: now,
@@ -80,4 +71,19 @@ function normalisePatterns(input: string[]): string[] {
     if (trimmed && !out.includes(trimmed)) out.push(trimmed)
   }
   return out
+}
+
+function validatePatternList(input: string[] | undefined, fieldName: string): void {
+  if (input === undefined) return
+  if (!Array.isArray(input)) {
+    throw createProblemError({ status: 400, title: `${fieldName} must be an array of strings` })
+  }
+  if (input.length > MAX_PATTERNS) {
+    throw createProblemError({ status: 400, title: `${fieldName} may contain at most ${MAX_PATTERNS} entries` })
+  }
+  for (const p of input) {
+    if (typeof p !== 'string' || p.length === 0 || p.length > MAX_PATTERN_LEN) {
+      throw createProblemError({ status: 400, title: `Each entry in ${fieldName} must be a non-empty string up to ${MAX_PATTERN_LEN} chars` })
+    }
+  }
 }

--- a/apps/openape-free-idp/server/database/schema.ts
+++ b/apps/openape-free-idp/server/database/schema.ts
@@ -180,10 +180,13 @@ export const yoloPolicies = sqliteTable('yolo_policies', {
   mode: text('mode').notNull().default('deny-list'),
   enabledBy: text('enabled_by').notNull(),
   denyRiskThreshold: text('deny_risk_threshold'),
-  // Despite the column name, in `mode='allow-list'` these are read as
-  // ALLOW-patterns, not deny-patterns. Renaming the column would force a
-  // full table recreate; the semantic is documented in the evaluator.
+  // Two independent pattern lists, one per mode. The active list is picked
+  // by `mode`. Keeping both means flipping the YOLO toggle in the UI doesn't
+  // destroy the inactive list (the previous single-list shape was confusing:
+  // the same array got relabeled as deny-patterns when YOLO was on and as
+  // allow-patterns when YOLO was off).
   denyPatterns: text('deny_patterns', { mode: 'json' }).notNull().default('[]'),
+  allowPatterns: text('allow_patterns', { mode: 'json' }).notNull().default('[]'),
   enabledAt: integer('enabled_at').notNull(),
   expiresAt: integer('expires_at'),
   updatedAt: integer('updated_at').notNull(),

--- a/apps/openape-free-idp/server/plugins/06.yolo-hook.ts
+++ b/apps/openape-free-idp/server/plugins/06.yolo-hook.ts
@@ -19,7 +19,7 @@ export default defineNitroPlugin(async () => {
   // on the absence of the `audience` column so it runs at most once per DB.
   try {
     const db = useDb()
-    // Fresh-DB shape (composite PK + mode).
+    // Fresh-DB shape (composite PK + mode + split pattern lists).
     await db.run(sql`CREATE TABLE IF NOT EXISTS yolo_policies (
       agent_email TEXT NOT NULL,
       audience TEXT NOT NULL DEFAULT '*',
@@ -27,6 +27,7 @@ export default defineNitroPlugin(async () => {
       enabled_by TEXT NOT NULL,
       deny_risk_threshold TEXT,
       deny_patterns TEXT NOT NULL DEFAULT '[]',
+      allow_patterns TEXT NOT NULL DEFAULT '[]',
       enabled_at INTEGER NOT NULL,
       expires_at INTEGER,
       updated_at INTEGER NOT NULL,
@@ -40,6 +41,7 @@ export default defineNitroPlugin(async () => {
     const colNames = Array.isArray(cols) ? cols.map((c: { name: string }) => c.name) : []
     const hasAudience = colNames.includes('audience')
     const hasMode = colNames.includes('mode')
+    const hasAllowPatterns = colNames.includes('allow_patterns')
     if (!hasAudience) {
       console.warn('[yolo] migrating yolo_policies → composite (agent_email, audience) PK')
       await db.run(sql`CREATE TABLE yolo_policies_v2 (
@@ -74,6 +76,27 @@ export default defineNitroPlugin(async () => {
         // creates the table with `mode`). Tolerate silently.
         if (!String(err).includes('duplicate column')) {
           console.error('[yolo] mode-column migration failed:', err)
+        }
+      }
+    }
+
+    // Split pattern lists per mode. Old rows used `deny_patterns` for both
+    // modes — in `mode='allow-list'` the same column was being read as the
+    // allow-list. Add `allow_patterns` and one-shot move existing allow-list
+    // rows' patterns into the new column. Idempotent: gated on column absence
+    // and clears `deny_patterns` on the moved rows so re-running this is a
+    // no-op for them too.
+    if (!hasAllowPatterns) {
+      try {
+        await db.run(sql`ALTER TABLE yolo_policies ADD COLUMN allow_patterns TEXT NOT NULL DEFAULT '[]'`)
+        await db.run(sql`UPDATE yolo_policies
+          SET allow_patterns = deny_patterns, deny_patterns = '[]'
+          WHERE mode = 'allow-list' AND deny_patterns != '[]'`)
+        console.warn('[yolo] added `allow_patterns` column and moved existing allow-list rows over')
+      }
+      catch (err) {
+        if (!String(err).includes('duplicate column')) {
+          console.error('[yolo] allow_patterns migration failed:', err)
         }
       }
     }

--- a/apps/openape-free-idp/server/utils/yolo-evaluator.ts
+++ b/apps/openape-free-idp/server/utils/yolo-evaluator.ts
@@ -17,7 +17,7 @@ export interface YoloDecision {
 export interface YoloDecisionContext {
   policy: YoloPolicy | null
   /**
-   * The string deny-patterns are matched against. Two shapes:
+   * The string the active pattern list is matched against. Two shapes:
    *
    * - For Commands / Root grants this is the joined command line (e.g.
    *   `"git push origin main"`). Operators write bash-style globs like
@@ -54,7 +54,7 @@ export function evaluateYoloPolicy(ctx: YoloDecisionContext): YoloDecision | nul
   // - allow-list: explicit allow-pattern → approve (further open).
   if (p.mode === 'allow-list') {
     // 1. Explicit allow-pattern match → approve.
-    for (const pattern of p.denyPatterns || []) {
+    for (const pattern of p.allowPatterns || []) {
       if (matchesGlob(target, pattern)) return { kind: 'yolo', decidedBy: p.enabledBy }
     }
     // 2. Risk ≤ threshold → approve.

--- a/apps/openape-free-idp/server/utils/yolo-policy-store.ts
+++ b/apps/openape-free-idp/server/utils/yolo-policy-store.ts
@@ -33,8 +33,18 @@ export interface YoloPolicy {
   enabledBy: string
   /** Auto-approval stops when the resolved shape risk meets or exceeds this. */
   denyRiskThreshold: RiskLevel | null
-  /** Glob patterns that drop the request back to the normal approval flow. */
+  /**
+   * Glob patterns that drop the request back to the normal approval flow.
+   * Active when `mode='deny-list'`; otherwise stored but inert.
+   */
   denyPatterns: string[]
+  /**
+   * Glob patterns that auto-approve a request even though the default is
+   * deny. Active when `mode='allow-list'`; otherwise stored but inert.
+   * Persisted independently of `denyPatterns` so flipping the UI toggle
+   * doesn't destroy the inactive list.
+   */
+  allowPatterns: string[]
   enabledAt: number
   /** Unix seconds; null = no expiry. */
   expiresAt: number | null
@@ -64,20 +74,23 @@ export interface YoloPolicyStore {
 
 type Row = typeof yoloPolicies.$inferSelect
 
-function mapRow(row: Row): YoloPolicy {
-  let patterns: string[] = []
-  if (Array.isArray(row.denyPatterns)) {
-    patterns = (row.denyPatterns as unknown[]).filter((p): p is string => typeof p === 'string')
+function readJsonStringArray(raw: unknown): string[] {
+  if (Array.isArray(raw)) {
+    return (raw as unknown[]).filter((p): p is string => typeof p === 'string')
   }
-  else if (typeof row.denyPatterns === 'string') {
+  if (typeof raw === 'string') {
     try {
-      const parsed = JSON.parse(row.denyPatterns)
+      const parsed = JSON.parse(raw)
       if (Array.isArray(parsed)) {
-        patterns = parsed.filter((p): p is string => typeof p === 'string')
+        return parsed.filter((p): p is string => typeof p === 'string')
       }
     }
     catch { /* leave empty */ }
   }
+  return []
+}
+
+function mapRow(row: Row): YoloPolicy {
   const mode = (row.mode === 'allow-list' ? 'allow-list' : 'deny-list') as YoloMode
   return {
     agentEmail: row.agentEmail,
@@ -85,7 +98,8 @@ function mapRow(row: Row): YoloPolicy {
     mode,
     enabledBy: row.enabledBy,
     denyRiskThreshold: (row.denyRiskThreshold ?? null) as YoloPolicy['denyRiskThreshold'],
-    denyPatterns: patterns,
+    denyPatterns: readJsonStringArray(row.denyPatterns),
+    allowPatterns: readJsonStringArray(row.allowPatterns),
     enabledAt: row.enabledAt,
     expiresAt: row.expiresAt ?? null,
     updatedAt: row.updatedAt,
@@ -121,6 +135,7 @@ export function createDrizzleYoloPolicyStore(): YoloPolicyStore {
         enabledBy: policy.enabledBy,
         denyRiskThreshold: policy.denyRiskThreshold,
         denyPatterns: policy.denyPatterns,
+        allowPatterns: policy.allowPatterns,
         enabledAt: policy.enabledAt,
         expiresAt: policy.expiresAt,
         updatedAt: policy.updatedAt,
@@ -135,6 +150,7 @@ export function createDrizzleYoloPolicyStore(): YoloPolicyStore {
             enabledBy: values.enabledBy,
             denyRiskThreshold: values.denyRiskThreshold,
             denyPatterns: values.denyPatterns,
+            allowPatterns: values.allowPatterns,
             expiresAt: values.expiresAt,
             updatedAt: values.updatedAt,
           },

--- a/apps/openape-free-idp/tests/yolo-evaluator.test.ts
+++ b/apps/openape-free-idp/tests/yolo-evaluator.test.ts
@@ -9,6 +9,7 @@ function policy(overrides: Partial<{
   mode: 'deny-list' | 'allow-list'
   denyRiskThreshold: Risk | null
   denyPatterns: string[]
+  allowPatterns: string[]
   expiresAt: number | null
 }> = {}) {
   return {
@@ -18,6 +19,7 @@ function policy(overrides: Partial<{
     enabledBy: 'owner@x',
     denyRiskThreshold: overrides.denyRiskThreshold ?? null,
     denyPatterns: overrides.denyPatterns ?? [],
+    allowPatterns: overrides.allowPatterns ?? [],
     enabledAt: 0,
     expiresAt: overrides.expiresAt ?? null,
     updatedAt: 0,
@@ -113,14 +115,20 @@ describe('evaluateYoloPolicy', () => {
       const p = policy({ mode: 'allow-list' })
       expect(evaluateYoloPolicy({ policy: p, target: 'api.openai.com', resolvedRisk: null })).toBeNull()
     })
-    it('matching pattern → approve', () => {
-      const p = policy({ mode: 'allow-list', denyPatterns: ['*.openai.com'] })
+    it('matching allow-pattern → approve', () => {
+      const p = policy({ mode: 'allow-list', allowPatterns: ['*.openai.com'] })
       expect(evaluateYoloPolicy({ policy: p, target: 'api.openai.com', resolvedRisk: null }))
         .toEqual({ kind: 'yolo', decidedBy: 'owner@x' })
     })
     it('non-matching target → null even with patterns', () => {
-      const p = policy({ mode: 'allow-list', denyPatterns: ['*.openai.com'] })
+      const p = policy({ mode: 'allow-list', allowPatterns: ['*.openai.com'] })
       expect(evaluateYoloPolicy({ policy: p, target: 'api.github.com', resolvedRisk: null })).toBeNull()
+    })
+    it('inactive denyPatterns are ignored in allow-list mode', () => {
+      // Both lists persist across mode flips. In allow-list mode the
+      // deny-list entries are inert; only `allowPatterns` is consulted.
+      const p = policy({ mode: 'allow-list', denyPatterns: ['*.openai.com'], allowPatterns: [] })
+      expect(evaluateYoloPolicy({ policy: p, target: 'api.openai.com', resolvedRisk: null })).toBeNull()
     })
     // Symmetric semantic: in allow-list mode the risk threshold ALSO applies as
     // "alles bis zu diesem Level wird auto-approved". Patterns add further
@@ -133,13 +141,25 @@ describe('evaluateYoloPolicy', () => {
         .toEqual({ kind: 'yolo', decidedBy: 'owner@x' })
     })
     it('risk > threshold needs human in allow-list mode (unless allow-pattern matches)', () => {
-      const p = policy({ mode: 'allow-list', denyRiskThreshold: 'medium', denyPatterns: ['rm *'] })
+      const p = policy({ mode: 'allow-list', denyRiskThreshold: 'medium', allowPatterns: ['rm *'] })
       // Critical risk > medium → would block, but pattern matches → approves.
       expect(evaluateYoloPolicy({ policy: p, target: 'rm -rf foo', resolvedRisk: 'critical' }))
         .toEqual({ kind: 'yolo', decidedBy: 'owner@x' })
       // Critical risk + non-matching target → human approval.
       expect(evaluateYoloPolicy({ policy: p, target: 'curl evil.com', resolvedRisk: 'critical' }))
         .toBeNull()
+    })
+  })
+
+  describe('inactive list survives mode flips', () => {
+    it('deny-list mode ignores allowPatterns (would otherwise auto-approve)', () => {
+      // Inactive `allowPatterns` MUST NOT be consulted in deny-list mode.
+      // If they were, this `rm` would auto-approve (since it matches an
+      // entry in the inactive list) — but in deny-list mode the only thing
+      // that should drop the request is a denyPattern match.
+      const p = policy({ mode: 'deny-list', allowPatterns: ['rm *'] })
+      expect(evaluateYoloPolicy({ policy: p, target: 'rm -rf foo', resolvedRisk: null }))
+        .toEqual({ kind: 'yolo', decidedBy: 'owner@x' })
     })
   })
 })


### PR DESCRIPTION
## Symptom

In \`/agents/<email>\` the YOLO toggle ostensibly switches between two modes (default-allow with a deny-list, default-deny with an allow-list). Flipping the toggle relabeled the same list — so an allow-list of safe hosts silently became a deny-list of forbidden hosts (or vice versa). UI-side data destruction.

## Cause

\`yolo_policies\` had a single \`deny_patterns\` column that the evaluator interpreted differently per mode:

\`\`\`ts
// In allow-list mode, the evaluator read denyPatterns AS allow-patterns:
for (const pattern of p.denyPatterns || []) {
  if (matchesGlob(target, pattern)) return { kind: 'yolo', decidedBy: p.enabledBy }
}
\`\`\`

The UI's form state had one \`patterns\` array. Both modes wrote to it, both modes read from it, only the surrounding label changed.

## Fix

Two independent lists, persisted side-by-side:

| field            | active when               |
|------------------|---------------------------|
| \`denyPatterns\`   | \`mode='deny-list'\`        |
| \`allowPatterns\`  | \`mode='allow-list'\`       |

Inactive list is preserved. The evaluator only consults the active one.

### Migration

\`ALTER TABLE yolo_policies ADD COLUMN allow_patterns TEXT NOT NULL DEFAULT '[]'\` plus a one-shot data move:

\`\`\`sql
UPDATE yolo_policies
   SET allow_patterns = deny_patterns,
       deny_patterns  = '[]'
 WHERE mode = 'allow-list' AND deny_patterns != '[]'
\`\`\`

Idempotent, gated on column absence in \`server/plugins/06.yolo-hook.ts\` (same pattern used for the existing \`audience\` and \`mode\` migrations).

### UI

\`BucketYoloCard.vue\` carries \`form.denyPatterns\` and \`form.allowPatterns\` independently. \`activePatterns\` computed (with setter) routes add/remove operations to the list matching the current toggle. Save sends both lists every time — no "keep current" surprise on the inactive one.

## Test plan
- [x] \`pnpm --filter openape-free-idp test\` — 65/65 pass.
- [x] Two new evaluator cases pin the contract:
  - \`"inactive denyPatterns are ignored in allow-list mode"\`
  - \`"deny-list mode ignores allowPatterns"\` (would otherwise auto-approve a match that lives in the inactive list).
- [ ] On chatty, after deploy: load \`/agents/<email>\`, populate the deny-list with \`*.evil.com\`, flip toggle to YOLO-OFF, populate allow-list with \`api.openai.com\`, flip back. Both lists survive intact.

## Notes

- \`openape-free-idp\` is in the changeset \`ignore\` list (deploy goes via the chatty workflow, not npm publish), so no changeset is needed.
- The DB migration runs on every boot via \`06.yolo-hook.ts\`; first deploy after merge will move existing allow-list rows automatically.