### PR TITLE
feat(openape-chat): server scaffold — DDISA auth, schema, REST

### DIFF
--- a/apps/openape-chat/app/app.config.ts
+++ b/apps/openape-chat/app/app.config.ts
@@ -1,0 +1,8 @@
+export default defineAppConfig({
+  ui: {
+    colors: {
+      primary: 'orange',
+      neutral: 'zinc',
+    },
+  },
+})

--- a/apps/openape-chat/app/app.vue
+++ b/apps/openape-chat/app/app.vue
@@ -1,0 +1,5 @@
+<template>
+  <UApp>
+    <NuxtPage />
+  </UApp>
+</template>

--- a/apps/openape-chat/app/assets/css/main.css
+++ b/apps/openape-chat/app/assets/css/main.css
@@ -1,0 +1,2 @@
+@import "tailwindcss";
+@import "@nuxt/ui";

--- a/apps/openape-chat/app/pages/index.vue
+++ b/apps/openape-chat/app/pages/index.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+const { data: me } = await useFetch<{ email: string, act: string } | null>('/api/me')
+</script>
+
+<template>
+  <div class="min-h-screen flex items-center justify-center p-8">
+    <div class="max-w-md w-full space-y-6 text-center">
+      <h1 class="text-3xl font-semibold">
+        OpenApe Chat
+      </h1>
+      <p class="text-zinc-400">
+        Team rooms and DMs for humans and agents.
+      </p>
+      <div v-if="me" class="space-y-2">
+        <p>
+          Signed in as <span class="font-mono">{{ me.email }}</span>
+          <span v-if="me.act === 'agent'" class="ml-2">🤖</span>
+        </p>
+        <p class="text-sm text-zinc-500">
+          The web UI for rooms and messages is coming next. For now use the REST API.
+        </p>
+      </div>
+      <div v-else>
+        <UButton to="/login" color="primary" size="lg">
+          Sign in
+        </UButton>
+      </div>
+    </div>
+  </div>
+</template>

--- a/apps/openape-chat/nuxt.config.ts
+++ b/apps/openape-chat/nuxt.config.ts
@@ -1,0 +1,26 @@
+export default defineNuxtConfig({
+  future: { compatibilityVersion: 4 },
+  nitro: { experimental: { asyncContext: true, websocket: true } },
+  modules: ['@nuxt/ui', '@openape/nuxt-auth-sp'],
+  css: ['~/assets/css/main.css'],
+  devtools: { enabled: true },
+  devServer: { port: 3007 },
+  compatibilityDate: '2025-01-01',
+  colorMode: { preference: 'dark' },
+
+  openapeSp: {
+    clientId: process.env.NUXT_OPENAPE_CLIENT_ID || 'chat.openape.ai',
+    spName: process.env.NUXT_OPENAPE_SP_NAME || 'OpenApe Chat',
+    sessionSecret: process.env.NUXT_OPENAPE_SP_SESSION_SECRET || 'change-me-chat-secret-at-least-32-chars-long',
+    openapeUrl: process.env.NUXT_OPENAPE_URL ?? '',
+    fallbackIdpUrl: process.env.NUXT_OPENAPE_SP_FALLBACK_IDP_URL || 'https://id.openape.ai',
+  },
+
+  runtimeConfig: {
+    tursoUrl: process.env.NUXT_TURSO_URL || 'file:./openape-chat.db',
+    tursoAuthToken: process.env.NUXT_TURSO_AUTH_TOKEN || '',
+    public: {
+      idpUrl: process.env.NUXT_PUBLIC_IDP_URL || 'https://id.openape.ai',
+    },
+  },
+})

--- a/apps/openape-chat/package.json
+++ b/apps/openape-chat/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@openape/chat",
+  "type": "module",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "postinstall": "nuxt prepare",
+    "build": "nuxt build",
+    "dev": "nuxt dev --port 3007",
+    "typecheck": "nuxi prepare && nuxt typecheck",
+    "lint": "eslint .",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@iconify-json/lucide": "^1.2.90",
+    "@libsql/client": "^0.14.0",
+    "@nuxt/ui": "4.4.0",
+    "@openape/auth": "workspace:*",
+    "@openape/core": "workspace:*",
+    "@openape/nuxt-auth-sp": "workspace:*",
+    "drizzle-orm": "^0.44.7",
+    "nuxt": "^4.3.1",
+    "tailwindcss": "^4.2.1",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@types/node": "^22.19.13",
+    "@vitest/coverage-istanbul": "^2.1.9",
+    "typescript": "^5.9.3",
+    "vitest": "^3.2.4"
+  }
+}

--- a/apps/openape-chat/server/api/me.get.ts
+++ b/apps/openape-chat/server/api/me.get.ts
@@ -1,0 +1,7 @@
+import { tryResolveCaller } from '../utils/auth'
+
+export default defineEventHandler(async (event) => {
+  const caller = await tryResolveCaller(event)
+  if (!caller) return null
+  return { email: caller.email, act: caller.act }
+})

--- a/apps/openape-chat/server/api/messages/[id].patch.ts
+++ b/apps/openape-chat/server/api/messages/[id].patch.ts
@@ -1,0 +1,37 @@
+import { eq } from 'drizzle-orm'
+import { z } from 'zod'
+import { useDb } from '../../database/drizzle'
+import { messages } from '../../database/schema'
+import { resolveCaller } from '../../utils/auth'
+
+const bodySchema = z.object({
+  body: z.string().trim().min(1).max(10_000),
+})
+
+export default defineEventHandler(async (event) => {
+  const caller = await resolveCaller(event)
+  const id = getRouterParam(event, 'id')
+  if (!id) throw createError({ statusCode: 400, statusMessage: 'Missing message id' })
+
+  const parsed = bodySchema.safeParse(await readBody(event))
+  if (!parsed.success) {
+    throw createError({ statusCode: 400, statusMessage: parsed.error.message })
+  }
+
+  const db = useDb()
+  const existing = await db.select().from(messages).where(eq(messages.id, id)).get()
+  if (!existing) {
+    throw createError({ statusCode: 404, statusMessage: 'Message not found' })
+  }
+  if (existing.senderEmail !== caller.email) {
+    throw createError({ statusCode: 403, statusMessage: 'Can only edit own messages' })
+  }
+
+  const editedAt = Math.floor(Date.now() / 1000)
+  await db
+    .update(messages)
+    .set({ body: parsed.data.body, editedAt })
+    .where(eq(messages.id, id))
+
+  return { ...existing, body: parsed.data.body, editedAt }
+})

--- a/apps/openape-chat/server/api/messages/[id]/reactions.delete.ts
+++ b/apps/openape-chat/server/api/messages/[id]/reactions.delete.ts
@@ -1,0 +1,31 @@
+import { and, eq } from 'drizzle-orm'
+import { z } from 'zod'
+import { useDb } from '../../../database/drizzle'
+import { reactions } from '../../../database/schema'
+import { resolveCaller } from '../../../utils/auth'
+
+const querySchema = z.object({
+  emoji: z.string().trim().min(1).max(32),
+})
+
+export default defineEventHandler(async (event) => {
+  const caller = await resolveCaller(event)
+  const id = getRouterParam(event, 'id')
+  if (!id) throw createError({ statusCode: 400, statusMessage: 'Missing message id' })
+
+  const parsed = querySchema.safeParse(getQuery(event))
+  if (!parsed.success) {
+    throw createError({ statusCode: 400, statusMessage: parsed.error.message })
+  }
+
+  const db = useDb()
+  await db
+    .delete(reactions)
+    .where(and(
+      eq(reactions.messageId, id),
+      eq(reactions.userEmail, caller.email),
+      eq(reactions.emoji, parsed.data.emoji),
+    ))
+
+  return { ok: true }
+})

--- a/apps/openape-chat/server/api/messages/[id]/reactions.post.ts
+++ b/apps/openape-chat/server/api/messages/[id]/reactions.post.ts
@@ -1,0 +1,37 @@
+import { eq } from 'drizzle-orm'
+import { z } from 'zod'
+import { useDb } from '../../../database/drizzle'
+import { messages, reactions } from '../../../database/schema'
+import { resolveCaller } from '../../../utils/auth'
+import { assertMember } from '../../../utils/membership'
+
+const bodySchema = z.object({
+  emoji: z.string().trim().min(1).max(32),
+})
+
+export default defineEventHandler(async (event) => {
+  const caller = await resolveCaller(event)
+  const id = getRouterParam(event, 'id')
+  if (!id) throw createError({ statusCode: 400, statusMessage: 'Missing message id' })
+
+  const parsed = bodySchema.safeParse(await readBody(event))
+  if (!parsed.success) {
+    throw createError({ statusCode: 400, statusMessage: parsed.error.message })
+  }
+
+  const db = useDb()
+  const target = await db.select().from(messages).where(eq(messages.id, id)).get()
+  if (!target) {
+    throw createError({ statusCode: 404, statusMessage: 'Message not found' })
+  }
+  await assertMember(target.roomId, caller.email)
+
+  const reaction = {
+    messageId: id,
+    userEmail: caller.email,
+    emoji: parsed.data.emoji,
+    createdAt: Math.floor(Date.now() / 1000),
+  }
+  await db.insert(reactions).values(reaction).onConflictDoNothing()
+  return reaction
+})

--- a/apps/openape-chat/server/api/rooms/[id]/join.post.ts
+++ b/apps/openape-chat/server/api/rooms/[id]/join.post.ts
@@ -1,0 +1,37 @@
+import { and, eq } from 'drizzle-orm'
+import { useDb } from '../../../database/drizzle'
+import { memberships, rooms } from '../../../database/schema'
+import { resolveCaller } from '../../../utils/auth'
+
+export default defineEventHandler(async (event) => {
+  const caller = await resolveCaller(event)
+  const id = getRouterParam(event, 'id')
+  if (!id) {
+    throw createError({ statusCode: 400, statusMessage: 'Missing room id' })
+  }
+
+  const db = useDb()
+  const room = await db.select().from(rooms).where(eq(rooms.id, id)).get()
+  if (!room) {
+    throw createError({ statusCode: 404, statusMessage: 'Room not found' })
+  }
+
+  // DMs are closed groups — joining must go through `/api/rooms` (POST) with
+  // explicit members; you can't self-join a DM.
+  if (room.kind === 'dm') {
+    throw createError({ statusCode: 403, statusMessage: 'DMs are not joinable; create a new DM via POST /api/rooms with members' })
+  }
+
+  await db.insert(memberships).values({
+    roomId: id,
+    userEmail: caller.email,
+    role: 'member',
+    joinedAt: Math.floor(Date.now() / 1000),
+  }).onConflictDoNothing()
+
+  return await db
+    .select()
+    .from(memberships)
+    .where(and(eq(memberships.roomId, id), eq(memberships.userEmail, caller.email)))
+    .get()
+})

--- a/apps/openape-chat/server/api/rooms/[id]/leave.post.ts
+++ b/apps/openape-chat/server/api/rooms/[id]/leave.post.ts
@@ -1,0 +1,19 @@
+import { and, eq } from 'drizzle-orm'
+import { useDb } from '../../../database/drizzle'
+import { memberships } from '../../../database/schema'
+import { resolveCaller } from '../../../utils/auth'
+
+export default defineEventHandler(async (event) => {
+  const caller = await resolveCaller(event)
+  const id = getRouterParam(event, 'id')
+  if (!id) {
+    throw createError({ statusCode: 400, statusMessage: 'Missing room id' })
+  }
+
+  const db = useDb()
+  await db
+    .delete(memberships)
+    .where(and(eq(memberships.roomId, id), eq(memberships.userEmail, caller.email)))
+
+  return { ok: true }
+})

--- a/apps/openape-chat/server/api/rooms/[id]/messages.get.ts
+++ b/apps/openape-chat/server/api/rooms/[id]/messages.get.ts
@@ -1,0 +1,39 @@
+import { and, desc, eq, lt } from 'drizzle-orm'
+import { z } from 'zod'
+import { useDb } from '../../../database/drizzle'
+import { messages } from '../../../database/schema'
+import { resolveCaller } from '../../../utils/auth'
+import { assertMember } from '../../../utils/membership'
+
+const querySchema = z.object({
+  before: z.coerce.number().int().positive().optional(),
+  limit: z.coerce.number().int().min(1).max(200).default(50),
+})
+
+export default defineEventHandler(async (event) => {
+  const caller = await resolveCaller(event)
+  const id = getRouterParam(event, 'id')
+  if (!id) throw createError({ statusCode: 400, statusMessage: 'Missing room id' })
+
+  await assertMember(id, caller.email)
+
+  const parsed = querySchema.safeParse(getQuery(event))
+  if (!parsed.success) {
+    throw createError({ statusCode: 400, statusMessage: parsed.error.message })
+  }
+
+  const db = useDb()
+  const where = parsed.data.before
+    ? and(eq(messages.roomId, id), lt(messages.createdAt, parsed.data.before))
+    : eq(messages.roomId, id)
+
+  const rows = await db
+    .select()
+    .from(messages)
+    .where(where)
+    .orderBy(desc(messages.createdAt))
+    .limit(parsed.data.limit)
+
+  // Return oldest-first so the client can append in order without reversing.
+  return rows.reverse()
+})

--- a/apps/openape-chat/server/api/rooms/[id]/messages.post.ts
+++ b/apps/openape-chat/server/api/rooms/[id]/messages.post.ts
@@ -1,0 +1,42 @@
+import { randomUUID } from 'node:crypto'
+import { z } from 'zod'
+import { useDb } from '../../../database/drizzle'
+import { messages } from '../../../database/schema'
+import { resolveCaller } from '../../../utils/auth'
+import { assertMember } from '../../../utils/membership'
+
+const bodySchema = z.object({
+  body: z.string().trim().min(1).max(10_000),
+  reply_to: z.string().uuid().optional(),
+})
+
+export default defineEventHandler(async (event) => {
+  const caller = await resolveCaller(event)
+  const id = getRouterParam(event, 'id')
+  if (!id) throw createError({ statusCode: 400, statusMessage: 'Missing room id' })
+
+  await assertMember(id, caller.email)
+
+  const parsed = bodySchema.safeParse(await readBody(event))
+  if (!parsed.success) {
+    throw createError({ statusCode: 400, statusMessage: parsed.error.message })
+  }
+
+  const message = {
+    id: randomUUID(),
+    roomId: id,
+    senderEmail: caller.email,
+    senderAct: caller.act,
+    body: parsed.data.body,
+    replyTo: parsed.data.reply_to ?? null,
+    createdAt: Math.floor(Date.now() / 1000),
+    editedAt: null as number | null,
+  }
+
+  const db = useDb()
+  await db.insert(messages).values(message)
+
+  // WS broadcast hook: PR 2 will publish this message via the realtime
+  // dispatcher. For now the REST round-trip is the only delivery path.
+  return message
+})

--- a/apps/openape-chat/server/api/rooms/index.get.ts
+++ b/apps/openape-chat/server/api/rooms/index.get.ts
@@ -1,0 +1,24 @@
+import { eq } from 'drizzle-orm'
+import { useDb } from '../../database/drizzle'
+import { memberships, rooms } from '../../database/schema'
+import { resolveCaller } from '../../utils/auth'
+
+export default defineEventHandler(async (event) => {
+  const caller = await resolveCaller(event)
+  const db = useDb()
+
+  const result = await db
+    .select({
+      id: rooms.id,
+      name: rooms.name,
+      kind: rooms.kind,
+      createdByEmail: rooms.createdByEmail,
+      createdAt: rooms.createdAt,
+      role: memberships.role,
+    })
+    .from(memberships)
+    .innerJoin(rooms, eq(memberships.roomId, rooms.id))
+    .where(eq(memberships.userEmail, caller.email))
+
+  return result
+})

--- a/apps/openape-chat/server/api/rooms/index.post.ts
+++ b/apps/openape-chat/server/api/rooms/index.post.ts
@@ -1,0 +1,51 @@
+import { randomUUID } from 'node:crypto'
+import { z } from 'zod'
+import { useDb } from '../../database/drizzle'
+import { memberships, rooms } from '../../database/schema'
+import { resolveCaller } from '../../utils/auth'
+
+const bodySchema = z.object({
+  name: z.string().trim().min(1).max(100),
+  kind: z.enum(['channel', 'dm']).default('channel'),
+  members: z.array(z.string().email()).default([]),
+})
+
+export default defineEventHandler(async (event) => {
+  const caller = await resolveCaller(event)
+  const parsed = bodySchema.safeParse(await readBody(event))
+  if (!parsed.success) {
+    throw createError({ statusCode: 400, statusMessage: parsed.error.message })
+  }
+
+  const id = randomUUID()
+  const now = Math.floor(Date.now() / 1000)
+  const db = useDb()
+
+  await db.insert(rooms).values({
+    id,
+    name: parsed.data.name,
+    kind: parsed.data.kind,
+    createdByEmail: caller.email,
+    createdAt: now,
+  })
+
+  // Caller is always a member; admin role for channels, no role distinction for DMs
+  // (both members are equal in DM context).
+  const allMembers = new Set([caller.email, ...parsed.data.members])
+  for (const email of allMembers) {
+    await db.insert(memberships).values({
+      roomId: id,
+      userEmail: email,
+      role: email === caller.email ? 'admin' : 'member',
+      joinedAt: now,
+    }).onConflictDoNothing()
+  }
+
+  return {
+    id,
+    name: parsed.data.name,
+    kind: parsed.data.kind,
+    createdByEmail: caller.email,
+    createdAt: now,
+  }
+})

--- a/apps/openape-chat/server/database/drizzle.ts
+++ b/apps/openape-chat/server/database/drizzle.ts
@@ -1,0 +1,18 @@
+import { createClient } from '@libsql/client'
+import { drizzle } from 'drizzle-orm/libsql'
+import { useRuntimeConfig } from 'nitropack/runtime'
+import * as schema from './schema'
+
+let _db: ReturnType<typeof drizzle<typeof schema>> | null = null
+
+export function useDb() {
+  if (!_db) {
+    const config = useRuntimeConfig()
+    const client = createClient({
+      url: config.tursoUrl as string,
+      authToken: (config.tursoAuthToken as string) || undefined,
+    })
+    _db = drizzle(client, { schema })
+  }
+  return _db
+}

--- a/apps/openape-chat/server/database/schema.ts
+++ b/apps/openape-chat/server/database/schema.ts
@@ -1,0 +1,47 @@
+import { integer, primaryKey, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+
+export const rooms = sqliteTable('rooms', {
+  id: text('id').primaryKey(),
+  name: text('name').notNull(),
+  // 'channel' = many-member room, 'dm' = exactly two members
+  kind: text('kind', { enum: ['channel', 'dm'] }).notNull(),
+  createdByEmail: text('created_by_email').notNull(),
+  createdAt: integer('created_at').notNull(),
+})
+
+export const memberships = sqliteTable('memberships', {
+  roomId: text('room_id').notNull(),
+  userEmail: text('user_email').notNull(),
+  role: text('role', { enum: ['member', 'admin'] }).notNull().default('member'),
+  joinedAt: integer('joined_at').notNull(),
+}, t => ({
+  pk: primaryKey({ columns: [t.roomId, t.userEmail] }),
+}))
+
+export const messages = sqliteTable('messages', {
+  id: text('id').primaryKey(),
+  roomId: text('room_id').notNull(),
+  senderEmail: text('sender_email').notNull(),
+  // 'human' or 'agent' — purely a display hint, not a permission boundary in v1
+  senderAct: text('sender_act', { enum: ['human', 'agent'] }).notNull(),
+  body: text('body').notNull(),
+  replyTo: text('reply_to'),
+  createdAt: integer('created_at').notNull(),
+  editedAt: integer('edited_at'),
+})
+
+export const reactions = sqliteTable('reactions', {
+  messageId: text('message_id').notNull(),
+  userEmail: text('user_email').notNull(),
+  emoji: text('emoji').notNull(),
+  createdAt: integer('created_at').notNull(),
+}, t => ({
+  pk: primaryKey({ columns: [t.messageId, t.userEmail, t.emoji] }),
+}))
+
+export type Room = typeof rooms.$inferSelect
+export type NewRoom = typeof rooms.$inferInsert
+export type Membership = typeof memberships.$inferSelect
+export type Message = typeof messages.$inferSelect
+export type NewMessage = typeof messages.$inferInsert
+export type Reaction = typeof reactions.$inferSelect

--- a/apps/openape-chat/server/plugins/02.database.ts
+++ b/apps/openape-chat/server/plugins/02.database.ts
@@ -1,0 +1,55 @@
+import { sql } from 'drizzle-orm'
+import { useDb } from '../database/drizzle'
+
+// Auto-create tables at startup. Pattern mirrors apps/openape-free-idp:
+// idempotent CREATE TABLE IF NOT EXISTS so a fresh DB just works on first
+// boot and existing prod DBs aren't disturbed.
+export default defineNitroPlugin(async () => {
+  if (process.env.OPENAPE_E2E === '1') return
+
+  try {
+    const db = useDb()
+
+    await db.run(sql`CREATE TABLE IF NOT EXISTS rooms (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      kind TEXT NOT NULL,
+      created_by_email TEXT NOT NULL,
+      created_at INTEGER NOT NULL
+    )`)
+    await db.run(sql`CREATE INDEX IF NOT EXISTS idx_rooms_created_by ON rooms(created_by_email)`)
+
+    await db.run(sql`CREATE TABLE IF NOT EXISTS memberships (
+      room_id TEXT NOT NULL,
+      user_email TEXT NOT NULL,
+      role TEXT NOT NULL DEFAULT 'member',
+      joined_at INTEGER NOT NULL,
+      PRIMARY KEY (room_id, user_email)
+    )`)
+    await db.run(sql`CREATE INDEX IF NOT EXISTS idx_memberships_user_email ON memberships(user_email)`)
+
+    await db.run(sql`CREATE TABLE IF NOT EXISTS messages (
+      id TEXT PRIMARY KEY,
+      room_id TEXT NOT NULL,
+      sender_email TEXT NOT NULL,
+      sender_act TEXT NOT NULL,
+      body TEXT NOT NULL,
+      reply_to TEXT,
+      created_at INTEGER NOT NULL,
+      edited_at INTEGER
+    )`)
+    await db.run(sql`CREATE INDEX IF NOT EXISTS idx_messages_room_created ON messages(room_id, created_at)`)
+
+    await db.run(sql`CREATE TABLE IF NOT EXISTS reactions (
+      message_id TEXT NOT NULL,
+      user_email TEXT NOT NULL,
+      emoji TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      PRIMARY KEY (message_id, user_email, emoji)
+    )`)
+    await db.run(sql`CREATE INDEX IF NOT EXISTS idx_reactions_message ON reactions(message_id)`)
+  }
+  catch (err) {
+    console.error('[database] Table creation failed (tables may already exist):', err)
+  }
+})

--- a/apps/openape-chat/server/utils/auth.ts
+++ b/apps/openape-chat/server/utils/auth.ts
@@ -1,0 +1,100 @@
+import type { H3Event } from 'h3'
+import { createRemoteJWKS, verifyJWT } from '@openape/core'
+
+// `getSpSession`, `createError`, `getHeader`, `getQuery`, and `useRuntimeConfig`
+// are all auto-imported by Nuxt 4 (the SP module + nitro), so we don't import
+// them explicitly here.
+
+export interface Caller {
+  email: string
+  act: 'human' | 'agent'
+  source: 'cookie' | 'bearer'
+}
+
+interface DDISAClaims {
+  sub?: string
+  email?: string
+  act?: 'human' | 'agent' | string
+}
+
+let _jwksCache: ReturnType<typeof createRemoteJWKS> | null = null
+
+function getJwks() {
+  if (!_jwksCache) {
+    const idpUrl = useRuntimeConfig().public.idpUrl as string
+    const url = new URL('/.well-known/jwks.json', idpUrl).toString()
+    _jwksCache = createRemoteJWKS(url)
+  }
+  return _jwksCache
+}
+
+/**
+ * Unifies the two ways a caller can hit chat.openape.ai:
+ *
+ * 1. Web UI — browser cookie session set by `@openape/nuxt-auth-sp` after the
+ *    DDISA OAuth callback. Stored claims live on `session.data.claims`.
+ * 2. Plugin / agent — `Authorization: Bearer <token>` (HTTP) or `?token=<bearer>`
+ *    (WebSocket query). Verified against the IdP's JWKS.
+ *
+ * Both paths surface the same shape so route handlers don't branch on caller
+ * type. `act` defaults to `'human'` if a token doesn't carry the claim.
+ */
+export async function resolveCaller(event: H3Event): Promise<Caller> {
+  const bearer = extractBearer(event)
+  if (bearer) {
+    return await verifyBearer(bearer)
+  }
+
+  const session = await getSpSession(event)
+  const claims = (session.data as { claims?: DDISAClaims })?.claims
+  if (!claims?.email) {
+    throw createError({ statusCode: 401, statusMessage: 'Not authenticated' })
+  }
+  return {
+    email: claims.email,
+    act: claims.act === 'agent' ? 'agent' : 'human',
+    source: 'cookie',
+  }
+}
+
+/** Same as `resolveCaller` but returns `null` instead of throwing on 401. */
+export async function tryResolveCaller(event: H3Event): Promise<Caller | null> {
+  try {
+    return await resolveCaller(event)
+  }
+  catch {
+    return null
+  }
+}
+
+function extractBearer(event: H3Event): string | null {
+  const header = getHeader(event, 'authorization') || getHeader(event, 'Authorization')
+  if (header && header.toLowerCase().startsWith('bearer ')) {
+    return header.slice(7).trim() || null
+  }
+  // WebSocket upgrade requests can't carry custom headers reliably across
+  // browsers, so we accept ?token=… on the upgrade URL instead.
+  const q = getQuery(event)
+  const t = q.token
+  if (typeof t === 'string' && t.length > 0) return t
+  return null
+}
+
+async function verifyBearer(token: string): Promise<Caller> {
+  try {
+    const { payload } = await verifyJWT<DDISAClaims>(token, getJwks())
+    const email = payload.email || payload.sub
+    if (!email) {
+      throw createError({ statusCode: 401, statusMessage: 'Token missing email/sub' })
+    }
+    return {
+      email,
+      act: payload.act === 'agent' ? 'agent' : 'human',
+      source: 'bearer',
+    }
+  }
+  catch (err) {
+    if (err && typeof err === 'object' && 'statusCode' in err) throw err
+    throw createError({ statusCode: 401, statusMessage: 'Invalid bearer token' })
+  }
+}

--- a/apps/openape-chat/server/utils/membership.ts
+++ b/apps/openape-chat/server/utils/membership.ts
@@ -1,0 +1,16 @@
+import { and, eq } from 'drizzle-orm'
+import { useDb } from '../database/drizzle'
+import { memberships } from '../database/schema'
+
+export async function assertMember(roomId: string, email: string) {
+  const db = useDb()
+  const m = await db
+    .select()
+    .from(memberships)
+    .where(and(eq(memberships.roomId, roomId), eq(memberships.userEmail, email)))
+    .get()
+  if (!m) {
+    throw createError({ statusCode: 403, statusMessage: 'Not a member of this room' })
+  }
+  return m
+}

--- a/apps/openape-chat/tests/schema.test.ts
+++ b/apps/openape-chat/tests/schema.test.ts
@@ -1,0 +1,89 @@
+import { createClient } from '@libsql/client'
+import { eq, sql } from 'drizzle-orm'
+import { drizzle } from 'drizzle-orm/libsql'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { memberships, messages, reactions, rooms } from '../server/database/schema'
+
+// Smoke test for the chat DB schema: spin up an in-memory SQLite, run the
+// same CREATE TABLE statements the production startup plugin runs, and
+// exercise insert/select on each table to catch typos in the schema or the
+// migration script. This file is intentionally low-level — route-handler
+// behaviour gets covered by integration tests once the WS layer lands.
+
+let db: ReturnType<typeof drizzle<{ rooms: typeof rooms, memberships: typeof memberships, messages: typeof messages, reactions: typeof reactions }>>
+
+beforeEach(async () => {
+  const client = createClient({ url: ':memory:' })
+  db = drizzle(client, { schema: { rooms, memberships, messages, reactions } })
+
+  await db.run(sql`CREATE TABLE rooms (id TEXT PRIMARY KEY, name TEXT NOT NULL, kind TEXT NOT NULL, created_by_email TEXT NOT NULL, created_at INTEGER NOT NULL)`)
+  await db.run(sql`CREATE TABLE memberships (room_id TEXT NOT NULL, user_email TEXT NOT NULL, role TEXT NOT NULL DEFAULT 'member', joined_at INTEGER NOT NULL, PRIMARY KEY (room_id, user_email))`)
+  await db.run(sql`CREATE TABLE messages (id TEXT PRIMARY KEY, room_id TEXT NOT NULL, sender_email TEXT NOT NULL, sender_act TEXT NOT NULL, body TEXT NOT NULL, reply_to TEXT, created_at INTEGER NOT NULL, edited_at INTEGER)`)
+  await db.run(sql`CREATE TABLE reactions (message_id TEXT NOT NULL, user_email TEXT NOT NULL, emoji TEXT NOT NULL, created_at INTEGER NOT NULL, PRIMARY KEY (message_id, user_email, emoji))`)
+})
+
+afterEach(() => {
+  // libsql client doesn't expose close() but :memory: dies with the process anyway.
+})
+
+describe('chat schema', () => {
+  it('inserts and reads a channel room', async () => {
+    await db.insert(rooms).values({
+      id: 'r1', name: 'team-alpha', kind: 'channel', createdByEmail: 'patrick@hofmann.eco', createdAt: 1,
+    })
+    const got = await db.select().from(rooms).where(eq(rooms.id, 'r1')).get()
+    expect(got).toMatchObject({ id: 'r1', name: 'team-alpha', kind: 'channel' })
+  })
+
+  it('enforces composite PK on memberships', async () => {
+    await db.insert(rooms).values({ id: 'r1', name: 'r', kind: 'channel', createdByEmail: 'p@x', createdAt: 1 })
+    await db.insert(memberships).values({ roomId: 'r1', userEmail: 'p@x', role: 'admin', joinedAt: 1 })
+    await expect(
+      db.insert(memberships).values({ roomId: 'r1', userEmail: 'p@x', role: 'member', joinedAt: 2 }),
+    ).rejects.toThrow()
+  })
+
+  it('stores agent-typed messages with reactions', async () => {
+    await db.insert(rooms).values({ id: 'r1', name: 'r', kind: 'channel', createdByEmail: 'p@x', createdAt: 1 })
+    await db.insert(messages).values({
+      id: 'm1', roomId: 'r1', senderEmail: 'agent-a@id.openape.ai', senderAct: 'agent', body: 'hello', createdAt: 10,
+    })
+    await db.insert(reactions).values({
+      messageId: 'm1', userEmail: 'p@x', emoji: '👍', createdAt: 11,
+    })
+
+    const msg = await db.select().from(messages).where(eq(messages.id, 'm1')).get()
+    expect(msg?.senderAct).toBe('agent')
+    const rs = await db.select().from(reactions).where(eq(reactions.messageId, 'm1'))
+    expect(rs).toHaveLength(1)
+    expect(rs[0]?.emoji).toBe('👍')
+  })
+
+  it('allows multiple emojis from the same user but rejects duplicates', async () => {
+    await db.insert(rooms).values({ id: 'r1', name: 'r', kind: 'channel', createdByEmail: 'p@x', createdAt: 1 })
+    await db.insert(messages).values({ id: 'm1', roomId: 'r1', senderEmail: 'p@x', senderAct: 'human', body: 'x', createdAt: 1 })
+    await db.insert(reactions).values({ messageId: 'm1', userEmail: 'p@x', emoji: '👍', createdAt: 1 })
+    await db.insert(reactions).values({ messageId: 'm1', userEmail: 'p@x', emoji: '🔥', createdAt: 1 })
+    await expect(
+      db.insert(reactions).values({ messageId: 'm1', userEmail: 'p@x', emoji: '👍', createdAt: 2 }),
+    ).rejects.toThrow()
+  })
+
+  it('lists memberships joined to rooms (the GET /api/rooms shape)', async () => {
+    const now = 1
+    await db.insert(rooms).values({ id: 'r1', name: 'alpha', kind: 'channel', createdByEmail: 'p@x', createdAt: now })
+    await db.insert(rooms).values({ id: 'r2', name: 'beta', kind: 'channel', createdByEmail: 'q@x', createdAt: now })
+    await db.insert(memberships).values({ roomId: 'r1', userEmail: 'p@x', role: 'admin', joinedAt: now })
+    await db.insert(memberships).values({ roomId: 'r2', userEmail: 'p@x', role: 'member', joinedAt: now })
+    await db.insert(memberships).values({ roomId: 'r2', userEmail: 'q@x', role: 'admin', joinedAt: now })
+
+    const result = await db
+      .select({ id: rooms.id, name: rooms.name, role: memberships.role })
+      .from(memberships)
+      .innerJoin(rooms, eq(memberships.roomId, rooms.id))
+      .where(eq(memberships.userEmail, 'p@x'))
+
+    expect(result).toHaveLength(2)
+    expect(result.map(r => r.id).sort()).toEqual(['r1', 'r2'])
+  })
+})

--- a/apps/openape-chat/tsconfig.json
+++ b/apps/openape-chat/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./.nuxt/tsconfig.json"
+}

--- a/apps/openape-chat/vitest.config.ts
+++ b/apps/openape-chat/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.ts'],
+    globals: true,
+    environment: 'node',
+  },
+  esbuild: {
+    tsconfigRaw: {
+      compilerOptions: {
+        target: 'ES2022',
+        module: 'ESNext',
+        moduleResolution: 'Bundler',
+      },
+    },
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,6 +222,52 @@ importers:
         specifier: ^5.7.0
         version: 5.9.3
 
+  apps/openape-chat:
+    dependencies:
+      '@iconify-json/lucide':
+        specifier: ^1.2.90
+        version: 1.2.97
+      '@libsql/client':
+        specifier: ^0.14.0
+        version: 0.14.0
+      '@nuxt/ui':
+        specifier: 4.4.0
+        version: 4.4.0(f8b28fdd830e2f9656e8e27b700b79cf)
+      '@openape/auth':
+        specifier: workspace:*
+        version: link:../../packages/auth
+      '@openape/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@openape/nuxt-auth-sp':
+        specifier: workspace:*
+        version: link:../../modules/nuxt-auth-sp
+      drizzle-orm:
+        specifier: ^0.44.7
+        version: 0.44.7(@libsql/client@0.14.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(bun-types@1.3.10)(gel@2.2.0)
+      nuxt:
+        specifier: ^4.3.1
+        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@libsql/client@0.14.0)(@parcel/watcher@2.5.6)(@types/node@22.19.15)(@vue/compiler-sfc@3.5.30)(aws4fetch@1.0.20)(better-sqlite3@12.6.2)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.14.0)(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@libsql/client@0.14.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(bun-types@1.3.10)(gel@2.2.0)))(drizzle-orm@0.44.7(@libsql/client@0.14.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(bun-types@1.3.10)(gel@2.2.0))(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.11(rollup@4.59.0))(rollup@4.59.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2)
+      tailwindcss:
+        specifier: ^4.2.1
+        version: 4.2.1
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@types/node':
+        specifier: ^22.19.13
+        version: 22.19.15
+      '@vitest/coverage-istanbul':
+        specifier: ^2.1.9
+        version: 2.1.9(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.19.15)(happy-dom@18.0.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.15)(happy-dom@18.0.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+
   apps/openape-free-idp:
     dependencies:
       '@iconify-json/lucide':
@@ -14650,6 +14696,22 @@ snapshots:
       test-exclude: 7.0.2
       tinyrainbow: 1.2.0
       vitest: 2.1.9(@types/node@22.19.15)(happy-dom@18.0.1)(lightningcss@1.32.0)(terser@5.46.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitest/coverage-istanbul@2.1.9(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.19.15)(happy-dom@18.0.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@istanbuljs/schema': 0.1.3
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-instrument: 6.0.3
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      magicast: 0.3.5
+      test-exclude: 7.0.2
+      tinyrainbow: 1.2.0
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.15)(happy-dom@18.0.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
## Summary

PR 1 of the **chat.openape.ai** roadmap (per [the plan](https://github.com/openape-ai/openape/blob/main/.claude/plans/openape-chat.md) — local copy in this session). Scaffolds a greenfield Nuxt 4 app at \`apps/openape-chat\` with DDISA auth, Drizzle/LibSQL persistence, and a complete REST surface for rooms, messages, and reactions. **No WebSocket layer and no real web UI yet** — those land in PR 2 (mobile-first responsive UI + PWA + SW + WS realtime). The Claude Code plugin (\`openape-ai/claude-plugin-openape-chat\`) is a separate repo, PR 3.

## What's in

- **Schema** (\`server/database/schema.ts\`): \`rooms\`, \`memberships\`, \`messages\`, \`reactions\`. Auto-created at startup via the canonical idempotent \`CREATE TABLE IF NOT EXISTS\` pattern from \`apps/openape-free-idp\`.
- **Auth** (\`server/utils/auth.ts\`): \`resolveCaller(event)\` unifies cookie-session callers (Web UI via \`@openape/nuxt-auth-sp\`) and Bearer-token callers (Claude plugin / spawned agents). JWKS verify via \`@openape/core\`'s \`verifyJWT\` + module-cached \`createRemoteJWKS\`. \`act === 'agent'\` is a display hint, not a permission boundary in v1.
- **REST** (\`server/api/\`): full CRUD for rooms, memberships, messages, reactions. All bodies zod-validated. Membership enforced before any room-scoped read or write.
- **Minimal landing page** (\`app/pages/index.vue\`): fetches \`/api/me\`, shows email + 🤖 badge for agents.

## What's not in

- WebSocket realtime — PR 2.
- Mobile-first web UI for rooms/chat, PWA manifest + install hint, service-worker with Network-First strategy and update-banner — PR 2.
- Web-Push notifications (only when installed) — separate PR after UI lands.
- The Claude Code plugin (\`claude-plugin-openape-chat\`) — PR 3 in a separate repo (\`openape-ai/claude-plugin-openape-chat\`, mirrors the layout of \`anthropics/claude-plugins-official/external_plugins/telegram\`).

## Test plan

- [x] \`pnpm --filter @openape/chat typecheck\` — clean
- [x] \`pnpm --filter @openape/chat lint\` — clean
- [x] \`pnpm --filter @openape/chat test\` — 5/5 schema tests pass (composite-PK enforcement, agent-typed messages, reactions uniqueness, GET /api/rooms join shape)
- [ ] Manual probe with curl after first deploy to chatty:3007