### PR TITLE
feat(auth): include approver in IdP access_token claims

### DIFF
--- a/modules/nuxt-auth-idp/src/runtime/server/routes/token.post.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/routes/token.post.ts
@@ -25,7 +25,7 @@ function resolveUserClaimsFactory() {
   const { userStore } = useIdpStores()
   return async (userId: string, scope?: string) => {
     const scopes = parseScope(scope)
-    const claims: { email?: string, name?: string } = {}
+    const claims: { email?: string, name?: string, approver?: string } = {}
 
     const includeAll = scopes.size === 0
     const needsUser = includeAll || scopes.has('email') || scopes.has('profile')
@@ -38,6 +38,13 @@ function resolveUserClaimsFactory() {
         }
         if (includeAll || scopes.has('profile')) {
           claims.name = user.name
+        }
+        // Always surface approver when known so SPs (preview.openape.ai and
+        // future tools) can route push notifications and grant approvals
+        // without a server-to-server callback to the IdP. Undefined means
+        // the user has no separate approver (acts as their own).
+        if (user.approver) {
+          claims.approver = user.approver
         }
       }
     }

--- a/packages/auth/src/__tests__/token.test.ts
+++ b/packages/auth/src/__tests__/token.test.ts
@@ -499,6 +499,34 @@ describe('issueAssertion', () => {
     expect(payload.name).toBe('Alice')
   })
 
+  it('includes approver claim when provided', async () => {
+    const keyStore = new InMemoryKeyStore()
+
+    const assertion = await issueAssertion(
+      { sub: 'agent@example.com', aud: 'sp.example.com', nonce: 'n', approver: 'patrick@hofmann.eco' },
+      keyStore,
+      'https://idp.example.com',
+    )
+
+    const key = await keyStore.getSigningKey()
+    const { payload } = await verifyJWT(assertion, key.publicKey)
+    expect(payload.approver).toBe('patrick@hofmann.eco')
+  })
+
+  it('omits approver claim when not provided', async () => {
+    const keyStore = new InMemoryKeyStore()
+
+    const assertion = await issueAssertion(
+      { sub: 'alice@example.com', aud: 'sp.example.com', nonce: 'n' },
+      keyStore,
+      'https://idp.example.com',
+    )
+
+    const key = await keyStore.getSigningKey()
+    const { payload } = await verifyJWT(assertion, key.publicKey)
+    expect(payload.approver).toBeUndefined()
+  })
+
   it('includes kid in JWT header', async () => {
     const keyStore = new InMemoryKeyStore()
 

--- a/packages/auth/src/idp/refresh.ts
+++ b/packages/auth/src/idp/refresh.ts
@@ -25,7 +25,7 @@ export async function handleRefreshGrant(
   const { newToken, userId } = await refreshStore.consume(refreshToken)
 
   // Resolve user claims (same as in authorization_code flow)
-  let extraClaims: { email?: string, name?: string } = {}
+  let extraClaims: { email?: string, name?: string, approver?: string } = {}
   if (resolveUserClaims) {
     // Use offline_access scope to indicate refresh context
     extraClaims = await resolveUserClaims(userId, 'openid email profile')
@@ -38,6 +38,7 @@ export async function handleRefreshGrant(
       nonce: crypto.randomUUID(),
       email: extraClaims.email,
       name: extraClaims.name,
+      approver: extraClaims.approver,
     },
     keyStore,
     issuer,

--- a/packages/auth/src/idp/token.ts
+++ b/packages/auth/src/idp/token.ts
@@ -24,7 +24,7 @@ export interface TokenExchangeResult {
 }
 
 export interface UserClaimsResolver {
-  (userId: string, scope?: string): Promise<{ email?: string, name?: string }>
+  (userId: string, scope?: string): Promise<{ email?: string, name?: string, approver?: string }>
 }
 
 /**
@@ -69,7 +69,7 @@ export async function handleTokenExchange(
   await codeStore.delete(params.code)
 
   // Resolve user claims based on scope
-  let extraClaims: { email?: string, name?: string } = {}
+  let extraClaims: { email?: string, name?: string, approver?: string } = {}
   if (resolveUserClaims) {
     extraClaims = await resolveUserClaims(codeEntry.userId, codeEntry.scope)
   }
@@ -84,6 +84,7 @@ export async function handleTokenExchange(
       delegate: codeEntry.delegate,
       email: extraClaims.email,
       name: extraClaims.name,
+      approver: extraClaims.approver,
       authorization_details: codeEntry.authorizationDetails,
       delegation_act: codeEntry.delegationAct,
       delegation_grant: codeEntry.delegationGrant,
@@ -123,6 +124,13 @@ export interface AssertionClaimsInput {
   delegate?: DDISADelegateClaim
   email?: string
   name?: string
+  /**
+   * Email of the user who reviews this user's pending grants and previews.
+   * Surfaced as a claim so SPs (preview.openape.ai, future tools) can route
+   * approvals/notifications without a server-to-server callback to the IdP.
+   * Empty/undefined means the user has no separate approver.
+   */
+  approver?: string
   authorization_details?: OpenApeAuthorizationDetail[]
   /** RFC 8693 delegation: the actual actor */
   delegation_act?: DelegationActClaim
@@ -141,7 +149,7 @@ export async function issueAssertion(
   const key = await keyStore.getSigningKey()
   const now = Math.floor(Date.now() / 1000)
 
-  const payload: DDISAAssertionClaims & { email?: string, name?: string, authorization_details?: OpenApeAuthorizationDetail[] } = {
+  const payload: DDISAAssertionClaims & { email?: string, name?: string, approver?: string, authorization_details?: OpenApeAuthorizationDetail[] } = {
     iss: issuer,
     sub: claims.sub,
     aud: claims.aud,
@@ -166,6 +174,10 @@ export async function issueAssertion(
 
   if (claims.name) {
     payload.name = claims.name
+  }
+
+  if (claims.approver) {
+    payload.approver = claims.approver
   }
 
   if (claims.authorization_details?.length) {


### PR DESCRIPTION
## Summary

Pre-req for the upcoming \`preview.openape.ai\` rollout. The new SP needs to know who reviews each uploader's work to route push notifications, but it has no DB access to the IdP \`users\` table. Solving this with a server-to-server callback for every upload is wasteful when the IdP already knows the answer at token-mint time.

This change surfaces the existing \`users.approver\` field as a JWT claim. The cli-exchange flow then carries it transitively into every SP-token, so SPs read it from the verified JWT without an extra round-trip.

- \`AssertionClaimsInput\` and \`UserClaimsResolver\` gain optional \`approver\` field
- \`issueAssertion\` writes \`payload.approver\` when present
- \`handleTokenExchange\` and \`handleRefreshGrant\` pass it through
- \`nuxt-auth-idp\` \`resolveUserClaimsFactory\` reads \`user.approver\` from the store
- Tests assert the claim is included when provided and omitted when not

Plan: \`~/.claude/plans/ich-h-tte-nun-gerne-moonlit-sutton.md\`.

## Test plan

- [x] \`pnpm --filter @openape/auth test\` — 99 passed (incl. 2 new for approver claim presence/absence)
- [x] \`pnpm --filter @openape/auth lint\` clean
- [x] \`pnpm --filter @openape/nuxt-auth-idp exec eslint src/runtime/server/routes/token.post.ts\` clean