### PR TITLE
fix(openape-chat): wrap PWA components in <ClientOnly>

### DIFF
--- a/apps/openape-chat/app/app.vue
+++ b/apps/openape-chat/app/app.vue
@@ -1,7 +1,9 @@
 <template>
   <UApp>
     <NuxtPage />
-    <InstallBanner />
-    <UpdateAvailable />
+    <ClientOnly>
+      <InstallBanner />
+      <UpdateAvailable />
+    </ClientOnly>
   </UApp>
 </template>

--- a/apps/openape-chat/app/pages/index.vue
+++ b/apps/openape-chat/app/pages/index.vue
@@ -89,7 +89,9 @@ async function logout() {
     </header>
 
     <main class="flex-1 overflow-y-auto pb-24 md:pb-4">
-      <EnableNotifications />
+      <ClientOnly>
+        <EnableNotifications />
+      </ClientOnly>
       <p v-if="!rooms?.length" class="p-8 text-center text-zinc-500 text-sm">
         No rooms yet. Create one to start chatting.
       </p>


### PR DESCRIPTION
## Summary

The first deploy threw repeated SSR errors:

\`\`\`
TypeError: Cannot use 'in' operator to search for 'serviceWorker' in undefined
\`\`\`

Cause: \`useRegisterSW\` (UpdateAvailable.vue) plus the navigator/matchMedia probes (InstallBanner.vue, EnableNotifications.vue) all assume browser globals are present. They aren't during SSR — Nuxt's setup phase runs server-side.

Fix: wrap these three components in \`<ClientOnly>\` (in app.vue and pages/index.vue). They have no meaningful server output anyway — install banner, update toast, "enable notifications" panel are pure client UI. Server skips rendering them, hydrates client-side once mounted.

## Test plan

- [x] Build clean (\`pnpm --filter @openape/chat build\`)
- [x] Lint + typecheck + 6/6 unit tests still pass
- [x] Deployed to chatty; server logs clean of unhandledRejection traces.
- [x] https://chat.openape.ai/login renders cleanly server-side, client hydrates the install banner / SW update toast.