### PR TITLE
fix(apes): destroy refuses with clear hint when no TTY

### DIFF
--- a/.changeset/apes-destroy-no-tty-clear-error.md
+++ b/.changeset/apes-destroy-no-tty-clear-error.md
@@ -1,0 +1,9 @@
+---
+"@openape/apes": patch
+---
+
+apes: `apes agents destroy` refuses with a clear hint when there's no TTY (was: opaque `uv_tty_init returned EINVAL` crash)
+
+Calling `apes agents destroy <name>` from a non-TTY context (CI, subprocess, automation) used to crash with an unreadable Node-internal stack trace because `consola.prompt` requires a controlling terminal. Detect `!process.stdin.isTTY` upfront and refuse with `"No TTY available for the interactive confirmation. Re-run with --force …"` instead.
+
+The `--force` flag has always existed for exactly this case; we just weren't surfacing it. No behavior change for interactive use.

--- a/packages/apes/src/commands/agents/destroy.ts
+++ b/packages/apes/src/commands/agents/destroy.ts
@@ -78,6 +78,17 @@ export const destroyAgentCommand = defineCommand({
           : `• Hard-delete IdP agent ${idpAgent!.email} and all its SSH keys`)
       }
       consola.warn(`About to destroy "${name}":\n${consequences.join('\n')}`)
+      // Without a TTY, consola.prompt would crash with `uv_tty_init returned
+      // EINVAL` and leave the user with an opaque stack trace. Detect and
+      // refuse with a clear hint instead — `--force` is the explicit
+      // non-interactive path (CI, subprocess invocations, this script's
+      // own caller when piped).
+      if (!process.stdin.isTTY) {
+        throw new CliError(
+          'No TTY available for the interactive confirmation. Re-run with --force '
+          + 'to skip the prompt (this is the same flag CI uses).',
+        )
+      }
       const confirmed = await consola.prompt('Proceed?', { type: 'confirm', initial: false })
       if (typeof confirmed === 'symbol' || !confirmed) {
         throw new CliExit(0)

--- a/packages/apes/test/agents-destroy.test.ts
+++ b/packages/apes/test/agents-destroy.test.ts
@@ -104,6 +104,28 @@ describe('apes agents destroy', () => {
     })
   })
 
+  it('refuses with a clear hint when no TTY and --force was not passed (was: opaque uv_tty_init crash)', async () => {
+    const { apiFetch } = await import('../src/http.js')
+    vi.mocked(apiFetch).mockResolvedValueOnce([AGENT] as any)
+    macosUserMock.readMacOSUser.mockReturnValue(null)
+
+    // Force a non-TTY stdin for the duration of this test. Vitest spawns
+    // workers without a controlling terminal, so isTTY is already false,
+    // but we set it explicitly so the assertion stays valid even if a
+    // future test runner attaches one.
+    const originalIsTTY = process.stdin.isTTY
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true })
+    try {
+      const { destroyAgentCommand } = await import('../src/commands/agents/destroy.js')
+      await expect((destroyAgentCommand as any).run({
+        args: { name: 'agent-a' },
+      })).rejects.toThrow(/No TTY available.*--force/)
+    }
+    finally {
+      Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true })
+    }
+  })
+
   it('--keep-os-user skips the privileged escapes call entirely', async () => {
     const { apiFetch } = await import('../src/http.js')
     const { execFileSync } = await import('node:child_process')

--- a/packages/apes/test/bash-hook-behavior.test.ts
+++ b/packages/apes/test/bash-hook-behavior.test.ts
@@ -1,0 +1,109 @@
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync, chmodSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { BASH_VIA_APE_SHELL_HOOK_SOURCE } from '../src/lib/agent-bootstrap'
+
+/**
+ * Behavioral tests for the Claude Code PreToolUse Bash hook. The hook is
+ * what makes spawned agents safe — every `bash -c <cmd>` claude tries to
+ * run gets rewritten to `ape-shell -c <cmd>` so it goes through the grant
+ * flow instead of executing freely. The drift test next door
+ * (agents-bash-hook-source.test.ts) only proves the source file matches
+ * the inlined string. This file proves the source actually does what we
+ * claim it does: read tool_input.command from stdin, emit a hookSpecific
+ * Output that swaps the command for the wrapped form.
+ *
+ * We materialize the hook to a tempdir, pipe synthetic JSON to it via
+ * spawnSync, and assert the JSON it writes back matches the hookSpecific
+ * Output schema Claude expects.
+ */
+describe('bash-via-ape-shell hook: behavior', () => {
+  let scriptPath: string
+  let tmp: string
+
+  beforeAll(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'apes-bash-hook-'))
+    scriptPath = join(tmp, 'bash-via-ape-shell.sh')
+    writeFileSync(scriptPath, BASH_VIA_APE_SHELL_HOOK_SOURCE, { mode: 0o755 })
+    chmodSync(scriptPath, 0o755)
+  })
+
+  afterAll(() => {
+    rmSync(tmp, { recursive: true, force: true })
+  })
+
+  function runHook(input: unknown): { code: number, stdout: string, stderr: string } {
+    const res = spawnSync('bash', [scriptPath], {
+      input: JSON.stringify(input),
+      encoding: 'utf-8',
+    })
+    return { code: res.status ?? -1, stdout: res.stdout, stderr: res.stderr }
+  }
+
+  it('rewrites a plain command to `ape-shell -c <quoted>`', () => {
+    const { code, stdout } = runHook({ tool_input: { command: 'ls /etc' } })
+    expect(code).toBe(0)
+    const out = JSON.parse(stdout)
+    expect(out.hookSpecificOutput.hookEventName).toBe('PreToolUse')
+    expect(out.hookSpecificOutput.updatedToolInput.command).toBe(`ape-shell -c 'ls /etc'`)
+  })
+
+  it('quotes commands containing single quotes safely', () => {
+    const { code, stdout } = runHook({ tool_input: { command: `echo 'hi from claude'` } })
+    expect(code).toBe(0)
+    const out = JSON.parse(stdout)
+    // shlex.quote escapes ' by closing the quote, inserting \', reopening
+    expect(out.hookSpecificOutput.updatedToolInput.command).toBe(
+      `ape-shell -c 'echo '"'"'hi from claude'"'"''`,
+    )
+  })
+
+  it('preserves compound commands as a single wrapped string', () => {
+    const { code, stdout } = runHook({ tool_input: { command: 'cd /tmp && ls && echo done' } })
+    expect(code).toBe(0)
+    const out = JSON.parse(stdout)
+    expect(out.hookSpecificOutput.updatedToolInput.command).toBe(
+      `ape-shell -c 'cd /tmp && ls && echo done'`,
+    )
+  })
+
+  it('handles commands with backslashes and special chars', () => {
+    const { code, stdout } = runHook({ tool_input: { command: `grep -E '\\d+' /tmp/x` } })
+    expect(code).toBe(0)
+    const out = JSON.parse(stdout)
+    // Whole original goes inside the outer single-quoted ape-shell -c arg;
+    // shlex handles the embedded quotes by escaping, never unwrapping.
+    const wrapped = out.hookSpecificOutput.updatedToolInput.command as string
+    expect(wrapped.startsWith(`ape-shell -c '`)).toBe(true)
+    expect(wrapped.endsWith(`'`)).toBe(true)
+  })
+
+  it('handles a 10 KB command without truncating', () => {
+    const long = `echo ${'x'.repeat(10_000)}`
+    const { code, stdout } = runHook({ tool_input: { command: long } })
+    expect(code).toBe(0)
+    const out = JSON.parse(stdout)
+    const wrapped = out.hookSpecificOutput.updatedToolInput.command as string
+    expect(wrapped).toContain('x'.repeat(10_000))
+    expect(wrapped.startsWith(`ape-shell -c 'echo `)).toBe(true)
+  })
+
+  it('emits valid JSON even for empty command (claude shouldn\'t send this, but be defensive)', () => {
+    const { code, stdout } = runHook({ tool_input: { command: '' } })
+    expect(code).toBe(0)
+    const out = JSON.parse(stdout)
+    expect(out.hookSpecificOutput.updatedToolInput.command).toBe(`ape-shell -c ''`)
+  })
+
+  it('settings.json registers the hook for the Bash tool with PreToolUse', async () => {
+    const { CLAUDE_SETTINGS_JSON } = await import('../src/lib/agent-bootstrap')
+    const parsed = JSON.parse(CLAUDE_SETTINGS_JSON)
+    expect(parsed.hooks.PreToolUse).toBeDefined()
+    const bashHook = parsed.hooks.PreToolUse.find((h: { matcher: string }) => h.matcher === 'Bash')
+    expect(bashHook).toBeDefined()
+    expect(bashHook.hooks[0].type).toBe('command')
+    expect(bashHook.hooks[0].command).toBe('$HOME/.claude/hooks/bash-via-ape-shell.sh')
+  })
+})


### PR DESCRIPTION
## Summary

\`apes agents destroy <name>\` from a non-TTY shell (CI, subprocess, automation) used to crash with the opaque \`uv_tty_init returned EINVAL\` because \`consola.prompt\` needs a controlling terminal. Detect \`!process.stdin.isTTY\` upfront and refuse with the actionable hint \"No TTY available for the interactive confirmation. Re-run with --force …\" instead.

\`--force\` has always existed for this; we just weren't surfacing it. No change for interactive use.

## Test plan

- [x] New unit test that mocks \`process.stdin.isTTY = false\` and asserts the new error message
- [x] All 599 existing tests pass (no regressions)