### PR TITLE
feat(apes): apes login <email> + DDISA mismatch guard

### DIFF
--- a/.changeset/apes-login-positional-mismatch.md
+++ b/.changeset/apes-login-positional-mismatch.md
@@ -1,0 +1,10 @@
+---
+"@openape/apes": minor
+---
+
+apes: `apes login <email>` accepts the email as a positional argument, and DDISA mismatches refuse to log in unless `--force` is passed
+
+Two UX improvements to `apes login`:
+
+- **Positional email**: `apes login patrick@hofmann.eco` now works directly. The legacy `--email` flag stays around as an alias.
+- **DDISA mismatch guard**: when an explicit `--idp` (or `APES_IDP` env, or `defaults.idp` in config.toml) selects a different IdP than the email's domain DDISA record points at, the login refuses with a clear diagnostic. Pass `--force` to bypass. This catches the foot-gun where `apes login --idp https://id.openape.at` produces a token that downstream SPs (e.g. `preview.openape.ai`, `chat.openape.ai`) reject with "IdP mismatch" because they trust the DDISA-resolved IdP instead. Auto-discovered IdPs (no explicit override) bypass the guard since by definition they can't mismatch.

--- a/packages/apes/src/commands/auth/login.ts
+++ b/packages/apes/src/commands/auth/login.ts
@@ -25,6 +25,11 @@ export const loginCommand = defineCommand({
     description: 'Authenticate with an OpenApe IdP',
   },
   args: {
+    user: {
+      type: 'positional',
+      required: false,
+      description: 'Agent email (e.g. patrick@hofmann.eco). Extracted from <key>.pub comment if omitted.',
+    },
     idp: {
       type: 'string',
       description: 'IdP URL (e.g. https://id.openape.at). Auto-discovered via DDISA DNS if omitted.',
@@ -35,26 +40,59 @@ export const loginCommand = defineCommand({
     },
     email: {
       type: 'string',
-      description: 'Agent email. Extracted from <key>.pub comment if omitted.',
+      description: 'Same as the positional email — flag form for backwards compatibility.',
     },
     browser: {
       type: 'boolean',
       description: 'Force browser (PKCE) login even if an SSH key exists',
     },
+    force: {
+      type: 'boolean',
+      description: 'Override DDISA mismatch warnings (use with care)',
+    },
   },
   async run({ args }) {
+    // Positional `user` and the legacy `--email` flag both set email.
+    // Positional wins when both are present (it's the new ergonomic form).
+    const emailArg = (typeof args.user === 'string' && args.user.includes('@'))
+      ? args.user
+      : (typeof args.email === 'string' ? args.email : undefined)
+
     const resolved = await resolveLoginInputs({
       key: args.key,
       idp: args.idp,
-      email: args.email,
+      email: emailArg,
       browser: args.browser,
     })
+
+    if (resolved.ddisaMismatch && !args.force) {
+      const { dnsIdp, chosenIdp, domain } = resolved.ddisaMismatch
+      throw new CliError(
+        `IdP mismatch for ${domain}.\n\n`
+        + `  Authoritative DDISA: ${dnsIdp}\n`
+        + `  You selected:        ${chosenIdp}\n\n`
+        + `Logging in against a different IdP than DDISA points to means SPs that\n`
+        + `trust the DDISA-resolved IdP (e.g. preview.openape.ai) will reject the\n`
+        + `resulting token with "IdP mismatch".\n\n`
+        + `Fix one of:\n`
+        + `  • Drop --idp/APES_IDP/config.defaults.idp — DDISA will auto-pick ${dnsIdp}\n`
+        + `  • Update _ddisa.${domain} if ${chosenIdp} is genuinely the correct IdP\n`
+        + `  • Re-run with --force to authenticate anyway (NOT recommended)`,
+      )
+    }
+    if (resolved.ddisaMismatch && args.force) {
+      consola.warn(
+        `Bypassing DDISA mismatch — ${resolved.ddisaMismatch.domain} resolves to `
+        + `${resolved.ddisaMismatch.dnsIdp}, but you forced ${resolved.ddisaMismatch.chosenIdp}.`,
+      )
+    }
 
     if (resolved.keyPath) {
       if (!resolved.email) {
         throw new CliError(
-          `Agent email required for key-based login. Add an email comment to `
-          + `${resolved.keyPath}.pub (ssh-keygen -C <email>) or pass --email <agent-email>.`,
+          `Agent email required for key-based login. Pass it as a positional `
+          + `(\`apes login <email>\`), set --email, or add an email comment to `
+          + `${resolved.keyPath}.pub via ssh-keygen -C <email>.`,
         )
       }
       if (!resolved.idp) {

--- a/packages/apes/src/commands/auth/resolve-login.ts
+++ b/packages/apes/src/commands/auth/resolve-login.ts
@@ -17,6 +17,13 @@ export interface ResolvedLoginInputs {
   keyPath?: string
   email?: string
   idp?: string
+  /**
+   * Set when the chosen `idp` came from an explicit flag/env/config but the
+   * email's domain has a DDISA record pointing at a *different* IdP. The
+   * caller decides whether to refuse (default), warn-and-continue (`--force`),
+   * etc. `undefined` means no mismatch (or no DDISA record to compare against).
+   */
+  ddisaMismatch?: { dnsIdp: string, chosenIdp: string, domain: string }
 }
 
 const DEFAULT_KEY = join(homedir(), '.ssh', 'id_ed25519')
@@ -84,14 +91,18 @@ export async function resolveLoginInputs(
     )
   }
   let idp: string | undefined
+  let idpSource: 'flag' | 'env' | 'config' | 'ddisa' | undefined
   if (flags.idp) {
     idp = flags.idp
+    idpSource = 'flag'
   }
   else if (process.env.APES_IDP) {
     idp = process.env.APES_IDP
+    idpSource = 'env'
   }
   else if (process.env.GRAPES_IDP) {
     idp = process.env.GRAPES_IDP
+    idpSource = 'env'
     consola.warn(
       'GRAPES_IDP is deprecated, use APES_IDP instead. '
       + 'GRAPES_IDP support will be removed in a future release.',
@@ -99,20 +110,40 @@ export async function resolveLoginInputs(
   }
   else if (config.defaults?.idp) {
     idp = config.defaults.idp
+    idpSource = 'config'
   }
-  else if (email && email.includes('@')) {
+
+  // Always probe DDISA when we have an email — both as the auto-discovery
+  // path (when no explicit IdP was supplied) and as a sanity-check against
+  // explicit overrides. The caller surfaces the resulting mismatch and
+  // gates it behind --force.
+  let ddisaIdp: string | undefined
+  let ddisaDomain: string | undefined
+  if (email && email.includes('@')) {
     const domain = email.split('@')[1]!
+    ddisaDomain = domain
     try {
       const record = await resolveDDISA(domain)
-      if (record?.idp) {
-        idp = record.idp
-        consola.info(`Discovered IdP via DDISA (_ddisa.${domain}): ${idp}`)
-      }
+      if (record?.idp) ddisaIdp = record.idp
     }
     catch {
-      // DNS failure is non-fatal — caller will surface a clear error
+      // DNS failure is non-fatal
     }
   }
 
-  return { keyPath, email, idp }
+  if (!idp && ddisaIdp && ddisaDomain) {
+    idp = ddisaIdp
+    idpSource = 'ddisa'
+    consola.info(`Discovered IdP via DDISA (_ddisa.${ddisaDomain}): ${idp}`)
+  }
+
+  // Mismatch only matters when the user explicitly chose an IdP that differs
+  // from the authoritative DNS record. Auto-discovered IdPs (idpSource ===
+  // 'ddisa') are by definition the DDISA record, so they can't mismatch.
+  let ddisaMismatch: ResolvedLoginInputs['ddisaMismatch']
+  if (idp && ddisaIdp && ddisaDomain && idp !== ddisaIdp && idpSource !== 'ddisa') {
+    ddisaMismatch = { dnsIdp: ddisaIdp, chosenIdp: idp, domain: ddisaDomain }
+  }
+
+  return { keyPath, email, idp, ddisaMismatch }
 }

--- a/packages/apes/test/resolve-login.test.ts
+++ b/packages/apes/test/resolve-login.test.ts
@@ -193,6 +193,72 @@ describe('resolveLoginInputs', () => {
     expect(warnSpy.mock.calls[0]?.[0]).toMatch(/Both APES_IDP and GRAPES_IDP/)
     warnSpy.mockRestore()
   })
+
+  describe('ddisaMismatch', () => {
+    it('flags mismatch when --idp differs from DDISA', async () => {
+      process.env.DDISA_MOCK_RECORDS = JSON.stringify({
+        'hofmann.example': { idp: 'https://id.openape.ai', mode: 'open' },
+      })
+      const { resolveLoginInputs } = await import('../src/commands/auth/resolve-login')
+
+      const result = await resolveLoginInputs({
+        email: 'patrick@hofmann.example',
+        idp: 'https://id.openape.at',
+        browser: true, // skip key resolution to keep the test focused
+      })
+
+      expect(result.idp).toBe('https://id.openape.at')
+      expect(result.ddisaMismatch).toEqual({
+        dnsIdp: 'https://id.openape.ai',
+        chosenIdp: 'https://id.openape.at',
+        domain: 'hofmann.example',
+      })
+    })
+
+    it('no mismatch when --idp matches DDISA', async () => {
+      process.env.DDISA_MOCK_RECORDS = JSON.stringify({
+        'hofmann.example': { idp: 'https://id.openape.ai', mode: 'open' },
+      })
+      const { resolveLoginInputs } = await import('../src/commands/auth/resolve-login')
+
+      const result = await resolveLoginInputs({
+        email: 'patrick@hofmann.example',
+        idp: 'https://id.openape.ai',
+        browser: true,
+      })
+
+      expect(result.ddisaMismatch).toBeUndefined()
+    })
+
+    it('no mismatch when IdP is auto-discovered from DDISA (no explicit override)', async () => {
+      process.env.DDISA_MOCK_RECORDS = JSON.stringify({
+        'hofmann.example': { idp: 'https://id.openape.ai', mode: 'open' },
+      })
+      const { resolveLoginInputs } = await import('../src/commands/auth/resolve-login')
+
+      const result = await resolveLoginInputs({
+        email: 'patrick@hofmann.example',
+        browser: true,
+      })
+
+      expect(result.idp).toBe('https://id.openape.ai')
+      expect(result.ddisaMismatch).toBeUndefined()
+    })
+
+    it('no mismatch when domain has no DDISA record (fallback path)', async () => {
+      // No DDISA_MOCK_RECORDS — resolveDDISA returns null
+      const { resolveLoginInputs } = await import('../src/commands/auth/resolve-login')
+
+      const result = await resolveLoginInputs({
+        email: 'patrick@unknown.example',
+        idp: 'https://id.openape.at',
+        browser: true,
+      })
+
+      expect(result.idp).toBe('https://id.openape.at')
+      expect(result.ddisaMismatch).toBeUndefined()
+    })
+  })
 })
 
 describe('readPublicKeyComment', () => {


### PR DESCRIPTION
## Summary

Two UX improvements to \`apes login\`, driven by today's IdP-mismatch debugging session:

- **Positional email**: \`apes login patrick@hofmann.eco\` works directly (no \`--email\` flag needed). \`--email\` stays as an alias for backwards compat.
- **DDISA mismatch guard**: when an explicit \`--idp\` / \`APES_IDP\` / \`config.defaults.idp\` differs from the email-domain's DDISA record, refuse the login with a clear diagnostic listing both. \`--force\` bypasses. Auto-discovered IdPs (no explicit override) skip the guard — by definition they can't mismatch.

This catches the foot-gun where \`apes login --idp https://id.openape.at\` produces a token that downstream SPs (preview.openape.ai, chat.openape.ai) reject with "IdP mismatch" — now caught at login time with an actionable message instead of after the round-trip.

## Test plan

- [x] \`pnpm --filter @openape/apes test\` — 589 passed (incl. 4 new \`ddisaMismatch\` cases)
- [x] \`pnpm --filter @openape/apes build\` clean, lint clean
- [x] \`apes login --help\` shows \`USAGE apes login [OPTIONS] [USER]\` with \`--force\` listed