### PR TITLE
feat(apes): apes agents register/spawn/list/destroy

### DIFF
--- a/packages/apes/README.md
+++ b/packages/apes/README.md
@@ -149,8 +149,17 @@ Goodbye.
 | `apes login` | PKCE browser login or ed25519 key-based agent login |
 | `apes logout` | Clear stored auth |
 | `apes whoami` | Show current identity |
-| `apes enroll` | Enroll an agent at the IdP |
+| `apes enroll` | Enroll an agent at the IdP (interactive, browser approval) |
 | `apes register-user` | Register a new human user |
+
+### Agents
+
+| Command | Description |
+|---|---|
+| `apes agents register --name <n> --public-key <line>` | Register an agent at the IdP using a public key supplied by the agent. Returns the assigned email so the agent can `apes login` from its own machine. |
+| `apes agents spawn <n>` | macOS-only. Provision a local agent end-to-end: macOS user, ed25519 keypair, IdP registration, agent token, ape-shell as login shell, Claude Code Bash hook. Privileged setup runs through `apes run --as root` (DDISA-approved). |
+| `apes agents list [--json] [--include-inactive]` | List agents owned by the current user, with local OS-user cross-reference. |
+| `apes agents destroy <n> [--force] [--soft] [--keep-os-user]` | Tear down an agent. Idempotent; safe for CI with `--force`. |
 
 ### Grants
 
@@ -184,6 +193,54 @@ Auth and config are stored in `~/.config/apes/`:
 apes config get defaults.idp
 apes config set defaults.idp https://id.example.com
 ```
+
+## Spawning ephemeral agents (macOS)
+
+`apes agents spawn <name>` provisions a complete local agent in one shot:
+
+```bash
+apes login patrick@hofmann.eco
+apes agents spawn agent-a
+# → DDISA approval prompt for the as=root grant (one-time per spawn)
+# → "Agent agent-a spawned. Run: apes run --as agent-a -- claude --session-name agent-a --dangerously-skip-permissions"
+
+apes agents list
+# NAME     EMAIL                                          ACTIVE  OS-USER  HOME
+# agent-a  agent-a+patrick+hofmann_eco@id.openape.ai      ✓       ✓        /Users/agent-a
+
+apes run --as agent-a -- claude --session-name agent-a --dangerously-skip-permissions
+# Claude Code runs as agent-a; every Bash tool call is rewritten to
+# `ape-shell -c <cmd>` by ~/.claude/hooks/bash-via-ape-shell.sh, so the
+# agent cannot run a shell command without an apes grant.
+
+apes agents destroy agent-a --force
+# → DDISA approval for the as=root teardown grant; agent and OS user are gone
+```
+
+Pre-flight requirements (one-time):
+
+```bash
+echo "$(which ape-shell)" | sudo tee -a /etc/shells
+# `escapes` (Rust setuid binary) installed on PATH for `apes run --as root`
+```
+
+For remote agents that run on another machine, register without provisioning:
+
+```bash
+# On the agent's machine:
+ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519 -N ""
+
+# On your machine (logged in as the parent):
+apes agents register --name agent-x --public-key "$(ssh agent-host cat ~/.ssh/id_ed25519.pub)" --json
+# → {"email":"agent-x+patrick+hofmann_eco@id.openape.ai","name":"agent-x","owner":"patrick@hofmann.eco","approver":"patrick@hofmann.eco","idp":"https://id.openape.ai"}
+
+# Tell the agent to log in:
+# apes login --idp https://id.openape.ai --email agent-x+patrick+hofmann_eco@id.openape.ai --key ~/.ssh/id_ed25519
+```
+
+`destroy --keep-os-user --force` reverses just the IdP side without invoking
+`apes run --as root`, so it's safe for CI loops where no DDISA approver is
+available.
 
 ## MCP Server
 

--- a/packages/apes/scripts/bash-via-ape-shell.sh
+++ b/packages/apes/scripts/bash-via-ape-shell.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# PreToolUse hook for the Bash tool: rewrite the tool input so the
+# original command runs via `ape-shell -c <cmd>`. That re-routes every
+# Bash invocation through the apes grant flow, so the agent cannot
+# execute shell commands without an approved grant.
+exec python3 -c '
+import json, shlex, sys
+data = json.load(sys.stdin)
+cmd = data["tool_input"]["command"]
+wrapped = "ape-shell -c " + shlex.quote(cmd)
+out = {"hookSpecificOutput": {"hookEventName": "PreToolUse", "updatedToolInput": {"command": wrapped}}}
+print(json.dumps(out))
+'

--- a/packages/apes/src/cli.ts
+++ b/packages/apes/src/cli.ts
@@ -18,6 +18,7 @@ import { delegateCommand } from './commands/grants/delegate'
 import { delegationsCommand } from './commands/grants/delegations'
 import { delegationRevokeCommand } from './commands/grants/delegation-revoke'
 import { adminCommand } from './commands/admin/index'
+import { agentsCommand } from './commands/agents/index'
 import { adapterCommand } from './commands/adapter/index'
 import { runCommand } from './commands/run'
 import { proxyCommand } from './commands/proxy'
@@ -140,6 +141,7 @@ const main = defineCommand({
     whoami: whoamiCommand,
     health: healthCommand,
     grants: grantsCommand,
+    agents: agentsCommand,
     admin: adminCommand,
     run: runCommand,
     proxy: proxyCommand,

--- a/packages/apes/src/commands/agents/destroy.ts
+++ b/packages/apes/src/commands/agents/destroy.ts
@@ -1,0 +1,130 @@
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { defineCommand } from 'citty'
+import consola from 'consola'
+import { getIdpUrl, loadAuth } from '../../config'
+import { CliError, CliExit } from '../../errors'
+import { apiFetch } from '../../http'
+import { AGENT_NAME_REGEX, buildDestroyTeardownScript } from '../../lib/agent-bootstrap'
+import { isDarwin, readMacOSUser, whichBinary } from '../../lib/macos-user'
+
+interface IdpUser {
+  email: string
+  name: string
+  owner: string | null
+  isActive: boolean
+}
+
+export const destroyAgentCommand = defineCommand({
+  meta: {
+    name: 'destroy',
+    description: 'Tear down an agent: remove macOS user, hard-delete IdP agent, drop all SSH keys',
+  },
+  args: {
+    name: {
+      type: 'positional',
+      description: 'Agent name to destroy',
+      required: true,
+    },
+    force: {
+      type: 'boolean',
+      description: 'Skip the interactive confirmation. Required for CI.',
+    },
+    soft: {
+      type: 'boolean',
+      description: 'Soft deactivate at the IdP (PATCH isActive=false) instead of hard-delete',
+    },
+    'keep-os-user': {
+      type: 'boolean',
+      description: 'Skip OS-side teardown. Useful for CI where the agent has no OS user.',
+    },
+  },
+  async run({ args }) {
+    const name = args.name as string
+    if (!AGENT_NAME_REGEX.test(name)) {
+      throw new CliError(
+        `Invalid agent name "${name}". Must match /^[a-z][a-z0-9-]{0,23}$/.`,
+      )
+    }
+
+    const auth = loadAuth()
+    if (!auth) {
+      throw new CliError('Not authenticated. Run `apes login` first.')
+    }
+    const idp = getIdpUrl()
+    if (!idp) {
+      throw new CliError('No IdP URL configured. Run `apes login` first.')
+    }
+
+    const owned = await apiFetch<IdpUser[]>('/api/my-agents', { idp })
+    const idpAgent = owned.find(u => u.name === name)
+    const idpExists = idpAgent !== undefined
+
+    const osUserExists = !args['keep-os-user'] && isDarwin() && readMacOSUser(name) !== null
+
+    if (!idpExists && !osUserExists) {
+      consola.info(`Nothing to destroy: no IdP agent and no OS user named "${name}".`)
+      return
+    }
+
+    if (!args.force) {
+      const consequences: string[] = []
+      if (osUserExists) consequences.push(`• Remove macOS user ${name} and rm -rf /Users/${name}`)
+      if (idpExists) {
+        consequences.push(args.soft
+          ? `• Deactivate IdP agent ${idpAgent!.email} (PATCH isActive=false)`
+          : `• Hard-delete IdP agent ${idpAgent!.email} and all its SSH keys`)
+      }
+      consola.warn(`About to destroy "${name}":\n${consequences.join('\n')}`)
+      const confirmed = await consola.prompt('Proceed?', { type: 'confirm', initial: false })
+      if (typeof confirmed === 'symbol' || !confirmed) {
+        throw new CliExit(0)
+      }
+    }
+
+    if (osUserExists) {
+      const apes = whichBinary('apes')
+      if (!apes) {
+        throw new CliError('`apes` not found on PATH. Install @openape/apes globally first.')
+      }
+      const escapes = whichBinary('escapes')
+      if (!escapes) {
+        throw new CliError('`escapes` not found on PATH; OS teardown requires escapes.')
+      }
+      const scratch = mkdtempSync(join(tmpdir(), `apes-destroy-${name}-`))
+      const scriptPath = join(scratch, 'teardown.sh')
+      try {
+        const script = buildDestroyTeardownScript({ name, homeDir: `/Users/${name}` })
+        writeFileSync(scriptPath, script, { mode: 0o700 })
+        consola.start('Running teardown as root via `apes run --as root`…')
+        consola.info('You will be asked to approve the as=root grant in your DDISA inbox.')
+        execFileSync(apes, ['run', '--as', 'root', '--', 'bash', scriptPath], { stdio: 'inherit' })
+      }
+      finally {
+        rmSync(scratch, { recursive: true, force: true })
+      }
+    }
+    else if (!args['keep-os-user'] && isDarwin()) {
+      consola.info('No macOS user to remove (skipped).')
+    }
+
+    if (idpExists) {
+      const id = encodeURIComponent(idpAgent!.email)
+      if (args.soft) {
+        await apiFetch(`/api/my-agents/${id}`, { method: 'PATCH', body: { isActive: false }, idp })
+        consola.success(`Deactivated IdP agent ${idpAgent!.email}`)
+      }
+      else {
+        await apiFetch(`/api/my-agents/${id}`, { method: 'DELETE', idp })
+        consola.success(`Deleted IdP agent ${idpAgent!.email}`)
+      }
+    }
+    else {
+      consola.info('No IdP agent to remove (skipped).')
+    }
+
+    consola.success(`Destroyed ${name}.`)
+  },
+})

--- a/packages/apes/src/commands/agents/index.ts
+++ b/packages/apes/src/commands/agents/index.ts
@@ -1,0 +1,18 @@
+import { defineCommand } from 'citty'
+import { destroyAgentCommand } from './destroy'
+import { listAgentsCommand } from './list'
+import { registerAgentCommand } from './register'
+import { spawnAgentCommand } from './spawn'
+
+export const agentsCommand = defineCommand({
+  meta: {
+    name: 'agents',
+    description: 'Manage owned agents (register, spawn, list, destroy)',
+  },
+  subCommands: {
+    register: registerAgentCommand,
+    spawn: spawnAgentCommand,
+    list: listAgentsCommand,
+    destroy: destroyAgentCommand,
+  },
+})

--- a/packages/apes/src/commands/agents/list.ts
+++ b/packages/apes/src/commands/agents/list.ts
@@ -1,0 +1,81 @@
+import { defineCommand } from 'citty'
+import consola from 'consola'
+import { getIdpUrl, loadAuth } from '../../config'
+import { CliError } from '../../errors'
+import { apiFetch } from '../../http'
+import { isDarwin, listMacOSUserNames } from '../../lib/macos-user'
+
+interface IdpUser {
+  email: string
+  name: string
+  owner: string | null
+  approver: string | null
+  type: string | null
+  isActive: boolean
+  createdAt: number
+}
+
+export const listAgentsCommand = defineCommand({
+  meta: {
+    name: 'list',
+    description: 'List agents owned by the current user, with local OS-user status',
+  },
+  args: {
+    json: {
+      type: 'boolean',
+      description: 'Output as JSON',
+    },
+    'include-inactive': {
+      type: 'boolean',
+      description: 'Include agents whose IdP record is deactivated (default hides them)',
+    },
+  },
+  async run({ args }) {
+    const auth = loadAuth()
+    if (!auth) {
+      throw new CliError('Not authenticated. Run `apes login` first.')
+    }
+    const idp = getIdpUrl()
+    if (!idp) {
+      throw new CliError('No IdP URL configured. Run `apes login` first.')
+    }
+
+    const all = await apiFetch<IdpUser[]>('/api/my-agents', { idp })
+    const filtered = args['include-inactive']
+      ? all
+      : all.filter(u => u.isActive !== false)
+
+    const osUsers = isDarwin() ? listMacOSUserNames() : new Set<string>()
+    const home = (name: string) => `/Users/${name}`
+
+    const rows = filtered.map(u => ({
+      name: u.name,
+      email: u.email,
+      isActive: u.isActive !== false,
+      osUser: osUsers.has(u.name),
+      home: osUsers.has(u.name) ? home(u.name) : null,
+    }))
+
+    if (args.json) {
+      process.stdout.write(`${JSON.stringify(rows, null, 2)}\n`)
+      return
+    }
+
+    if (rows.length === 0) {
+      consola.info(args['include-inactive'] ? 'No agents found.' : 'No active agents found. Use --include-inactive to show deactivated.')
+      return
+    }
+
+    const nameW = Math.max(4, ...rows.map(r => r.name.length))
+    const emailW = Math.max(5, ...rows.map(r => r.email.length))
+    const header = `${'NAME'.padEnd(nameW)}  ${'EMAIL'.padEnd(emailW)}  ACTIVE  OS-USER  HOME`
+    console.log(header)
+    console.log('-'.repeat(header.length))
+    for (const r of rows) {
+      const active = r.isActive ? '✓' : '✗'
+      const os = r.osUser ? '✓' : '✗'
+      const homeCol = r.home ?? (isDarwin() ? '(missing)' : '(non-darwin)')
+      console.log(`${r.name.padEnd(nameW)}  ${r.email.padEnd(emailW)}  ${active.padEnd(6)}  ${os.padEnd(7)}  ${homeCol}`)
+    }
+  },
+})

--- a/packages/apes/src/commands/agents/register.ts
+++ b/packages/apes/src/commands/agents/register.ts
@@ -1,0 +1,99 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { defineCommand } from 'citty'
+import consola from 'consola'
+import { getIdpUrl, loadAuth } from '../../config'
+import { CliError } from '../../errors'
+import { AGENT_NAME_REGEX, registerAgentAtIdp, SSH_ED25519_PREFIX, SSH_ED25519_REGEX } from '../../lib/agent-bootstrap'
+
+export const registerAgentCommand = defineCommand({
+  meta: {
+    name: 'register',
+    description: 'Register an agent at the IdP using a supplied public key',
+  },
+  args: {
+    name: {
+      type: 'string',
+      description: 'Agent name (lowercase, [a-z0-9-], 1–24 chars, must start with a letter)',
+      required: true,
+    },
+    'public-key': {
+      type: 'string',
+      description: 'Full ssh-ed25519 public key line (e.g. "ssh-ed25519 AAAAC3...")',
+    },
+    'public-key-file': {
+      type: 'string',
+      description: 'Path to a .pub file containing the ssh-ed25519 line',
+    },
+    json: {
+      type: 'boolean',
+      description: 'Emit machine-readable JSON instead of a human summary',
+    },
+  },
+  async run({ args }) {
+    const auth = loadAuth()
+    if (!auth) {
+      throw new CliError('Not authenticated. Run `apes login` first.')
+    }
+
+    const idp = getIdpUrl()
+    if (!idp) {
+      throw new CliError('No IdP URL configured. Run `apes login` first.')
+    }
+
+    const name = args.name
+    if (!AGENT_NAME_REGEX.test(name)) {
+      throw new CliError(
+        `Invalid agent name "${name}". Must match /^[a-z][a-z0-9-]{0,23}$/ — `
+        + `lowercase letters, digits and hyphens, 1–24 chars, must start with a letter.`,
+      )
+    }
+
+    let publicKey: string | undefined = args['public-key']
+    const keyFile = args['public-key-file']
+
+    if (publicKey && keyFile) {
+      throw new CliError('Pass either --public-key or --public-key-file, not both.')
+    }
+
+    if (!publicKey && keyFile) {
+      if (!existsSync(keyFile)) {
+        throw new CliError(`Public-key file not found: ${keyFile}`)
+      }
+      publicKey = readFileSync(keyFile, 'utf-8').trim()
+    }
+
+    if (!publicKey) {
+      throw new CliError('Provide --public-key "<ssh-ed25519 line>" or --public-key-file <path>.')
+    }
+
+    if (!publicKey.startsWith(SSH_ED25519_PREFIX) || !SSH_ED25519_REGEX.test(publicKey)) {
+      throw new CliError(
+        'Public key must be a full ssh-ed25519 line, e.g. '
+        + '"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA... [optional comment]".',
+      )
+    }
+
+    const result = await registerAgentAtIdp({ name, publicKey, idp })
+
+    if (args.json) {
+      process.stdout.write(`${JSON.stringify({
+        email: result.email,
+        name: result.name,
+        owner: result.owner,
+        approver: result.approver,
+        idp,
+      })}\n`)
+      return
+    }
+
+    consola.success('Agent registered.')
+    console.log(`  Name:     ${result.name}`)
+    console.log(`  Email:    ${result.email}`)
+    console.log(`  IdP:      ${idp}`)
+    console.log(`  Owner:    ${result.owner}`)
+    console.log(`  Approver: ${result.approver}`)
+    console.log('')
+    console.log('Tell the agent to log in with:')
+    console.log(`  apes login --idp ${idp} --email ${result.email} --key <path-to-matching-private-key>`)
+  },
+})

--- a/packages/apes/src/commands/agents/spawn.ts
+++ b/packages/apes/src/commands/agents/spawn.ts
@@ -1,0 +1,146 @@
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { defineCommand } from 'citty'
+import consola from 'consola'
+import { getIdpUrl, loadAuth } from '../../config'
+import { CliError } from '../../errors'
+import {
+  AGENT_NAME_REGEX,
+  BASH_VIA_APE_SHELL_HOOK_SOURCE,
+  buildAgentAuthJson,
+  buildSpawnSetupScript,
+  CLAUDE_SETTINGS_JSON,
+  issueAgentToken,
+  registerAgentAtIdp,
+} from '../../lib/agent-bootstrap'
+import { generateKeyPairInMemory } from '../../lib/keygen'
+import { isDarwin, isShellRegistered, readMacOSUser, whichBinary } from '../../lib/macos-user'
+
+export const spawnAgentCommand = defineCommand({
+  meta: {
+    name: 'spawn',
+    description: 'Provision a local macOS agent end-to-end (OS user, keypair, IdP agent, ape-shell, Claude hook)',
+  },
+  args: {
+    name: {
+      type: 'positional',
+      description: 'Agent name — also the macOS short username (lowercase, [a-z0-9-], must start with a letter)',
+      required: true,
+    },
+    shell: {
+      type: 'string',
+      description: 'Override login shell. Default: $(which ape-shell)',
+    },
+    'no-claude-hook': {
+      type: 'boolean',
+      description: 'Skip writing ~/.claude/settings.json + the Bash-rewrite hook',
+    },
+  },
+  async run({ args }) {
+    const name = args.name as string
+    if (!AGENT_NAME_REGEX.test(name)) {
+      throw new CliError(
+        `Invalid agent name "${name}". Must match /^[a-z][a-z0-9-]{0,23}$/ — `
+        + `lowercase letters, digits and hyphens, 1–24 chars, must start with a letter.`,
+      )
+    }
+
+    if (!isDarwin()) {
+      throw new CliError(
+        `\`apes agents spawn\` is currently macOS-only. Detected platform: ${process.platform}. `
+        + `Linux support is a follow-up; for now, use \`apes agents register\` plus a manually provisioned user.`,
+      )
+    }
+
+    const auth = loadAuth()
+    if (!auth) {
+      throw new CliError('Not authenticated. Run `apes login` first.')
+    }
+    const idp = getIdpUrl()
+    if (!idp) {
+      throw new CliError('No IdP URL configured. Run `apes login` first.')
+    }
+
+    const apeShell = args.shell ?? whichBinary('ape-shell')
+    if (!apeShell) {
+      throw new CliError('`ape-shell` not found on PATH. Install @openape/apes globally first.')
+    }
+    const apes = whichBinary('apes')
+    if (!apes) {
+      throw new CliError('`apes` not found on PATH. Install @openape/apes globally first.')
+    }
+    const escapes = whichBinary('escapes')
+    if (!escapes) {
+      throw new CliError(
+        '`escapes` not found on PATH. spawn delegates the privileged setup phase to escapes; '
+        + 'install it before running spawn.',
+      )
+    }
+    if (!isShellRegistered(apeShell)) {
+      throw new CliError(
+        `${apeShell} is not registered in /etc/shells. macOS refuses to set it as a login shell. Run:\n`
+        + `  echo ${apeShell} | sudo tee -a /etc/shells\n`
+        + 'and try again.',
+      )
+    }
+
+    const existing = readMacOSUser(name)
+    if (existing) {
+      throw new CliError(`macOS user "${name}" already exists (uid=${existing.uid ?? '?'}). Refusing to overwrite.`)
+    }
+
+    const homeDir = `/Users/${name}`
+    const scratch = mkdtempSync(join(tmpdir(), `apes-spawn-${name}-`))
+    const scriptPath = join(scratch, 'setup.sh')
+
+    try {
+      consola.start(`Generating keypair for ${name}…`)
+      const { privatePem, publicSshLine } = generateKeyPairInMemory()
+
+      consola.start(`Registering agent at ${idp}…`)
+      const registration = await registerAgentAtIdp({ name, publicKey: publicSshLine, idp })
+      consola.success(`Registered as ${registration.email}`)
+
+      consola.start('Issuing agent access token…')
+      const { token, expiresIn } = await issueAgentToken({
+        idp,
+        agentEmail: registration.email,
+        privateKeyPem: privatePem,
+      })
+
+      const authJson = buildAgentAuthJson({
+        idp,
+        accessToken: token,
+        email: registration.email,
+        expiresAt: Math.floor(Date.now() / 1000) + expiresIn,
+      })
+
+      const includeClaudeHook = !args['no-claude-hook']
+      const script = buildSpawnSetupScript({
+        name,
+        homeDir,
+        shellPath: apeShell,
+        privateKeyPem: privatePem,
+        publicKeySshLine: publicSshLine,
+        authJson,
+        claudeSettingsJson: includeClaudeHook ? CLAUDE_SETTINGS_JSON : null,
+        hookScriptSource: includeClaudeHook ? BASH_VIA_APE_SHELL_HOOK_SOURCE : null,
+      })
+      writeFileSync(scriptPath, script, { mode: 0o700 })
+
+      consola.start('Running privileged setup as root via `apes run --as root`…')
+      consola.info('You will be asked to approve the as=root grant in your DDISA inbox.')
+      execFileSync(apes, ['run', '--as', 'root', '--', 'bash', scriptPath], { stdio: 'inherit' })
+
+      consola.success(`Agent ${name} spawned.`)
+      console.log('')
+      console.log('Run as the agent with:')
+      console.log(`  apes run --as ${name} -- claude --session-name ${name} --dangerously-skip-permissions`)
+    }
+    finally {
+      rmSync(scratch, { recursive: true, force: true })
+    }
+  },
+})

--- a/packages/apes/src/commands/enroll.ts
+++ b/packages/apes/src/commands/enroll.ts
@@ -1,14 +1,13 @@
 import { Buffer } from 'node:buffer'
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import { execFile } from 'node:child_process'
-import { generateKeyPairSync, sign } from 'node:crypto'
-import { dirname, resolve } from 'node:path'
-import { homedir } from 'node:os'
+import { sign } from 'node:crypto'
 import { defineCommand } from 'citty'
 import consola from 'consola'
 import { loadEd25519PrivateKey } from '../ssh-key'
-import { getAgentChallengeEndpoint, getAgentAuthenticateEndpoint } from '../http'
-import { saveAuth, saveConfig, loadConfig } from '../config'
+import { generateAndSaveKey, readPublicKey, resolveKeyPath } from '../lib/keygen'
+import { getAgentAuthenticateEndpoint, getAgentChallengeEndpoint } from '../http'
+import { loadConfig, saveAuth, saveConfig } from '../config'
 import { CliError, CliExit } from '../errors'
 
 const DEFAULT_IDP_URL = 'https://id.openape.at'
@@ -16,67 +15,9 @@ const DEFAULT_KEY_PATH = '~/.ssh/id_ed25519'
 const POLL_INTERVAL = 3000
 const POLL_TIMEOUT = 300_000 // 5 minutes
 
-function resolvePath(p: string): string {
-  return resolve(p.replace(/^~/, homedir()))
-}
-
 function openBrowser(url: string) {
   const cmd = process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'start' : 'xdg-open'
   execFile(cmd, [url], () => {})
-}
-
-function readPublicKey(keyPath: string): string {
-  const pubPath = `${keyPath}.pub`
-  if (existsSync(pubPath)) {
-    return readFileSync(pubPath, 'utf-8').trim()
-  }
-
-  // Derive public key from private key
-  const keyContent = readFileSync(keyPath, 'utf-8')
-  const privateKey = loadEd25519PrivateKey(keyContent)
-  const jwk = privateKey.export({ format: 'jwk' }) as { x: string }
-  const pubBytes = Buffer.from(jwk.x, 'base64url')
-
-  // Format as OpenSSH public key
-  const keyTypeStr = 'ssh-ed25519'
-  const keyTypeLen = Buffer.alloc(4)
-  keyTypeLen.writeUInt32BE(keyTypeStr.length)
-  const pubKeyLen = Buffer.alloc(4)
-  pubKeyLen.writeUInt32BE(pubBytes.length)
-  const blob = Buffer.concat([keyTypeLen, Buffer.from(keyTypeStr), pubKeyLen, pubBytes])
-
-  return `ssh-ed25519 ${blob.toString('base64')}`
-}
-
-function generateAndSaveKey(keyPath: string): string {
-  const resolved = resolvePath(keyPath)
-  const dir = dirname(resolved)
-
-  if (!existsSync(dir)) {
-    mkdirSync(dir, { recursive: true })
-  }
-
-  // Generate Ed25519 key pair
-  const { publicKey, privateKey } = generateKeyPairSync('ed25519')
-
-  // Export private key in PKCS8 PEM format (universally readable)
-  const privatePem = privateKey.export({ type: 'pkcs8', format: 'pem' }) as string
-  writeFileSync(resolved, privatePem, { mode: 0o600 })
-
-  // Export public key in OpenSSH format
-  const jwk = publicKey.export({ format: 'jwk' }) as { x: string }
-  const pubBytes = Buffer.from(jwk.x, 'base64url')
-  const keyTypeStr = 'ssh-ed25519'
-  const keyTypeLen = Buffer.alloc(4)
-  keyTypeLen.writeUInt32BE(keyTypeStr.length)
-  const pubKeyLen = Buffer.alloc(4)
-  pubKeyLen.writeUInt32BE(pubBytes.length)
-  const blob = Buffer.concat([keyTypeLen, Buffer.from(keyTypeStr), pubKeyLen, pubBytes])
-  const pubKeyStr = `ssh-ed25519 ${blob.toString('base64')}`
-
-  writeFileSync(`${resolved}.pub`, `${pubKeyStr}\n`, { mode: 0o644 })
-
-  return pubKeyStr
 }
 
 async function pollForEnrollment(
@@ -84,7 +25,7 @@ async function pollForEnrollment(
   agentEmail: string,
   keyPath: string,
 ): Promise<{ token: string, expiresIn: number }> {
-  const resolvedKey = resolvePath(keyPath)
+  const resolvedKey = resolveKeyPath(keyPath)
   const keyContent = readFileSync(resolvedKey, 'utf-8')
   const privateKey = loadEd25519PrivateKey(keyContent)
 
@@ -164,7 +105,7 @@ export const enrollCommand = defineCommand({
       || DEFAULT_KEY_PATH
 
     // 2. Handle key
-    const resolvedKey = resolvePath(keyPath)
+    const resolvedKey = resolveKeyPath(keyPath)
     let publicKey: string
 
     if (existsSync(resolvedKey)) {

--- a/packages/apes/src/lib/agent-bootstrap.ts
+++ b/packages/apes/src/lib/agent-bootstrap.ts
@@ -1,0 +1,254 @@
+import { Buffer } from 'node:buffer'
+import { createPrivateKey, sign } from 'node:crypto'
+import { apiFetch, getAgentAuthenticateEndpoint, getAgentChallengeEndpoint } from '../http'
+
+export const AGENT_NAME_REGEX = /^[a-z][a-z0-9-]{0,23}$/
+export const SSH_ED25519_PREFIX = 'ssh-ed25519 '
+export const SSH_ED25519_REGEX = /^ssh-ed25519 [A-Za-z0-9+/=]+(\s.*)?$/
+
+export interface RegisterAgentResponse {
+  email: string
+  name: string
+  owner: string
+  approver: string
+  status: string
+}
+
+export async function registerAgentAtIdp(input: {
+  name: string
+  publicKey: string
+  idp?: string
+}): Promise<RegisterAgentResponse> {
+  return await apiFetch<RegisterAgentResponse>('/api/enroll', {
+    method: 'POST',
+    body: { name: input.name, publicKey: input.publicKey },
+    idp: input.idp,
+  })
+}
+
+export interface IssuedAgentToken {
+  token: string
+  expiresIn: number
+}
+
+/**
+ * Single-shot challenge/authenticate using a privately held PEM key.
+ * Used by `spawn` after registering the agent: we already know the keypair
+ * works (we just generated it), so we skip the polling loop in `enroll.ts`.
+ */
+export async function issueAgentToken(input: {
+  idp: string
+  agentEmail: string
+  privateKeyPem: string
+}): Promise<IssuedAgentToken> {
+  const privateKey = createPrivateKey(input.privateKeyPem)
+
+  const challengeUrl = await getAgentChallengeEndpoint(input.idp)
+  const challengeResp = await fetch(challengeUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ agent_id: input.agentEmail }),
+  })
+  if (!challengeResp.ok) {
+    const text = await challengeResp.text().catch(() => '')
+    throw new Error(`Challenge failed (${challengeResp.status}): ${text}`)
+  }
+  const { challenge } = await challengeResp.json() as { challenge: string }
+
+  const signature = sign(null, Buffer.from(challenge), privateKey).toString('base64')
+
+  const authenticateUrl = await getAgentAuthenticateEndpoint(input.idp)
+  const authResp = await fetch(authenticateUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ agent_id: input.agentEmail, challenge, signature }),
+  })
+  if (!authResp.ok) {
+    const text = await authResp.text().catch(() => '')
+    throw new Error(`Authenticate failed (${authResp.status}): ${text}`)
+  }
+  const result = await authResp.json() as { token: string, expires_in: number }
+  return { token: result.token, expiresIn: result.expires_in || 3600 }
+}
+
+export interface SpawnSetupScriptInput {
+  name: string
+  homeDir: string
+  shellPath: string
+  privateKeyPem: string
+  publicKeySshLine: string
+  authJson: string
+  claudeSettingsJson: string | null
+  hookScriptSource: string | null
+}
+
+const SH_HEREDOC_DELIMITER = 'APES_HEREDOC_END'
+
+function shHeredoc(content: string): string {
+  if (content.includes(SH_HEREDOC_DELIMITER)) {
+    throw new Error(`Refusing to emit heredoc: content contains ${SH_HEREDOC_DELIMITER}`)
+  }
+  return `<< '${SH_HEREDOC_DELIMITER}'\n${content}\n${SH_HEREDOC_DELIMITER}`
+}
+
+export function buildSpawnSetupScript(input: SpawnSetupScriptInput): string {
+  const { name, homeDir, shellPath } = input
+
+  // Trailing newline on PEM keeps OpenSSL happy. JSON files we write as-is.
+  const privatePemForHeredoc = input.privateKeyPem.endsWith('\n')
+    ? input.privateKeyPem
+    : `${input.privateKeyPem}\n`
+
+  const claudeBlock = input.claudeSettingsJson && input.hookScriptSource
+    ? `
+mkdir -p "$HOME_DIR/.claude/hooks"
+cat > "$HOME_DIR/.claude/settings.json" ${shHeredoc(input.claudeSettingsJson)}
+cat > "$HOME_DIR/.claude/hooks/bash-via-ape-shell.sh" ${shHeredoc(input.hookScriptSource)}
+chmod 755 "$HOME_DIR/.claude/hooks/bash-via-ape-shell.sh"
+`
+    : ''
+
+  return `#!/bin/bash
+set -euo pipefail
+
+NAME=${shQuote(name)}
+HOME_DIR=${shQuote(homeDir)}
+SHELL_PATH=${shQuote(shellPath)}
+
+if dscl . -read "/Users/$NAME" >/dev/null 2>&1; then
+  echo "User $NAME already exists; refusing to overwrite." >&2
+  exit 1
+fi
+
+# Pick the next free UID in the [200, 500) hidden service-account range.
+# Starts the running max at 199 so an empty range yields 200 after the
+# floor check; otherwise NEXT_UID = max(existing in-range UIDs) + 1.
+NEXT_UID=199
+for uid in $(dscl . -list /Users UniqueID | awk '$2 >= 200 && $2 < 500 {print $2}'); do
+  if [ "$uid" -ge "$NEXT_UID" ]; then
+    NEXT_UID=$((uid + 1))
+  fi
+done
+if [ "$NEXT_UID" -lt 200 ]; then
+  NEXT_UID=200
+fi
+if [ "$NEXT_UID" -ge 500 ]; then
+  echo "No free UID in [200, 500) — refusing to clobber a real user." >&2
+  exit 1
+fi
+
+dscl . -create "/Users/$NAME"
+dscl . -create "/Users/$NAME" UserShell "$SHELL_PATH"
+dscl . -create "/Users/$NAME" RealName "OpenApe Agent $NAME"
+dscl . -create "/Users/$NAME" UniqueID "$NEXT_UID"
+dscl . -create "/Users/$NAME" PrimaryGroupID 20
+dscl . -create "/Users/$NAME" NFSHomeDirectory "$HOME_DIR"
+dscl . -create "/Users/$NAME" IsHidden 1
+
+mkdir -p "$HOME_DIR/.ssh" "$HOME_DIR/.config/apes"
+
+cat > "$HOME_DIR/.ssh/id_ed25519" ${shHeredoc(privatePemForHeredoc.trimEnd())}
+cat > "$HOME_DIR/.ssh/id_ed25519.pub" ${shHeredoc(`${input.publicKeySshLine}`)}
+cat > "$HOME_DIR/.config/apes/auth.json" ${shHeredoc(input.authJson)}
+${claudeBlock}
+chown -R "$NAME:staff" "$HOME_DIR"
+chmod 700 "$HOME_DIR/.ssh"
+chmod 700 "$HOME_DIR/.config"
+chmod 600 "$HOME_DIR/.ssh/id_ed25519"
+chmod 644 "$HOME_DIR/.ssh/id_ed25519.pub"
+chmod 600 "$HOME_DIR/.config/apes/auth.json"
+
+echo "OK $NAME uid=$NEXT_UID home=$HOME_DIR"
+`
+}
+
+export interface DestroyTeardownScriptInput {
+  name: string
+  homeDir: string
+}
+
+export function buildDestroyTeardownScript(input: DestroyTeardownScriptInput): string {
+  const { name, homeDir } = input
+  return `#!/bin/bash
+# Best-effort teardown. set -u catches typos; we deliberately do NOT use -e
+# because pkill / launchctl are allowed to fail when the user has no live
+# sessions, and dscl -delete is allowed to fail when the user is already gone.
+set -u
+
+NAME=${shQuote(name)}
+HOME_DIR=${shQuote(homeDir)}
+
+UID_OF=$(dscl . -read "/Users/$NAME" UniqueID 2>/dev/null | awk '/UniqueID:/ {print $2}')
+
+if [ -n "$UID_OF" ]; then
+  launchctl bootout "user/$UID_OF" 2>/dev/null || true
+  pkill -9 -u "$UID_OF" 2>/dev/null || true
+fi
+
+if [ -d "$HOME_DIR" ] && [ "$HOME_DIR" != "/" ] && [ "$HOME_DIR" != "" ]; then
+  rm -rf "$HOME_DIR"
+fi
+
+dscl . -delete "/Users/$NAME" 2>/dev/null || true
+
+echo "OK destroyed $NAME"
+`
+}
+
+/**
+ * Quote a string for safe use as a single bash argument.
+ * Wraps in single quotes and escapes embedded single quotes.
+ */
+export function shQuote(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`
+}
+
+export interface AuthJsonInput {
+  idp: string
+  accessToken: string
+  email: string
+  expiresAt: number
+}
+
+export function buildAgentAuthJson(input: AuthJsonInput): string {
+  return `${JSON.stringify({
+    idp: input.idp,
+    access_token: input.accessToken,
+    email: input.email,
+    expires_at: input.expiresAt,
+  }, null, 2)}\n`
+}
+
+export const CLAUDE_SETTINGS_JSON: string = `${JSON.stringify({
+  hooks: {
+    PreToolUse: [
+      {
+        matcher: 'Bash',
+        hooks: [
+          { type: 'command', command: '$HOME/.claude/hooks/bash-via-ape-shell.sh' },
+        ],
+      },
+    ],
+  },
+}, null, 2)}\n`
+
+/**
+ * Inlined source of `packages/apes/scripts/bash-via-ape-shell.sh`.
+ * Kept identical to the .sh file via the bundled-hook-source.test.ts
+ * drift check; resolving the file at runtime is unreliable across
+ * dev/built/installed layouts, so we embed once at build time.
+ */
+export const BASH_VIA_APE_SHELL_HOOK_SOURCE = `#!/bin/bash
+# PreToolUse hook for the Bash tool: rewrite the tool input so the
+# original command runs via \`ape-shell -c <cmd>\`. That re-routes every
+# Bash invocation through the apes grant flow, so the agent cannot
+# execute shell commands without an approved grant.
+exec python3 -c '
+import json, shlex, sys
+data = json.load(sys.stdin)
+cmd = data["tool_input"]["command"]
+wrapped = "ape-shell -c " + shlex.quote(cmd)
+out = {"hookSpecificOutput": {"hookEventName": "PreToolUse", "updatedToolInput": {"command": wrapped}}}
+print(json.dumps(out))
+'
+`

--- a/packages/apes/src/lib/keygen.ts
+++ b/packages/apes/src/lib/keygen.ts
@@ -1,0 +1,71 @@
+import { Buffer } from 'node:buffer'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { generateKeyPairSync } from 'node:crypto'
+import { homedir } from 'node:os'
+import { dirname, resolve } from 'node:path'
+import { loadEd25519PrivateKey } from '../ssh-key'
+
+export function resolveKeyPath(p: string): string {
+  return resolve(p.replace(/^~/, homedir()))
+}
+
+function buildSshEd25519Line(rawPub: Buffer): string {
+  const keyTypeStr = 'ssh-ed25519'
+  const keyTypeLen = Buffer.alloc(4)
+  keyTypeLen.writeUInt32BE(keyTypeStr.length)
+  const pubKeyLen = Buffer.alloc(4)
+  pubKeyLen.writeUInt32BE(rawPub.length)
+  const blob = Buffer.concat([keyTypeLen, Buffer.from(keyTypeStr), pubKeyLen, rawPub])
+  return `ssh-ed25519 ${blob.toString('base64')}`
+}
+
+export function readPublicKey(keyPath: string): string {
+  const pubPath = `${keyPath}.pub`
+  if (existsSync(pubPath)) {
+    return readFileSync(pubPath, 'utf-8').trim()
+  }
+
+  const keyContent = readFileSync(keyPath, 'utf-8')
+  const privateKey = loadEd25519PrivateKey(keyContent)
+  const jwk = privateKey.export({ format: 'jwk' }) as { x: string }
+  const pubBytes = Buffer.from(jwk.x, 'base64url')
+  return buildSshEd25519Line(pubBytes)
+}
+
+export function generateAndSaveKey(keyPath: string): string {
+  const resolved = resolveKeyPath(keyPath)
+  const dir = dirname(resolved)
+
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true })
+  }
+
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519')
+
+  const privatePem = privateKey.export({ type: 'pkcs8', format: 'pem' }) as string
+  writeFileSync(resolved, privatePem, { mode: 0o600 })
+
+  const jwk = publicKey.export({ format: 'jwk' }) as { x: string }
+  const pubBytes = Buffer.from(jwk.x, 'base64url')
+  const pubKeyStr = buildSshEd25519Line(pubBytes)
+
+  writeFileSync(`${resolved}.pub`, `${pubKeyStr}\n`, { mode: 0o644 })
+
+  return pubKeyStr
+}
+
+export interface GeneratedKeyPair {
+  privatePem: string
+  publicSshLine: string
+}
+
+export function generateKeyPairInMemory(): GeneratedKeyPair {
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519')
+  const privatePem = privateKey.export({ type: 'pkcs8', format: 'pem' }) as string
+  const jwk = publicKey.export({ format: 'jwk' }) as { x: string }
+  const pubBytes = Buffer.from(jwk.x, 'base64url')
+  return {
+    privatePem,
+    publicSshLine: buildSshEd25519Line(pubBytes),
+  }
+}

--- a/packages/apes/src/lib/macos-user.ts
+++ b/packages/apes/src/lib/macos-user.ts
@@ -1,0 +1,91 @@
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+
+export interface MacOSUserSummary {
+  name: string
+  uid: number | null
+  shell: string | null
+}
+
+export function isDarwin(): boolean {
+  return process.platform === 'darwin'
+}
+
+/**
+ * Read a single user via `dscl . -read /Users/<name>`.
+ * Returns null when the user doesn't exist (dscl exits non-zero with a
+ * `eDSRecordNotFound`-style error). Any other error propagates.
+ */
+export function readMacOSUser(name: string): MacOSUserSummary | null {
+  let output: string
+  try {
+    output = execFileSync('dscl', ['.', '-read', `/Users/${name}`], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+  }
+  catch {
+    return null
+  }
+
+  const uidMatch = output.match(/UniqueID:\s*(\d+)/)
+  const shellMatch = output.match(/UserShell:\s*(\S.*)$/m)
+  return {
+    name,
+    uid: uidMatch ? Number.parseInt(uidMatch[1]!, 10) : null,
+    shell: shellMatch ? shellMatch[1]!.trim() : null,
+  }
+}
+
+/**
+ * List all macOS user names via `dscl . -list /Users`.
+ * Returns the raw set of names (no filtering), one per line.
+ */
+export function listMacOSUserNames(): Set<string> {
+  let output: string
+  try {
+    output = execFileSync('dscl', ['.', '-list', '/Users'], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+  }
+  catch {
+    return new Set()
+  }
+  return new Set(
+    output
+      .split('\n')
+      .map(line => line.trim())
+      .filter(line => line.length > 0),
+  )
+}
+
+/**
+ * Resolve a binary on PATH using `which`. Returns the absolute path or null.
+ */
+export function whichBinary(name: string): string | null {
+  try {
+    const out = execFileSync('which', [name], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim()
+    return out || null
+  }
+  catch {
+    return null
+  }
+}
+
+/**
+ * Check whether the given shell path is registered in /etc/shells. macOS
+ * (and chsh on most Unixes) refuses to set a login shell that isn't listed.
+ */
+export function isShellRegistered(shellPath: string): boolean {
+  if (!existsSync('/etc/shells')) return false
+  const content = readFileSync('/etc/shells', 'utf-8')
+  return content
+    .split('\n')
+    .map(l => l.trim())
+    .filter(l => l && !l.startsWith('#'))
+    .includes(shellPath)
+}

--- a/packages/apes/test/agents-bash-hook-source.test.ts
+++ b/packages/apes/test/agents-bash-hook-source.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { BASH_VIA_APE_SHELL_HOOK_SOURCE } from '../src/lib/agent-bootstrap'
+
+// Drift check: the inlined hook source in agent-bootstrap.ts must stay
+// byte-identical to scripts/bash-via-ape-shell.sh. We embed at build time
+// (rather than fs-resolve at runtime) because the script lives at different
+// relative paths in dev vs. installed layouts; this test guards the inline.
+describe('bundled bash-via-ape-shell hook source', () => {
+  const here = dirname(fileURLToPath(import.meta.url))
+  const scriptPath = resolve(here, '../scripts/bash-via-ape-shell.sh')
+
+  it('matches the on-disk script byte-for-byte', () => {
+    const onDisk = readFileSync(scriptPath, 'utf-8')
+    expect(BASH_VIA_APE_SHELL_HOOK_SOURCE).toBe(onDisk)
+  })
+
+  it('starts with a bash shebang', () => {
+    expect(BASH_VIA_APE_SHELL_HOOK_SOURCE.startsWith('#!/bin/bash\n')).toBe(true)
+  })
+})

--- a/packages/apes/test/agents-bootstrap.test.ts
+++ b/packages/apes/test/agents-bootstrap.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  AGENT_NAME_REGEX,
+  buildAgentAuthJson,
+  buildDestroyTeardownScript,
+  buildSpawnSetupScript,
+  CLAUDE_SETTINGS_JSON,
+  registerAgentAtIdp,
+  shQuote,
+  SSH_ED25519_REGEX,
+} from '../src/lib/agent-bootstrap'
+
+vi.mock('../src/http.js', () => ({
+  apiFetch: vi.fn(),
+  getAgentChallengeEndpoint: vi.fn(async (idp: string) => `${idp}/api/agent/challenge`),
+  getAgentAuthenticateEndpoint: vi.fn(async (idp: string) => `${idp}/api/agent/authenticate`),
+}))
+
+describe('AGENT_NAME_REGEX', () => {
+  it.each([
+    ['agent-a', true],
+    ['a', true],
+    ['agent-1', true],
+    ['ABC', false],
+    ['1agent', false],
+    ['-leading', false],
+    [`too-long-${'x'.repeat(50)}`, false],
+    ['has space', false],
+    ['', false],
+  ])('matches %s -> %s', (name, expected) => {
+    expect(AGENT_NAME_REGEX.test(name)).toBe(expected)
+  })
+})
+
+describe('SSH_ED25519_REGEX', () => {
+  it('accepts a typical key with comment', () => {
+    expect(SSH_ED25519_REGEX.test('ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBz1WSDX me@host')).toBe(true)
+  })
+  it('accepts a key without comment', () => {
+    expect(SSH_ED25519_REGEX.test('ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBz1WSDX')).toBe(true)
+  })
+  it('rejects rsa', () => {
+    expect(SSH_ED25519_REGEX.test('ssh-rsa AAAA')).toBe(false)
+  })
+  it('rejects empty', () => {
+    expect(SSH_ED25519_REGEX.test('')).toBe(false)
+  })
+})
+
+describe('shQuote', () => {
+  it('wraps simple strings', () => {
+    expect(shQuote('agent-a')).toBe(`'agent-a'`)
+  })
+  it('escapes embedded single quotes', () => {
+    expect(shQuote(`it's`)).toBe(`'it'\\''s'`)
+  })
+})
+
+describe('buildAgentAuthJson', () => {
+  it('emits a stable, parseable auth.json', () => {
+    const out = buildAgentAuthJson({
+      idp: 'https://id.openape.ai',
+      accessToken: 'tok',
+      email: 'agent-a+patrick+hofmann_eco@id.openape.ai',
+      expiresAt: 1234567890,
+    })
+    const parsed = JSON.parse(out)
+    expect(parsed).toEqual({
+      idp: 'https://id.openape.ai',
+      access_token: 'tok',
+      email: 'agent-a+patrick+hofmann_eco@id.openape.ai',
+      expires_at: 1234567890,
+    })
+    expect(out.endsWith('\n')).toBe(true)
+  })
+})
+
+describe('CLAUDE_SETTINGS_JSON', () => {
+  it('registers a Bash PreToolUse hook pointing at the bundled script path', () => {
+    const parsed = JSON.parse(CLAUDE_SETTINGS_JSON)
+    const matchers = parsed.hooks.PreToolUse
+    expect(matchers).toHaveLength(1)
+    expect(matchers[0].matcher).toBe('Bash')
+    expect(matchers[0].hooks[0].command).toBe('$HOME/.claude/hooks/bash-via-ape-shell.sh')
+  })
+})
+
+describe('buildSpawnSetupScript', () => {
+  const baseInput = {
+    name: 'agent-a',
+    homeDir: '/Users/agent-a',
+    shellPath: '/usr/local/bin/ape-shell',
+    privateKeyPem: '-----BEGIN PRIVATE KEY-----\nDEADBEEF\n-----END PRIVATE KEY-----\n',
+    publicKeySshLine: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBz1WSDX',
+    authJson: '{"idp":"https://id.openape.ai"}\n',
+  }
+
+  it('with claude hook: includes settings.json + hook script blocks', () => {
+    const script = buildSpawnSetupScript({
+      ...baseInput,
+      claudeSettingsJson: CLAUDE_SETTINGS_JSON,
+      hookScriptSource: '#!/bin/bash\necho hi\n',
+    })
+    expect(script).toContain(`NAME='agent-a'`)
+    expect(script).toContain(`HOME_DIR='/Users/agent-a'`)
+    expect(script).toContain(`SHELL_PATH='/usr/local/bin/ape-shell'`)
+    expect(script).toContain('dscl . -create "/Users/$NAME" UserShell "$SHELL_PATH"')
+    expect(script).toContain('mkdir -p "$HOME_DIR/.claude/hooks"')
+    expect(script).toContain('chown -R "$NAME:staff" "$HOME_DIR"')
+    expect(script).toContain('chmod 600 "$HOME_DIR/.config/apes/auth.json"')
+    expect(script).toMatch(/refusing to overwrite/i)
+    expect(script).toContain('IsHidden 1')
+  })
+
+  it('without claude hook: no .claude blocks', () => {
+    const script = buildSpawnSetupScript({
+      ...baseInput,
+      claudeSettingsJson: null,
+      hookScriptSource: null,
+    })
+    expect(script).not.toContain('.claude')
+  })
+
+  it('refuses inputs that collide with the heredoc delimiter', () => {
+    expect(() => buildSpawnSetupScript({
+      ...baseInput,
+      privateKeyPem: 'APES_HEREDOC_END pwned',
+      claudeSettingsJson: null,
+      hookScriptSource: null,
+    })).toThrow(/Refusing to emit heredoc/)
+  })
+})
+
+describe('buildDestroyTeardownScript', () => {
+  it('produces a script that deletes the user and home dir', () => {
+    const script = buildDestroyTeardownScript({ name: 'agent-a', homeDir: '/Users/agent-a' })
+    expect(script).toContain(`NAME='agent-a'`)
+    expect(script).toContain(`HOME_DIR='/Users/agent-a'`)
+    expect(script).toContain('launchctl bootout "user/$UID_OF"')
+    expect(script).toContain('pkill -9 -u "$UID_OF"')
+    expect(script).toContain('rm -rf "$HOME_DIR"')
+    expect(script).toContain('dscl . -delete "/Users/$NAME"')
+  })
+
+  it('guards against empty/root home', () => {
+    const script = buildDestroyTeardownScript({ name: 'agent-a', homeDir: '/Users/agent-a' })
+    expect(script).toContain('"$HOME_DIR" != "/"')
+  })
+})
+
+describe('registerAgentAtIdp', () => {
+  it('POSTs to /api/enroll with name + publicKey and returns the IdP response', async () => {
+    const http = await import('../src/http.js')
+    ;(http.apiFetch as any).mockResolvedValue({
+      email: 'agent-a+patrick+hofmann_eco@id.openape.ai',
+      name: 'agent-a',
+      owner: 'patrick@hofmann.eco',
+      approver: 'patrick@hofmann.eco',
+      status: 'active',
+    })
+
+    const result = await registerAgentAtIdp({
+      name: 'agent-a',
+      publicKey: 'ssh-ed25519 AAAA...',
+      idp: 'https://id.openape.ai',
+    })
+    expect(http.apiFetch).toHaveBeenCalledWith('/api/enroll', {
+      method: 'POST',
+      body: { name: 'agent-a', publicKey: 'ssh-ed25519 AAAA...' },
+      idp: 'https://id.openape.ai',
+    })
+    expect(result.email).toBe('agent-a+patrick+hofmann_eco@id.openape.ai')
+  })
+})

--- a/packages/apes/test/agents-destroy.test.ts
+++ b/packages/apes/test/agents-destroy.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../src/config.js', () => ({
+  loadAuth: vi.fn(() => ({ idp: 'https://id.openape.ai', email: 'patrick@hofmann.eco', access_token: 't', expires_at: 9_999_999_999 })),
+  getIdpUrl: vi.fn(() => 'https://id.openape.ai'),
+}))
+
+vi.mock('../src/http.js', () => ({
+  apiFetch: vi.fn(),
+}))
+
+const macosUserMock = {
+  isDarwin: vi.fn(() => true),
+  readMacOSUser: vi.fn(),
+  whichBinary: vi.fn((name: string) => `/usr/local/bin/${name}`),
+  listMacOSUserNames: vi.fn(() => new Set<string>()),
+  isShellRegistered: vi.fn(),
+}
+vi.mock('../src/lib/macos-user.js', () => macosUserMock)
+
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn(),
+}))
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>()
+  return {
+    ...actual,
+    mkdtempSync: vi.fn(() => '/tmp/apes-destroy-test'),
+    rmSync: vi.fn(),
+    writeFileSync: vi.fn(),
+  }
+})
+
+const AGENT = {
+  email: 'agent-a+patrick+hofmann_eco@id.openape.ai',
+  name: 'agent-a',
+  owner: 'patrick@hofmann.eco',
+  isActive: true,
+}
+
+describe('apes agents destroy', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    macosUserMock.readMacOSUser.mockReturnValue(null)
+    macosUserMock.isDarwin.mockReturnValue(true)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.resetModules()
+  })
+
+  it('rejects an invalid agent name', async () => {
+    const { destroyAgentCommand } = await import('../src/commands/agents/destroy.js')
+    await expect((destroyAgentCommand as any).run({
+      args: { name: 'BadName', force: true },
+    })).rejects.toThrow(/Invalid agent name/)
+  })
+
+  it('exits cleanly when neither IdP agent nor OS user exists (idempotency)', async () => {
+    const { apiFetch } = await import('../src/http.js')
+    vi.mocked(apiFetch).mockResolvedValueOnce([] as any)
+    macosUserMock.readMacOSUser.mockReturnValue(null)
+
+    const { destroyAgentCommand } = await import('../src/commands/agents/destroy.js')
+    await (destroyAgentCommand as any).run({ args: { name: 'agent-a', force: true } })
+
+    expect(apiFetch).toHaveBeenCalledTimes(1)
+    expect(apiFetch).toHaveBeenCalledWith('/api/my-agents', { idp: 'https://id.openape.ai' })
+  })
+
+  it('hard-deletes the IdP agent when present and OS user is missing', async () => {
+    const { apiFetch } = await import('../src/http.js')
+    vi.mocked(apiFetch)
+      .mockResolvedValueOnce([AGENT] as any)
+      .mockResolvedValueOnce({ ok: true } as any)
+    macosUserMock.readMacOSUser.mockReturnValue(null)
+
+    const { destroyAgentCommand } = await import('../src/commands/agents/destroy.js')
+    await (destroyAgentCommand as any).run({ args: { name: 'agent-a', force: true } })
+
+    expect(apiFetch).toHaveBeenNthCalledWith(2, `/api/my-agents/${encodeURIComponent(AGENT.email)}`, {
+      method: 'DELETE',
+      idp: 'https://id.openape.ai',
+    })
+  })
+
+  it('--soft sends PATCH isActive=false instead of DELETE', async () => {
+    const { apiFetch } = await import('../src/http.js')
+    vi.mocked(apiFetch)
+      .mockResolvedValueOnce([AGENT] as any)
+      .mockResolvedValueOnce({ ...AGENT, isActive: false } as any)
+    macosUserMock.readMacOSUser.mockReturnValue(null)
+
+    const { destroyAgentCommand } = await import('../src/commands/agents/destroy.js')
+    await (destroyAgentCommand as any).run({ args: { name: 'agent-a', force: true, soft: true } })
+
+    expect(apiFetch).toHaveBeenNthCalledWith(2, `/api/my-agents/${encodeURIComponent(AGENT.email)}`, {
+      method: 'PATCH',
+      body: { isActive: false },
+      idp: 'https://id.openape.ai',
+    })
+  })
+
+  it('--keep-os-user skips the privileged escapes call entirely', async () => {
+    const { apiFetch } = await import('../src/http.js')
+    const { execFileSync } = await import('node:child_process')
+    vi.mocked(apiFetch)
+      .mockResolvedValueOnce([AGENT] as any)
+      .mockResolvedValueOnce({ ok: true } as any)
+    macosUserMock.readMacOSUser.mockReturnValue({ name: 'agent-a', uid: 250, shell: '/usr/local/bin/ape-shell' })
+
+    const { destroyAgentCommand } = await import('../src/commands/agents/destroy.js')
+    await (destroyAgentCommand as any).run({ args: { name: 'agent-a', force: true, 'keep-os-user': true } })
+
+    expect(execFileSync).not.toHaveBeenCalled()
+    expect(apiFetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('runs the teardown script via apes run --as root when OS user exists', async () => {
+    const { apiFetch } = await import('../src/http.js')
+    const { execFileSync } = await import('node:child_process')
+    vi.mocked(apiFetch)
+      .mockResolvedValueOnce([AGENT] as any)
+      .mockResolvedValueOnce({ ok: true } as any)
+    macosUserMock.readMacOSUser.mockReturnValue({ name: 'agent-a', uid: 250, shell: '/usr/local/bin/ape-shell' })
+
+    const { destroyAgentCommand } = await import('../src/commands/agents/destroy.js')
+    await (destroyAgentCommand as any).run({ args: { name: 'agent-a', force: true } })
+
+    expect(execFileSync).toHaveBeenCalledTimes(1)
+    const [bin, argv] = vi.mocked(execFileSync).mock.calls[0]!
+    expect(bin).toBe('/usr/local/bin/apes')
+    expect(argv).toEqual(['run', '--as', 'root', '--', 'bash', '/tmp/apes-destroy-test/teardown.sh'])
+  })
+})

--- a/packages/apes/test/agents-list.test.ts
+++ b/packages/apes/test/agents-list.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../src/config.js', () => ({
+  loadAuth: vi.fn(() => ({ idp: 'https://id.openape.ai', email: 'patrick@hofmann.eco', access_token: 't', expires_at: 9_999_999_999 })),
+  getIdpUrl: vi.fn(() => 'https://id.openape.ai'),
+}))
+
+vi.mock('../src/http.js', () => ({
+  apiFetch: vi.fn(),
+}))
+
+vi.mock('../src/lib/macos-user.js', () => ({
+  isDarwin: vi.fn(() => true),
+  listMacOSUserNames: vi.fn(() => new Set(['agent-a', 'patrick'])),
+  readMacOSUser: vi.fn(),
+  whichBinary: vi.fn(),
+  isShellRegistered: vi.fn(),
+}))
+
+const TWO_AGENTS = [
+  { email: 'agent-a+patrick+hofmann_eco@id.openape.ai', name: 'agent-a', owner: 'patrick@hofmann.eco', approver: 'patrick@hofmann.eco', type: 'agent', isActive: true, createdAt: 1 },
+  { email: 'agent-b+patrick+hofmann_eco@id.openape.ai', name: 'agent-b', owner: 'patrick@hofmann.eco', approver: 'patrick@hofmann.eco', type: 'agent', isActive: true, createdAt: 2 },
+  { email: 'old+patrick+hofmann_eco@id.openape.ai', name: 'old', owner: 'patrick@hofmann.eco', approver: 'patrick@hofmann.eco', type: 'agent', isActive: false, createdAt: 3 },
+]
+
+describe('apes agents list', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>
+  let writeSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+  })
+
+  afterEach(() => {
+    logSpy.mockRestore()
+    writeSpy.mockRestore()
+    vi.resetModules()
+  })
+
+  function output(): string {
+    return logSpy.mock.calls.map(c => c.join(' ')).join('\n')
+  }
+
+  it('default output hides inactive and shows OS-USER cross-reference', async () => {
+    const { apiFetch } = await import('../src/http.js')
+    vi.mocked(apiFetch).mockResolvedValueOnce(TWO_AGENTS as any)
+
+    const { listAgentsCommand } = await import('../src/commands/agents/list.js')
+    await (listAgentsCommand as any).run({ args: {} })
+
+    const out = output()
+    expect(out).toMatch(/agent-a/)
+    expect(out).toMatch(/agent-b/)
+    expect(out).not.toMatch(/\bold\b/)
+    expect(out).toContain('/Users/agent-a')
+    expect(out).toContain('(missing)')
+  })
+
+  it('--include-inactive shows deactivated agents', async () => {
+    const { apiFetch } = await import('../src/http.js')
+    vi.mocked(apiFetch).mockResolvedValueOnce(TWO_AGENTS as any)
+
+    const { listAgentsCommand } = await import('../src/commands/agents/list.js')
+    await (listAgentsCommand as any).run({ args: { 'include-inactive': true } })
+
+    const out = output()
+    expect(out).toMatch(/\bold\b/)
+  })
+
+  it('--json emits parseable array', async () => {
+    const { apiFetch } = await import('../src/http.js')
+    vi.mocked(apiFetch).mockResolvedValueOnce(TWO_AGENTS as any)
+
+    const { listAgentsCommand } = await import('../src/commands/agents/list.js')
+    await (listAgentsCommand as any).run({ args: { json: true } })
+
+    expect(writeSpy).toHaveBeenCalled()
+    const out = (writeSpy.mock.calls[0]![0] as string).trim()
+    const parsed = JSON.parse(out)
+    expect(parsed).toHaveLength(2)
+    expect(parsed[0]).toMatchObject({ name: 'agent-a', osUser: true, home: '/Users/agent-a', isActive: true })
+    expect(parsed[1]).toMatchObject({ name: 'agent-b', osUser: false, home: null })
+  })
+
+  it('GETs /api/my-agents with the configured idp', async () => {
+    const { apiFetch } = await import('../src/http.js')
+    vi.mocked(apiFetch).mockResolvedValueOnce([] as any)
+
+    const { listAgentsCommand } = await import('../src/commands/agents/list.js')
+    await (listAgentsCommand as any).run({ args: {} })
+
+    expect(apiFetch).toHaveBeenCalledWith('/api/my-agents', { idp: 'https://id.openape.ai' })
+  })
+})

--- a/packages/apes/test/agents-register.test.ts
+++ b/packages/apes/test/agents-register.test.ts
@@ -1,0 +1,118 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../src/config.js', () => ({
+  loadAuth: vi.fn(() => ({ idp: 'https://id.openape.ai', email: 'patrick@hofmann.eco', access_token: 't', expires_at: 9_999_999_999 })),
+  getIdpUrl: vi.fn(() => 'https://id.openape.ai'),
+}))
+
+vi.mock('../src/http.js', () => ({
+  apiFetch: vi.fn(),
+}))
+
+const REG_RESULT = {
+  email: 'agent-a+patrick+hofmann_eco@id.openape.ai',
+  name: 'agent-a',
+  owner: 'patrick@hofmann.eco',
+  approver: 'patrick@hofmann.eco',
+  status: 'active',
+}
+
+describe('apes agents register', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>
+  let writeSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+  })
+
+  afterEach(() => {
+    logSpy.mockRestore()
+    writeSpy.mockRestore()
+    vi.resetModules()
+  })
+
+  it('rejects an invalid agent name', async () => {
+    const { registerAgentCommand } = await import('../src/commands/agents/register.js')
+    await expect((registerAgentCommand as any).run({
+      args: { name: 'BadName', 'public-key': 'ssh-ed25519 AAAA' },
+    })).rejects.toThrow(/Invalid agent name/)
+  })
+
+  it('rejects a non-ssh-ed25519 public key', async () => {
+    const { registerAgentCommand } = await import('../src/commands/agents/register.js')
+    await expect((registerAgentCommand as any).run({
+      args: { name: 'agent-a', 'public-key': 'ssh-rsa AAAA' },
+    })).rejects.toThrow(/ssh-ed25519/)
+  })
+
+  it('rejects when both --public-key and --public-key-file are supplied', async () => {
+    const { registerAgentCommand } = await import('../src/commands/agents/register.js')
+    await expect((registerAgentCommand as any).run({
+      args: { name: 'agent-a', 'public-key': 'ssh-ed25519 AAAA', 'public-key-file': '/tmp/x' },
+    })).rejects.toThrow(/either --public-key or --public-key-file/)
+  })
+
+  it('reads --public-key-file and POSTs to /api/enroll with the parsed key', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'apes-reg-'))
+    const pubFile = join(dir, 'k.pub')
+    writeFileSync(pubFile, 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5 me@host\n')
+
+    try {
+      const { apiFetch } = await import('../src/http.js')
+      vi.mocked(apiFetch).mockResolvedValueOnce(REG_RESULT as any)
+
+      const { registerAgentCommand } = await import('../src/commands/agents/register.js')
+      await (registerAgentCommand as any).run({
+        args: { name: 'agent-a', 'public-key-file': pubFile },
+      })
+
+      expect(apiFetch).toHaveBeenCalledWith('/api/enroll', {
+        method: 'POST',
+        body: { name: 'agent-a', publicKey: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5 me@host' },
+        idp: 'https://id.openape.ai',
+      })
+    }
+    finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('--json emits a single line of parseable JSON to stdout', async () => {
+    const { apiFetch } = await import('../src/http.js')
+    vi.mocked(apiFetch).mockResolvedValueOnce(REG_RESULT as any)
+
+    const { registerAgentCommand } = await import('../src/commands/agents/register.js')
+    await (registerAgentCommand as any).run({
+      args: { name: 'agent-a', 'public-key': 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5', json: true },
+    })
+
+    expect(writeSpy).toHaveBeenCalled()
+    const out = (writeSpy.mock.calls[0]![0] as string).trim()
+    const parsed = JSON.parse(out)
+    expect(parsed).toEqual({
+      email: 'agent-a+patrick+hofmann_eco@id.openape.ai',
+      name: 'agent-a',
+      owner: 'patrick@hofmann.eco',
+      approver: 'patrick@hofmann.eco',
+      idp: 'https://id.openape.ai',
+    })
+  })
+
+  it('default output prints the login hint', async () => {
+    const { apiFetch } = await import('../src/http.js')
+    vi.mocked(apiFetch).mockResolvedValueOnce(REG_RESULT as any)
+
+    const { registerAgentCommand } = await import('../src/commands/agents/register.js')
+    await (registerAgentCommand as any).run({
+      args: { name: 'agent-a', 'public-key': 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5' },
+    })
+
+    const lines = logSpy.mock.calls.map(c => c.join(' ')).join('\n')
+    expect(lines).toContain('apes login --idp https://id.openape.ai --email agent-a+patrick+hofmann_eco@id.openape.ai')
+  })
+})

--- a/packages/apes/test/agents-roundtrip.live.test.ts
+++ b/packages/apes/test/agents-roundtrip.live.test.ts
@@ -1,0 +1,120 @@
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { randomBytes } from 'node:crypto'
+import { afterAll, describe, expect, it } from 'vitest'
+
+// LIVE-gated end-to-end roundtrip. Hits whatever IdP the local `apes login`
+// session points at, plus (for spawn/destroy) a working `escapes` install
+// and an approver willing to OK the as=root grant.
+//
+// Run with: LIVE=1 pnpm vitest run agents-roundtrip.live
+//
+// Two paths exercised:
+// 1. register → list → destroy --keep-os-user --force (no escapes needed)
+// 2. spawn → list (asserts OS user present) → destroy --force
+const SHOULD_RUN = process.env.LIVE === '1' || process.env.OPENAPE_LIVE_TEST === '1'
+
+const APES_BIN = process.env.APES_BIN || 'apes'
+
+function apes(...argv: string[]): string {
+  return execFileSync(APES_BIN, argv, { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'inherit'] })
+}
+
+function genName(prefix: string): string {
+  return `${prefix}-${randomBytes(3).toString('hex')}`
+}
+
+interface ListEntry {
+  email: string
+  name: string
+  isActive: boolean
+  osUser: boolean
+  home: string | null
+}
+
+function listAgentsJson(): ListEntry[] {
+  return JSON.parse(apes('agents', 'list', '--json'))
+}
+
+describe.skipIf(!SHOULD_RUN)('apes agents — LIVE roundtrip', () => {
+  const cleanupNames: string[] = []
+
+  afterAll(() => {
+    // Best-effort cleanup so failed mid-test runs don't leak agents.
+    for (const name of cleanupNames) {
+      try { apes('agents', 'destroy', name, '--keep-os-user', '--force') }
+      catch {}
+    }
+  })
+
+  it('register → list → destroy --keep-os-user --force', () => {
+    const name = genName('it-reg')
+    cleanupNames.push(name)
+
+    const tmp = mkdtempSync(join(tmpdir(), 'apes-it-'))
+    const keyPath = join(tmp, 'id_ed25519')
+    try {
+      execFileSync('ssh-keygen', ['-t', 'ed25519', '-f', keyPath, '-N', '', '-q', '-C', name], { stdio: 'ignore' })
+      const pub = readFileSync(`${keyPath}.pub`, 'utf-8').trim()
+
+      const out = apes('agents', 'register', '--name', name, '--public-key', pub, '--json').trim()
+      const reg = JSON.parse(out)
+      expect(reg.name).toBe(name)
+      expect(reg.email).toContain(`${name}+`)
+
+      const before = listAgentsJson()
+      expect(before.find(a => a.name === name)).toBeDefined()
+
+      apes('agents', 'destroy', name, '--keep-os-user', '--force')
+
+      const after = listAgentsJson()
+      expect(after.find(a => a.name === name)).toBeUndefined()
+    }
+    finally {
+      rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+
+  it.skipIf(!process.env.OPENAPE_LIVE_SPAWN)('spawn → list → destroy --force (requires OPENAPE_LIVE_SPAWN=1 and approver)', () => {
+    const name = genName('it-spw')
+    cleanupNames.push(name)
+
+    apes('agents', 'spawn', name, '--no-claude-hook')
+
+    const list = listAgentsJson()
+    const entry = list.find(a => a.name === name)
+    expect(entry).toBeDefined()
+    expect(entry!.osUser).toBe(true)
+    expect(entry!.home).toBe(`/Users/${name}`)
+
+    apes('agents', 'destroy', name, '--force')
+
+    const after = listAgentsJson()
+    expect(after.find(a => a.name === name)).toBeUndefined()
+
+    // Idempotency: a second destroy on a now-clean name is a no-op (exit 0).
+    apes('agents', 'destroy', name, '--force')
+  })
+
+  it('idempotent destroy on a name that never existed', () => {
+    const name = genName('it-noop')
+    apes('agents', 'destroy', name, '--keep-os-user', '--force')
+  })
+})
+
+// Stub spec ensures the file is picked up by the test runner even when
+// SHOULD_RUN is false; without it, `describe.skipIf(true)` produces "no tests
+// found" and the CLI exits non-zero.
+describe('apes agents — LIVE roundtrip (placeholder)', () => {
+  it('skipped unless LIVE=1', () => {
+    if (!SHOULD_RUN) {
+      console.log('agents-roundtrip.live: skipped (set LIVE=1 to run)')
+    }
+    expect(true).toBe(true)
+  })
+})
+
+// Silence unused-import warnings when SHOULD_RUN=false.
+void writeFileSync

--- a/packages/apes/test/agents-spawn.test.ts
+++ b/packages/apes/test/agents-spawn.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// ----------------------------------------------------------------------------
+// Mocks: spawn touches a lot of system surfaces, so we stub each one and let
+// the orchestration logic run end-to-end against the stubs.
+// ----------------------------------------------------------------------------
+
+vi.mock('../src/config.js', () => ({
+  loadAuth: vi.fn(() => ({ idp: 'https://id.openape.ai', email: 'patrick@hofmann.eco', access_token: 't', expires_at: 9_999_999_999 })),
+  getIdpUrl: vi.fn(() => 'https://id.openape.ai'),
+}))
+
+const macosUserMock = {
+  isDarwin: vi.fn(() => true),
+  readMacOSUser: vi.fn(() => null),
+  whichBinary: vi.fn((name: string) => `/usr/local/bin/${name}`),
+  isShellRegistered: vi.fn(() => true),
+  listMacOSUserNames: vi.fn(() => new Set<string>()),
+}
+vi.mock('../src/lib/macos-user.js', () => macosUserMock)
+
+vi.mock('../src/lib/keygen.js', async () => {
+  const actual = await vi.importActual<typeof import('../src/lib/keygen.js')>('../src/lib/keygen.js')
+  return {
+    ...actual,
+    generateKeyPairInMemory: vi.fn(() => ({
+      privatePem: '-----BEGIN PRIVATE KEY-----\nFAKE\n-----END PRIVATE KEY-----\n',
+      publicSshLine: 'ssh-ed25519 AAAAFAKE',
+    })),
+  }
+})
+
+const bootstrapMock = {
+  AGENT_NAME_REGEX: /^[a-z][a-z0-9-]{0,23}$/,
+  CLAUDE_SETTINGS_JSON: '{}',
+  BASH_VIA_APE_SHELL_HOOK_SOURCE: '#!/bin/bash\n',
+  registerAgentAtIdp: vi.fn(async () => ({
+    email: 'agent-a+patrick+hofmann_eco@id.openape.ai',
+    name: 'agent-a',
+    owner: 'patrick@hofmann.eco',
+    approver: 'patrick@hofmann.eco',
+    status: 'active',
+  })),
+  issueAgentToken: vi.fn(async () => ({ token: 'agent-token', expiresIn: 3600 })),
+  buildAgentAuthJson: vi.fn(() => '{"idp":"x"}\n'),
+  buildSpawnSetupScript: vi.fn(() => '#!/bin/bash\necho setup\n'),
+}
+vi.mock('../src/lib/agent-bootstrap.js', () => bootstrapMock)
+
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn(),
+}))
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>()
+  return {
+    ...actual,
+    mkdtempSync: vi.fn(() => '/tmp/apes-spawn-test'),
+    rmSync: vi.fn(),
+    writeFileSync: vi.fn(),
+  }
+})
+
+describe('apes agents spawn', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    macosUserMock.isDarwin.mockReturnValue(true)
+    macosUserMock.readMacOSUser.mockReturnValue(null)
+    macosUserMock.whichBinary.mockImplementation((name: string) => `/usr/local/bin/${name}`)
+    macosUserMock.isShellRegistered.mockReturnValue(true)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.resetModules()
+  })
+
+  it('rejects an invalid agent name', async () => {
+    const { spawnAgentCommand } = await import('../src/commands/agents/spawn.js')
+    await expect((spawnAgentCommand as any).run({
+      args: { name: 'BadName' },
+    })).rejects.toThrow(/Invalid agent name/)
+  })
+
+  it('rejects on non-darwin platforms', async () => {
+    macosUserMock.isDarwin.mockReturnValue(false)
+    const { spawnAgentCommand } = await import('../src/commands/agents/spawn.js')
+    await expect((spawnAgentCommand as any).run({
+      args: { name: 'agent-a' },
+    })).rejects.toThrow(/macOS-only/)
+  })
+
+  it('rejects when ape-shell is not in /etc/shells', async () => {
+    macosUserMock.isShellRegistered.mockReturnValue(false)
+    const { spawnAgentCommand } = await import('../src/commands/agents/spawn.js')
+    await expect((spawnAgentCommand as any).run({
+      args: { name: 'agent-a' },
+    })).rejects.toThrow(/not registered in \/etc\/shells/)
+  })
+
+  it('rejects when target macOS user already exists', async () => {
+    macosUserMock.readMacOSUser.mockReturnValue({ name: 'agent-a', uid: 250, shell: '/bin/zsh' })
+    const { spawnAgentCommand } = await import('../src/commands/agents/spawn.js')
+    await expect((spawnAgentCommand as any).run({
+      args: { name: 'agent-a' },
+    })).rejects.toThrow(/already exists/)
+  })
+
+  it('rejects when escapes binary is missing', async () => {
+    macosUserMock.whichBinary.mockImplementation((n: string) => n === 'escapes' ? null : `/usr/local/bin/${n}`)
+    const { spawnAgentCommand } = await import('../src/commands/agents/spawn.js')
+    await expect((spawnAgentCommand as any).run({
+      args: { name: 'agent-a' },
+    })).rejects.toThrow(/escapes/)
+  })
+
+  it('happy path: registers, issues token, runs setup via apes run --as root, cleans up', async () => {
+    const { execFileSync } = await import('node:child_process')
+    const { rmSync, writeFileSync } = await import('node:fs')
+
+    const { spawnAgentCommand } = await import('../src/commands/agents/spawn.js')
+    await (spawnAgentCommand as any).run({ args: { name: 'agent-a' } })
+
+    expect(bootstrapMock.registerAgentAtIdp).toHaveBeenCalledWith({
+      name: 'agent-a',
+      publicKey: 'ssh-ed25519 AAAAFAKE',
+      idp: 'https://id.openape.ai',
+    })
+    expect(bootstrapMock.issueAgentToken).toHaveBeenCalledWith({
+      idp: 'https://id.openape.ai',
+      agentEmail: 'agent-a+patrick+hofmann_eco@id.openape.ai',
+      privateKeyPem: '-----BEGIN PRIVATE KEY-----\nFAKE\n-----END PRIVATE KEY-----\n',
+    })
+    expect(bootstrapMock.buildSpawnSetupScript).toHaveBeenCalledTimes(1)
+    const buildArgs = bootstrapMock.buildSpawnSetupScript.mock.calls[0]![0] as any
+    expect(buildArgs.claudeSettingsJson).toBe('{}') // hook included by default
+    expect(buildArgs.shellPath).toBe('/usr/local/bin/ape-shell')
+
+    expect(writeFileSync).toHaveBeenCalledWith(
+      '/tmp/apes-spawn-test/setup.sh',
+      '#!/bin/bash\necho setup\n',
+      { mode: 0o700 },
+    )
+
+    expect(execFileSync).toHaveBeenCalledTimes(1)
+    const [bin, argv] = vi.mocked(execFileSync).mock.calls[0]!
+    expect(bin).toBe('/usr/local/bin/apes')
+    expect(argv).toEqual(['run', '--as', 'root', '--', 'bash', '/tmp/apes-spawn-test/setup.sh'])
+
+    expect(rmSync).toHaveBeenCalledWith('/tmp/apes-spawn-test', { recursive: true, force: true })
+  })
+
+  it('--no-claude-hook passes nulls for the claude settings + hook source', async () => {
+    const { spawnAgentCommand } = await import('../src/commands/agents/spawn.js')
+    await (spawnAgentCommand as any).run({ args: { name: 'agent-a', 'no-claude-hook': true } })
+
+    const buildArgs = bootstrapMock.buildSpawnSetupScript.mock.calls[0]![0] as any
+    expect(buildArgs.claudeSettingsJson).toBeNull()
+    expect(buildArgs.hookScriptSource).toBeNull()
+  })
+
+  it('cleans up the scratch dir even when escapes fails', async () => {
+    const { execFileSync } = await import('node:child_process')
+    vi.mocked(execFileSync).mockImplementation(() => { throw new Error('approval denied') })
+    const { rmSync } = await import('node:fs')
+
+    const { spawnAgentCommand } = await import('../src/commands/agents/spawn.js')
+    await expect((spawnAgentCommand as any).run({ args: { name: 'agent-a' } })).rejects.toThrow(/approval denied/)
+
+    expect(rmSync).toHaveBeenCalledWith('/tmp/apes-spawn-test', { recursive: true, force: true })
+  })
+})


### PR DESCRIPTION
## Summary

- Adds the **`apes agents`** namespace with four subcommands so spawning + tearing down ephemeral agents stops being a hand-assembly job:
  - `register --name X --public-key '<line>'` — parent-authenticated POST /api/enroll, returns the assigned agent email so a remote agent can `apes login` from its own machine.
  - `spawn <name>` (macOS) — generates an ed25519 keypair, registers it at the IdP, issues an agent access token, then runs a bash setup script under `apes run --as root` that creates a hidden macOS service user, places `~/.ssh/id_ed25519`, writes `~/.config/apes/auth.json`, sets ape-shell as login shell, and drops a Claude Code PreToolUse hook that rewrites every Bash tool call to `ape-shell -c '<cmd>'`. One DDISA approval per spawn, no `sudo` involved.
  - `list [--json] [--include-inactive]` — GET /api/my-agents with local /Users cross-reference (orphaned IdP agents show as `OS-USER ✗`).
  - `destroy <name> [--force] [--soft] [--keep-os-user]` — idempotent teardown, hard-delete by default, `--keep-os-user` skips the privileged escapes call so CI loops without an approver still work.
- Shared helpers (`packages/apes/src/lib/`): `agent-bootstrap.ts` (registerAgentAtIdp, issueAgentToken, setup-/teardown-script builders, inlined bash-via-ape-shell hook source guarded by a drift test), `macos-user.ts` (read-only dscl wrappers, /etc/shells check). `lib/keygen.ts` extracted from `commands/enroll.ts` so both flows share the same crypto.

## How the Claude hook works

```bash
~/.claude/settings.json  → PreToolUse on Bash → ~/.claude/hooks/bash-via-ape-shell.sh
                            → reads tool_input.command from stdin
                            → emits {"hookSpecificOutput":{"updatedToolInput":{"command":"ape-shell -c '<cmd>'"}}}
```

Shell command is mediated; Edit/Write/Read/Glob/Grep stay direct so the agent can still navigate the filesystem freely.

## Pre-flight (one-time per host)

```bash
echo "$(which ape-shell)" | sudo tee -a /etc/shells
# escapes installed on PATH for `apes run --as root`
```

## End-to-end use

```bash
apes login patrick@hofmann.eco
apes agents spawn agent-a
apes run --as agent-a -- claude --session-name agent-a --dangerously-skip-permissions
apes agents destroy agent-a --force
```

## Test plan

- [x] `pnpm --filter @openape/apes typecheck` — clean
- [x] `pnpm --filter @openape/apes lint` — only one pre-existing warning in `src/shapes/adapters.ts`
- [x] `pnpm --filter @openape/apes build` — clean, no `[INEFFECTIVE_DYNAMIC_IMPORT]` warnings
- [x] `pnpm exec vitest run` in `packages/apes` — **583 passed, 3 skipped** (3 LIVE-gated roundtrip cases). 50 new tests across 7 new test files cover validation paths, IdP-call sequencing, output formats, idempotency, and scratch-dir cleanup on failure for spawn.
- [ ] Manual macOS roundtrip on a host with `escapes` + `ape-shell` registered in `/etc/shells` — spawn, list, run claude as the agent, destroy.
- [ ] LIVE roundtrip: `LIVE=1 OPENAPE_LIVE_SPAWN=1 pnpm exec vitest run agents-roundtrip.live` against a local IdP.

## Out of scope

- Linux pathway for `spawn` (macOS only by decision; `register` is platform-agnostic and does work on Linux).
- `apes agents update` (rotate-key) — separate follow-up.