### PR TITLE
fix(openape-chat): titleTemplate via plugin (function survives build)

### DIFF
--- a/apps/openape-chat/app/plugins/head.ts
+++ b/apps/openape-chat/app/plugins/head.ts
@@ -1,0 +1,12 @@
+// Function-form titleTemplate has to live in a plugin: nuxt.config head is
+// serialized at build time, so a function gets stringified and unhead
+// silently treats it as a literal title (PR #210 hit this — every page
+// rendered just its own title without the " — OpenApe Chat" suffix).
+//
+// Plugins run at runtime, so the function keeps its identity and unhead
+// invokes it correctly.
+export default defineNuxtPlugin(() => {
+  useHead({
+    titleTemplate: (title?: string) => title ? `${title} — OpenApe Chat` : 'OpenApe Chat',
+  })
+})

--- a/apps/openape-chat/nuxt.config.ts
+++ b/apps/openape-chat/nuxt.config.ts
@@ -16,13 +16,9 @@ export default defineNuxtConfig({
   // "alpha — OpenApe Chat".
   app: {
     head: {
-      // Function form of titleTemplate: when a page sets a useHead title
-      // we render "<title> — OpenApe Chat", otherwise just "OpenApe Chat".
-      // Avoids the doubled "OpenApe Chat — OpenApe Chat" you get if you
-      // combine a static `title` with `'%s — OpenApe Chat'`. The cast is
-      // because @nuxt/schema's type narrows to string, while unhead
-      // supports the function at runtime.
-      titleTemplate: ((title?: string) => title ? `${title} — OpenApe Chat` : 'OpenApe Chat') as unknown as string,
+      // titleTemplate lives in app/plugins/head.ts as a function — a
+      // function placed here is serialized at build time and silently
+      // dropped, leaving pages without their " — OpenApe Chat" suffix.
       link: [
         { rel: 'icon', type: 'image/svg+xml', href: '/favicon.svg' },
         { rel: 'apple-touch-icon', href: '/icon-192.png', sizes: '192x192' },


### PR DESCRIPTION
PR #210's function-form titleTemplate got serialized to a string at build time. Move it to app/plugins/head.ts so the function survives.