### PR TITLE
feat(openape-chat): admin can manage room members + roles

### DIFF
--- a/apps/openape-chat/app/components/MemberManager.vue
+++ b/apps/openape-chat/app/components/MemberManager.vue
@@ -1,0 +1,226 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+
+interface Member {
+  userEmail: string
+  role: 'member' | 'admin'
+  joinedAt: number
+}
+
+const props = defineProps<{
+  open: boolean
+  roomId: string
+  myEmail: string | null | undefined
+  myRole: 'member' | 'admin' | null
+}>()
+
+const emit = defineEmits<{
+  'update:open': [value: boolean]
+  'changed': []
+}>()
+
+const open = computed({
+  get: () => props.open,
+  set: v => emit('update:open', v),
+})
+
+const members = ref<Member[]>([])
+const loading = ref(false)
+const errorMsg = ref<string | null>(null)
+
+const newEmail = ref('')
+const newRole = ref<'member' | 'admin'>('member')
+const adding = ref(false)
+
+async function load() {
+  if (!props.roomId) return
+  loading.value = true
+  errorMsg.value = null
+  try {
+    members.value = await $fetch<Member[]>(`/api/rooms/${props.roomId}/members`)
+  }
+  catch (err) {
+    errorMsg.value = err instanceof Error ? err.message : 'Could not load members.'
+  }
+  finally {
+    loading.value = false
+  }
+}
+
+watch(() => props.open, (v) => {
+  if (v) load()
+})
+
+async function add() {
+  const email = newEmail.value.trim()
+  if (!email || adding.value) return
+  errorMsg.value = null
+  adding.value = true
+  try {
+    await $fetch(`/api/rooms/${props.roomId}/members`, {
+      method: 'POST',
+      body: { email, role: newRole.value },
+    })
+    newEmail.value = ''
+    newRole.value = 'member'
+    await load()
+    emit('changed')
+  }
+  catch (err) {
+    errorMsg.value = err instanceof Error ? err.message : 'Could not add member.'
+  }
+  finally {
+    adding.value = false
+  }
+}
+
+async function setRole(member: Member, role: 'member' | 'admin') {
+  if (member.role === role) return
+  errorMsg.value = null
+  try {
+    await $fetch(`/api/rooms/${props.roomId}/members/${encodeURIComponent(member.userEmail)}`, {
+      method: 'PATCH',
+      body: { role },
+    })
+    await load()
+    emit('changed')
+  }
+  catch (err) {
+    errorMsg.value = err instanceof Error ? err.message : 'Could not change role.'
+  }
+}
+
+async function remove(member: Member) {
+  if (member.userEmail === props.myEmail) return
+  errorMsg.value = null
+  try {
+    await $fetch(`/api/rooms/${props.roomId}/members/${encodeURIComponent(member.userEmail)}`, {
+      method: 'DELETE',
+    })
+    await load()
+    emit('changed')
+  }
+  catch (err) {
+    errorMsg.value = err instanceof Error ? err.message : 'Could not remove member.'
+  }
+}
+
+const isAdmin = computed(() => props.myRole === 'admin')
+</script>
+
+<template>
+  <UModal v-model:open="open" :ui="{ content: 'max-w-md' }">
+    <template #content>
+      <div class="p-6 space-y-5">
+        <div class="flex items-start justify-between gap-3">
+          <div>
+            <h2 class="text-lg font-semibold">
+              Members
+            </h2>
+            <p class="text-xs text-zinc-500">
+              {{ isAdmin ? 'Add, remove, or change roles.' : 'Read-only — only admins can edit.' }}
+            </p>
+          </div>
+          <UButton
+            icon="i-lucide-x"
+            color="neutral"
+            variant="ghost"
+            size="sm"
+            aria-label="Close"
+            @click="open = false"
+          />
+        </div>
+
+        <p v-if="errorMsg" class="text-sm text-red-400">
+          {{ errorMsg }}
+        </p>
+
+        <form v-if="isAdmin" class="space-y-2" @submit.prevent="add">
+          <UFormField label="Add member by email" :ui="{ label: 'text-xs' }">
+            <div class="flex gap-2">
+              <UInput
+                v-model="newEmail"
+                type="email"
+                placeholder="alice@example.com"
+                class="flex-1"
+                :disabled="adding"
+              />
+              <USelect
+                v-model="newRole"
+                :items="[
+                  { value: 'member', label: 'Member' },
+                  { value: 'admin', label: 'Admin' },
+                ]"
+                :disabled="adding"
+              />
+              <UButton
+                type="submit"
+                color="primary"
+                :loading="adding"
+                :disabled="!newEmail.trim() || adding"
+                icon="i-lucide-user-plus"
+                aria-label="Add"
+              />
+            </div>
+          </UFormField>
+        </form>
+
+        <div class="space-y-2">
+          <p v-if="loading" class="text-sm text-zinc-500">
+            Loading…
+          </p>
+          <ul v-else class="divide-y divide-zinc-800 -mx-2">
+            <li v-for="m of members" :key="m.userEmail" class="px-2 py-2 flex items-center gap-2">
+              <UIcon
+                :name="m.role === 'admin' ? 'i-lucide-shield' : 'i-lucide-user'"
+                :class="m.role === 'admin' ? 'text-primary-400' : 'text-zinc-500'"
+                class="size-4 shrink-0"
+              />
+              <div class="flex-1 min-w-0">
+                <p class="text-sm font-medium truncate">
+                  {{ m.userEmail }}
+                  <span v-if="m.userEmail === myEmail" class="text-xs text-zinc-500 font-normal">(you)</span>
+                </p>
+                <p class="text-xs text-zinc-500 capitalize">
+                  {{ m.role }}
+                </p>
+              </div>
+              <template v-if="isAdmin">
+                <UButton
+                  v-if="m.role === 'member'"
+                  size="xs"
+                  color="neutral"
+                  variant="soft"
+                  :title="m.userEmail === myEmail ? 'You can promote yourself' : 'Promote to admin'"
+                  @click="setRole(m, 'admin')"
+                >
+                  Make admin
+                </UButton>
+                <UButton
+                  v-else-if="m.userEmail !== myEmail"
+                  size="xs"
+                  color="neutral"
+                  variant="soft"
+                  title="Demote to member"
+                  @click="setRole(m, 'member')"
+                >
+                  Demote
+                </UButton>
+                <UButton
+                  v-if="m.userEmail !== myEmail"
+                  size="xs"
+                  color="error"
+                  variant="ghost"
+                  icon="i-lucide-user-minus"
+                  aria-label="Remove from room"
+                  title="Remove from room"
+                  @click="remove(m)"
+                />
+              </template>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </template>
+  </UModal>
+</template>

--- a/apps/openape-chat/app/composables/useChat.ts
+++ b/apps/openape-chat/app/composables/useChat.ts
@@ -19,7 +19,10 @@ interface Reaction {
 }
 
 interface ChatFrame {
-  type: 'message' | 'reaction' | 'reaction-removed' | 'edit' | 'hello' | 'error'
+  type:
+    | 'message' | 'reaction' | 'reaction-removed' | 'edit'
+    | 'membership-added' | 'membership-changed' | 'membership-removed'
+    | 'hello' | 'error'
   room_id?: string
   payload?: Message | Reaction | { messageId: string, userEmail: string, emoji: string } | Record<string, unknown>
   email?: string

--- a/apps/openape-chat/app/pages/rooms/[id].vue
+++ b/apps/openape-chat/app/pages/rooms/[id].vue
@@ -41,6 +41,7 @@ const loading = ref(true)
 const scrollEl = ref<HTMLElement>()
 const roomInfo = ref<RoomInfo | null>(null)
 const roomError = ref<string | null>(null)
+const membersOpen = ref(false)
 
 async function loadRoomInfo() {
   roomError.value = null
@@ -142,6 +143,23 @@ onMounted(async () => {
       const p = frame.payload as { messageId: string, userEmail: string, emoji: string }
       removeReactionLocal(p.messageId, p.userEmail, p.emoji)
     }
+    else if (frame.type === 'membership-removed') {
+      const p = frame.payload as { roomId: string, userEmail: string }
+      // If I'm the one being removed, kick myself out of the room view.
+      // The next loadRoomInfo would 404 anyway; this just makes the
+      // transition immediate instead of waiting for the next interaction.
+      if (p.userEmail === user.value?.sub) {
+        navigateTo('/')
+      }
+    }
+    else if (frame.type === 'membership-changed') {
+      const p = frame.payload as { roomId: string, userEmail: string, role: 'member' | 'admin' }
+      // Refresh local role so the admin UI flips when someone promotes
+      // or demotes me without requiring a page reload.
+      if (p.userEmail === user.value?.sub && roomInfo.value) {
+        roomInfo.value = { ...roomInfo.value, role: p.role }
+      }
+    }
   })
 })
 
@@ -206,6 +224,15 @@ function reactionsFor(messageId: string) {
       <h1 class="font-semibold flex-1 truncate">
         {{ roomInfo?.name ?? roomId }}
       </h1>
+      <UButton
+        v-if="roomInfo"
+        :icon="roomInfo.role === 'admin' ? 'i-lucide-settings' : 'i-lucide-users'"
+        size="sm"
+        color="neutral"
+        variant="ghost"
+        :aria-label="roomInfo.role === 'admin' ? 'Manage members' : 'View members'"
+        @click="membersOpen = true"
+      />
       <span class="text-xs px-2 py-0.5 rounded-full" :class="chat.connected.value ? 'text-emerald-400' : 'text-zinc-500'">
         {{ chat.connected.value ? '● live' : '○ offline' }}
       </span>
@@ -242,5 +269,13 @@ function reactionsFor(messageId: string) {
     </main>
 
     <SendBox v-if="roomInfo" @send="send" />
+
+    <MemberManager
+      v-if="roomInfo"
+      v-model:open="membersOpen"
+      :room-id="roomId"
+      :my-email="user?.sub"
+      :my-role="roomInfo.role"
+    />
   </div>
 </template>

--- a/apps/openape-chat/server/api/rooms/[id]/members/[email].delete.ts
+++ b/apps/openape-chat/server/api/rooms/[id]/members/[email].delete.ts
@@ -1,0 +1,47 @@
+import { and, eq } from 'drizzle-orm'
+import { useDb } from '../../../../database/drizzle'
+import { memberships } from '../../../../database/schema'
+import { resolveCaller } from '../../../../utils/auth'
+import { broadcastToRoom } from '../../../../utils/realtime'
+import { requireRole } from '../../../../utils/room-access'
+
+export default defineEventHandler(async (event) => {
+  const caller = await resolveCaller(event)
+  const id = getRouterParam(event, 'id')
+  const email = decodeURIComponent(getRouterParam(event, 'email') ?? '')
+  if (!id || !email) {
+    throw createError({ statusCode: 400, statusMessage: 'Missing room id or email' })
+  }
+
+  await requireRole(id, caller.email, 'admin')
+
+  // Self-removal guard: an admin cannot remove themselves. To leave the
+  // room they'd have to ask another admin to do it (or use the user-facing
+  // /api/rooms/:id/leave endpoint which is intentionally not gated by
+  // admin role — but that's also the route a regular member uses to walk
+  // out, and we don't want admins accidentally orphaning the room).
+  if (email === caller.email) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'You cannot remove yourself. Ask another admin to do it.',
+    })
+  }
+
+  const db = useDb()
+  const result = await db
+    .delete(memberships)
+    .where(and(eq(memberships.roomId, id), eq(memberships.userEmail, email)))
+    .returning()
+
+  if (result.length === 0) {
+    throw createError({ statusCode: 404, statusMessage: 'Member not found in room' })
+  }
+
+  await broadcastToRoom(id, {
+    type: 'membership-removed',
+    room_id: id,
+    payload: { roomId: id, userEmail: email },
+  })
+
+  return { ok: true }
+})

--- a/apps/openape-chat/server/api/rooms/[id]/members/[email].patch.ts
+++ b/apps/openape-chat/server/api/rooms/[id]/members/[email].patch.ts
@@ -1,0 +1,56 @@
+import { and, eq } from 'drizzle-orm'
+import { z } from 'zod'
+import { useDb } from '../../../../database/drizzle'
+import { memberships } from '../../../../database/schema'
+import { resolveCaller } from '../../../../utils/auth'
+import { broadcastToRoom } from '../../../../utils/realtime'
+import { requireRole } from '../../../../utils/room-access'
+
+const bodySchema = z.object({
+  role: z.enum(['member', 'admin']),
+})
+
+export default defineEventHandler(async (event) => {
+  const caller = await resolveCaller(event)
+  const id = getRouterParam(event, 'id')
+  const email = decodeURIComponent(getRouterParam(event, 'email') ?? '')
+  if (!id || !email) {
+    throw createError({ statusCode: 400, statusMessage: 'Missing room id or email' })
+  }
+
+  await requireRole(id, caller.email, 'admin')
+
+  const parsed = bodySchema.safeParse(await readBody(event))
+  if (!parsed.success) {
+    throw createError({ statusCode: 400, statusMessage: parsed.error.message })
+  }
+
+  // Self-demotion guard: an admin cannot demote themselves to member.
+  // (They'd have to ask another admin.) This avoids a room ending up with
+  // zero admins by accident.
+  if (email === caller.email && parsed.data.role !== 'admin') {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'You cannot demote yourself. Ask another admin to do it.',
+    })
+  }
+
+  const db = useDb()
+  const result = await db
+    .update(memberships)
+    .set({ role: parsed.data.role })
+    .where(and(eq(memberships.roomId, id), eq(memberships.userEmail, email)))
+    .returning()
+
+  if (result.length === 0) {
+    throw createError({ statusCode: 404, statusMessage: 'Member not found in room' })
+  }
+
+  await broadcastToRoom(id, {
+    type: 'membership-changed',
+    room_id: id,
+    payload: { roomId: id, userEmail: email, role: parsed.data.role },
+  })
+
+  return result[0]
+})

--- a/apps/openape-chat/server/api/rooms/[id]/members/index.get.ts
+++ b/apps/openape-chat/server/api/rooms/[id]/members/index.get.ts
@@ -1,0 +1,25 @@
+import { eq } from 'drizzle-orm'
+import { useDb } from '../../../../database/drizzle'
+import { memberships } from '../../../../database/schema'
+import { resolveCaller } from '../../../../utils/auth'
+import { requireRole } from '../../../../utils/room-access'
+
+// Members of a room can list the other members. Non-members get the
+// same 404 they get for the room itself.
+export default defineEventHandler(async (event) => {
+  const caller = await resolveCaller(event)
+  const id = getRouterParam(event, 'id')
+  if (!id) throw createError({ statusCode: 400, statusMessage: 'Missing room id' })
+
+  await requireRole(id, caller.email, 'member')
+
+  const db = useDb()
+  return await db
+    .select({
+      userEmail: memberships.userEmail,
+      role: memberships.role,
+      joinedAt: memberships.joinedAt,
+    })
+    .from(memberships)
+    .where(eq(memberships.roomId, id))
+})

--- a/apps/openape-chat/server/api/rooms/[id]/members/index.post.ts
+++ b/apps/openape-chat/server/api/rooms/[id]/members/index.post.ts
@@ -1,0 +1,48 @@
+import { z } from 'zod'
+import { useDb } from '../../../../database/drizzle'
+import { memberships } from '../../../../database/schema'
+import { resolveCaller } from '../../../../utils/auth'
+import { broadcastToRoom } from '../../../../utils/realtime'
+import { requireRole } from '../../../../utils/room-access'
+
+const bodySchema = z.object({
+  email: z.string().email(),
+  role: z.enum(['member', 'admin']).default('member'),
+})
+
+export default defineEventHandler(async (event) => {
+  const caller = await resolveCaller(event)
+  const id = getRouterParam(event, 'id')
+  if (!id) throw createError({ statusCode: 400, statusMessage: 'Missing room id' })
+
+  await requireRole(id, caller.email, 'admin')
+
+  const parsed = bodySchema.safeParse(await readBody(event))
+  if (!parsed.success) {
+    throw createError({ statusCode: 400, statusMessage: parsed.error.message })
+  }
+
+  const row = {
+    roomId: id,
+    userEmail: parsed.data.email,
+    role: parsed.data.role,
+    joinedAt: Math.floor(Date.now() / 1000),
+  }
+
+  const db = useDb()
+  await db
+    .insert(memberships)
+    .values(row)
+    .onConflictDoUpdate({
+      target: [memberships.roomId, memberships.userEmail],
+      set: { role: row.role },
+    })
+
+  await broadcastToRoom(id, {
+    type: 'membership-added',
+    room_id: id,
+    payload: row,
+  })
+
+  return row
+})

--- a/apps/openape-chat/server/utils/realtime.ts
+++ b/apps/openape-chat/server/utils/realtime.ts
@@ -39,6 +39,7 @@ export function peerCount(): number {
 
 export interface ChatFrame {
   type: 'message' | 'reaction' | 'reaction-removed' | 'edit'
+    | 'membership-added' | 'membership-changed' | 'membership-removed'
   room_id: string
   payload: Record<string, unknown>
 }

--- a/apps/openape-chat/server/utils/room-access.ts
+++ b/apps/openape-chat/server/utils/room-access.ts
@@ -1,0 +1,31 @@
+import { and, eq } from 'drizzle-orm'
+import { useDb } from '../database/drizzle'
+import { memberships } from '../database/schema'
+
+export type RoomRole = 'member' | 'admin'
+
+/**
+ * Resolve the caller's role in a room. Throws 404 for non-members so the
+ * UI sees the same response as for non-existent rooms — non-members
+ * shouldn't be able to confirm a room exists. Throws 403 when an admin
+ * action is required and the caller is only a regular member.
+ */
+export async function requireRole(
+  roomId: string,
+  email: string,
+  required: 'member' | 'admin' = 'member',
+): Promise<RoomRole> {
+  const db = useDb()
+  const m = await db
+    .select()
+    .from(memberships)
+    .where(and(eq(memberships.roomId, roomId), eq(memberships.userEmail, email)))
+    .get()
+  if (!m) {
+    throw createError({ statusCode: 404, statusMessage: 'Room not found' })
+  }
+  if (required === 'admin' && m.role !== 'admin') {
+    throw createError({ statusCode: 403, statusMessage: 'Admin role required' })
+  }
+  return m.role as RoomRole
+}


### PR DESCRIPTION
## Summary

Admins can now add/remove members and promote/demote roles. Self-demotion and self-removal are blocked so a room never ends up with zero admins.

- **Server** (\`server/api/rooms/[id]/members/*\`):
  - \`GET\` lists members (members-only).
  - \`POST\` adds by email + role (admin-only, idempotent upsert).
  - \`PATCH /<email>\` changes role; rejects self-demotion.
  - \`DELETE /<email>\` removes; rejects self-removal.
  - New \`server/utils/room-access.ts\` consolidates the role check, returning 404 (not 403) when the caller isn't a member at all — keeps non-members from probing room ids.
- **WS frames**: \`membership-added\`, \`membership-changed\`, \`membership-removed\`. Connected members see live changes without refetch; if I'm removed I get bounced to \`/\`; if I'm promoted/demoted my local role flips so admin controls appear/disappear.
- **Client**: new \`MemberManager.vue\` modal opened from the room header. Admins get add-form + per-row Promote/Demote/Remove; members see read-only.

## Test plan

- [x] typecheck + lint + 6/6 tests + build all clean
- [ ] Deploy
- [ ] As admin: open room → settings cog → add second user → second user opens the room and can see messages
- [ ] As admin: promote second user → demote them → remove them → second user gets bounced to /
- [ ] As admin: try to demote/remove self → blocked with clear message
- [ ] As member: settings shows users icon, modal is read-only