### PR TITLE
fix(openape-chat): rooms 404 for non-members, no join-by-link

### DIFF
--- a/apps/openape-chat/app/pages/rooms/[id].vue
+++ b/apps/openape-chat/app/pages/rooms/[id].vue
@@ -32,8 +32,7 @@ interface RoomInfo {
   kind: 'channel' | 'dm'
   createdByEmail: string
   createdAt: number
-  isMember: boolean
-  role: 'member' | 'admin' | null
+  role: 'member' | 'admin'
 }
 
 const messages = ref<Message[]>([])
@@ -42,7 +41,6 @@ const loading = ref(true)
 const scrollEl = ref<HTMLElement>()
 const roomInfo = ref<RoomInfo | null>(null)
 const roomError = ref<string | null>(null)
-const joining = ref(false)
 
 async function loadRoomInfo() {
   roomError.value = null
@@ -52,10 +50,12 @@ async function loadRoomInfo() {
   catch (err) {
     const status = (err as { statusCode?: number })?.statusCode
     if (status === 404) {
-      roomError.value = 'This room does not exist.'
+      // The server returns 404 both for "room doesn't exist" and "you're
+      // not a member" — this is intentional, non-members should not be
+      // able to discover that a room exists at all.
+      roomError.value = 'Raum für diesen User nicht verfügbar.'
     }
     else if (status === 401) {
-      // Session likely expired — bounce to login.
       navigateTo('/login')
     }
     else {
@@ -66,7 +66,7 @@ async function loadRoomInfo() {
 }
 
 async function loadMessages() {
-  if (!roomInfo.value?.isMember) {
+  if (!roomInfo.value) {
     messages.value = []
     loading.value = false
     return
@@ -86,22 +86,6 @@ async function loadMessages() {
 async function loadInitial() {
   await loadRoomInfo()
   await loadMessages()
-}
-
-async function joinRoom() {
-  if (joining.value) return
-  joining.value = true
-  try {
-    await $fetch(`/api/rooms/${roomId.value}/join`, { method: 'POST' })
-    await loadRoomInfo()
-    await loadMessages()
-  }
-  catch (err) {
-    roomError.value = err instanceof Error ? err.message : 'Could not join room.'
-  }
-  finally {
-    joining.value = false
-  }
 }
 
 function scrollToBottom(behavior: ScrollBehavior = 'smooth') {
@@ -238,37 +222,6 @@ function reactionsFor(messageId: string) {
         </UButton>
       </div>
 
-      <div v-else-if="roomInfo && !roomInfo.isMember" class="max-w-sm mx-auto py-12 text-center space-y-4">
-        <UIcon
-          :name="roomInfo.kind === 'dm' ? 'i-lucide-lock' : 'i-lucide-hash'"
-          class="size-10 text-zinc-600 mx-auto"
-        />
-        <div class="space-y-1">
-          <h2 class="text-lg font-semibold">
-            {{ roomInfo.name }}
-          </h2>
-          <p class="text-sm text-zinc-400">
-            <template v-if="roomInfo.kind === 'channel'">
-              You're not a member of this channel yet.
-            </template>
-            <template v-else>
-              This is a direct conversation. Ask {{ roomInfo.createdByEmail }} to add you.
-            </template>
-          </p>
-        </div>
-        <UButton
-          v-if="roomInfo.kind === 'channel'"
-          color="primary"
-          :loading="joining"
-          @click="joinRoom"
-        >
-          Join channel
-        </UButton>
-        <UButton v-else to="/" color="neutral" variant="soft">
-          Back to rooms
-        </UButton>
-      </div>
-
       <template v-else>
         <p v-if="loading" class="text-center text-sm text-zinc-500 py-8">
           Loading…
@@ -288,6 +241,6 @@ function reactionsFor(messageId: string) {
       </template>
     </main>
 
-    <SendBox v-if="roomInfo?.isMember" @send="send" />
+    <SendBox v-if="roomInfo" @send="send" />
   </div>
 </template>

--- a/apps/openape-chat/server/api/rooms/[id]/index.get.ts
+++ b/apps/openape-chat/server/api/rooms/[id]/index.get.ts
@@ -3,31 +3,34 @@ import { useDb } from '../../../database/drizzle'
 import { memberships, rooms } from '../../../database/schema'
 import { resolveCaller } from '../../../utils/auth'
 
-// Room metadata + the caller's own membership status. Returned even when
-// the caller is NOT a member of the room — that's intentional, the Web UI
-// uses this to show a "Join this channel" prompt instead of a dead end
-// when someone follows a shared link.
-//
-// Privacy: a non-member learns the room exists, its name, and its kind,
-// but nothing about other members or messages. For closed/DM rooms we
-// could narrow this further; for channels (the open kind) it's fine
-// because channel names are essentially public anyway.
+// Room metadata for members only. Non-members get the same 404 a
+// non-existent room id gets — by design: the room should be invisible
+// to people who haven't been invited. Discovering rooms by guessing
+// or by sharing a URL is not how membership happens; the creator adds
+// members explicitly via the room-creation flow (or, later, an invite
+// endpoint).
 export default defineEventHandler(async (event) => {
   const caller = await resolveCaller(event)
   const id = getRouterParam(event, 'id')
   if (!id) throw createError({ statusCode: 400, statusMessage: 'Missing room id' })
 
   const db = useDb()
-  const room = await db.select().from(rooms).where(eq(rooms.id, id)).get()
-  if (!room) {
-    throw createError({ statusCode: 404, statusMessage: 'Room not found' })
-  }
-
   const m = await db
     .select()
     .from(memberships)
     .where(and(eq(memberships.roomId, id), eq(memberships.userEmail, caller.email)))
     .get()
+  if (!m) {
+    // Indistinguishable from "room doesn't exist" on purpose — non-members
+    // shouldn't be able to confirm a room id even exists.
+    throw createError({ statusCode: 404, statusMessage: 'Room not found' })
+  }
+
+  const room = await db.select().from(rooms).where(eq(rooms.id, id)).get()
+  if (!room) {
+    // Membership row pointing at a deleted room — treat as gone.
+    throw createError({ statusCode: 404, statusMessage: 'Room not found' })
+  }
 
   return {
     id: room.id,
@@ -35,7 +38,6 @@ export default defineEventHandler(async (event) => {
     kind: room.kind,
     createdByEmail: room.createdByEmail,
     createdAt: room.createdAt,
-    isMember: !!m,
-    role: m?.role ?? null,
+    role: m.role,
   }
 })


### PR DESCRIPTION
## Summary

PR #206 exposed room metadata to non-members and offered a "Join channel" button — wrong default. Rooms should be invisible to people who haven't been invited; membership comes from the creator's add-list, not from following a shared URL.

- **\`GET /api/rooms/:id\`** — returns 404 for non-members (and for non-existent ids), making them indistinguishable. No name, kind, or creator email leaks.
- **Web UI room view** — 404 surfaces as "Raum für diesen User nicht verfügbar." with a Back-to-rooms button. The "Join channel" branch is gone; \`SendBox\` only renders for members.

The \`POST /api/rooms/:id/join\` endpoint stays for v2 (an invite-link flow could grant time-bound join tokens), but no UI path calls it anymore.

## Test plan

- [x] typecheck + lint + 6/6 tests + build all clean
- [ ] Deploy to chatty
- [ ] Second user opens a room URL they're not invited to → "Raum für diesen User nicht verfügbar." + Back button
- [ ] Member opens their own room → list + send still work