### PR TITLE
feat(openape-chat): Web Push notifications (only when installed)

### DIFF
--- a/apps/openape-chat/app/components/EnableNotifications.vue
+++ b/apps/openape-chat/app/components/EnableNotifications.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+const push = usePushSubscription()
+const busy = ref(false)
+const error = ref<string | null>(null)
+
+async function toggle() {
+  busy.value = true
+  error.value = null
+  try {
+    if (push.subscribed.value) {
+      await push.disable()
+    }
+    else {
+      const ok = await push.enable()
+      if (!ok) error.value = 'Notifications not enabled. Check browser permissions.'
+    }
+  }
+  finally {
+    busy.value = false
+  }
+}
+</script>
+
+<template>
+  <div v-if="push.supported.value" class="px-4 py-3 border-t border-zinc-800 flex items-center gap-3">
+    <UIcon name="i-lucide-bell" class="size-4 text-zinc-500" />
+    <div class="flex-1 text-sm">
+      <p class="font-medium">
+        Notifications
+      </p>
+      <p class="text-zinc-500 text-xs">
+        {{ push.subscribed.value ? 'Enabled — you will be pinged on new messages.' : 'Get pinged when someone messages you.' }}
+      </p>
+    </div>
+    <UButton
+      :color="push.subscribed.value ? 'neutral' : 'primary'"
+      :variant="push.subscribed.value ? 'soft' : 'solid'"
+      size="sm"
+      :loading="busy"
+      @click="toggle"
+    >
+      {{ push.subscribed.value ? 'Disable' : 'Enable' }}
+    </UButton>
+  </div>
+  <p v-if="error" class="px-4 pb-2 text-xs text-red-400">
+    {{ error }}
+  </p>
+</template>

--- a/apps/openape-chat/app/composables/usePushSubscription.ts
+++ b/apps/openape-chat/app/composables/usePushSubscription.ts
@@ -1,0 +1,138 @@
+import { onMounted, ref } from 'vue'
+
+interface PushHandle {
+  supported: ReturnType<typeof ref<boolean>>
+  subscribed: ReturnType<typeof ref<boolean>>
+  permissionGranted: ReturnType<typeof ref<boolean>>
+  /**
+   * Ask the browser for notification permission and create a Push
+   * subscription. Returns true on success, false otherwise (denied,
+   * unsupported, or fetch failed). Safe to call multiple times — already-
+   * subscribed sessions short-circuit.
+   */
+  enable: () => Promise<boolean>
+  disable: () => Promise<void>
+}
+
+/**
+ * Web-Push integration. Deliberately gated on `display-mode: standalone`
+ * so we never prompt the user for the Notification permission on a normal
+ * browser tab. The prompt is only shown after the app is installed (Add
+ * to Home Screen on iOS, install prompt on Android/Chrome) — at that
+ * point the user has explicitly opted in to "treat this like a real app",
+ * and notifications make sense.
+ */
+export function usePushSubscription(): PushHandle {
+  const supported = ref(false)
+  const subscribed = ref(false)
+  const permissionGranted = ref(false)
+
+  function isStandalone(): boolean {
+    if (typeof window === 'undefined') return false
+    if (window.matchMedia('(display-mode: standalone)').matches) return true
+    return (window.navigator as { standalone?: boolean }).standalone === true
+  }
+
+  async function getRegistration(): Promise<ServiceWorkerRegistration | null> {
+    if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) return null
+    return await navigator.serviceWorker.ready
+  }
+
+  async function refresh() {
+    if (typeof window === 'undefined') return
+    if (!('Notification' in window) || !('PushManager' in window)) {
+      supported.value = false
+      return
+    }
+    if (!isStandalone()) {
+      // Don't even probe state on non-installed tabs — we never want the
+      // permission UI to flash there.
+      supported.value = false
+      return
+    }
+    supported.value = true
+    permissionGranted.value = Notification.permission === 'granted'
+    const reg = await getRegistration()
+    const sub = await reg?.pushManager.getSubscription()
+    subscribed.value = !!sub
+  }
+
+  function urlBase64ToUint8Array(base64: string): Uint8Array {
+    const padding = '='.repeat((4 - base64.length % 4) % 4)
+    const b64 = (base64 + padding).replace(/-/g, '+').replace(/_/g, '/')
+    const raw = atob(b64)
+    const out = new Uint8Array(raw.length)
+    for (let i = 0; i < raw.length; i++) out[i] = raw.charCodeAt(i)
+    return out
+  }
+
+  async function enable(): Promise<boolean> {
+    await refresh()
+    if (!supported.value) return false
+    if (subscribed.value) return true
+
+    const perm = await Notification.requestPermission()
+    permissionGranted.value = perm === 'granted'
+    if (perm !== 'granted') return false
+
+    const reg = await getRegistration()
+    if (!reg) return false
+
+    const { vapidPublicKey } = await $fetch<{ vapidPublicKey: string }>('/api/push/vapid')
+    if (!vapidPublicKey) return false
+
+    let sub: globalThis.PushSubscription
+    try {
+      // applicationServerKey expects a BufferSource — but the latest
+      // lib.dom narrowed it to ArrayBuffer (excluding SharedArrayBuffer)
+      // and Uint8Array<ArrayBuffer> via slice() returns the union. Allocate
+      // a fresh ArrayBuffer with the bytes copied in to satisfy both.
+      const keyBytes = urlBase64ToUint8Array(vapidPublicKey)
+      const keyBuffer = new ArrayBuffer(keyBytes.byteLength)
+      new Uint8Array(keyBuffer).set(keyBytes)
+      sub = await reg.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: keyBuffer,
+      })
+    }
+    catch {
+      return false
+    }
+
+    const json = sub.toJSON() as { endpoint: string, keys: { p256dh: string, auth: string } }
+    try {
+      await $fetch('/api/push/subscribe', {
+        method: 'POST',
+        body: { endpoint: json.endpoint, keys: json.keys },
+      })
+    }
+    catch {
+      // Backend rejected — drop the local subscription so the next attempt
+      // doesn't think we're already enrolled.
+      await sub.unsubscribe().catch(() => {})
+      return false
+    }
+    subscribed.value = true
+    return true
+  }
+
+  async function disable() {
+    const reg = await getRegistration()
+    const sub = await reg?.pushManager.getSubscription()
+    if (!sub) {
+      subscribed.value = false
+      return
+    }
+    const endpoint = sub.endpoint
+    await sub.unsubscribe().catch(() => {})
+    subscribed.value = false
+    await $fetch('/api/push/subscribe', {
+      method: 'DELETE',
+      body: { endpoint },
+    }).catch(() => { /* server is best-effort */ })
+  }
+
+  onMounted(refresh)
+
+  return { supported, subscribed, permissionGranted, enable, disable }
+}

--- a/apps/openape-chat/app/pages/index.vue
+++ b/apps/openape-chat/app/pages/index.vue
@@ -89,6 +89,7 @@ async function logout() {
     </header>
 
     <main class="flex-1 overflow-y-auto pb-24 md:pb-4">
+      <EnableNotifications />
       <p v-if="!rooms?.length" class="p-8 text-center text-zinc-500 text-sm">
         No rooms yet. Create one to start chatting.
       </p>

--- a/apps/openape-chat/nuxt.config.ts
+++ b/apps/openape-chat/nuxt.config.ts
@@ -19,8 +19,16 @@ export default defineNuxtConfig({
   runtimeConfig: {
     tursoUrl: process.env.NUXT_TURSO_URL || 'file:./openape-chat.db',
     tursoAuthToken: process.env.NUXT_TURSO_AUTH_TOKEN || '',
+    // VAPID keypair for Web Push. Generate once with `npx web-push
+    // generate-vapid-keys` and persist to env. The public key is fine to
+    // ship to clients (they include it when subscribing); the private key
+    // and subject (a mailto: that push services can use to contact us if
+    // we misbehave) are server-side only.
+    vapidPrivateKey: process.env.NUXT_VAPID_PRIVATE_KEY || '',
+    vapidSubject: process.env.NUXT_VAPID_SUBJECT || 'mailto:patrick@hofmann.eco',
     public: {
       idpUrl: process.env.NUXT_PUBLIC_IDP_URL || 'https://id.openape.ai',
+      vapidPublicKey: process.env.NUXT_PUBLIC_VAPID_PUBLIC_KEY || '',
     },
   },
 
@@ -31,6 +39,13 @@ export default defineNuxtConfig({
   // back to cache when offline. This is the single most important guard
   // against "users stuck on a 6-week-old build" SW horror stories.
   pwa: {
+    // injectManifest lets us own the SW source so we can handle `push` and
+    // `notificationclick` events ourselves. Workbox helpers are still
+    // available — we use precacheAndRoute + registerRoute for caching, and
+    // hand-write the push event listeners.
+    strategies: 'injectManifest',
+    srcDir: 'public',
+    filename: 'sw.ts',
     registerType: 'autoUpdate',
     manifest: {
       name: 'OpenApe Chat',
@@ -41,53 +56,20 @@ export default defineNuxtConfig({
       display: 'standalone',
       start_url: '/',
       scope: '/',
-      // Single SVG icon for now — Patrick can swap in proper PNG raster icons
-      // (192/512 incl. maskable) before the production deploy. SVG works in
-      // Chrome/Safari/Firefox PWA installs as of 2024+.
       icons: [
         { src: '/icon.svg', sizes: 'any', type: 'image/svg+xml', purpose: 'any maskable' },
       ],
     },
-    workbox: {
+    injectManifest: {
       globPatterns: ['**/*.{js,css,html,ico,png,svg,webmanifest}'],
-      navigateFallback: null, // never serve a cached HTML shell — we want NetworkFirst
-      runtimeCaching: [
-        {
-          urlPattern: /\/api\/.*/i,
-          handler: 'NetworkFirst',
-          options: {
-            cacheName: 'api-cache',
-            expiration: { maxEntries: 100, maxAgeSeconds: 60 * 60 * 24 },
-            networkTimeoutSeconds: 5,
-          },
-        },
-        {
-          urlPattern: /\/_nuxt\/.*/i,
-          handler: 'CacheFirst',
-          options: {
-            cacheName: 'nuxt-assets',
-            expiration: { maxEntries: 200, maxAgeSeconds: 60 * 60 * 24 * 30 },
-          },
-        },
-        {
-          urlPattern: ({ request }) => request.destination === 'document',
-          handler: 'NetworkFirst',
-          options: {
-            cacheName: 'html-cache',
-            networkTimeoutSeconds: 3,
-          },
-        },
-      ],
     },
     client: {
       installPrompt: true,
-      // Force the SW to take control on first visit so users see a fresh
-      // build immediately on next reload, not after the second.
       periodicSyncForUpdates: 60 * 60, // check hourly while tab is open
     },
     devOptions: {
-      // Don't run the SW in `pnpm dev` — it makes HMR unreliable and isn't
-      // representative of production behaviour.
+      // Don't run the SW in `pnpm dev` — HMR + SW caching is a debugging
+      // nightmare and not representative of prod behaviour anyway.
       enabled: false,
     },
   },

--- a/apps/openape-chat/package.json
+++ b/apps/openape-chat/package.json
@@ -22,10 +22,12 @@
     "drizzle-orm": "^0.44.7",
     "nuxt": "^4.3.1",
     "tailwindcss": "^4.2.1",
+    "web-push": "^3.6.7",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "^22.19.13",
+    "@types/web-push": "^3.6.4",
     "@vitest/coverage-istanbul": "^2.1.9",
     "typescript": "^5.9.3",
     "vitest": "^3.2.4"

--- a/apps/openape-chat/public/sw.ts
+++ b/apps/openape-chat/public/sw.ts
@@ -1,0 +1,124 @@
+/// <reference lib="webworker" />
+
+// Service worker for OpenApe Chat. We use injectManifest so we own this
+// file and can register `push` + `notificationclick` handlers — vite-pwa's
+// generateSW mode doesn't expose those.
+//
+// Caching strategy is the same as the v1 SW (PR 2): NetworkFirst for HTML
+// and /api/**, CacheFirst for /_nuxt/** (hashed filenames make this safe).
+
+import { CacheFirst, NetworkFirst } from 'workbox-strategies'
+import { ExpirationPlugin } from 'workbox-expiration'
+import { precacheAndRoute, cleanupOutdatedCaches } from 'workbox-precaching'
+import { registerRoute } from 'workbox-routing'
+
+declare const self: ServiceWorkerGlobalScope & { __WB_MANIFEST: Array<{ url: string, revision: string | null }> }
+
+cleanupOutdatedCaches()
+precacheAndRoute(self.__WB_MANIFEST ?? [])
+
+registerRoute(
+  ({ url }) => url.pathname.startsWith('/api/'),
+  new NetworkFirst({
+    cacheName: 'api-cache',
+    networkTimeoutSeconds: 5,
+    plugins: [new ExpirationPlugin({ maxEntries: 100, maxAgeSeconds: 60 * 60 * 24 })],
+  }),
+)
+
+registerRoute(
+  ({ url }) => url.pathname.startsWith('/_nuxt/'),
+  new CacheFirst({
+    cacheName: 'nuxt-assets',
+    plugins: [new ExpirationPlugin({ maxEntries: 200, maxAgeSeconds: 60 * 60 * 24 * 30 })],
+  }),
+)
+
+registerRoute(
+  ({ request }) => request.destination === 'document',
+  new NetworkFirst({
+    cacheName: 'html-cache',
+    networkTimeoutSeconds: 3,
+  }),
+)
+
+// ---------------------------------------------------------------------------
+// Push notifications — only fire when the app is installed (display-mode:
+// standalone). On non-installed tabs the push subscription is never created
+// in the first place, so we don't need a runtime guard here.
+// ---------------------------------------------------------------------------
+
+interface PushPayload {
+  type?: string
+  room_id?: string
+  title?: string
+  body?: string
+  sender?: string
+}
+
+self.addEventListener('push', (event) => {
+  let data: PushPayload = {}
+  try {
+    if (event.data) data = event.data.json() as PushPayload
+  }
+  catch {
+    // Some push services deliver an empty payload to wake the SW; show a
+    // generic notification rather than swallow it.
+    data = { title: 'OpenApe Chat', body: 'New activity' }
+  }
+
+  const title = data.title ?? `${data.sender ?? 'Someone'} in OpenApe Chat`
+  const body = data.body ?? 'New message'
+  const tag = data.room_id ? `room:${data.room_id}` : 'openape-chat'
+
+  event.waitUntil(self.registration.showNotification(title, {
+    body,
+    tag, // collapse multiple pushes for the same room into one notification
+    icon: '/icon.svg',
+    badge: '/icon.svg',
+    data,
+  }))
+})
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close()
+  const data = event.notification.data as PushPayload | undefined
+  const target = data?.room_id ? `/rooms/${data.room_id}` : '/'
+
+  event.waitUntil((async () => {
+    const clientsList = await self.clients.matchAll({ type: 'window', includeUncontrolled: true })
+    // If a window is already open at the right URL, focus it; otherwise
+    // open a new one. Falls back to focusing any open window if the URL
+    // can't be opened (e.g. file: scheme).
+    for (const client of clientsList) {
+      try {
+        const url = new URL(client.url)
+        if (url.pathname === target) {
+          await client.focus()
+          return
+        }
+      }
+      catch { /* unparseable client URL — ignore */ }
+    }
+    if (clientsList.length > 0) {
+      // Navigate the first available window to the target.
+      const first = clientsList[0]
+      if ('navigate' in first && typeof first.navigate === 'function') {
+        await first.navigate(target)
+        await first.focus()
+        return
+      }
+    }
+    await self.clients.openWindow(target)
+  })())
+})
+
+self.addEventListener('install', () => {
+  // Activate the new SW immediately on install so users see fresh behaviour
+  // on their next reload (not the one after that).
+  self.skipWaiting()
+})
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim())
+})

--- a/apps/openape-chat/server/api/push/subscribe.delete.ts
+++ b/apps/openape-chat/server/api/push/subscribe.delete.ts
@@ -1,0 +1,30 @@
+import { and, eq } from 'drizzle-orm'
+import { z } from 'zod'
+import { useDb } from '../../database/drizzle'
+import { pushSubscriptions } from '../../database/schema'
+import { resolveCaller } from '../../utils/auth'
+
+const bodySchema = z.object({
+  endpoint: z.string().url(),
+})
+
+export default defineEventHandler(async (event) => {
+  const caller = await resolveCaller(event)
+  const parsed = bodySchema.safeParse(await readBody(event))
+  if (!parsed.success) {
+    throw createError({ statusCode: 400, statusMessage: parsed.error.message })
+  }
+
+  // Owner check: only the subscriber can revoke. Otherwise an attacker who
+  // captured an endpoint URL could delete it for someone else (annoying,
+  // not a privilege escalation, but still avoidable).
+  const db = useDb()
+  await db
+    .delete(pushSubscriptions)
+    .where(and(
+      eq(pushSubscriptions.endpoint, parsed.data.endpoint),
+      eq(pushSubscriptions.userEmail, caller.email),
+    ))
+
+  return { ok: true }
+})

--- a/apps/openape-chat/server/api/push/subscribe.post.ts
+++ b/apps/openape-chat/server/api/push/subscribe.post.ts
@@ -1,0 +1,47 @@
+import { z } from 'zod'
+import { useDb } from '../../database/drizzle'
+import { pushSubscriptions } from '../../database/schema'
+import { resolveCaller } from '../../utils/auth'
+
+const bodySchema = z.object({
+  endpoint: z.string().url(),
+  keys: z.object({
+    p256dh: z.string().min(1),
+    auth: z.string().min(1),
+  }),
+})
+
+// Upsert the subscription. The endpoint URL is the natural primary key —
+// it's stable per (browser, install) — so the same client re-subscribing
+// (after token rotation, browser update, etc.) just updates its row.
+export default defineEventHandler(async (event) => {
+  const caller = await resolveCaller(event)
+  const parsed = bodySchema.safeParse(await readBody(event))
+  if (!parsed.success) {
+    throw createError({ statusCode: 400, statusMessage: parsed.error.message })
+  }
+
+  const row = {
+    endpoint: parsed.data.endpoint,
+    userEmail: caller.email,
+    p256dh: parsed.data.keys.p256dh,
+    auth: parsed.data.keys.auth,
+    createdAt: Math.floor(Date.now() / 1000),
+  }
+
+  const db = useDb()
+  await db
+    .insert(pushSubscriptions)
+    .values(row)
+    .onConflictDoUpdate({
+      target: pushSubscriptions.endpoint,
+      set: {
+        userEmail: row.userEmail,
+        p256dh: row.p256dh,
+        auth: row.auth,
+        createdAt: row.createdAt,
+      },
+    })
+
+  return { ok: true }
+})

--- a/apps/openape-chat/server/api/push/vapid.get.ts
+++ b/apps/openape-chat/server/api/push/vapid.get.ts
@@ -1,0 +1,6 @@
+// The browser needs the VAPID public key (server identity) when calling
+// PushManager.subscribe(). Public so any logged-in user can fetch it.
+export default defineEventHandler(() => {
+  const key = (useRuntimeConfig().public.vapidPublicKey as string) || ''
+  return { vapidPublicKey: key }
+})

--- a/apps/openape-chat/server/api/rooms/[id]/messages.post.ts
+++ b/apps/openape-chat/server/api/rooms/[id]/messages.post.ts
@@ -4,6 +4,7 @@ import { useDb } from '../../../database/drizzle'
 import { messages } from '../../../database/schema'
 import { resolveCaller } from '../../../utils/auth'
 import { assertMember } from '../../../utils/membership'
+import { notifyRoomMembers } from '../../../utils/push'
 import { broadcastToRoom } from '../../../utils/realtime'
 
 const bodySchema = z.object({
@@ -38,5 +39,16 @@ export default defineEventHandler(async (event) => {
   await db.insert(messages).values(message)
 
   await broadcastToRoom(id, { type: 'message', room_id: id, payload: message })
+
+  // Web-Push fan-out for offline / installed clients. Best-effort and async
+  // — we don't block the REST response on push delivery, and the helper
+  // silently no-ops if VAPID isn't configured (dev environments).
+  void notifyRoomMembers(id, caller.email, {
+    title: caller.email,
+    body: parsed.data.body.length > 140 ? `${parsed.data.body.slice(0, 140)}…` : parsed.data.body,
+    room_id: id,
+    sender: caller.email,
+  })
+
   return message
 })

--- a/apps/openape-chat/server/database/schema.ts
+++ b/apps/openape-chat/server/database/schema.ts
@@ -39,9 +39,22 @@ export const reactions = sqliteTable('reactions', {
   pk: primaryKey({ columns: [t.messageId, t.userEmail, t.emoji] }),
 }))
 
+// Web-Push subscriptions. One row per (user, endpoint). Endpoint is the
+// browser's push service URL — it's stable per (user, browser, install)
+// and is used as the natural primary key for upserts. p256dh + auth are
+// the public encryption keys the server must use to encrypt push payloads.
+export const pushSubscriptions = sqliteTable('push_subscriptions', {
+  endpoint: text('endpoint').primaryKey(),
+  userEmail: text('user_email').notNull(),
+  p256dh: text('p256dh').notNull(),
+  auth: text('auth').notNull(),
+  createdAt: integer('created_at').notNull(),
+})
+
 export type Room = typeof rooms.$inferSelect
 export type NewRoom = typeof rooms.$inferInsert
 export type Membership = typeof memberships.$inferSelect
 export type Message = typeof messages.$inferSelect
 export type NewMessage = typeof messages.$inferInsert
 export type Reaction = typeof reactions.$inferSelect
+export type PushSubscription = typeof pushSubscriptions.$inferSelect

--- a/apps/openape-chat/server/plugins/02.database.ts
+++ b/apps/openape-chat/server/plugins/02.database.ts
@@ -48,6 +48,15 @@ export default defineNitroPlugin(async () => {
       PRIMARY KEY (message_id, user_email, emoji)
     )`)
     await db.run(sql`CREATE INDEX IF NOT EXISTS idx_reactions_message ON reactions(message_id)`)
+
+    await db.run(sql`CREATE TABLE IF NOT EXISTS push_subscriptions (
+      endpoint TEXT PRIMARY KEY,
+      user_email TEXT NOT NULL,
+      p256dh TEXT NOT NULL,
+      auth TEXT NOT NULL,
+      created_at INTEGER NOT NULL
+    )`)
+    await db.run(sql`CREATE INDEX IF NOT EXISTS idx_push_subs_user ON push_subscriptions(user_email)`)
   }
   catch (err) {
     console.error('[database] Table creation failed (tables may already exist):', err)

--- a/apps/openape-chat/server/utils/push.ts
+++ b/apps/openape-chat/server/utils/push.ts
@@ -1,0 +1,84 @@
+import { eq, inArray } from 'drizzle-orm'
+import webpush from 'web-push'
+import { useDb } from '../database/drizzle'
+import { memberships, pushSubscriptions } from '../database/schema'
+
+let _configured = false
+
+function ensureConfigured(): boolean {
+  if (_configured) return true
+  const cfg = useRuntimeConfig()
+  const publicKey = (cfg.public.vapidPublicKey as string) || ''
+  const privateKey = (cfg.vapidPrivateKey as string) || ''
+  const subject = (cfg.vapidSubject as string) || ''
+  if (!publicKey || !privateKey) {
+    return false
+  }
+  webpush.setVapidDetails(subject, publicKey, privateKey)
+  _configured = true
+  return true
+}
+
+export interface PushNotice {
+  title: string
+  body: string
+  room_id?: string
+  sender?: string
+}
+
+/**
+ * Best-effort fan-out to web-push subscriptions. Skips entirely if VAPID
+ * keys aren't configured (lets dev environments run without push) and
+ * silently drops 404/410 endpoints (those are dead — Apple, Chrome,
+ * Firefox all use those status codes for revoked subscriptions).
+ *
+ * `senderEmail` is excluded from the recipient set: you don't get a push
+ * for your own message.
+ */
+export async function notifyRoomMembers(roomId: string, senderEmail: string, notice: PushNotice): Promise<void> {
+  if (!ensureConfigured()) return
+
+  const db = useDb()
+  const recipients = await db
+    .select({ userEmail: memberships.userEmail })
+    .from(memberships)
+    .where(eq(memberships.roomId, roomId))
+  const recipientEmails = recipients
+    .map(r => r.userEmail)
+    .filter(e => e !== senderEmail)
+  if (recipientEmails.length === 0) return
+
+  const subs = await db
+    .select()
+    .from(pushSubscriptions)
+    .where(inArray(pushSubscriptions.userEmail, recipientEmails))
+  if (subs.length === 0) return
+
+  const payload = JSON.stringify({
+    type: 'message',
+    room_id: roomId,
+    title: notice.title,
+    body: notice.body,
+    sender: notice.sender,
+  })
+
+  // Fire-and-forget per subscription. Dead endpoints get pruned so we
+  // don't keep retrying them; legitimate transient failures (5xx) are
+  // logged and forgotten — push services will retry the next message.
+  await Promise.all(subs.map(async (sub) => {
+    try {
+      await webpush.sendNotification(
+        { endpoint: sub.endpoint, keys: { p256dh: sub.p256dh, auth: sub.auth } },
+        payload,
+      )
+    }
+    catch (err: unknown) {
+      const status = (err as { statusCode?: number })?.statusCode
+      if (status === 404 || status === 410) {
+        await db.delete(pushSubscriptions).where(eq(pushSubscriptions.endpoint, sub.endpoint)).catch(() => {})
+        return
+      }
+      console.warn(`[push] send failed for ${sub.userEmail}: ${(err as Error)?.message ?? err}`)
+    }
+  }))
+}

--- a/apps/openape-chat/tests/schema.test.ts
+++ b/apps/openape-chat/tests/schema.test.ts
@@ -2,7 +2,7 @@ import { createClient } from '@libsql/client'
 import { eq, sql } from 'drizzle-orm'
 import { drizzle } from 'drizzle-orm/libsql'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { memberships, messages, reactions, rooms } from '../server/database/schema'
+import { memberships, messages, pushSubscriptions, reactions, rooms } from '../server/database/schema'
 
 // Smoke test for the chat DB schema: spin up an in-memory SQLite, run the
 // same CREATE TABLE statements the production startup plugin runs, and
@@ -10,16 +10,17 @@ import { memberships, messages, reactions, rooms } from '../server/database/sche
 // migration script. This file is intentionally low-level — route-handler
 // behaviour gets covered by integration tests once the WS layer lands.
 
-let db: ReturnType<typeof drizzle<{ rooms: typeof rooms, memberships: typeof memberships, messages: typeof messages, reactions: typeof reactions }>>
+let db: ReturnType<typeof drizzle<{ rooms: typeof rooms, memberships: typeof memberships, messages: typeof messages, reactions: typeof reactions, pushSubscriptions: typeof pushSubscriptions }>>
 
 beforeEach(async () => {
   const client = createClient({ url: ':memory:' })
-  db = drizzle(client, { schema: { rooms, memberships, messages, reactions } })
+  db = drizzle(client, { schema: { rooms, memberships, messages, reactions, pushSubscriptions } })
 
   await db.run(sql`CREATE TABLE rooms (id TEXT PRIMARY KEY, name TEXT NOT NULL, kind TEXT NOT NULL, created_by_email TEXT NOT NULL, created_at INTEGER NOT NULL)`)
   await db.run(sql`CREATE TABLE memberships (room_id TEXT NOT NULL, user_email TEXT NOT NULL, role TEXT NOT NULL DEFAULT 'member', joined_at INTEGER NOT NULL, PRIMARY KEY (room_id, user_email))`)
   await db.run(sql`CREATE TABLE messages (id TEXT PRIMARY KEY, room_id TEXT NOT NULL, sender_email TEXT NOT NULL, sender_act TEXT NOT NULL, body TEXT NOT NULL, reply_to TEXT, created_at INTEGER NOT NULL, edited_at INTEGER)`)
   await db.run(sql`CREATE TABLE reactions (message_id TEXT NOT NULL, user_email TEXT NOT NULL, emoji TEXT NOT NULL, created_at INTEGER NOT NULL, PRIMARY KEY (message_id, user_email, emoji))`)
+  await db.run(sql`CREATE TABLE push_subscriptions (endpoint TEXT PRIMARY KEY, user_email TEXT NOT NULL, p256dh TEXT NOT NULL, auth TEXT NOT NULL, created_at INTEGER NOT NULL)`)
 })
 
 afterEach(() => {
@@ -67,6 +68,20 @@ describe('chat schema', () => {
     await expect(
       db.insert(reactions).values({ messageId: 'm1', userEmail: 'p@x', emoji: '👍', createdAt: 2 }),
     ).rejects.toThrow()
+  })
+
+  it('rejects duplicate push subscription endpoints (PK enforced)', async () => {
+    const sub = {
+      endpoint: 'https://fcm.googleapis.com/fcm/send/abc123',
+      userEmail: 'p@x',
+      p256dh: 'BNc...',
+      auth: 'aaa',
+      createdAt: 1,
+    }
+    await db.insert(pushSubscriptions).values(sub)
+    await expect(db.insert(pushSubscriptions).values({ ...sub, userEmail: 'q@x' })).rejects.toThrow()
+    const got = await db.select().from(pushSubscriptions).where(eq(pushSubscriptions.endpoint, sub.endpoint)).get()
+    expect(got?.userEmail).toBe('p@x')
   })
 
   it('lists memberships joined to rooms (the GET /api/rooms shape)', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,6 +254,9 @@ importers:
       tailwindcss:
         specifier: ^4.2.1
         version: 4.2.1
+      web-push:
+        specifier: ^3.6.7
+        version: 3.6.7
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -261,6 +264,9 @@ importers:
       '@types/node':
         specifier: ^22.19.13
         version: 22.19.15
+      '@types/web-push':
+        specifier: ^3.6.4
+        version: 3.6.4
       '@vitest/coverage-istanbul':
         specifier: ^2.1.9
         version: 2.1.9(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.19.15)(happy-dom@18.0.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
@@ -4588,6 +4594,9 @@ packages:
   '@types/web-bluetooth@0.0.21':
     resolution: {integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==}
 
+  '@types/web-push@3.6.4':
+    resolution: {integrity: sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==}
+
   '@types/whatwg-mimetype@3.0.2':
     resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
 
@@ -5210,6 +5219,9 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
+  asn1.js@5.4.1:
+    resolution: {integrity: sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==}
+
   asn1js@3.0.7:
     resolution: {integrity: sha512-uLvq6KJu04qoQM6gvBfKFjlh6Gl0vOKQuR5cJMDHQkmwfMOQeN3F3SHCv9SNYSL+CRoHvOGFfllDlVz03GQjvQ==}
     engines: {node: '>=12.0.0'}
@@ -5360,6 +5372,9 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
+  bn.js@4.12.3:
+    resolution: {integrity: sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==}
+
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
@@ -5392,6 +5407,9 @@ packages:
   buffer-crc32@1.0.0:
     resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
     engines: {node: '>=8.0.0'}
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -6049,6 +6067,9 @@ packages:
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   editorconfig@1.0.7:
     resolution: {integrity: sha512-e0GOtq/aTQhVdNyDU9e02+wz9oDDM+SIOQxWME2QRjzRX5yyLAuHDE+0aE8vHb9XRC8XD37eO2u57+F09JqFhw==}
@@ -7032,6 +7053,10 @@ packages:
     resolution: {integrity: sha512-S9wWkJ/VSY9/k4qcjG318bqJNruzE4HySUhFYknwmu6LBP97KLLfwNf+n4V1BHurvFNkSKLFnK/RsuUnRTf9Vw==}
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
 
+  http_ece@1.2.0:
+    resolution: {integrity: sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==}
+    engines: {node: '>=16'}
+
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
     engines: {node: '>= 6'}
@@ -7497,6 +7522,12 @@ packages:
   jsonpointer@5.0.1:
     resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
     engines: {node: '>=0.10.0'}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -7997,6 +8028,9 @@ packages:
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
+
+  minimalistic-assert@1.0.1:
+    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
   minimark@0.2.0:
     resolution: {integrity: sha512-AmtWU9pO0C2/3AM2pikaVhJ//8E5rOpJ7+ioFQfjIq+wCsBeuZoxPd97hBFZ9qrI7DMHZudwGH3r8A7BMnsIew==}
@@ -10476,6 +10510,11 @@ packages:
 
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
+
+  web-push@3.6.7:
+    resolution: {integrity: sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==}
+    engines: {node: '>= 16'}
+    hasBin: true
 
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
@@ -16082,6 +16121,10 @@ snapshots:
 
   '@types/web-bluetooth@0.0.21': {}
 
+  '@types/web-push@3.6.4':
+    dependencies:
+      '@types/node': 22.19.15
+
   '@types/whatwg-mimetype@3.0.2': {}
 
   '@types/ws@8.18.1':
@@ -16869,12 +16912,19 @@ snapshots:
   arraybuffer.prototype.slice@1.0.4:
     dependencies:
       array-buffer-byte-length: 1.0.2
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       define-properties: 1.2.1
       es-abstract: 1.24.2
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
+
+  asn1.js@5.4.1:
+    dependencies:
+      bn.js: 4.12.3
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+      safer-buffer: 2.1.2
 
   asn1js@3.0.7:
     dependencies:
@@ -17013,6 +17063,8 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  bn.js@4.12.3: {}
+
   body-parser@2.2.2:
     dependencies:
       bytes: 3.1.2
@@ -17059,6 +17111,8 @@ snapshots:
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
   buffer-crc32@1.0.0: {}
+
+  buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
 
@@ -17584,6 +17638,10 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
+
   editorconfig@1.0.7:
     dependencies:
       '@one-ini/wasm': 0.1.1
@@ -17696,7 +17754,7 @@ snapshots:
       array-buffer-byte-length: 1.0.2
       arraybuffer.prototype.slice: 1.0.4
       available-typed-arrays: 1.0.7
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       data-view-buffer: 1.0.2
       data-view-byte-length: 1.0.2
@@ -18652,7 +18710,7 @@ snapshots:
 
   function.prototype.name@1.1.8:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       define-properties: 1.2.1
       functions-have-names: 1.2.3
@@ -19050,6 +19108,8 @@ snapshots:
 
   http-shutdown@1.2.2: {}
 
+  http_ece@1.2.0: {}
+
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
@@ -19205,7 +19265,7 @@ snapshots:
 
   is-array-buffer@3.0.5:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
 
@@ -19539,6 +19599,17 @@ snapshots:
       graceful-fs: 4.2.11
 
   jsonpointer@5.0.1: {}
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
 
   keyv@4.5.4:
     dependencies:
@@ -20191,6 +20262,8 @@ snapshots:
   mimic-fn@4.0.0: {}
 
   mimic-response@3.1.0: {}
+
+  minimalistic-assert@1.0.1: {}
 
   minimark@0.2.0: {}
 
@@ -21222,7 +21295,7 @@ snapshots:
 
   object.assign@4.1.7:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
@@ -22012,7 +22085,7 @@ snapshots:
 
   reflect.getprototypeof@1.0.10:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       define-properties: 1.2.1
       es-abstract: 1.24.2
       es-errors: 1.3.0
@@ -22046,7 +22119,7 @@ snapshots:
 
   regexp.prototype.flags@1.5.4:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       define-properties: 1.2.1
       es-errors: 1.3.0
       get-proto: 1.0.1
@@ -22718,7 +22791,7 @@ snapshots:
 
   string.prototype.matchall@4.0.12:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-abstract: 1.24.2
@@ -22734,7 +22807,7 @@ snapshots:
 
   string.prototype.trim@1.2.10:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       define-data-property: 1.1.4
       define-properties: 1.2.1
@@ -22744,14 +22817,14 @@ snapshots:
 
   string.prototype.trimend@1.0.9:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
   string.prototype.trimstart@1.0.8:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
@@ -23143,7 +23216,7 @@ snapshots:
 
   typed-array-byte-length@1.0.3:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       for-each: 0.3.5
       gopd: 1.2.0
       has-proto: 1.2.0
@@ -23152,7 +23225,7 @@ snapshots:
   typed-array-byte-offset@1.0.4:
     dependencies:
       available-typed-arrays: 1.0.7
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       for-each: 0.3.5
       gopd: 1.2.0
       has-proto: 1.2.0
@@ -23161,7 +23234,7 @@ snapshots:
 
   typed-array-length@1.0.7:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       for-each: 0.3.5
       gopd: 1.2.0
       is-typed-array: 1.1.15
@@ -24138,6 +24211,16 @@ snapshots:
   w3c-keyname@2.2.8: {}
 
   web-namespaces@2.0.1: {}
+
+  web-push@3.6.7:
+    dependencies:
+      asn1.js: 5.4.1
+      http_ece: 1.2.0
+      https-proxy-agent: 7.0.6
+      jws: 4.0.1
+      minimist: 1.2.8
+    transitivePeerDependencies:
+      - supports-color
 
   web-streams-polyfill@3.3.3: {}
 


### PR DESCRIPTION
## Summary

PR 4 — final piece of the chat.openape.ai roadmap. Sends browser push notifications when a message lands in a room you're a member of, **but only after you've installed the PWA** (\`display-mode: standalone\`). On a normal browser tab the Notification permission UI is never even probed.

- **Schema + migration**: \`push_subscriptions(endpoint PK, user_email, p256dh, auth, created_at)\`. Idempotent \`CREATE TABLE\`. Endpoint is the natural primary key — stable per (browser, install).
- **REST**: \`GET /api/push/vapid\`, \`POST /api/push/subscribe\` (upsert, auth-required), \`DELETE /api/push/subscribe\` (owner-only).
- **Server-side fan-out** (\`server/utils/push.ts\`): \`notifyRoomMembers\` is called from \`messages.post.ts\` after the WS broadcast. Best-effort and async — the REST response doesn't block on push delivery. 404/410 endpoints get pruned automatically (all major push services use those for revoked subs). Senders are excluded from their own message's recipient set. Silently no-ops if VAPID keys aren't configured (so dev environments run without push).
- **Service worker** (\`public/sw.ts\`): switched vite-pwa strategy from \`generateSW\` to \`injectManifest\` so we can register \`push\` + \`notificationclick\` listeners. All v1 caching strategies preserved (NetworkFirst for HTML and \`/api/**\`, CacheFirst for \`/_nuxt/**\`). Push handler uses \`tag: room:<id>\` so multiple pushes for the same room collapse into one notification. Click handler focuses an existing window on the right \`/rooms/:id\` if open, otherwise navigates or opens.
- **Client** (\`composables/usePushSubscription.ts\` + \`components/EnableNotifications.vue\`): the panel only renders when the app is installed (display-mode: standalone). \`enable()\` requests permission, fetches the public VAPID key, calls \`pushManager.subscribe\`, posts to backend. \`disable()\` reverses cleanly.

## Generate VAPID keys before deploy

```sh
npx web-push generate-vapid-keys
# Then in env:
#   NUXT_VAPID_PRIVATE_KEY=<private>
#   NUXT_PUBLIC_VAPID_PUBLIC_KEY=<public>
#   NUXT_VAPID_SUBJECT=mailto:patrick@hofmann.eco
```

## Test plan

- [x] \`pnpm --filter @openape/chat typecheck\` — clean
- [x] \`pnpm --filter @openape/chat lint\` — clean
- [x] \`pnpm --filter @openape/chat test\` — 6/6 (includes new \`push_subscriptions\` PK test)
- [ ] After deploy + VAPID keys: install PWA on iPhone Safari and Pixel Chrome, enable notifications, send a message from a second tab/account, confirm the notification arrives with right title/body and clicking opens the room.

## What's not in

- Per-room mute / DM-only modes — granular preferences are a follow-up.
- Read-receipt tracking that suppresses pushes to recently-active members — needs presence signal (v2 via WS).