### PR TITLE
feat(apes,idp): apes sessions list/remove (self-service)

### DIFF
--- a/.changeset/apes-sessions-self.md
+++ b/.changeset/apes-sessions-self.md
@@ -1,0 +1,17 @@
+---
+"@openape/apes": minor
+"@openape/nuxt-auth-idp": minor
+---
+
+apes/idp: `apes sessions list` and `apes sessions remove <id>` for self-service device management
+
+You can now see and revoke your own refresh-token families across devices without admin privileges:
+
+- `apes sessions list` — one row per `apes login` (one row per device), with familyId, clientId, createdAt, expiresAt
+- `apes sessions remove <familyId>` — revokes that specific family. The device using it fails its next token refresh with `Token family revoked` and has to `apes login` again
+
+Backed by two new IdP endpoints under `/api/me/sessions/…`:
+- `GET /api/me/sessions` — lists the caller's families (filtered to `userId = sub` from the authenticated session/JWT)
+- `DELETE /api/me/sessions/[familyId]` — ownership-checked: 404 if the family belongs to a different user, never 403, so users can't probe other users' familyIds
+
+The pre-existing admin endpoints at `/api/admin/sessions` (cross-user, requires admin role) stay as-is.

--- a/modules/nuxt-auth-idp/src/runtime/server/api/me/sessions/[familyId].delete.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/api/me/sessions/[familyId].delete.ts
@@ -1,0 +1,35 @@
+import { defineEventHandler, getRouterParam, setResponseStatus } from 'h3'
+import { requireAuth } from '../../../utils/admin'
+import { createProblemError } from '../../../utils/problem'
+import { useIdpStores } from '../../../utils/stores'
+
+/**
+ * DELETE /api/me/sessions/[familyId] — revoke one of the caller's
+ * refresh-token families. The other device that was using this family
+ * will fail its next refresh with "Token family revoked" and the user
+ * will need to `apes login` again on that device.
+ *
+ * Ownership-checked: a user can only revoke their own sessions even if
+ * they know another user's familyId. Admin path is at
+ * `/api/admin/sessions/[familyId]`.
+ */
+export default defineEventHandler(async (event) => {
+  const callerEmail = await requireAuth(event)
+  const familyId = getRouterParam(event, 'familyId') ?? ''
+  if (!familyId) {
+    throw createProblemError({ status: 400, title: 'familyId required' })
+  }
+
+  const { refreshTokenStore } = useIdpStores()
+  // Verify ownership before revoking — the caller must own the family.
+  const families = await refreshTokenStore.listFamilies({ userId: callerEmail, limit: 100 })
+  const owned = families.data.find(f => f.familyId === familyId)
+  if (!owned) {
+    // 404 (not 403) so users can't probe for other users' familyIds.
+    throw createProblemError({ status: 404, title: 'Session not found' })
+  }
+
+  await refreshTokenStore.revokeFamily(familyId)
+  setResponseStatus(event, 204)
+  return null
+})

--- a/modules/nuxt-auth-idp/src/runtime/server/api/me/sessions/index.get.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/api/me/sessions/index.get.ts
@@ -1,0 +1,23 @@
+import { defineEventHandler, getQuery } from 'h3'
+import { requireAuth } from '../../../utils/admin'
+import { useIdpStores } from '../../../utils/stores'
+
+/**
+ * GET /api/me/sessions — list refresh-token families belonging to the
+ * caller. Each family corresponds to one `apes login` (one device); they
+ * rotate their refresh tokens independently and are revoked individually.
+ *
+ * Auth: any authenticated caller (cookie session OR Bearer JWT) — we
+ * filter by `userId` so users only see their own sessions, never anyone
+ * else's. Admin endpoint at `/api/admin/sessions` covers the cross-user
+ * listing path.
+ */
+export default defineEventHandler(async (event) => {
+  const userId = await requireAuth(event)
+  const query = getQuery(event)
+  const limit = query.limit ? Number(query.limit) : undefined
+  const cursor = query.cursor as string | undefined
+
+  const { refreshTokenStore } = useIdpStores()
+  return await refreshTokenStore.listFamilies({ userId, limit, cursor })
+})

--- a/packages/apes/src/cli.ts
+++ b/packages/apes/src/cli.ts
@@ -31,6 +31,7 @@ import { initCommand } from './commands/init/index'
 import { enrollCommand } from './commands/enroll'
 import { registerUserCommand } from './commands/register-user'
 import { utilsCommand } from './commands/utils/index'
+import { sessionsCommand } from './commands/sessions/index'
 import { dnsCheckCommand } from './commands/dns-check'
 import { healthCommand } from './commands/health'
 import { workflowsCommand } from './commands/workflows'
@@ -138,6 +139,7 @@ const main = defineCommand({
     'register-user': registerUserCommand,
     'dns-check': dnsCheckCommand,
     utils: utilsCommand,
+    sessions: sessionsCommand,
     login: loginCommand,
     logout: logoutCommand,
     whoami: whoamiCommand,

--- a/packages/apes/src/commands/sessions/index.ts
+++ b/packages/apes/src/commands/sessions/index.ts
@@ -1,0 +1,19 @@
+import { defineCommand } from 'citty'
+import { sessionsListCommand } from './list'
+import { sessionsRemoveCommand } from './remove'
+
+/**
+ * `apes sessions …` — manage your own refresh-token families across
+ * devices. One family per `apes login`. Use `list` to see what's active,
+ * `remove <familyId>` to revoke a stale device.
+ */
+export const sessionsCommand = defineCommand({
+  meta: {
+    name: 'sessions',
+    description: 'Manage your active refresh-token sessions across devices',
+  },
+  subCommands: {
+    list: sessionsListCommand,
+    remove: sessionsRemoveCommand,
+  },
+})

--- a/packages/apes/src/commands/sessions/list.ts
+++ b/packages/apes/src/commands/sessions/list.ts
@@ -1,0 +1,48 @@
+import { defineCommand } from 'citty'
+import consola from 'consola'
+import { apiFetch } from '../../http'
+
+interface Family {
+  familyId: string
+  userId: string
+  clientId: string
+  createdAt: number
+  expiresAt: number
+  revoked: boolean
+}
+
+interface ListResponse {
+  data: Family[]
+  pagination?: { cursor: string | null, has_more: boolean }
+}
+
+export const sessionsListCommand = defineCommand({
+  meta: {
+    name: 'list',
+    description: 'List your active refresh-token families (one per logged-in device).',
+  },
+  args: {
+    json: { type: 'boolean', description: 'JSON output' },
+    limit: { type: 'string', description: 'Max rows (default 50)' },
+  },
+  async run({ args }) {
+    const path = args.limit ? `/api/me/sessions?limit=${encodeURIComponent(String(args.limit))}` : '/api/me/sessions'
+    const result = await apiFetch<ListResponse>(path)
+
+    if (args.json) {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`)
+      return
+    }
+
+    if (result.data.length === 0) {
+      consola.info('No active sessions.')
+      return
+    }
+
+    for (const f of result.data) {
+      const created = new Date(f.createdAt).toISOString()
+      const expires = new Date(f.expiresAt).toISOString()
+      console.log(`${f.familyId}  client=${f.clientId}  created=${created}  expires=${expires}`)
+    }
+  },
+})

--- a/packages/apes/src/commands/sessions/remove.ts
+++ b/packages/apes/src/commands/sessions/remove.ts
@@ -1,0 +1,24 @@
+import { defineCommand } from 'citty'
+import consola from 'consola'
+import { apiFetch } from '../../http'
+import { CliError } from '../../errors'
+
+export const sessionsRemoveCommand = defineCommand({
+  meta: {
+    name: 'remove',
+    description: 'Revoke one of your active refresh-token families by id.',
+  },
+  args: {
+    familyId: {
+      type: 'positional',
+      required: true,
+      description: 'Family id (from `apes sessions list`).',
+    },
+  },
+  async run({ args }) {
+    const id = String(args.familyId).trim()
+    if (!id) throw new CliError('familyId required')
+    await apiFetch(`/api/me/sessions/${encodeURIComponent(id)}`, { method: 'DELETE' })
+    consola.success(`Session ${id} revoked. The device using it will need to \`apes login\` again on its next refresh.`)
+  },
+})


### PR DESCRIPTION
## Summary

Two new IdP endpoints + CLI subcommands so users can see and revoke their own refresh-token families across devices, without admin privileges.

- \`GET /api/me/sessions\` — lists the caller's families (one per \`apes login\` / one per device); filtered server-side to \`userId = sub\`
- \`DELETE /api/me/sessions/[familyId]\` — ownership-checked: returns 404 if the family belongs to a different user, never 403 (probe-resistant)
- \`apes sessions list\` / \`apes sessions list --json\` — calls the GET endpoint, prints familyId, clientId, createdAt, expiresAt
- \`apes sessions remove <familyId>\` — calls the DELETE endpoint; the device using that family fails its next refresh with \`Token family revoked\` and has to \`apes login\` again

Pre-existing \`/api/admin/sessions\` cross-user endpoints (\`requireAdmin\`) stay as-is.

## Test plan

- [x] Build clean, lint clean
- [x] \`apes sessions --help\` shows list/remove subcommands
- [ ] Live: deploy IdP, run \`apes sessions list\` from one device, see one family; \`apes login\` on a second device, list shows two families; \`apes sessions remove <other-id>\` revokes; second device's next refresh fails with \"Token family revoked\"