### PR TITLE
feat(openape-free-idp): web push for pending grants

### DIFF
--- a/apps/openape-free-idp/app/components/EnableNotifications.vue
+++ b/apps/openape-free-idp/app/components/EnableNotifications.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+const push = usePushSubscription()
+const busy = ref(false)
+const error = ref<string | null>(null)
+
+async function toggle() {
+  busy.value = true
+  error.value = null
+  try {
+    if (push.subscribed.value) {
+      await push.disable()
+    }
+    else {
+      const ok = await push.enable()
+      if (!ok) error.value = 'Notifications not enabled. Check browser permissions.'
+    }
+  }
+  finally {
+    busy.value = false
+  }
+}
+</script>
+
+<template>
+  <div v-if="push.supported.value" class="w-full px-4 py-3 border border-gray-800 rounded-lg flex items-center gap-3 bg-gray-900/40">
+    <UIcon name="i-lucide-bell" class="size-5 text-gray-400" />
+    <div class="flex-1 text-sm text-left">
+      <p class="font-medium text-white">
+        Approval-Benachrichtigungen
+      </p>
+      <p class="text-gray-500 text-xs">
+        {{ push.subscribed.value
+          ? 'Aktiv — du wirst gepingt, wenn ein Grant auf deine Approval wartet.'
+          : 'Push-Benachrichtigung wenn ein Grant deine Approval braucht.' }}
+      </p>
+    </div>
+    <UButton
+      :color="push.subscribed.value ? 'neutral' : 'primary'"
+      :variant="push.subscribed.value ? 'soft' : 'solid'"
+      size="sm"
+      :loading="busy"
+      @click="toggle"
+    >
+      {{ push.subscribed.value ? 'Aus' : 'Ein' }}
+    </UButton>
+  </div>
+  <p v-if="error" class="px-4 pt-1 text-xs text-red-400">
+    {{ error }}
+  </p>
+</template>

--- a/apps/openape-free-idp/app/composables/usePushSubscription.ts
+++ b/apps/openape-free-idp/app/composables/usePushSubscription.ts
@@ -1,0 +1,135 @@
+import { onMounted, ref } from 'vue'
+
+interface PushHandle {
+  supported: ReturnType<typeof ref<boolean>>
+  subscribed: ReturnType<typeof ref<boolean>>
+  permissionGranted: ReturnType<typeof ref<boolean>>
+  /**
+   * Ask the browser for notification permission and create a Push
+   * subscription. Returns true on success, false otherwise (denied,
+   * unsupported, or fetch failed). Safe to call multiple times —
+   * already-subscribed sessions short-circuit.
+   */
+  enable: () => Promise<boolean>
+  disable: () => Promise<void>
+}
+
+/**
+ * Web-Push integration. Deliberately gated on `display-mode: standalone`
+ * so we never prompt the user for the Notification permission on a normal
+ * browser tab. The prompt is only shown after the IdP is installed (Add
+ * to Home Screen on iOS, install prompt on Android/Chrome) — at that
+ * point the user has explicitly opted in to "treat this like a real app",
+ * and notifications make sense.
+ */
+export function usePushSubscription(): PushHandle {
+  const supported = ref(false)
+  const subscribed = ref(false)
+  const permissionGranted = ref(false)
+
+  function isStandalone(): boolean {
+    if (typeof window === 'undefined') return false
+    if (window.matchMedia('(display-mode: standalone)').matches) return true
+    return (window.navigator as { standalone?: boolean }).standalone === true
+  }
+
+  async function getRegistration(): Promise<ServiceWorkerRegistration | null> {
+    if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) return null
+    return await navigator.serviceWorker.ready
+  }
+
+  async function refresh() {
+    if (typeof window === 'undefined') return
+    if (!('Notification' in window) || !('PushManager' in window)) {
+      supported.value = false
+      return
+    }
+    if (!isStandalone()) {
+      supported.value = false
+      return
+    }
+    supported.value = true
+    permissionGranted.value = Notification.permission === 'granted'
+    const reg = await getRegistration()
+    const sub = await reg?.pushManager.getSubscription()
+    subscribed.value = !!sub
+  }
+
+  function urlBase64ToUint8Array(base64: string): Uint8Array {
+    const padding = '='.repeat((4 - base64.length % 4) % 4)
+    const b64 = (base64 + padding).replace(/-/g, '+').replace(/_/g, '/')
+    const raw = atob(b64)
+    const out = new Uint8Array(raw.length)
+    for (let i = 0; i < raw.length; i++) out[i] = raw.charCodeAt(i)
+    return out
+  }
+
+  async function enable(): Promise<boolean> {
+    await refresh()
+    if (!supported.value) return false
+    if (subscribed.value) return true
+
+    const perm = await Notification.requestPermission()
+    permissionGranted.value = perm === 'granted'
+    if (perm !== 'granted') return false
+
+    const reg = await getRegistration()
+    if (!reg) return false
+
+    const { vapidPublicKey } = await $fetch<{ vapidPublicKey: string }>('/api/push/vapid')
+    if (!vapidPublicKey) return false
+
+    let sub: globalThis.PushSubscription
+    try {
+      // applicationServerKey expects a BufferSource. Newer lib.dom narrows
+      // Uint8Array<ArrayBuffer>; allocating a fresh ArrayBuffer with the
+      // bytes copied in satisfies both.
+      const keyBytes = urlBase64ToUint8Array(vapidPublicKey)
+      const keyBuffer = new ArrayBuffer(keyBytes.byteLength)
+      new Uint8Array(keyBuffer).set(keyBytes)
+      sub = await reg.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: keyBuffer,
+      })
+    }
+    catch {
+      return false
+    }
+
+    const json = sub.toJSON() as { endpoint: string, keys: { p256dh: string, auth: string } }
+    try {
+      await $fetch('/api/push/subscribe', {
+        method: 'POST',
+        body: { endpoint: json.endpoint, keys: json.keys },
+      })
+    }
+    catch {
+      // Backend rejected — drop the local subscription so the next
+      // attempt doesn't think we're already enrolled.
+      await sub.unsubscribe().catch(() => {})
+      return false
+    }
+    subscribed.value = true
+    return true
+  }
+
+  async function disable() {
+    const reg = await getRegistration()
+    const sub = await reg?.pushManager.getSubscription()
+    if (!sub) {
+      subscribed.value = false
+      return
+    }
+    const endpoint = sub.endpoint
+    await sub.unsubscribe().catch(() => {})
+    subscribed.value = false
+    await $fetch('/api/push/subscribe', {
+      method: 'DELETE',
+      body: { endpoint },
+    }).catch(() => { /* server is best-effort */ })
+  }
+
+  onMounted(refresh)
+
+  return { supported, subscribed, permissionGranted, enable, disable }
+}

--- a/apps/openape-free-idp/app/pages/index.vue
+++ b/apps/openape-free-idp/app/pages/index.vue
@@ -68,6 +68,10 @@ async function handleLogout() {
             Abmelden
           </UButton>
         </div>
+
+        <ClientOnly>
+          <EnableNotifications />
+        </ClientOnly>
       </div>
     </UCard>
 

--- a/apps/openape-free-idp/app/plugins/head.ts
+++ b/apps/openape-free-idp/app/plugins/head.ts
@@ -1,0 +1,11 @@
+// Function-form titleTemplate has to live in a plugin: nuxt.config head is
+// serialized at build time, so a function gets stringified and unhead
+// silently treats it as a literal title (the same hit chat in PR #211).
+//
+// Plugins run at runtime, so the function keeps its identity and unhead
+// invokes it on every page render.
+export default defineNuxtPlugin(() => {
+  useHead({
+    titleTemplate: (title?: string) => title ? `${title} — OpenApe IdP` : 'OpenApe IdP',
+  })
+})

--- a/apps/openape-free-idp/nuxt.config.ts
+++ b/apps/openape-free-idp/nuxt.config.ts
@@ -4,9 +4,25 @@ const localIssuer = process.env.OPENAPE_ISSUER || 'https://id.openape.ai'
 export default defineNuxtConfig({
   future: { compatibilityVersion: 4 },
   nitro: { experimental: { asyncContext: true } },
-  modules: ['@nuxt/ui', '@openape/nuxt-auth-idp', '@sentry/nuxt/module'],
+  modules: ['@nuxt/ui', '@openape/nuxt-auth-idp', '@sentry/nuxt/module', '@vite-pwa/nuxt'],
   css: ['~/assets/css/main.css'],
   colorMode: { preference: 'dark' },
+
+  app: {
+    head: {
+      link: [
+        { rel: 'icon', type: 'image/svg+xml', href: '/favicon.svg' },
+        { rel: 'apple-touch-icon', href: '/favicon.svg' },
+      ],
+      meta: [
+        { name: 'theme-color', content: '#18181b' },
+        { name: 'description', content: 'OpenApe Identity Provider — passkeys, agents, grants.' },
+        { name: 'apple-mobile-web-app-capable', content: 'yes' },
+        { name: 'apple-mobile-web-app-status-bar-style', content: 'black-translucent' },
+        { name: 'apple-mobile-web-app-title', content: 'OpenApe IdP' },
+      ],
+    },
+  },
 
   openapeIdp: {
     sessionSecret: process.env.OPENAPE_SESSION_SECRET || '',
@@ -27,8 +43,52 @@ export default defineNuxtConfig({
     resendFrom: 'auth@openape.ai',
     tursoUrl: '',
     tursoAuthToken: '',
+    // VAPID keypair for grant-approval push notifications. Generate once
+    // with `scripts/generate-idp-vapid.sh` and persist to env. The public
+    // key is sent to clients (PushManager.subscribe needs it); private key
+    // and subject (a mailto: that push services can use to contact us if
+    // we misbehave) are server-side only. Defaults to empty so dev still
+    // boots without push — the helper silently no-ops in that case.
+    vapidPrivateKey: process.env.NUXT_VAPID_PRIVATE_KEY || '',
+    vapidSubject: process.env.NUXT_VAPID_SUBJECT || 'mailto:patrick@hofmann.eco',
     public: {
       maxAgentsPerUser: 10,
+      vapidPublicKey: process.env.NUXT_PUBLIC_VAPID_PUBLIC_KEY || '',
+    },
+  },
+
+  // PWA + custom service worker. injectManifest mode lets us own sw.ts so
+  // we can register `push` and `notificationclick` handlers (vite-pwa's
+  // generateSW mode can't expose those). srcDir: '..' resolves to the
+  // Nuxt project root (apps/openape-free-idp/sw.ts) — see the chat app's
+  // PR #203 for why the file lives outside app/ rather than under it.
+  pwa: {
+    strategies: 'injectManifest',
+    srcDir: '..',
+    filename: 'sw.ts',
+    registerType: 'autoUpdate',
+    manifest: {
+      name: 'OpenApe IdP',
+      short_name: 'OpenApe IdP',
+      description: 'Passkeys, agents, and grant approval — for the open web.',
+      theme_color: '#18181b',
+      background_color: '#18181b',
+      display: 'standalone',
+      start_url: '/',
+      scope: '/',
+      icons: [
+        { src: '/favicon.svg', sizes: 'any', type: 'image/svg+xml', purpose: 'any maskable' },
+      ],
+    },
+    injectManifest: {
+      globPatterns: ['**/*.{js,css,html,ico,png,svg,webmanifest}'],
+    },
+    client: {
+      installPrompt: true,
+      periodicSyncForUpdates: 60 * 60,
+    },
+    devOptions: {
+      enabled: false, // SW + HMR is a debugging nightmare in dev
     },
   },
 

--- a/apps/openape-free-idp/package.json
+++ b/apps/openape-free-idp/package.json
@@ -26,13 +26,16 @@
     "@openape/nuxt-auth-idp": "workspace:*",
     "@openape/vue-components": "workspace:*",
     "@sentry/nuxt": "^10.47.0",
+    "@vite-pwa/nuxt": "^1.0.4",
     "drizzle-orm": "^0.44.7",
     "nuxt": "^4.0.0",
     "resend": "^4.0.0",
-    "tailwindcss": "^4.0.0"
+    "tailwindcss": "^4.0.0",
+    "web-push": "^3.6.7"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
+    "@types/web-push": "^3.6.4",
     "typescript": "^5.7.0",
     "vitest": "^3.0.0",
     "vue-tsc": "^2.0.0"

--- a/apps/openape-free-idp/server/api/push/subscribe.delete.ts
+++ b/apps/openape-free-idp/server/api/push/subscribe.delete.ts
@@ -1,0 +1,28 @@
+import { and, eq } from 'drizzle-orm'
+import { z } from 'zod'
+import { useDb } from '../../database/drizzle'
+import { pushSubscriptions } from '../../database/schema'
+
+const bodySchema = z.object({
+  endpoint: z.string().url(),
+})
+
+// Owner-only revoke: an attacker who captured an endpoint URL shouldn't
+// be able to silently unsubscribe someone else.
+export default defineEventHandler(async (event) => {
+  const email = await requireAuth(event)
+  const parsed = bodySchema.safeParse(await readBody(event))
+  if (!parsed.success) {
+    throw createError({ statusCode: 400, statusMessage: parsed.error.message })
+  }
+
+  const db = useDb()
+  await db
+    .delete(pushSubscriptions)
+    .where(and(
+      eq(pushSubscriptions.endpoint, parsed.data.endpoint),
+      eq(pushSubscriptions.userEmail, email),
+    ))
+
+  return { ok: true }
+})

--- a/apps/openape-free-idp/server/api/push/subscribe.post.ts
+++ b/apps/openape-free-idp/server/api/push/subscribe.post.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod'
+import { useDb } from '../../database/drizzle'
+import { pushSubscriptions } from '../../database/schema'
+
+const bodySchema = z.object({
+  endpoint: z.string().url(),
+  keys: z.object({
+    p256dh: z.string().min(1),
+    auth: z.string().min(1),
+  }),
+})
+
+// Upsert by endpoint. The browser may re-subscribe (after token rotation,
+// browser update, etc.) with the same endpoint URL — we don't want a new
+// row each time, just refreshed keys.
+export default defineEventHandler(async (event) => {
+  const email = await requireAuth(event)
+  const parsed = bodySchema.safeParse(await readBody(event))
+  if (!parsed.success) {
+    throw createError({ statusCode: 400, statusMessage: parsed.error.message })
+  }
+
+  const row = {
+    endpoint: parsed.data.endpoint,
+    userEmail: email,
+    p256dh: parsed.data.keys.p256dh,
+    auth: parsed.data.keys.auth,
+    createdAt: Math.floor(Date.now() / 1000),
+  }
+
+  const db = useDb()
+  await db
+    .insert(pushSubscriptions)
+    .values(row)
+    .onConflictDoUpdate({
+      target: pushSubscriptions.endpoint,
+      set: {
+        userEmail: row.userEmail,
+        p256dh: row.p256dh,
+        auth: row.auth,
+        createdAt: row.createdAt,
+      },
+    })
+
+  return { ok: true }
+})

--- a/apps/openape-free-idp/server/api/push/vapid.get.ts
+++ b/apps/openape-free-idp/server/api/push/vapid.get.ts
@@ -1,0 +1,6 @@
+// PushManager.subscribe() needs the VAPID public key. Public on purpose —
+// the key is what the browser embeds in the subscription it sends back.
+export default defineEventHandler(() => {
+  const key = (useRuntimeConfig().public.vapidPublicKey as string) || ''
+  return { vapidPublicKey: key }
+})

--- a/apps/openape-free-idp/server/database/schema.ts
+++ b/apps/openape-free-idp/server/database/schema.ts
@@ -206,3 +206,20 @@ export const sshKeys = sqliteTable('ssh_keys', {
   index('idx_ssh_keys_user_email').on(table.userEmail),
   index('idx_ssh_keys_public_key').on(table.publicKey),
 ])
+
+// --- Milestone 7: Web Push for grant approvers ---
+// One row per (user, browser-install) pair. The endpoint URL is the
+// browser's push-service URL — stable per (browser, install) — and is
+// used as the natural primary key. p256dh + auth are the public keys
+// the server uses to encrypt push payloads; without them, web-push
+// can't deliver. Subscriptions are pruned when a 404/410 comes back
+// (browser uninstalled the PWA or revoked permission).
+export const pushSubscriptions = sqliteTable('push_subscriptions', {
+  endpoint: text('endpoint').primaryKey(),
+  userEmail: text('user_email').notNull(),
+  p256dh: text('p256dh').notNull(),
+  auth: text('auth').notNull(),
+  createdAt: integer('created_at').notNull(),
+}, table => [
+  index('idx_push_subs_user_email').on(table.userEmail),
+])

--- a/apps/openape-free-idp/server/plugins/02.database.ts
+++ b/apps/openape-free-idp/server/plugins/02.database.ts
@@ -137,6 +137,19 @@ export default defineNitroPlugin(async () => {
     // /api/grants and /api/standing-grants call 500s on existing prod DBs.
     try { await db.run(sql`ALTER TABLE grants ADD COLUMN decided_by_standing_grant TEXT`) }
     catch { /* already present */ }
+
+    // Web Push subscriptions for grant-approval notifications. Endpoint is
+    // the browser-push-service URL (stable per browser install) and serves
+    // as the natural primary key; the helper upserts on it so re-subscribing
+    // the same browser doesn't create duplicate rows.
+    await db.run(sql`CREATE TABLE IF NOT EXISTS push_subscriptions (
+      endpoint TEXT PRIMARY KEY,
+      user_email TEXT NOT NULL,
+      p256dh TEXT NOT NULL,
+      auth TEXT NOT NULL,
+      created_at INTEGER NOT NULL
+    )`)
+    await db.run(sql`CREATE INDEX IF NOT EXISTS idx_push_subs_user_email ON push_subscriptions(user_email)`)
   }
   catch (err) {
     console.error('[database] Table creation failed (tables may already exist):', err)

--- a/apps/openape-free-idp/server/utils/drizzle-grant-store.ts
+++ b/apps/openape-free-idp/server/utils/drizzle-grant-store.ts
@@ -3,6 +3,7 @@ import type { GrantListParams, GrantStore } from '@openape/grants'
 import { and, desc, eq, inArray, lt, sql } from 'drizzle-orm'
 import { useDb } from '../database/drizzle'
 import { grants } from '../database/schema'
+import { notifyApproverOfPendingGrant } from './push'
 
 interface ExtendedGrantStore extends GrantStore {
   findAll: () => Promise<OpenApeGrant[]>
@@ -61,6 +62,8 @@ export function createDrizzleGrantStore(): ExtendedGrantStore {
   return {
     async save(grant) {
       const row = grantToRow(grant)
+      const isInsert = !(await db.select({ id: grants.id }).from(grants).where(eq(grants.id, grant.id)).get())
+
       await db.insert(grants).values(row).onConflictDoUpdate({
         target: grants.id,
         set: {
@@ -80,6 +83,17 @@ export function createDrizzleGrantStore(): ExtendedGrantStore {
           autoApprovalKind: row.autoApprovalKind,
         },
       })
+
+      // Push the approver — only on a fresh insert (not on every save which
+      // is also called for status updates), and only when the grant
+      // actually needs human action. Auto-approved grants (YOLO / standing-
+      // grant match) carry an autoApprovalKind and don't pollute push.
+      // Fire-and-forget: a failing push must never break grant creation.
+      if (isInsert && grant.status === 'pending' && !grant.auto_approval_kind) {
+        void notifyApproverOfPendingGrant(grant).catch((err: unknown) =>
+          console.warn('[push] approver notification failed:', err),
+        )
+      }
     },
 
     async findById(id) {

--- a/apps/openape-free-idp/server/utils/push.ts
+++ b/apps/openape-free-idp/server/utils/push.ts
@@ -1,0 +1,87 @@
+import type { OpenApeGrant } from '@openape/core'
+import { eq } from 'drizzle-orm'
+import webpush from 'web-push'
+import { useDb } from '../database/drizzle'
+import { pushSubscriptions, users } from '../database/schema'
+import { summarizeRequest } from './summarize-grant'
+
+let _configured = false
+
+function ensureVapidConfigured(): boolean {
+  if (_configured) return true
+  const cfg = useRuntimeConfig()
+  const publicKey = (cfg.public.vapidPublicKey as string) || ''
+  const privateKey = (cfg.vapidPrivateKey as string) || ''
+  const subject = (cfg.vapidSubject as string) || ''
+  if (!publicKey || !privateKey) return false
+  webpush.setVapidDetails(subject, publicKey, privateKey)
+  _configured = true
+  return true
+}
+
+/**
+ * Best-effort fan-out of a Web Push notification to whoever should
+ * approve a freshly-created pending grant.
+ *
+ * Approver resolution: there's no `approver` column on `grants` today —
+ * approver is derived from the requester's user row (`users.approver`).
+ * Agents have an explicit approver set when they're enrolled; humans
+ * (no `approver` row) get no notification, which is correct since
+ * humans don't need someone else to approve their own grants.
+ *
+ * Skips silently when:
+ *   - VAPID keys aren't configured (dev environments)
+ *   - Requester has no user row, or no `approver` set
+ *   - Approver has no push subscriptions
+ *   - The grant is auto-approved (caller is responsible for that check;
+ *     this helper assumes status='pending' and !auto_approval_kind)
+ *
+ * Endpoints that come back 404 or 410 are pruned — those are dead and
+ * the browser/PWA is gone for good.
+ */
+export async function notifyApproverOfPendingGrant(grant: OpenApeGrant): Promise<void> {
+  if (!ensureVapidConfigured()) return
+
+  const db = useDb()
+  const requester = await db
+    .select()
+    .from(users)
+    .where(eq(users.email, grant.request.requester))
+    .get()
+  if (!requester?.approver) return
+
+  const subs = await db
+    .select()
+    .from(pushSubscriptions)
+    .where(eq(pushSubscriptions.userEmail, requester.approver))
+  if (subs.length === 0) return
+
+  const summary = summarizeRequest(grant.request)
+  const payload = JSON.stringify({
+    type: 'grant-pending',
+    grant_id: grant.id,
+    title: 'Approval needed',
+    body: `${grant.request.requester}: ${summary}`,
+    deep_link: `/grant-approval?grant_id=${encodeURIComponent(grant.id)}`,
+  })
+
+  await Promise.all(subs.map(async (sub) => {
+    try {
+      await webpush.sendNotification(
+        { endpoint: sub.endpoint, keys: { p256dh: sub.p256dh, auth: sub.auth } },
+        payload,
+      )
+    }
+    catch (err: unknown) {
+      const status = (err as { statusCode?: number })?.statusCode
+      if (status === 404 || status === 410) {
+        await db
+          .delete(pushSubscriptions)
+          .where(eq(pushSubscriptions.endpoint, sub.endpoint))
+          .catch(() => {})
+        return
+      }
+      console.warn(`[push] approver send failed for ${sub.userEmail}: ${(err as Error)?.message ?? err}`)
+    }
+  }))
+}

--- a/apps/openape-free-idp/server/utils/summarize-grant.ts
+++ b/apps/openape-free-idp/server/utils/summarize-grant.ts
@@ -1,0 +1,23 @@
+import type { OpenApeGrant } from '@openape/core'
+
+/**
+ * Compress a grant request into a single line for the push body.
+ * Push notifications truncate aggressively on mobile (often around
+ * 100 chars on Android, less on iOS), so prefer the most actionable
+ * field: the command being run, falling back to a reason or the bare
+ * audience name.
+ *
+ * Pure helper, no side effects, no nitro/runtime imports — kept in its
+ * own file so unit tests can import it without spinning up the Nitro
+ * runtime.
+ */
+export function summarizeRequest(req: OpenApeGrant['request']): string {
+  if (Array.isArray(req.command) && req.command.length > 0) {
+    const joined = req.command.join(' ')
+    return joined.length > 90 ? `${joined.slice(0, 90)}…` : joined
+  }
+  if (req.reason) {
+    return req.reason.length > 90 ? `${req.reason.slice(0, 90)}…` : req.reason
+  }
+  return req.audience ?? 'grant request'
+}

--- a/apps/openape-free-idp/sw.ts
+++ b/apps/openape-free-idp/sw.ts
@@ -1,0 +1,126 @@
+/// <reference lib="webworker" />
+
+// Service worker for the OpenApe IdP. We use injectManifest so we own this
+// file and can register `push` + `notificationclick` handlers — vite-pwa's
+// generateSW mode doesn't expose those.
+//
+// Caching strategy mirrors apps/openape-chat: NetworkFirst for HTML and
+// /api/**, CacheFirst for /_nuxt/** (filenames are hashed on every build,
+// so cache hits are always for the right version).
+
+import { CacheFirst, NetworkFirst } from 'workbox-strategies'
+import { ExpirationPlugin } from 'workbox-expiration'
+import { precacheAndRoute, cleanupOutdatedCaches } from 'workbox-precaching'
+import { registerRoute } from 'workbox-routing'
+
+declare const self: ServiceWorkerGlobalScope & { __WB_MANIFEST: Array<{ url: string, revision: string | null }> }
+
+cleanupOutdatedCaches()
+precacheAndRoute(self.__WB_MANIFEST ?? [])
+
+registerRoute(
+  ({ url }) => url.pathname.startsWith('/api/'),
+  new NetworkFirst({
+    cacheName: 'api-cache',
+    networkTimeoutSeconds: 5,
+    plugins: [new ExpirationPlugin({ maxEntries: 100, maxAgeSeconds: 60 * 60 * 24 })],
+  }),
+)
+
+registerRoute(
+  ({ url }) => url.pathname.startsWith('/_nuxt/'),
+  new CacheFirst({
+    cacheName: 'nuxt-assets',
+    plugins: [new ExpirationPlugin({ maxEntries: 200, maxAgeSeconds: 60 * 60 * 24 * 30 })],
+  }),
+)
+
+registerRoute(
+  ({ request }) => request.destination === 'document',
+  new NetworkFirst({
+    cacheName: 'html-cache',
+    networkTimeoutSeconds: 3,
+  }),
+)
+
+// ---------------------------------------------------------------------------
+// Push notifications — only fire when the IdP is installed as a PWA
+// (display-mode: standalone). Subscriptions are never created on a normal
+// browser tab, so we don't need a runtime guard here.
+// ---------------------------------------------------------------------------
+
+interface PushPayload {
+  type?: string
+  grant_id?: string
+  title?: string
+  body?: string
+  deep_link?: string
+}
+
+self.addEventListener('push', (event) => {
+  let data: PushPayload = {}
+  try {
+    if (event.data) data = event.data.json() as PushPayload
+  }
+  catch {
+    // Some push services deliver an empty payload to wake the SW; show a
+    // generic notification rather than swallow it.
+    data = { title: 'OpenApe IdP', body: 'New activity' }
+  }
+
+  const title = data.title ?? 'Approval needed'
+  const body = data.body ?? 'A grant is waiting for your approval.'
+  // Coalesce multiple pushes for the same grant into one notification —
+  // re-sends (e.g. retries by web-push when the device was offline) won't
+  // pile up four copies on the lock screen.
+  const tag = data.grant_id ? `grant:${data.grant_id}` : 'openape-idp'
+
+  event.waitUntil(self.registration.showNotification(title, {
+    body,
+    tag,
+    icon: '/favicon.svg',
+    badge: '/favicon.svg',
+    data,
+  }))
+})
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close()
+  const data = event.notification.data as PushPayload | undefined
+  const target = data?.deep_link ?? '/'
+
+  event.waitUntil((async () => {
+    const clientsList = await self.clients.matchAll({ type: 'window', includeUncontrolled: true })
+    // If a window is already open at the right URL, focus it; otherwise
+    // navigate the first available window or open a new one.
+    for (const client of clientsList) {
+      try {
+        const url = new URL(client.url)
+        if (url.pathname + url.search === target) {
+          await client.focus()
+          return
+        }
+      }
+      catch { /* unparseable client URL — ignore */ }
+    }
+    if (clientsList.length > 0) {
+      const first = clientsList[0]
+      if ('navigate' in first && typeof first.navigate === 'function') {
+        await first.navigate(target)
+        await first.focus()
+        return
+      }
+    }
+    await self.clients.openWindow(target)
+  })())
+})
+
+self.addEventListener('install', () => {
+  // Activate the new SW immediately on install so users see fresh behaviour
+  // on their next reload (not the one after that).
+  self.skipWaiting()
+})
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim())
+})

--- a/apps/openape-free-idp/tests/notify-approver.test.ts
+++ b/apps/openape-free-idp/tests/notify-approver.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { summarizeRequest } from '../server/utils/summarize-grant'
+
+// Pure helper test for `summarizeRequest`. The full notifyApprover
+// fan-out is exercised end-to-end via the manual deploy probe
+// (described in this PR's plan); spinning up an in-memory IdP +
+// mocked web-push to mirror that here is more ceremony than value
+// at this stage.
+
+describe('summarizeRequest', () => {
+  it('joins command array with spaces', () => {
+    expect(summarizeRequest({
+      requester: 'a@b', target_host: 'h', audience: 'shapes',
+      command: ['git', 'status'],
+    } as Parameters<typeof summarizeRequest>[0])).toBe('git status')
+  })
+
+  it('truncates long commands with an ellipsis', () => {
+    const cmd = ['bash', 'a'.repeat(200)]
+    const out = summarizeRequest({
+      requester: 'a@b', target_host: 'h', audience: 'shapes', command: cmd,
+    } as Parameters<typeof summarizeRequest>[0])
+    expect(out.endsWith('…')).toBe(true)
+    expect(out.length).toBeLessThanOrEqual(91) // 90 + ellipsis
+  })
+
+  it('falls back to reason when no command', () => {
+    expect(summarizeRequest({
+      requester: 'a@b', target_host: 'h', audience: 'escapes',
+      reason: 'restart database',
+    } as Parameters<typeof summarizeRequest>[0])).toBe('restart database')
+  })
+
+  it('falls back to audience when no command and no reason', () => {
+    expect(summarizeRequest({
+      requester: 'a@b', target_host: 'h', audience: 'shapes',
+    } as Parameters<typeof summarizeRequest>[0])).toBe('shapes')
+  })
+
+  it('handles empty command array via reason fallback', () => {
+    expect(summarizeRequest({
+      requester: 'a@b', target_host: 'h', audience: 'shapes',
+      command: [], reason: 'deploy',
+    } as Parameters<typeof summarizeRequest>[0])).toBe('deploy')
+  })
+})

--- a/apps/openape-free-idp/tests/push-schema.test.ts
+++ b/apps/openape-free-idp/tests/push-schema.test.ts
@@ -1,0 +1,76 @@
+import { createClient } from '@libsql/client'
+import { eq, sql } from 'drizzle-orm'
+import { drizzle } from 'drizzle-orm/libsql'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { pushSubscriptions } from '../server/database/schema'
+
+// Spin up an in-memory SQLite, run the same CREATE TABLE the production
+// startup plugin runs, and exercise insert/select on the new
+// push_subscriptions table to catch typos in either definition.
+
+let db: ReturnType<typeof drizzle<{ pushSubscriptions: typeof pushSubscriptions }>>
+
+beforeEach(async () => {
+  const client = createClient({ url: ':memory:' })
+  db = drizzle(client, { schema: { pushSubscriptions } })
+
+  await db.run(sql`CREATE TABLE push_subscriptions (
+    endpoint TEXT PRIMARY KEY,
+    user_email TEXT NOT NULL,
+    p256dh TEXT NOT NULL,
+    auth TEXT NOT NULL,
+    created_at INTEGER NOT NULL
+  )`)
+})
+
+afterEach(() => {
+  // libsql :memory: dies with the test process.
+})
+
+describe('push_subscriptions schema', () => {
+  it('inserts and reads a subscription row', async () => {
+    await db.insert(pushSubscriptions).values({
+      endpoint: 'https://fcm.googleapis.com/fcm/send/abc123',
+      userEmail: 'patrick@hofmann.eco',
+      p256dh: 'BN…',
+      auth: 'aa…',
+      createdAt: 1,
+    })
+    const got = await db
+      .select()
+      .from(pushSubscriptions)
+      .where(eq(pushSubscriptions.endpoint, 'https://fcm.googleapis.com/fcm/send/abc123'))
+      .get()
+    expect(got).toMatchObject({ userEmail: 'patrick@hofmann.eco', p256dh: 'BN…' })
+  })
+
+  it('rejects duplicate endpoints (PK enforced)', async () => {
+    const sub = {
+      endpoint: 'https://fcm.googleapis.com/fcm/send/abc123',
+      userEmail: 'patrick@hofmann.eco',
+      p256dh: 'BN…',
+      auth: 'aa…',
+      createdAt: 1,
+    }
+    await db.insert(pushSubscriptions).values(sub)
+    await expect(db.insert(pushSubscriptions).values({ ...sub, userEmail: 'other@x' })).rejects.toThrow()
+  })
+
+  it('lets the same user have multiple subscriptions (different endpoints)', async () => {
+    await db.insert(pushSubscriptions).values({
+      endpoint: 'https://fcm.googleapis.com/fcm/send/aaa',
+      userEmail: 'patrick@hofmann.eco',
+      p256dh: 'BN1', auth: 'a1', createdAt: 1,
+    })
+    await db.insert(pushSubscriptions).values({
+      endpoint: 'https://updates.push.services.mozilla.com/wpush/v1/zzz',
+      userEmail: 'patrick@hofmann.eco',
+      p256dh: 'BN2', auth: 'a2', createdAt: 2,
+    })
+    const rows = await db
+      .select()
+      .from(pushSubscriptions)
+      .where(eq(pushSubscriptions.userEmail, 'patrick@hofmann.eco'))
+    expect(rows).toHaveLength(2)
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -303,6 +303,9 @@ importers:
       '@sentry/nuxt':
         specifier: ^10.47.0
         version: 10.47.0(7aed8207d6b1feafbea1b7d4ec43e3d7)
+      '@vite-pwa/nuxt':
+        specifier: ^1.0.4
+        version: 1.1.1(magicast@0.5.2)(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(workbox-build@7.4.0)(workbox-window@7.4.0)
       drizzle-orm:
         specifier: ^0.44.7
         version: 0.44.7(@libsql/client@0.14.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.6.2)(bun-types@1.3.10)(gel@2.2.0)
@@ -315,10 +318,16 @@ importers:
       tailwindcss:
         specifier: ^4.0.0
         version: 4.2.1
+      web-push:
+        specifier: ^3.6.7
+        version: 3.6.7
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.15
+      '@types/web-push':
+        specifier: ^3.6.4
+        version: 3.6.4
       typescript:
         specifier: ^5.7.0
         version: 5.9.3

--- a/scripts/generate-idp-vapid.sh
+++ b/scripts/generate-idp-vapid.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# Generate a VAPID keypair for the openape-free-idp Web Push integration
+# (id.openape.ai approver notifications) and print the env block to copy
+# into the chatty .env file.
+#
+# Run once before the first deploy. The keys must remain stable across
+# deploys — clients re-subscribe under the same public key, and rotating
+# the private key while subscriptions exist will cause those pushes to
+# fail server-side until the next browser-side subscribe.
+#
+# Note: id.openape.ai uses its own keypair, not the chat one. Push
+# services bind subscriptions to a specific public key per origin.
+#
+# Usage:
+#   ./scripts/generate-idp-vapid.sh > /tmp/idp-vapid.env
+#   scp /tmp/idp-vapid.env openape@chatty.delta-mind.at:/home/openape/projects/openape-free-idp/shared/.env
+#   # then on chatty: chmod 600 …/shared/.env
+#
+# Or echo to stdout and inspect first.
+
+set -euo pipefail
+
+if ! command -v npx >/dev/null 2>&1; then
+  echo "npx not found — install Node.js 20+ first" >&2
+  exit 1
+fi
+
+SUBJECT="${VAPID_SUBJECT:-mailto:patrick@hofmann.eco}"
+
+KEYS_JSON=$(npx --yes -p web-push@^3 web-push generate-vapid-keys --json 2>/dev/null)
+
+if command -v jq >/dev/null 2>&1; then
+  PUB=$(printf '%s' "$KEYS_JSON" | jq -r '.publicKey')
+  PRIV=$(printf '%s' "$KEYS_JSON" | jq -r '.privateKey')
+else
+  PUB=$(printf '%s' "$KEYS_JSON" | node -e 'let s="";process.stdin.on("data",d=>s+=d);process.stdin.on("end",()=>console.log(JSON.parse(s).publicKey))')
+  PRIV=$(printf '%s' "$KEYS_JSON" | node -e 'let s="";process.stdin.on("data",d=>s+=d);process.stdin.on("end",()=>console.log(JSON.parse(s).privateKey))')
+fi
+
+if [ -z "${PUB:-}" ] || [ -z "${PRIV:-}" ]; then
+  echo "Failed to parse VAPID keypair from web-push output" >&2
+  echo "$KEYS_JSON" >&2
+  exit 1
+fi
+
+cat <<EOF
+# Web Push VAPID keys for id.openape.ai. Append (or merge) to:
+#   /home/openape/projects/openape-free-idp/shared/.env  (chmod 600)
+# Generated $(date -u +%Y-%m-%dT%H:%M:%SZ).
+
+NUXT_PUBLIC_VAPID_PUBLIC_KEY=${PUB}
+NUXT_VAPID_PRIVATE_KEY=${PRIV}
+NUXT_VAPID_SUBJECT=${SUBJECT}
+EOF


### PR DESCRIPTION
## Summary

When a fresh grant lands with `status='pending'` and no `auto_approval_kind`, fan out a Web Push notification to the requester's `users.approver` so the approver doesn't have to keep an apes CLI window open to know they need to act. Tap routes to `/grant-approval?grant_id=<id>`.

Mirrors the chat.openape.ai push stack (PRs #200–#211): `@vite-pwa/nuxt` with `injectManifest`, custom `sw.ts` at project root, `push_subscriptions` table keyed on endpoint, `EnableNotifications` gated on `display-mode: standalone`.

Hook lives in `drizzle-grant-store.save()` (canonical state transition, fires only on a fresh insert with `status='pending' && !auto_approval_kind`) so internal grant-creation paths don't slip past — and YOLO/standing-grant auto-approvals don't pollute push.

`summarizeRequest` extracted to its own dep-free module so unit tests can import it without spinning up the Nitro runtime.

**Out of scope for v1:** requester-side notifications post-approve/deny, WS realtime inbox updates, multi-approver. Plan: `.claude/plans/ich-h-tte-nun-gerne-moonlit-sutton.md`.

## Test plan

- [x] `pnpm --filter openape-free-idp typecheck` clean
- [x] `pnpm --filter openape-free-idp lint` clean
- [x] `pnpm --filter openape-free-idp test` — 73/73 passing (incl. new `push-schema.test.ts` + `notify-approver.test.ts`)
- [ ] Generate VAPID keys via `scripts/generate-idp-vapid.sh`, append to chatty's shared `.env`, redeploy
- [ ] Install id.openape.ai as PWA, enable notifications, spawn an agent → expect push within ~5s
- [ ] Tap push → opens `/grant-approval?grant_id=…`, approve, agent run continues
- [ ] Auto-approved (YOLO/standing) grants do NOT trigger push