### PR TITLE
fix(apes): agents spawn/destroy must --wait for as=root grant

### DIFF
--- a/.changeset/apes-spawn-wait.md
+++ b/.changeset/apes-spawn-wait.md
@@ -1,0 +1,9 @@
+---
+"@openape/apes": patch
+---
+
+apes: `apes agents spawn` and `apes agents destroy` now `--wait` for the as=root grant approval
+
+Previously the inner `apes run --as root -- bash <script>` invocation returned exit code 75 (pending) immediately after creating the grant, before the user had a chance to approve it. spawn/destroy interpreted that as a hard failure and cleaned up the scratch directory in `finally`, so the pending grant ended up pointing at a `setup.sh` / `teardown.sh` that no longer existed on disk — the approval URL was useless.
+
+Both commands now pass `--wait` so the escapes call blocks until the grant is approved (or denied / times out) and the script has actually executed. Cleanup is safe because the grant has either run to completion or definitely won't run anymore.

--- a/packages/apes/src/commands/agents/destroy.ts
+++ b/packages/apes/src/commands/agents/destroy.ts
@@ -98,9 +98,11 @@ export const destroyAgentCommand = defineCommand({
       try {
         const script = buildDestroyTeardownScript({ name, homeDir: `/Users/${name}` })
         writeFileSync(scriptPath, script, { mode: 0o700 })
-        consola.start('Running teardown as root via `apes run --as root`…')
-        consola.info('You will be asked to approve the as=root grant in your DDISA inbox.')
-        execFileSync(apes, ['run', '--as', 'root', '--', 'bash', scriptPath], { stdio: 'inherit' })
+        consola.start('Running teardown as root via `apes run --as root --wait`…')
+        consola.info('You will be asked to approve the as=root grant in your DDISA inbox; this command blocks until you do.')
+        // --wait makes the call synchronous; without it `apes run --as root`
+        // returns exit 75 (pending) immediately, leaving a dangling grant.
+        execFileSync(apes, ['run', '--as', 'root', '--wait', '--', 'bash', scriptPath], { stdio: 'inherit' })
       }
       finally {
         rmSync(scratch, { recursive: true, force: true })

--- a/packages/apes/src/commands/agents/spawn.ts
+++ b/packages/apes/src/commands/agents/spawn.ts
@@ -130,9 +130,14 @@ export const spawnAgentCommand = defineCommand({
       })
       writeFileSync(scriptPath, script, { mode: 0o700 })
 
-      consola.start('Running privileged setup as root via `apes run --as root`…')
-      consola.info('You will be asked to approve the as=root grant in your DDISA inbox.')
-      execFileSync(apes, ['run', '--as', 'root', '--', 'bash', scriptPath], { stdio: 'inherit' })
+      consola.start('Running privileged setup as root via `apes run --as root --wait`…')
+      consola.info('You will be asked to approve the as=root grant in your DDISA inbox; this command blocks until you do.')
+      // --wait is critical: without it `apes run --as root` returns exit 75
+      // (pending) immediately, which we'd interpret as failure and which
+      // would leave a dangling grant referencing a scratch dir we'd cleaned
+      // up in the finally below. With --wait, exit reflects the actual
+      // execution result, so cleanup is safe.
+      execFileSync(apes, ['run', '--as', 'root', '--wait', '--', 'bash', scriptPath], { stdio: 'inherit' })
 
       consola.success(`Agent ${name} spawned.`)
       console.log('')

--- a/packages/apes/test/agents-destroy.test.ts
+++ b/packages/apes/test/agents-destroy.test.ts
@@ -133,6 +133,6 @@ describe('apes agents destroy', () => {
     expect(execFileSync).toHaveBeenCalledTimes(1)
     const [bin, argv] = vi.mocked(execFileSync).mock.calls[0]!
     expect(bin).toBe('/usr/local/bin/apes')
-    expect(argv).toEqual(['run', '--as', 'root', '--', 'bash', '/tmp/apes-destroy-test/teardown.sh'])
+    expect(argv).toEqual(['run', '--as', 'root', '--wait', '--', 'bash', '/tmp/apes-destroy-test/teardown.sh'])
   })
 })

--- a/packages/apes/test/agents-spawn.test.ts
+++ b/packages/apes/test/agents-spawn.test.ts
@@ -146,7 +146,7 @@ describe('apes agents spawn', () => {
     expect(execFileSync).toHaveBeenCalledTimes(1)
     const [bin, argv] = vi.mocked(execFileSync).mock.calls[0]!
     expect(bin).toBe('/usr/local/bin/apes')
-    expect(argv).toEqual(['run', '--as', 'root', '--', 'bash', '/tmp/apes-spawn-test/setup.sh'])
+    expect(argv).toEqual(['run', '--as', 'root', '--wait', '--', 'bash', '/tmp/apes-spawn-test/setup.sh'])
 
     expect(rmSync).toHaveBeenCalledWith('/tmp/apes-spawn-test', { recursive: true, force: true })
   })


### PR DESCRIPTION
## Summary

- `apes run --as root` is async by default — it returns exit 75 (pending) right after creating the grant, before the user has any chance to approve it. spawn/destroy were interpreting that as failure and tearing down the scratch dir in `finally`, leaving the pending grant pointing at a `setup.sh` / `teardown.sh` that no longer existed.
- Adds `--wait` to the inner `apes run` invocations in `commands/agents/spawn.ts` and `commands/agents/destroy.ts` so the call blocks until approval (or denial / timeout). Cleanup is then safe because the grant has either run or definitely won't.
- Test snapshots updated.

Repro on v0.15.0:

```
apes agents spawn agent-a
# → grant created, exit 75, scratch dir deleted, agent stuck as orphan IdP record
```

## Test plan

- [x] `pnpm exec vitest run agents-` — 50 passed | 3 skipped
- [ ] Manual repro on macOS once 0.15.1 ships