### PR TITLE
fix(openape-chat): real favicon + page titles

### DIFF
--- a/apps/openape-chat/app/pages/login.vue
+++ b/apps/openape-chat/app/pages/login.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 const { user, fetchUser } = useOpenApeAuth()
 
+useHead({ title: 'Sign in' })
+
 onMounted(async () => {
   await fetchUser()
   if (user.value) navigateTo('/')

--- a/apps/openape-chat/app/pages/rooms/[id].vue
+++ b/apps/openape-chat/app/pages/rooms/[id].vue
@@ -43,6 +43,13 @@ const roomInfo = ref<RoomInfo | null>(null)
 const roomError = ref<string | null>(null)
 const membersOpen = ref(false)
 
+// Per-page title — falls back to a generic placeholder while the
+// metadata loads, then updates to the room name. The titleTemplate
+// from nuxt.config appends " — OpenApe Chat".
+useHead({
+  title: () => roomInfo.value?.name ?? 'Room',
+})
+
 async function loadRoomInfo() {
   roomError.value = null
   try {

--- a/apps/openape-chat/nuxt.config.ts
+++ b/apps/openape-chat/nuxt.config.ts
@@ -8,6 +8,33 @@ export default defineNuxtConfig({
   compatibilityDate: '2025-01-01',
   colorMode: { preference: 'dark' },
 
+  // Browser tab title + favicon. The favicon mirrors id.openape.ai's
+  // pattern (single emoji in a 100×100 SVG) — clean at every zoom level
+  // and indistinguishable from a hand-drawn raster on retina displays.
+  // Per-page <Title>…</Title> overrides this via useHead/Head; everything
+  // else inherits the titleTemplate so e.g. /rooms/<name> reads
+  // "alpha — OpenApe Chat".
+  app: {
+    head: {
+      title: 'OpenApe Chat',
+      // %s substitutes the per-page useHead title; if a page omits one,
+      // the standalone `title` above is used and the template is skipped.
+      titleTemplate: '%s — OpenApe Chat',
+      link: [
+        { rel: 'icon', type: 'image/svg+xml', href: '/favicon.svg' },
+        { rel: 'apple-touch-icon', href: '/icon-192.png', sizes: '192x192' },
+        { rel: 'apple-touch-icon', href: '/icon-512.png', sizes: '512x512' },
+      ],
+      meta: [
+        { name: 'theme-color', content: '#18181b' },
+        { name: 'description', content: 'Team rooms and DMs for humans and agents.' },
+        { name: 'apple-mobile-web-app-capable', content: 'yes' },
+        { name: 'apple-mobile-web-app-status-bar-style', content: 'black-translucent' },
+        { name: 'apple-mobile-web-app-title', content: 'OpenApe Chat' },
+      ],
+    },
+  },
+
   openapeSp: {
     clientId: process.env.NUXT_OPENAPE_CLIENT_ID || 'chat.openape.ai',
     spName: process.env.NUXT_OPENAPE_SP_NAME || 'OpenApe Chat',

--- a/apps/openape-chat/public/favicon.svg
+++ b/apps/openape-chat/public/favicon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <text y=".9em" font-size="90">💬</text>
+</svg>


### PR DESCRIPTION
## Summary

Browser tabs showed no icon (Nuxt default 78-byte \`favicon.ico\`) and the title fell back to empty. Fixed both, mirroring the pattern \`id.openape.ai\` uses (single emoji in a 100×100 SVG).

- \`public/favicon.svg\` — 💬 emoji.
- \`nuxt.config.ts\` head: \`title\` + \`titleTemplate: '%s — OpenApe Chat'\`, \`<link rel=icon>\`, \`apple-touch-icon\` (the 192/512 PNGs already shipped for the PWA), \`apple-mobile-web-app-*\` so iOS installs get the right launcher title and splash colors.
- \`pages/login.vue\` → \`Sign in — OpenApe Chat\`
- \`pages/rooms/[id].vue\` → \`<room name> — OpenApe Chat\` once metadata loads, falls back to \`Room — OpenApe Chat\` while loading.

## Test plan

- [x] typecheck + lint + 6/6 tests + build all clean
- [ ] Deploy
- [ ] Open chat.openape.ai in Chromium → tab shows 💬 + "OpenApe Chat"
- [ ] Open /rooms/<id> → tab title is "<room name> — OpenApe Chat"
- [ ] Open /login → tab title is "Sign in — OpenApe Chat"
- [ ] iOS Add to Home Screen → installed app shows "OpenApe Chat", not the URL