### PR TITLE
feat(apes): auto-refresh tokens for every command (not just ape-shell)

### DIFF
--- a/.changeset/apes-auto-refresh-all-commands.md
+++ b/.changeset/apes-auto-refresh-all-commands.md
@@ -1,0 +1,11 @@
+---
+"@openape/apes": minor
+---
+
+apes: auto-refresh expired tokens for every command (not just `ape-shell`)
+
+`ape-shell` has always rotated stale tokens transparently via the ed25519 challenge-response or OAuth refresh-token flow. The other `apes …` commands didn't — `apes whoami`, `apes grants list`, `apes agents list`, etc. either showed `EXPIRED` or threw `401 Not authenticated` even when a refresh path was available.
+
+The refresh now runs at CLI entry for every subcommand except the ones that genuinely shouldn't touch existing auth: `login`, `logout`, `init`, `enroll`, `register-user`, `dns-check`, `utils`, `explain`, `workflows`. Failure is silent — the actual command then surfaces a proper auth error if the token is genuinely unusable.
+
+Internally: extracted `ensureFreshToken()` from `apiFetch` and called it from `cli.ts` before `runMain(main)`.

--- a/packages/apes/src/cli.ts
+++ b/packages/apes/src/cli.ts
@@ -156,6 +156,38 @@ const main = defineCommand({
   },
 })
 
+// Auto-refresh: every command except those that don't need (or shouldn't
+// touch) existing auth gets a transparent token refresh before its handler
+// runs. Matches `ape-shell` behavior — users no longer need to re-`apes
+// login` when an SP rejects their token; the CLI rotates it on the next
+// invocation. login/logout obviously skip; init/enroll/register-user are
+// pre-auth bootstrap; dns-check/utils/explain/workflows are diagnostic and
+// offline-safe.
+const NO_REFRESH_COMMANDS = new Set([
+  'login', 'logout',
+  'init', 'enroll', 'register-user',
+  'dns-check', 'utils', 'explain', 'workflows',
+  '--help', '-h', 'help',
+  '--version', '-v',
+])
+
+async function maybeRefreshAuth(): Promise<void> {
+  const sub = process.argv[2]
+  if (!sub || NO_REFRESH_COMMANDS.has(sub)) return
+  const { loadAuth } = await import('./config.js')
+  if (!loadAuth()) return // not logged in — nothing to refresh
+  try {
+    const { ensureFreshToken } = await import('./http.js')
+    await ensureFreshToken()
+  }
+  catch {
+    // Refresh failures are non-fatal — the actual command will surface a
+    // proper auth error if the token is genuinely unusable.
+  }
+}
+
+await maybeRefreshAuth()
+
 runMain(main).catch((err) => {
   if (err instanceof CliExit) {
     process.exit(err.exitCode)

--- a/packages/apes/src/commands/auth/whoami.ts
+++ b/packages/apes/src/commands/auth/whoami.ts
@@ -14,6 +14,9 @@ export const whoamiCommand = defineCommand({
       throw new CliError('Not logged in. Run `apes login` first.')
     }
 
+    // Token freshness is handled centrally in cli.ts via ensureFreshToken
+    // before any subcommand other than login/logout/init/etc. runs. By the
+    // time we get here, auth.json is as fresh as it can be — we just print.
     const isAgent = auth.email.includes('agent+')
     const expiresAt = new Date(auth.expires_at * 1000).toISOString()
     const isExpired = Date.now() / 1000 > auth.expires_at
@@ -24,7 +27,7 @@ export const whoamiCommand = defineCommand({
     console.log(`Token: ${isExpired ? '⚠ EXPIRED' : 'valid'} (until ${expiresAt})`)
 
     if (isExpired) {
-      consola.warn('Token is expired. Run `apes login` to re-authenticate.')
+      consola.warn('Token is expired and could not be auto-refreshed. Run `apes login` to re-authenticate.')
     }
   },
 })

--- a/packages/apes/src/http.ts
+++ b/packages/apes/src/http.ts
@@ -200,6 +200,31 @@ async function refreshOAuthToken(): Promise<string | null> {
   }
 }
 
+/**
+ * Refresh the local IdP token if it has expired. Used by every code path
+ * that needs an access token — `apiFetch` for IdP-bound HTTP calls, plus
+ * any pure-introspection command (`apes whoami`, `apes config get …`)
+ * that previously only read local auth state and surfaced a stale
+ * "expired" without attempting renewal.
+ *
+ * Returns the fresh access token on success, or null when no refresh
+ * path is available (no agent key AND no refresh_token, or both refresh
+ * attempts failed). Callers decide what to do with null — `apiFetch`
+ * throws "Not authenticated", `whoami` falls back to the on-disk state.
+ */
+export async function ensureFreshToken(): Promise<string | null> {
+  const cached = getAuthToken()
+  if (cached) return cached
+
+  // Auto-refresh: priority (1) ed25519 agent key, (2) OAuth refresh_token.
+  // Agent-key first because it is concurrency-safe — every challenge is
+  // independent server-side, so parallel ape-shell spawns don't race.
+  const agentToken = await refreshAgentToken()
+  if (agentToken) return agentToken
+  const oauthToken = await refreshOAuthToken()
+  return oauthToken ?? null
+}
+
 export async function apiFetch<T = unknown>(
   path: string,
   options: {
@@ -209,16 +234,7 @@ export async function apiFetch<T = unknown>(
     token?: string
   } = {},
 ): Promise<T> {
-  let token = options.token || getAuthToken()
-
-  // Auto-refresh: priority (1) ed25519 agent key, (2) OAuth refresh_token.
-  // Agent-key first because it is concurrency-safe — every challenge is
-  // independent server-side, so parallel ape-shell spawns don't race.
-  if (!token) {
-    token = await refreshAgentToken()
-    if (!token)
-      token = await refreshOAuthToken()
-  }
+  const token = options.token ?? await ensureFreshToken()
 
   if (!token) {
     throw new Error('Not authenticated (token expired). Run `apes login` first.')


### PR DESCRIPTION
## Summary

\`ape-shell\` has always transparently rotated expired tokens via ed25519 challenge-response or OAuth refresh-token. The other \`apes …\` commands didn't — \`apes whoami\` showed \`EXPIRED\`, \`apes grants list\` threw 401, etc. Now every subcommand except the ones that genuinely shouldn't touch existing auth gets the same refresh on entry.

**Skip set** (no auto-refresh): \`login\`, \`logout\`, \`init\`, \`enroll\`, \`register-user\`, \`dns-check\`, \`utils\`, \`explain\`, \`workflows\`, plus help/version flags.

**Failure mode**: refresh errors are silent — the actual command then surfaces a proper auth error if the token is genuinely unusable. The refresh attempt should never block a working command from running.

**Internals**: extracted \`ensureFreshToken()\` from the existing \`apiFetch\` flow into a public helper, called from \`cli.ts\` via \`maybeRefreshAuth()\` before \`runMain(main)\`. \`apiFetch\` now consumes the same helper instead of duplicating the priority chain.

## Test plan

- [x] \`pnpm --filter @openape/apes test\` — 589 passed (no regressions)
- [x] \`pnpm --filter @openape/apes build\` clean, lint clean
- [x] Local smoke: \`apes whoami\` reports valid token (no manual login needed even after expiry)