### PR TITLE
fix(openape-chat): WS accepts cookie-session callers via /api/ws-token

### DIFF
--- a/apps/openape-chat/app/composables/useChat.ts
+++ b/apps/openape-chat/app/composables/useChat.ts
@@ -31,8 +31,10 @@ type Listener = (frame: ChatFrame) => void
 interface UseChatHandle {
   connected: ReturnType<typeof ref<boolean>>
   on: (fn: Listener) => () => void
-  // Cookie-session callers don't need to pass a token; agent/plugin callers do.
-  connect: (opts?: { token?: string }) => void
+  // Cookie-session callers don't need to pass a token — connect() mints one
+  // via /api/ws-token. Agent/plugin callers can pass their JWKS-signed
+  // bearer directly to skip the round-trip.
+  connect: (opts?: { token?: string }) => Promise<void>
   disconnect: () => void
 }
 
@@ -108,9 +110,23 @@ export function useChat(): UseChatHandle {
     return () => listeners.delete(fn)
   }
 
-  function connect(opts?: { token?: string }) {
+  async function connect(opts?: { token?: string }) {
     manualDisconnect = false
-    open(opts?.token)
+    let token = opts?.token
+    // Cookie-session callers (the Web UI) need a short-lived WS token —
+    // browsers can't put Authorization on the WS upgrade. The endpoint is
+    // cookie-authenticated, so any signed-in user can mint one.
+    if (!token) {
+      try {
+        const res = await $fetch<{ token: string }>('/api/ws-token')
+        token = res.token
+      }
+      catch {
+        // Couldn't mint a token (e.g. session expired) — let the WS open
+        // anyway and rely on the server-side 401 to surface.
+      }
+    }
+    open(token)
   }
 
   function disconnect() {

--- a/apps/openape-chat/server/api/ws-token.get.ts
+++ b/apps/openape-chat/server/api/ws-token.get.ts
@@ -1,0 +1,40 @@
+import { SignJWT } from 'jose'
+import { resolveCaller } from '../utils/auth'
+
+// Mint a short-lived HMAC-signed token the Web UI uses to authenticate its
+// WebSocket connection. The browser cannot send custom Authorization headers
+// on a WS upgrade; passing a cookie-derived token via `?token=` is the
+// canonical workaround.
+//
+// The token is signed with the SP session secret (HS256) and verified by
+// the WS handler. Lifetime is intentionally short — the Web UI re-fetches
+// per connect, and re-fetches on reconnect, so a 5-minute window is plenty.
+
+const TOKEN_TTL_SECONDS = 5 * 60
+
+export default defineEventHandler(async (event) => {
+  // Same auth resolver REST routes use — succeeds for cookie sessions and
+  // for Bearer-authenticated agents alike. Bearer callers don't need this
+  // endpoint (they connect WS with their own JWKS-verified token), but it
+  // doesn't hurt to issue one.
+  const caller = await resolveCaller(event)
+
+  const config = useRuntimeConfig()
+  const secret = (config.openapeSp?.sessionSecret as string) || ''
+  if (!secret) {
+    throw createError({ statusCode: 500, statusMessage: 'WS token secret not configured' })
+  }
+
+  const key = new TextEncoder().encode(secret)
+  const now = Math.floor(Date.now() / 1000)
+
+  const token = await new SignJWT({ email: caller.email, act: caller.act })
+    .setProtectedHeader({ alg: 'HS256', typ: 'JWT' })
+    .setIssuedAt(now)
+    .setExpirationTime(now + TOKEN_TTL_SECONDS)
+    .setIssuer('chat.openape.ai')
+    .setAudience('chat.openape.ai/ws')
+    .sign(key)
+
+  return { token, expires_in: TOKEN_TTL_SECONDS }
+})

--- a/apps/openape-chat/server/routes/api/ws.ts
+++ b/apps/openape-chat/server/routes/api/ws.ts
@@ -1,10 +1,16 @@
 import type { ChatPeer } from '../../utils/realtime'
 import { createRemoteJWKS, verifyJWT } from '@openape/core'
+import { jwtVerify } from 'jose'
 import { useRuntimeConfig } from 'nitropack/runtime'
 import { registerPeer, unregisterPeer } from '../../utils/realtime'
 
 interface DDISAClaims {
   sub?: string
+  act?: 'human' | 'agent' | string
+}
+
+interface WsTokenClaims {
+  email?: string
   act?: 'human' | 'agent' | string
 }
 
@@ -15,6 +21,16 @@ function jwks() {
     _jwks = createRemoteJWKS(new URL('/.well-known/jwks.json', idpUrl).toString())
   }
   return _jwks
+}
+
+let _wsTokenKey: Uint8Array | null = null
+function wsTokenKey(): Uint8Array | null {
+  if (!_wsTokenKey) {
+    const secret = (useRuntimeConfig().openapeSp?.sessionSecret as string) || ''
+    if (!secret) return null
+    _wsTokenKey = new TextEncoder().encode(secret)
+  }
+  return _wsTokenKey
 }
 
 // Per-peer auth state. Crossws gives a stable `peer.id`; we attach the
@@ -30,7 +46,37 @@ interface PeerCtx extends AuthCtx {
 
 const ctxByPeerId = new Map<string, PeerCtx>()
 
+/**
+ * Two token types resolve here:
+ *   1. JWKS-verified IdP-issued JWT — used by the Claude Code plugin and
+ *      any spawned agent, since they hold a real OpenApe access token in
+ *      their `auth.json`.
+ *   2. HS256-signed WS-token issued by `/api/ws-token` — used by the Web
+ *      UI, which can't pass an Authorization header on a WS upgrade and
+ *      doesn't have a JWKS-signed token in its session anyway.
+ *
+ * We try the HS256 path first when the local secret is configured because
+ * it's the common case (most connections come from the browser); on
+ * mismatch we fall through to JWKS verification.
+ */
 async function authenticateUpgrade(token: string): Promise<AuthCtx> {
+  const localKey = wsTokenKey()
+  if (localKey) {
+    try {
+      const { payload } = await jwtVerify<WsTokenClaims>(token, localKey, {
+        issuer: 'chat.openape.ai',
+        audience: 'chat.openape.ai/ws',
+        algorithms: ['HS256'],
+      })
+      if (payload.email) {
+        return { email: payload.email, act: payload.act === 'agent' ? 'agent' : 'human' }
+      }
+    }
+    catch {
+      // Not a local token — fall through to JWKS.
+    }
+  }
+
   const { payload } = await verifyJWT<DDISAClaims>(token, jwks())
   const email = payload.sub
   if (!email) throw new Error('Token missing sub')


### PR DESCRIPTION
## Summary

Pressing Enter or the send button in the Web UI didn't update the message list. PR #200's WS handler only accepts JWKS-verified Bearer tokens (designed for the Claude Code plugin / spawned agents). Browsers can't attach an Authorization header to a WS upgrade and the Web UI uses a cookie session anyway, so the upgrade was silently rejected with 401 — the sender's own broadcast frame never reached them.

Two pieces:

- **\`server/api/ws-token.get.ts\` (new)** — cookie-authenticated endpoint that mints a 5-minute HS256 JWT signed with the SP session secret. Web UI calls this once per connect.
- **\`server/routes/api/ws.ts\`** — \`authenticateUpgrade\` tries HS256 against the local secret first (with iss/aud assertions), falls through to JWKS for IdP tokens. Both paths produce the same AuthCtx.
- **\`app/composables/useChat.ts\`** — \`connect()\` is async; if no explicit token is passed, it fetches \`/api/ws-token\` before opening the socket. Plugin/agent callers still pass their bearer directly and skip the round-trip.

## Test plan

- [x] typecheck + lint + 6/6 tests + build all clean
- [ ] Deploy to chatty + send a message + verify the list updates without reload