### PR TITLE
fix(apes): agents destroy — sysadminctl + token-fresh ordering

### DIFF
--- a/.changeset/apes-destroy-token-and-dscl.md
+++ b/.changeset/apes-destroy-token-and-dscl.md
@@ -1,0 +1,11 @@
+---
+"@openape/apes": patch
+---
+
+apes: `apes agents destroy` now uses `sysadminctl -deleteUser` and runs the IdP DELETE before the long-blocking `apes run --as root --wait`
+
+Two follow-up fixes to the v0.15.0 destroy flow surfaced during real-world use:
+
+- **`dscl . -delete` failed silently** and left orphaned macOS user records. The teardown script wrapped the call in `2>/dev/null || true` so a failure (Open Directory metadata still attached, etc.) was swallowed without trace — the home dir was `rm -rf`'d but `dscl . -read /Users/<n>` still returned a record afterwards. Now the script prefers `sysadminctl -deleteUser` (the canonical macOS API, which also removes Open Directory metadata), falls back to `dscl . -delete` only if `sysadminctl` is missing, propagates failures with a clear stderr message, and post-verifies the record is gone before printing `OK destroyed`.
+
+- **Token-expiry between the two destroy phases** stranded the IdP record when the approver took longer than the access-token TTL to approve the as=root grant. The IdP DELETE on `/api/my-agents/<id>` ran *after* the long-blocking `apes run --as root --wait` call, so for PKCE-only logins (no refresh path) the parent token had already expired by then. Now the IdP DELETE/PATCH happens *before* the escapes call — the token is fresh from preflight, the long approval wait happens after all IdP I/O is done. Idempotency is preserved: re-running destroy on a partially-cleaned agent skips the absent half cleanly.

--- a/packages/apes/src/commands/agents/destroy.ts
+++ b/packages/apes/src/commands/agents/destroy.ts
@@ -84,6 +84,25 @@ export const destroyAgentCommand = defineCommand({
       }
     }
 
+    // IdP-side first: while the parent's bearer is still fresh from preflight.
+    // The escapes step below blocks for human approval, which can take longer
+    // than the token's TTL — running the IdP DELETE after that wait would
+    // surface a stale-token error and leave the agent record orphaned.
+    if (idpExists) {
+      const id = encodeURIComponent(idpAgent!.email)
+      if (args.soft) {
+        await apiFetch(`/api/my-agents/${id}`, { method: 'PATCH', body: { isActive: false }, idp })
+        consola.success(`Deactivated IdP agent ${idpAgent!.email}`)
+      }
+      else {
+        await apiFetch(`/api/my-agents/${id}`, { method: 'DELETE', idp })
+        consola.success(`Deleted IdP agent ${idpAgent!.email}`)
+      }
+    }
+    else {
+      consola.info('No IdP agent to remove (skipped).')
+    }
+
     if (osUserExists) {
       const apes = whichBinary('apes')
       if (!apes) {
@@ -110,21 +129,6 @@ export const destroyAgentCommand = defineCommand({
     }
     else if (!args['keep-os-user'] && isDarwin()) {
       consola.info('No macOS user to remove (skipped).')
-    }
-
-    if (idpExists) {
-      const id = encodeURIComponent(idpAgent!.email)
-      if (args.soft) {
-        await apiFetch(`/api/my-agents/${id}`, { method: 'PATCH', body: { isActive: false }, idp })
-        consola.success(`Deactivated IdP agent ${idpAgent!.email}`)
-      }
-      else {
-        await apiFetch(`/api/my-agents/${id}`, { method: 'DELETE', idp })
-        consola.success(`Deleted IdP agent ${idpAgent!.email}`)
-      }
-    }
-    else {
-      consola.info('No IdP agent to remove (skipped).')
     }
 
     consola.success(`Destroyed ${name}.`)

--- a/packages/apes/src/lib/agent-bootstrap.ts
+++ b/packages/apes/src/lib/agent-bootstrap.ts
@@ -172,7 +172,7 @@ export function buildDestroyTeardownScript(input: DestroyTeardownScriptInput): s
   return `#!/bin/bash
 # Best-effort teardown. set -u catches typos; we deliberately do NOT use -e
 # because pkill / launchctl are allowed to fail when the user has no live
-# sessions, and dscl -delete is allowed to fail when the user is already gone.
+# sessions.
 set -u
 
 NAME=${shQuote(name)}
@@ -189,7 +189,32 @@ if [ -d "$HOME_DIR" ] && [ "$HOME_DIR" != "/" ] && [ "$HOME_DIR" != "" ]; then
   rm -rf "$HOME_DIR"
 fi
 
-dscl . -delete "/Users/$NAME" 2>/dev/null || true
+# Delete the user record. \`sysadminctl -deleteUser\` is the canonical macOS
+# API and removes Open Directory metadata that \`dscl . -delete\` leaves
+# behind. Fall back to dscl if sysadminctl isn't available or rejects the
+# user. Surface a clear error if both fail — silent failure here is what
+# left orphaned dscl records on previous spawn/destroy round-trips.
+if command -v sysadminctl >/dev/null 2>&1; then
+  if sysadminctl -deleteUser "$NAME" 2>/dev/null; then
+    :
+  elif dscl . -read "/Users/$NAME" >/dev/null 2>&1; then
+    dscl . -delete "/Users/$NAME" || {
+      echo "ERROR: failed to delete user record /Users/$NAME" >&2
+      exit 1
+    }
+  fi
+elif dscl . -read "/Users/$NAME" >/dev/null 2>&1; then
+  dscl . -delete "/Users/$NAME" || {
+    echo "ERROR: failed to delete user record /Users/$NAME" >&2
+    exit 1
+  }
+fi
+
+# Verify the record is actually gone.
+if dscl . -read "/Users/$NAME" >/dev/null 2>&1; then
+  echo "ERROR: user record /Users/$NAME still exists after teardown" >&2
+  exit 1
+fi
 
 echo "OK destroyed $NAME"
 `

--- a/packages/apes/test/agents-bootstrap.test.ts
+++ b/packages/apes/test/agents-bootstrap.test.ts
@@ -139,7 +139,14 @@ describe('buildDestroyTeardownScript', () => {
     expect(script).toContain('launchctl bootout "user/$UID_OF"')
     expect(script).toContain('pkill -9 -u "$UID_OF"')
     expect(script).toContain('rm -rf "$HOME_DIR"')
+    expect(script).toContain('sysadminctl -deleteUser "$NAME"')
     expect(script).toContain('dscl . -delete "/Users/$NAME"')
+  })
+
+  it('post-verifies the user record is actually gone (no silent failure)', () => {
+    const script = buildDestroyTeardownScript({ name: 'agent-a', homeDir: '/Users/agent-a' })
+    expect(script).toContain('still exists after teardown')
+    expect(script).toContain('exit 1')
   })
 
   it('guards against empty/root home', () => {

--- a/packages/apes/test/agents-destroy.test.ts
+++ b/packages/apes/test/agents-destroy.test.ts
@@ -135,4 +135,28 @@ describe('apes agents destroy', () => {
     expect(bin).toBe('/usr/local/bin/apes')
     expect(argv).toEqual(['run', '--as', 'root', '--wait', '--', 'bash', '/tmp/apes-destroy-test/teardown.sh'])
   })
+
+  it('issues IdP DELETE before the long-blocking escapes call (token-fresh order)', async () => {
+    const { apiFetch } = await import('../src/http.js')
+    const { execFileSync } = await import('node:child_process')
+    const callOrder: string[] = []
+    vi.mocked(apiFetch).mockImplementation(async (path: any, opts?: any) => {
+      callOrder.push(`apiFetch:${opts?.method ?? 'GET'}:${path}`)
+      if (typeof path === 'string' && path === '/api/my-agents') return [AGENT] as any
+      return { ok: true }
+    })
+    vi.mocked(execFileSync).mockImplementation(((..._args: any[]) => {
+      callOrder.push('execFileSync:apes-run-as-root')
+      return Buffer.alloc(0)
+    }) as any)
+    macosUserMock.readMacOSUser.mockReturnValue({ name: 'agent-a', uid: 250, shell: '/usr/local/bin/ape-shell' })
+
+    const { destroyAgentCommand } = await import('../src/commands/agents/destroy.js')
+    await (destroyAgentCommand as any).run({ args: { name: 'agent-a', force: true } })
+
+    const deleteIdx = callOrder.findIndex(c => c.includes('DELETE:/api/my-agents/'))
+    const escapesIdx = callOrder.findIndex(c => c === 'execFileSync:apes-run-as-root')
+    expect(deleteIdx).toBeGreaterThanOrEqual(0)
+    expect(escapesIdx).toBeGreaterThan(deleteIdx)
+  })
 })


### PR DESCRIPTION
## Summary

Two real-world bugs surfaced during a manual roundtrip of v0.15.1 spawn → destroy:

1. **`dscl . -delete` swallowed silent failures**, leaving orphaned macOS user records. Home dir was `rm -rf`'d, dscl record stayed. Cause: `2>/dev/null || true` in the teardown script. Fix: prefer `sysadminctl -deleteUser` (canonical macOS API, removes Open Directory metadata), `dscl . -delete` as fallback, fail loudly with a stderr message, and post-verify the record is gone before printing `OK destroyed`.
2. **IdP DELETE ran AFTER the long-blocking `apes run --as root --wait`**, so for PKCE-only logins (no refresh path) the parent token had expired by the time we tried to DELETE `/api/my-agents/<id>`. OS user gone, IdP record orphaned. Fix: reorder destroy so the IdP DELETE/PATCH happens before the escapes call — token is then fresh from preflight, long approval wait happens after all IdP I/O is done. Idempotency is preserved.

Repro on v0.15.1:

```
apes agents spawn agent-a   # ok
apes agents destroy agent-a --force
# → grant approved 5 min later
# → "OK destroyed agent-a" (but dscl record actually still there)
# → "Not authenticated (token expired)" on the IdP DELETE step
```

## Test plan

- [x] `pnpm exec vitest run agents-` — 52 passed | 3 LIVE-skipped
- [x] Manual roundtrip on macOS with v0.15.1 confirmed both failure modes; v0.15.2 will be re-verified after release