### PR TITLE
fix(openape-chat): titleTemplate function — no more doubled title

### DIFF
--- a/apps/openape-chat/nuxt.config.ts
+++ b/apps/openape-chat/nuxt.config.ts
@@ -16,10 +16,13 @@ export default defineNuxtConfig({
   // "alpha — OpenApe Chat".
   app: {
     head: {
-      title: 'OpenApe Chat',
-      // %s substitutes the per-page useHead title; if a page omits one,
-      // the standalone `title` above is used and the template is skipped.
-      titleTemplate: '%s — OpenApe Chat',
+      // Function form of titleTemplate: when a page sets a useHead title
+      // we render "<title> — OpenApe Chat", otherwise just "OpenApe Chat".
+      // Avoids the doubled "OpenApe Chat — OpenApe Chat" you get if you
+      // combine a static `title` with `'%s — OpenApe Chat'`. The cast is
+      // because @nuxt/schema's type narrows to string, while unhead
+      // supports the function at runtime.
+      titleTemplate: ((title?: string) => title ? `${title} — OpenApe Chat` : 'OpenApe Chat') as unknown as string,
       link: [
         { rel: 'icon', type: 'image/svg+xml', href: '/favicon.svg' },
         { rel: 'apple-touch-icon', href: '/icon-192.png', sizes: '192x192' },


### PR DESCRIPTION
PR #209 produced \`"OpenApe Chat — OpenApe Chat"\` because unhead applied the \`'%s — OpenApe Chat'\` template against the static \`title: 'OpenApe Chat'\` default.

Switch to the function form so it renders \`<title> — OpenApe Chat\` only when a page sets a useHead title; bare \`OpenApe Chat\` otherwise. Cast through \`unknown\` because @nuxt/schema narrows the field to string while unhead supports the function at runtime.