### PR TITLE
fix(openape-chat): join-channel UX for non-members + decoupled WS

### DIFF
--- a/apps/openape-chat/app/pages/rooms/[id].vue
+++ b/apps/openape-chat/app/pages/rooms/[id].vue
@@ -26,12 +26,51 @@ const { user, fetchUser } = useOpenApeAuth()
 await fetchUser()
 if (!user.value && import.meta.client) navigateTo('/login')
 
+interface RoomInfo {
+  id: string
+  name: string
+  kind: 'channel' | 'dm'
+  createdByEmail: string
+  createdAt: number
+  isMember: boolean
+  role: 'member' | 'admin' | null
+}
+
 const messages = ref<Message[]>([])
 const reactions = ref<Map<string, Reaction[]>>(new Map())
 const loading = ref(true)
 const scrollEl = ref<HTMLElement>()
+const roomInfo = ref<RoomInfo | null>(null)
+const roomError = ref<string | null>(null)
+const joining = ref(false)
 
-async function loadInitial() {
+async function loadRoomInfo() {
+  roomError.value = null
+  try {
+    roomInfo.value = await $fetch<RoomInfo>(`/api/rooms/${roomId.value}`)
+  }
+  catch (err) {
+    const status = (err as { statusCode?: number })?.statusCode
+    if (status === 404) {
+      roomError.value = 'This room does not exist.'
+    }
+    else if (status === 401) {
+      // Session likely expired — bounce to login.
+      navigateTo('/login')
+    }
+    else {
+      roomError.value = err instanceof Error ? err.message : 'Could not load room info.'
+    }
+    roomInfo.value = null
+  }
+}
+
+async function loadMessages() {
+  if (!roomInfo.value?.isMember) {
+    messages.value = []
+    loading.value = false
+    return
+  }
   loading.value = true
   try {
     const rows = await $fetch<Message[]>(`/api/rooms/${roomId.value}/messages?limit=50`)
@@ -41,6 +80,27 @@ async function loadInitial() {
     loading.value = false
     await nextTick()
     scrollToBottom('instant')
+  }
+}
+
+async function loadInitial() {
+  await loadRoomInfo()
+  await loadMessages()
+}
+
+async function joinRoom() {
+  if (joining.value) return
+  joining.value = true
+  try {
+    await $fetch(`/api/rooms/${roomId.value}/join`, { method: 'POST' })
+    await loadRoomInfo()
+    await loadMessages()
+  }
+  catch (err) {
+    roomError.value = err instanceof Error ? err.message : 'Could not join room.'
+  }
+  finally {
+    joining.value = false
   }
 }
 
@@ -71,8 +131,12 @@ const chat = useChat()
 let off: (() => void) | undefined
 
 onMounted(async () => {
-  await loadInitial()
+  // Connect WS first so the live indicator updates regardless of whether
+  // we can read messages. Non-members watching a Join screen still get
+  // a fresh socket — when they join, broadcasts start flowing immediately
+  // without a reconnect dance.
   chat.connect()
+  await loadInitial()
   off = chat.on((frame) => {
     if (frame.room_id !== roomId.value) return
     if (frame.type === 'message') {
@@ -156,7 +220,7 @@ function reactionsFor(messageId: string) {
         aria-label="Back to rooms"
       />
       <h1 class="font-semibold flex-1 truncate">
-        {{ roomId }}
+        {{ roomInfo?.name ?? roomId }}
       </h1>
       <span class="text-xs px-2 py-0.5 rounded-full" :class="chat.connected.value ? 'text-emerald-400' : 'text-zinc-500'">
         {{ chat.connected.value ? '● live' : '○ offline' }}
@@ -164,23 +228,66 @@ function reactionsFor(messageId: string) {
     </header>
 
     <main ref="scrollEl" class="flex-1 overflow-y-auto px-3 py-3 space-y-3">
-      <p v-if="loading" class="text-center text-sm text-zinc-500 py-8">
-        Loading…
-      </p>
-      <p v-else-if="!messages.length" class="text-center text-sm text-zinc-500 py-8">
-        No messages yet. Be the first.
-      </p>
-      <MessageBubble
-        v-for="m of messages"
-        :key="m.id"
-        :message="m"
-        :reactions="reactionsFor(m.id)"
-        :my-email="user?.sub"
-        @react="emoji => react(m.id, emoji)"
-        @unreact="emoji => unreact(m.id, emoji)"
-      />
+      <div v-if="roomError" class="max-w-sm mx-auto py-12 text-center space-y-3">
+        <UIcon name="i-lucide-circle-alert" class="size-10 text-zinc-600 mx-auto" />
+        <p class="text-sm text-zinc-400">
+          {{ roomError }}
+        </p>
+        <UButton to="/" color="neutral" variant="soft" size="sm">
+          Back to rooms
+        </UButton>
+      </div>
+
+      <div v-else-if="roomInfo && !roomInfo.isMember" class="max-w-sm mx-auto py-12 text-center space-y-4">
+        <UIcon
+          :name="roomInfo.kind === 'dm' ? 'i-lucide-lock' : 'i-lucide-hash'"
+          class="size-10 text-zinc-600 mx-auto"
+        />
+        <div class="space-y-1">
+          <h2 class="text-lg font-semibold">
+            {{ roomInfo.name }}
+          </h2>
+          <p class="text-sm text-zinc-400">
+            <template v-if="roomInfo.kind === 'channel'">
+              You're not a member of this channel yet.
+            </template>
+            <template v-else>
+              This is a direct conversation. Ask {{ roomInfo.createdByEmail }} to add you.
+            </template>
+          </p>
+        </div>
+        <UButton
+          v-if="roomInfo.kind === 'channel'"
+          color="primary"
+          :loading="joining"
+          @click="joinRoom"
+        >
+          Join channel
+        </UButton>
+        <UButton v-else to="/" color="neutral" variant="soft">
+          Back to rooms
+        </UButton>
+      </div>
+
+      <template v-else>
+        <p v-if="loading" class="text-center text-sm text-zinc-500 py-8">
+          Loading…
+        </p>
+        <p v-else-if="!messages.length" class="text-center text-sm text-zinc-500 py-8">
+          No messages yet. Be the first.
+        </p>
+        <MessageBubble
+          v-for="m of messages"
+          :key="m.id"
+          :message="m"
+          :reactions="reactionsFor(m.id)"
+          :my-email="user?.sub"
+          @react="emoji => react(m.id, emoji)"
+          @unreact="emoji => unreact(m.id, emoji)"
+        />
+      </template>
     </main>
 
-    <SendBox @send="send" />
+    <SendBox v-if="roomInfo?.isMember" @send="send" />
   </div>
 </template>

--- a/apps/openape-chat/server/api/rooms/[id]/index.get.ts
+++ b/apps/openape-chat/server/api/rooms/[id]/index.get.ts
@@ -1,0 +1,41 @@
+import { and, eq } from 'drizzle-orm'
+import { useDb } from '../../../database/drizzle'
+import { memberships, rooms } from '../../../database/schema'
+import { resolveCaller } from '../../../utils/auth'
+
+// Room metadata + the caller's own membership status. Returned even when
+// the caller is NOT a member of the room — that's intentional, the Web UI
+// uses this to show a "Join this channel" prompt instead of a dead end
+// when someone follows a shared link.
+//
+// Privacy: a non-member learns the room exists, its name, and its kind,
+// but nothing about other members or messages. For closed/DM rooms we
+// could narrow this further; for channels (the open kind) it's fine
+// because channel names are essentially public anyway.
+export default defineEventHandler(async (event) => {
+  const caller = await resolveCaller(event)
+  const id = getRouterParam(event, 'id')
+  if (!id) throw createError({ statusCode: 400, statusMessage: 'Missing room id' })
+
+  const db = useDb()
+  const room = await db.select().from(rooms).where(eq(rooms.id, id)).get()
+  if (!room) {
+    throw createError({ statusCode: 404, statusMessage: 'Room not found' })
+  }
+
+  const m = await db
+    .select()
+    .from(memberships)
+    .where(and(eq(memberships.roomId, id), eq(memberships.userEmail, caller.email)))
+    .get()
+
+  return {
+    id: room.id,
+    name: room.name,
+    kind: room.kind,
+    createdByEmail: room.createdByEmail,
+    createdAt: room.createdAt,
+    isMember: !!m,
+    role: m?.role ?? null,
+  }
+})


### PR DESCRIPTION
## Summary

A second user opening a shared room URL got stuck on a permanent **\"○ offline\"** badge: \`assertMember\` threw 403 when loading messages, the catch-less \`await\` aborted \`onMounted\` before \`chat.connect()\` ran, and the WS never opened. Even after fixing that, there was no path to actually become a member from the room page.

Three pieces:

- **\`server/api/rooms/[id]/index.get.ts\` (new)** — \`GET /api/rooms/:id\` returns metadata + the caller's \`isMember\` flag for any authenticated user. Non-members see the room exists and its kind, but no message content or member list.
- **\`app/pages/rooms/[id].vue\`** — split \`loadInitial\` into \`loadRoomInfo\` + \`loadMessages\` (only loads messages if member). WS \`chat.connect()\` now runs *before* loadInitial so the live badge tracks the socket, not the membership check. Three render branches: error state, non-member-channel with a **Join channel** button, non-member-DM with a hint. \`<SendBox>\` is hidden for non-members.
- Header shows the room name once metadata loads (was always the UUID).

## Test plan

- [x] typecheck + lint + 6/6 tests + build all clean
- [ ] Deploy to chatty
- [ ] Second user opens \`https://chat.openape.ai/rooms/4efd…\` → sees \"Join channel\" button → clicks → enters the room → sees messages + live badge