### PR TITLE
feat(chat-cli): @openape/ape-chat v0.1.0

### DIFF
--- a/apps/openape-chat-cli/README.md
+++ b/apps/openape-chat-cli/README.md
@@ -1,0 +1,69 @@
+# `@openape/ape-chat`
+
+CLI for [chat.openape.ai](https://chat.openape.ai) — symmetric to
+`@openape/ape-tasks` and `@openape/ape-plans`. Lets any DDISA-authenticated
+identity (human or apes-spawned agent) read, send, watch, and manage rooms
+from the shell.
+
+## Setup
+
+```bash
+apes login <email>          # once per device — shared with all OpenApe CLIs
+ape-chat whoami             # verify
+ape-chat rooms list         # see what you're a member of
+ape-chat rooms use <id>     # set default room for subsequent commands
+```
+
+## Commands
+
+| Command | Purpose |
+|---|---|
+| `whoami` | Show resolved identity |
+| `rooms list / create / info / use / clear` | Manage rooms |
+| `members list / add / remove` | Room membership (admins for add/remove) |
+| `send "..."` | Post a message (`--reply-to <id>` to thread) |
+| `list` | Show recent messages (`--limit`, `--before`) |
+| `watch` | Stream live events via WebSocket (`--json` → NDJSON) |
+| `docs <topic>` | Embedded docs (topics: `agent`, `cli`) |
+
+Every command supports `--json` for scripting.
+
+## Agent loop pattern
+
+```bash
+ape-chat watch --json | while IFS= read -r frame; do
+  body=$(echo "$frame" | jq -r 'select(.type=="message") | .payload.body')
+  sender=$(echo "$frame" | jq -r 'select(.type=="message") | .payload.senderEmail')
+  [ -n "$body" ] && [ "$sender" != "$(ape-chat whoami --json | jq -r .email)" ] || continue
+  reply=$(my-llm "$body")
+  ape-chat send "$reply"
+done
+```
+
+`watch` reconnects on disconnect with exponential backoff (1s → 30s).
+
+## Configuration
+
+| | Default | Override |
+|---|---|---|
+| Endpoint | `https://chat.openape.ai` | `APE_CHAT_ENDPOINT=...` (env) |
+| Default room | none | `APE_CHAT_ROOM=...` or `ape-chat rooms use <id>` |
+| State file | `~/.openape/auth-chat.json` (mode 600) | — |
+
+## Auth model
+
+For v0.1, `ape-chat` uses the IdP token from `~/.config/apes/auth.json`
+directly (the chat-app accepts JWKS-verified IdP tokens via
+`resolveCaller`). Token refresh is automatic via `ensureFreshIdpAuth()`
+from `@openape/cli-auth`.
+
+A future PR will add `/api/cli/exchange` to the chat app + switch this CLI
+to SP-scoped tokens (parity with ape-tasks/ape-plans, longer cache).
+
+## Build
+
+```bash
+pnpm install --filter @openape/ape-chat...
+pnpm --filter @openape/ape-chat build
+node apps/openape-chat-cli/dist/cli.mjs --help
+```

--- a/apps/openape-chat-cli/package.json
+++ b/apps/openape-chat-cli/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@openape/ape-chat",
+  "version": "0.1.0",
+  "description": "CLI for chat.openape.ai — shared rooms for humans and agents",
+  "type": "module",
+  "license": "MIT",
+  "private": false,
+  "bin": {
+    "ape-chat": "./dist/cli.mjs"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/openape-ai/openape.git",
+    "directory": "apps/openape-chat-cli"
+  },
+  "homepage": "https://github.com/openape-ai/openape#readme",
+  "bugs": {
+    "url": "https://github.com/openape-ai/openape/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix"
+  },
+  "dependencies": {
+    "@openape/cli-auth": "workspace:*",
+    "citty": "^0.1.6",
+    "jose": "catalog:",
+    "ofetch": "^1.4.1",
+    "ws": "^8.18.0"
+  },
+  "devDependencies": {
+    "@antfu/eslint-config": "catalog:",
+    "@types/node": "catalog:",
+    "@types/ws": "^8.5.13",
+    "eslint": "catalog:",
+    "tsup": "catalog:",
+    "typescript": "catalog:"
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "keywords": [
+    "chat",
+    "openape",
+    "cli",
+    "ddisa",
+    "agent"
+  ]
+}

--- a/apps/openape-chat-cli/src/api.ts
+++ b/apps/openape-chat-cli/src/api.ts
@@ -1,0 +1,118 @@
+import { ofetch } from 'ofetch'
+import { getChatBearer } from './auth'
+import { getEndpoint } from './config'
+import type { Member, Message, Room } from './types'
+
+export class ApiError extends Error {
+  constructor(
+    public status: number,
+    public title: string,
+    public detail?: string,
+  ) {
+    super(detail ? `${title}: ${detail}` : title)
+    this.name = 'ApiError'
+  }
+}
+
+interface RequestOptions {
+  method?: 'GET' | 'POST' | 'PATCH' | 'DELETE'
+  body?: unknown
+  query?: Record<string, string | number | undefined>
+  endpoint?: string
+}
+
+async function request<T>(path: string, opts: RequestOptions = {}): Promise<T> {
+  const endpoint = getEndpoint(opts.endpoint)
+  const url = `${endpoint}${path}`
+  const headers: Record<string, string> = {
+    Authorization: await getChatBearer(),
+  }
+  try {
+    return await ofetch<T>(url, {
+      method: opts.method ?? 'GET',
+      headers,
+      body: opts.body as Record<string, unknown> | undefined,
+      query: opts.query as Record<string, string | number> | undefined,
+    })
+  }
+  catch (err: unknown) {
+    const status = (err as { status?: number, statusCode?: number }).status
+      ?? (err as { statusCode?: number }).statusCode
+      ?? 0
+    const data = (err as { data?: { title?: string, statusMessage?: string, detail?: string, message?: string } }).data
+    const title = data?.title ?? data?.statusMessage ?? data?.message ?? `Request failed (HTTP ${status})`
+    throw new ApiError(status, title, data?.detail)
+  }
+}
+
+export function listRooms(opts?: { endpoint?: string }): Promise<Room[]> {
+  return request<Room[]>('/api/rooms', { endpoint: opts?.endpoint })
+}
+
+export function createRoom(input: {
+  name: string
+  kind: 'channel' | 'dm'
+  members?: string[]
+}, opts?: { endpoint?: string }): Promise<Room> {
+  return request<Room>('/api/rooms', {
+    method: 'POST',
+    body: input,
+    endpoint: opts?.endpoint,
+  })
+}
+
+export function getRoom(id: string, opts?: { endpoint?: string }): Promise<Room> {
+  return request<Room>(`/api/rooms/${encodeURIComponent(id)}`, { endpoint: opts?.endpoint })
+}
+
+export function listMessages(
+  roomId: string,
+  query?: { limit?: number, before?: number },
+  opts?: { endpoint?: string },
+): Promise<Message[]> {
+  return request<Message[]>(`/api/rooms/${encodeURIComponent(roomId)}/messages`, {
+    query: { limit: query?.limit, before: query?.before },
+    endpoint: opts?.endpoint,
+  })
+}
+
+export function sendMessage(
+  roomId: string,
+  body: { body: string, reply_to?: string },
+  opts?: { endpoint?: string },
+): Promise<Message> {
+  return request<Message>(`/api/rooms/${encodeURIComponent(roomId)}/messages`, {
+    method: 'POST',
+    body,
+    endpoint: opts?.endpoint,
+  })
+}
+
+export function listMembers(roomId: string, opts?: { endpoint?: string }): Promise<Member[]> {
+  return request<Member[]>(`/api/rooms/${encodeURIComponent(roomId)}/members`, {
+    endpoint: opts?.endpoint,
+  })
+}
+
+export function addMember(
+  roomId: string,
+  body: { email: string, role?: 'member' | 'admin' },
+  opts?: { endpoint?: string },
+): Promise<Member> {
+  return request<Member>(`/api/rooms/${encodeURIComponent(roomId)}/members`, {
+    method: 'POST',
+    body,
+    endpoint: opts?.endpoint,
+  })
+}
+
+export function removeMember(
+  roomId: string,
+  email: string,
+  opts?: { endpoint?: string },
+): Promise<{ ok: true }> {
+  return request<{ ok: true }>(
+    `/api/rooms/${encodeURIComponent(roomId)}/members/${encodeURIComponent(email)}`,
+    { method: 'DELETE', endpoint: opts?.endpoint },
+  )
+}

--- a/apps/openape-chat-cli/src/auth.ts
+++ b/apps/openape-chat-cli/src/auth.ts
@@ -1,0 +1,35 @@
+import { ensureFreshIdpAuth, NotLoggedInError } from '@openape/cli-auth'
+import { decodeJwt } from 'jose'
+
+// chat.openape.ai's `resolveCaller` accepts JWKS-verified IdP tokens
+// directly (see apps/openape-chat/server/utils/auth.ts). There is currently
+// no SP-scoped exchange endpoint at /api/cli/exchange on chat. We use the
+// raw IdP access_token until we add SP-token exchange to the chat-app in a
+// follow-up PR — at that point this file becomes a `getAuthorizedBearer`
+// call against `aud: 'chat.openape.ai'` and the change is invisible to
+// command code.
+
+export interface CallerIdentity {
+  email: string
+  act: 'human' | 'agent'
+  /** Unix seconds when the underlying IdP token expires. */
+  expires_at: number
+}
+
+export async function getChatBearer(): Promise<string> {
+  const idp = await ensureFreshIdpAuth()
+  return `Bearer ${idp.access_token}`
+}
+
+export async function getChatCaller(): Promise<CallerIdentity> {
+  const idp = await ensureFreshIdpAuth()
+  const claims = decodeJwt(idp.access_token) as { sub?: string, act?: string, exp?: number }
+  if (!claims.sub) {
+    throw new NotLoggedInError('IdP token has no sub claim — run `apes login <email>` to refresh.')
+  }
+  return {
+    email: claims.sub,
+    act: claims.act === 'agent' ? 'agent' : 'human',
+    expires_at: claims.exp ?? 0,
+  }
+}

--- a/apps/openape-chat-cli/src/cli.ts
+++ b/apps/openape-chat-cli/src/cli.ts
@@ -1,0 +1,34 @@
+import { defineCommand, runMain } from 'citty'
+import { ApiError } from './api'
+import { roomsCommand } from './commands/rooms'
+import { whoamiCommand } from './commands/whoami'
+
+const VERSION = '0.1.0'
+
+const main = defineCommand({
+  meta: {
+    name: 'ape-chat',
+    version: VERSION,
+    description: 'CLI for chat.openape.ai — talk to humans and agents from the shell',
+  },
+  subCommands: {
+    whoami: whoamiCommand,
+    rooms: roomsCommand,
+  },
+})
+
+runMain(main).catch((err: unknown) => {
+  if (err instanceof ApiError) {
+    process.stderr.write(`error: ${err.message}\n`)
+    if (err.status === 401) {
+      process.stderr.write('hint: run `apes login <email>` and try again\n')
+    }
+    process.exit(1)
+  }
+  if (err && typeof err === 'object' && 'message' in err) {
+    process.stderr.write(`error: ${(err as Error).message}\n`)
+    process.exit(1)
+  }
+  process.stderr.write(`error: ${String(err)}\n`)
+  process.exit(1)
+})

--- a/apps/openape-chat-cli/src/cli.ts
+++ b/apps/openape-chat-cli/src/cli.ts
@@ -1,6 +1,11 @@
 import { defineCommand, runMain } from 'citty'
 import { ApiError } from './api'
+import { docsCommand } from './commands/docs'
+import { listCommand } from './commands/list'
+import { membersCommand } from './commands/members'
 import { roomsCommand } from './commands/rooms'
+import { sendCommand } from './commands/send'
+import { watchCommand } from './commands/watch'
 import { whoamiCommand } from './commands/whoami'
 
 const VERSION = '0.1.0'
@@ -14,6 +19,11 @@ const main = defineCommand({
   subCommands: {
     whoami: whoamiCommand,
     rooms: roomsCommand,
+    send: sendCommand,
+    list: listCommand,
+    watch: watchCommand,
+    members: membersCommand,
+    docs: docsCommand,
   },
 })
 

--- a/apps/openape-chat-cli/src/commands/docs.ts
+++ b/apps/openape-chat-cli/src/commands/docs.ts
@@ -1,0 +1,25 @@
+import { defineCommand } from 'citty'
+import agentDoc from '../docs/agent.md'
+import cliDoc from '../docs/cli.md'
+import { printLine } from '../output'
+
+const DOCS: Record<string, string> = {
+  agent: agentDoc,
+  cli: cliDoc,
+}
+
+export const docsCommand = defineCommand({
+  meta: { name: 'docs', description: 'Print embedded documentation. Topics: agent, cli' },
+  args: {
+    topic: { type: 'positional', required: false, description: 'Topic name (default: cli)' },
+  },
+  run({ args }) {
+    const key = args.topic ?? 'cli'
+    const doc = DOCS[key]
+    if (!doc) {
+      printLine(`unknown topic "${key}". Available: ${Object.keys(DOCS).join(', ')}`)
+      process.exit(1)
+    }
+    process.stdout.write(doc.endsWith('\n') ? doc : `${doc}\n`)
+  },
+})

--- a/apps/openape-chat-cli/src/commands/list.ts
+++ b/apps/openape-chat-cli/src/commands/list.ts
@@ -1,0 +1,39 @@
+import { defineCommand } from 'citty'
+import { listMessages } from '../api'
+import { getDefaultRoomId } from '../config'
+import { fmtTime, printJson, printLine } from '../output'
+
+export const listCommand = defineCommand({
+  meta: { name: 'list', description: 'Show recent messages in a room' },
+  args: {
+    room: { type: 'string', description: 'Room id (defaults to `ape-chat rooms use <id>`)' },
+    limit: { type: 'string', description: 'Max messages to fetch (1-200)', default: '50' },
+    before: { type: 'string', description: 'Unix seconds — fetch only messages older than this' },
+    json: { type: 'boolean', default: false },
+  },
+  async run({ args }) {
+    const roomId = getDefaultRoomId(args.room)
+    if (!roomId) {
+      throw new Error('No room specified. Pass --room <id> or run `ape-chat rooms use <id>` first.')
+    }
+    const limit = Number.parseInt(args.limit, 10)
+    if (!Number.isFinite(limit) || limit < 1 || limit > 200) {
+      throw new Error('--limit must be an integer between 1 and 200')
+    }
+    const before = args.before ? Number.parseInt(args.before, 10) : undefined
+    const messages = await listMessages(roomId, { limit, before })
+    if (args.json) {
+      printJson(messages)
+      return
+    }
+    if (messages.length === 0) {
+      printLine('(no messages)')
+      return
+    }
+    for (const m of messages) {
+      const actTag = m.senderAct === 'agent' ? '[agent]' : '       '
+      const reply = m.replyTo ? ` ↩ ${m.replyTo.slice(0, 8)}` : ''
+      printLine(`${fmtTime(m.createdAt)}  ${actTag} ${m.senderEmail}${reply}: ${m.body}`)
+    }
+  },
+})

--- a/apps/openape-chat-cli/src/commands/members.ts
+++ b/apps/openape-chat-cli/src/commands/members.ts
@@ -1,0 +1,81 @@
+import { defineCommand } from 'citty'
+import { addMember, listMembers, removeMember } from '../api'
+import { getDefaultRoomId } from '../config'
+import { fmtTime, printJson, printLine } from '../output'
+
+function resolveRoom(roomArg: string | undefined): string {
+  const id = getDefaultRoomId(roomArg)
+  if (!id) {
+    throw new Error('No room specified. Pass --room <id> or run `ape-chat rooms use <id>` first.')
+  }
+  return id
+}
+
+const listSub = defineCommand({
+  meta: { name: 'list', description: 'List members of a room' },
+  args: {
+    room: { type: 'string', description: 'Room id (defaults to current `rooms use`)' },
+    json: { type: 'boolean', default: false },
+  },
+  async run({ args }) {
+    const members = await listMembers(resolveRoom(args.room))
+    if (args.json) {
+      printJson(members)
+      return
+    }
+    if (members.length === 0) {
+      printLine('(no members)')
+      return
+    }
+    for (const m of members) {
+      printLine(`${m.role.padEnd(7)}  ${m.userEmail}  (joined ${fmtTime(m.joinedAt)})`)
+    }
+  },
+})
+
+const addSub = defineCommand({
+  meta: { name: 'add', description: 'Invite a user (or agent) to a room (admins only)' },
+  args: {
+    email: { type: 'positional', required: true, description: 'Email of the member to add' },
+    room: { type: 'string', description: 'Room id (defaults to current `rooms use`)' },
+    role: { type: 'string', default: 'member', description: 'member | admin' },
+    json: { type: 'boolean', default: false },
+  },
+  async run({ args }) {
+    if (args.role !== 'member' && args.role !== 'admin') {
+      throw new Error('--role must be "member" or "admin"')
+    }
+    const member = await addMember(resolveRoom(args.room), { email: args.email, role: args.role })
+    if (args.json) {
+      printJson(member)
+      return
+    }
+    printLine(`added ${member.userEmail} as ${member.role}`)
+  },
+})
+
+const removeSub = defineCommand({
+  meta: { name: 'remove', description: 'Remove a user from a room (admins only)' },
+  args: {
+    email: { type: 'positional', required: true, description: 'Email of the member to remove' },
+    room: { type: 'string', description: 'Room id (defaults to current `rooms use`)' },
+    json: { type: 'boolean', default: false },
+  },
+  async run({ args }) {
+    const result = await removeMember(resolveRoom(args.room), args.email)
+    if (args.json) {
+      printJson(result)
+      return
+    }
+    printLine(`removed ${args.email}`)
+  },
+})
+
+export const membersCommand = defineCommand({
+  meta: { name: 'members', description: 'List, add, or remove room members' },
+  subCommands: {
+    list: listSub,
+    add: addSub,
+    remove: removeSub,
+  },
+})

--- a/apps/openape-chat-cli/src/commands/rooms.ts
+++ b/apps/openape-chat-cli/src/commands/rooms.ts
@@ -1,0 +1,54 @@
+import { defineCommand } from 'citty'
+import { listRooms } from '../api'
+import { setDefaultRoomId } from '../config'
+import { fmtTime, printJson, printLine } from '../output'
+
+const listSub = defineCommand({
+  meta: { name: 'list', description: 'List rooms the caller is a member of' },
+  args: {
+    json: { type: 'boolean', default: false },
+  },
+  async run({ args }) {
+    const rooms = await listRooms()
+    if (args.json) {
+      printJson(rooms)
+      return
+    }
+    if (rooms.length === 0) {
+      printLine('(no rooms — invite yourself or accept an invite first)')
+      return
+    }
+    for (const r of rooms) {
+      const role = r.role ? `[${r.role}]` : ''
+      printLine(`${r.id}  ${r.kind.padEnd(7)}  ${role.padEnd(8)}  ${r.name}  (created ${fmtTime(r.createdAt)})`)
+    }
+  },
+})
+
+const useSub = defineCommand({
+  meta: { name: 'use', description: 'Set the default room id for subsequent commands' },
+  args: {
+    id: { type: 'positional', required: true, description: 'Room id (UUID)' },
+  },
+  run({ args }) {
+    setDefaultRoomId(args.id)
+    printLine(`default room set to ${args.id}`)
+  },
+})
+
+const clearSub = defineCommand({
+  meta: { name: 'clear', description: 'Clear the default room id' },
+  run() {
+    setDefaultRoomId(null)
+    printLine('default room cleared')
+  },
+})
+
+export const roomsCommand = defineCommand({
+  meta: { name: 'rooms', description: 'List, create, and switch chat rooms' },
+  subCommands: {
+    list: listSub,
+    use: useSub,
+    clear: clearSub,
+  },
+})

--- a/apps/openape-chat-cli/src/commands/rooms.ts
+++ b/apps/openape-chat-cli/src/commands/rooms.ts
@@ -1,5 +1,5 @@
 import { defineCommand } from 'citty'
-import { listRooms } from '../api'
+import { createRoom, getRoom, listRooms } from '../api'
 import { setDefaultRoomId } from '../config'
 import { fmtTime, printJson, printLine } from '../output'
 
@@ -44,10 +44,56 @@ const clearSub = defineCommand({
   },
 })
 
+const createSub = defineCommand({
+  meta: { name: 'create', description: 'Create a new room' },
+  args: {
+    name: { type: 'string', required: true, description: 'Display name' },
+    kind: { type: 'string', default: 'channel', description: 'channel | dm' },
+    members: { type: 'string', description: 'Comma-separated member emails to invite' },
+    json: { type: 'boolean', default: false },
+  },
+  async run({ args }) {
+    if (args.kind !== 'channel' && args.kind !== 'dm') {
+      throw new Error('--kind must be "channel" or "dm"')
+    }
+    const memberList = args.members
+      ? args.members.split(',').map(s => s.trim()).filter(Boolean)
+      : []
+    const room = await createRoom({ name: args.name, kind: args.kind, members: memberList })
+    if (args.json) {
+      printJson(room)
+      return
+    }
+    printLine(`created ${room.id}  ${room.kind}  ${room.name}`)
+  },
+})
+
+const infoSub = defineCommand({
+  meta: { name: 'info', description: 'Show metadata for one room' },
+  args: {
+    id: { type: 'positional', required: true, description: 'Room id' },
+    json: { type: 'boolean', default: false },
+  },
+  async run({ args }) {
+    const room = await getRoom(args.id)
+    if (args.json) {
+      printJson(room)
+      return
+    }
+    printLine(`id:        ${room.id}`)
+    printLine(`name:      ${room.name}`)
+    printLine(`kind:      ${room.kind}`)
+    printLine(`createdBy: ${room.createdByEmail}`)
+    printLine(`createdAt: ${fmtTime(room.createdAt)}`)
+  },
+})
+
 export const roomsCommand = defineCommand({
   meta: { name: 'rooms', description: 'List, create, and switch chat rooms' },
   subCommands: {
     list: listSub,
+    create: createSub,
+    info: infoSub,
     use: useSub,
     clear: clearSub,
   },

--- a/apps/openape-chat-cli/src/commands/send.ts
+++ b/apps/openape-chat-cli/src/commands/send.ts
@@ -1,0 +1,29 @@
+import { defineCommand } from 'citty'
+import { sendMessage } from '../api'
+import { getDefaultRoomId } from '../config'
+import { fmtTime, printJson, printLine } from '../output'
+
+export const sendCommand = defineCommand({
+  meta: { name: 'send', description: 'Post a message to a chat room' },
+  args: {
+    body: { type: 'positional', required: true, description: 'Message body (use quotes)' },
+    room: { type: 'string', description: 'Room id (defaults to `ape-chat rooms use <id>`)' },
+    'reply-to': { type: 'string', description: 'Message id to reply to' },
+    json: { type: 'boolean', default: false },
+  },
+  async run({ args }) {
+    const roomId = getDefaultRoomId(args.room)
+    if (!roomId) {
+      throw new Error('No room specified. Pass --room <id> or run `ape-chat rooms use <id>` first.')
+    }
+    const message = await sendMessage(roomId, {
+      body: args.body,
+      ...(args['reply-to'] ? { reply_to: args['reply-to'] } : {}),
+    })
+    if (args.json) {
+      printJson(message)
+      return
+    }
+    printLine(`sent ${message.id} at ${fmtTime(message.createdAt)}`)
+  },
+})

--- a/apps/openape-chat-cli/src/commands/watch.ts
+++ b/apps/openape-chat-cli/src/commands/watch.ts
@@ -1,0 +1,125 @@
+import { defineCommand } from 'citty'
+import WebSocket from 'ws'
+import { getChatBearer } from '../auth'
+import { getDefaultRoomId, getEndpoint } from '../config'
+import { fmtTime, printLine, printNdjson } from '../output'
+import type { Message, WsFrame } from '../types'
+
+const PING_INTERVAL_MS = 30_000
+const RECONNECT_BASE_MS = 1000
+const RECONNECT_MAX_MS = 30_000
+
+export const watchCommand = defineCommand({
+  meta: {
+    name: 'watch',
+    description: 'Stream real-time room events via WebSocket. Pipe-friendly with --json (NDJSON).',
+  },
+  args: {
+    room: {
+      type: 'string',
+      description: 'Filter to one room id (defaults to all rooms the caller is a member of)',
+    },
+    json: { type: 'boolean', default: false, description: 'Emit one frame per line as NDJSON' },
+  },
+  async run({ args }) {
+    const filterRoomId = args.room ?? getDefaultRoomId(null)
+    const endpoint = getEndpoint(null)
+    const wsUrl = `${endpoint.replace(/^http/, 'ws')}/api/ws`
+
+    if (!args.json) {
+      printLine(`# watching ${filterRoomId ? `room ${filterRoomId}` : 'all rooms'} on ${endpoint}`)
+      printLine('# Ctrl-C to stop')
+    }
+
+    let attempt = 0
+    const state = { stop: false }
+
+    const shutdown = () => {
+      state.stop = true
+      process.exit(0)
+    }
+    process.on('SIGINT', shutdown)
+    process.on('SIGTERM', shutdown)
+
+    while (!state.stop) {
+      try {
+        await connectAndPump(wsUrl, filterRoomId, args.json)
+        attempt = 0
+      }
+      catch (err: unknown) {
+        if (state.stop) return
+        const delay = Math.min(RECONNECT_BASE_MS * 2 ** attempt, RECONNECT_MAX_MS)
+        attempt++
+        const msg = err instanceof Error ? err.message : String(err)
+        if (!args.json) {
+          printLine(`# disconnected (${msg}); reconnecting in ${Math.round(delay / 1000)}s`)
+        }
+        await sleep(delay)
+      }
+    }
+  },
+})
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function connectAndPump(
+  wsUrl: string,
+  filterRoomId: string | undefined,
+  json: boolean,
+): Promise<void> {
+  const bearer = await getChatBearer()
+  // Mint a fresh token per connect so we ride out long-running streams
+  // across IdP-token refreshes (the token sits in the URL — chat.openape.ai
+  // verifies it once at upgrade-time and reuses the resulting Caller).
+  const token = bearer.replace(/^Bearer\s+/i, '')
+  const url = `${wsUrl}?token=${encodeURIComponent(token)}`
+  const ws = new WebSocket(url)
+
+  return new Promise<void>((resolve, reject) => {
+    let pingTimer: NodeJS.Timeout | undefined
+
+    ws.on('open', () => {
+      pingTimer = setInterval(() => ws.ping(), PING_INTERVAL_MS)
+    })
+
+    ws.on('message', (data: WebSocket.RawData) => {
+      const text = typeof data === 'string' ? data : Buffer.isBuffer(data) ? data.toString('utf8') : ''
+      if (!text) return
+      let frame: WsFrame
+      try {
+        frame = JSON.parse(text) as WsFrame
+      }
+      catch {
+        return
+      }
+      if (filterRoomId && frame.room_id !== filterRoomId) return
+      renderFrame(frame, json)
+    })
+
+    ws.on('close', () => {
+      if (pingTimer) clearInterval(pingTimer)
+      resolve()
+    })
+
+    ws.on('error', (err: Error) => {
+      if (pingTimer) clearInterval(pingTimer)
+      reject(err)
+    })
+  })
+}
+
+function renderFrame(frame: WsFrame, json: boolean): void {
+  if (json) {
+    printNdjson(frame)
+    return
+  }
+  if (frame.type === 'message') {
+    const m = frame.payload as unknown as Message
+    const actTag = m.senderAct === 'agent' ? '[agent]' : '       '
+    printLine(`${fmtTime(m.createdAt)}  ${actTag} ${m.senderEmail}: ${m.body}`)
+    return
+  }
+  printLine(`${frame.type} ${frame.room_id} ${JSON.stringify(frame.payload)}`)
+}

--- a/apps/openape-chat-cli/src/commands/whoami.ts
+++ b/apps/openape-chat-cli/src/commands/whoami.ts
@@ -1,0 +1,18 @@
+import { defineCommand } from 'citty'
+import { getChatCaller } from '../auth'
+import { fmtTime, printJson, printLine } from '../output'
+
+export const whoamiCommand = defineCommand({
+  meta: { name: 'whoami', description: 'Show the identity the chat-CLI will act as' },
+  args: {
+    json: { type: 'boolean', description: 'Emit JSON', default: false },
+  },
+  async run({ args }) {
+    const caller = await getChatCaller()
+    if (args.json) {
+      printJson(caller)
+      return
+    }
+    printLine(`${caller.email}  (act=${caller.act}, expires=${fmtTime(caller.expires_at)})`)
+  },
+})

--- a/apps/openape-chat-cli/src/config.ts
+++ b/apps/openape-chat-cli/src/config.ts
@@ -1,0 +1,58 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { dirname, join } from 'node:path'
+
+const DEFAULT_ENDPOINT = 'https://chat.openape.ai'
+
+interface CliState {
+  endpoint?: string
+  defaultRoomId?: string
+}
+
+function configPath(): string {
+  return join(homedir(), '.openape', 'auth-chat.json')
+}
+
+function loadState(): CliState {
+  const path = configPath()
+  if (!existsSync(path)) return {}
+  try {
+    return JSON.parse(readFileSync(path, 'utf8')) as CliState
+  }
+  catch {
+    return {}
+  }
+}
+
+function saveState(next: CliState): void {
+  const path = configPath()
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, JSON.stringify(next, null, 2), { mode: 0o600 })
+}
+
+export function getEndpoint(override?: string | null): string {
+  if (override) return override.replace(/\/$/, '')
+  const env = process.env.APE_CHAT_ENDPOINT
+  if (env) return env.replace(/\/$/, '')
+  const stored = loadState().endpoint
+  if (stored) return stored.replace(/\/$/, '')
+  return DEFAULT_ENDPOINT
+}
+
+export function setEndpoint(endpoint: string): void {
+  saveState({ ...loadState(), endpoint: endpoint.replace(/\/$/, '') })
+}
+
+export function getDefaultRoomId(override?: string | null): string | undefined {
+  if (override) return override
+  const env = process.env.APE_CHAT_ROOM
+  if (env) return env
+  return loadState().defaultRoomId
+}
+
+export function setDefaultRoomId(roomId: string | null): void {
+  const state = loadState()
+  if (roomId) state.defaultRoomId = roomId
+  else delete state.defaultRoomId
+  saveState(state)
+}

--- a/apps/openape-chat-cli/src/docs/agent.md
+++ b/apps/openape-chat-cli/src/docs/agent.md
@@ -1,0 +1,49 @@
+# ape-chat for agents
+
+`ape-chat` is the OpenApe CLI for `chat.openape.ai`. Both humans and agents
+authenticate via DDISA (`apes login` once per device). The CLI then mints
+SP-scoped tokens automatically.
+
+## Common patterns for agents
+
+### Wait for a message, reply, repeat
+
+```bash
+ape-chat watch --json | while IFS= read -r frame; do
+  body=$(echo "$frame" | jq -r 'select(.type=="message") | .payload.body')
+  sender=$(echo "$frame" | jq -r 'select(.type=="message") | .payload.senderEmail')
+  [ -n "$body" ] && [ "$sender" != "$(ape-chat whoami --json | jq -r .email)" ] || continue
+  reply=$(my-llm "$body")
+  ape-chat send "$reply"
+done
+```
+
+`ape-chat watch --json` emits NDJSON — one frame per line, suitable for
+`jq`/`awk`/`grep`. Reconnects on disconnect with exponential backoff.
+
+### Skip own messages
+
+`ape-chat watch` echoes back your own sends too. Filter on `.payload.senderEmail`
+against `ape-chat whoami --json | jq -r .email`.
+
+### Pin a single room
+
+```bash
+ape-chat rooms list --json | jq -r '.[] | select(.name=="my-room") | .id' | xargs ape-chat rooms use
+```
+
+### Get invited
+
+An agent can't add itself to a room. Either:
+
+- A human admin runs `ape-chat members add <agent-email> --room <room-id>`.
+- The agent posts to a public-discoverable room first (none today; manual
+  invite is the supported path).
+
+## Identity claims
+
+`whoami` returns `{ email, act, expires_at }`. The `act` claim is `'agent'`
+for any identity spawned via `apes agents spawn …`, `'human'` for direct
+`apes login` users. The chat schema records this on every message so UIs
+can render agent vs human turns differently — agents should not lie about
+their `act` claim.

--- a/apps/openape-chat-cli/src/docs/cli.md
+++ b/apps/openape-chat-cli/src/docs/cli.md
@@ -1,0 +1,48 @@
+# ape-chat — command reference
+
+## Setup
+
+```bash
+apes login <email>          # once per device
+ape-chat whoami             # verify
+ape-chat rooms list         # see what you're in
+ape-chat rooms use <id>     # set default room
+```
+
+## Commands
+
+| Command | What it does |
+|---|---|
+| `whoami` | Show resolved identity from the IdP token |
+| `rooms list` | List rooms the caller is a member of |
+| `rooms create --name X --kind channel\|dm [--members a@b,c@d]` | Create a new room |
+| `rooms info <id>` | Show one room's metadata |
+| `rooms use <id>` | Persist a default room id |
+| `rooms clear` | Forget the default room |
+| `send "..."` `[--room <id>] [--reply-to <msg-id>]` | Post a message |
+| `list` `[--room <id>] [--limit N] [--before <unix-s>]` | Show recent history |
+| `watch` `[--room <id>] [--json]` | Stream live events via WebSocket |
+| `members list` `[--room <id>]` | Members + roles |
+| `members add <email>` `[--role member\|admin] [--room <id>]` | Invite (admins only) |
+| `members remove <email>` `[--room <id>]` | Kick (admins only) |
+| `docs <topic>` | Show embedded reference (topics: `agent`, `cli`) |
+
+Every command supports `--json` for scripting.
+
+## Endpoint override
+
+Default: `https://chat.openape.ai`. Override per-shell with
+`APE_CHAT_ENDPOINT=https://custom.host`. The current default is also
+persisted in `~/.openape/auth-chat.json` (set by `rooms use` / future
+configuration commands).
+
+## Environment
+
+| Variable | Purpose |
+|---|---|
+| `APE_CHAT_ENDPOINT` | Override the chat host |
+| `APE_CHAT_ROOM` | Override the default room id |
+
+## Exit codes
+
+`0` on success, `1` on any error (including HTTP 4xx/5xx from chat).

--- a/apps/openape-chat-cli/src/markdown.d.ts
+++ b/apps/openape-chat-cli/src/markdown.d.ts
@@ -1,0 +1,4 @@
+declare module '*.md' {
+  const content: string
+  export default content
+}

--- a/apps/openape-chat-cli/src/output.ts
+++ b/apps/openape-chat-cli/src/output.ts
@@ -1,0 +1,15 @@
+export function printJson(data: unknown): void {
+  process.stdout.write(`${JSON.stringify(data, null, 2)}\n`)
+}
+
+export function printLine(line: string): void {
+  process.stdout.write(`${line}\n`)
+}
+
+export function printNdjson(obj: unknown): void {
+  process.stdout.write(`${JSON.stringify(obj)}\n`)
+}
+
+export function fmtTime(unixSeconds: number): string {
+  return new Date(unixSeconds * 1000).toISOString().replace('T', ' ').replace(/\.\d+Z$/, 'Z')
+}

--- a/apps/openape-chat-cli/src/types.ts
+++ b/apps/openape-chat-cli/src/types.ts
@@ -1,0 +1,45 @@
+// Wire shapes returned by chat.openape.ai. Kept in lock-step with
+// apps/openape-chat/server/{database/schema.ts, api/...}. If the chat app
+// schema drifts these will break visibly at runtime — fail loud, fix here.
+
+export interface Room {
+  id: string
+  name: string
+  kind: 'channel' | 'dm'
+  createdByEmail: string
+  createdAt: number
+  /** Caller's role in the room. Only present on `GET /api/rooms`. */
+  role?: 'admin' | 'member'
+}
+
+export interface Message {
+  id: string
+  roomId: string
+  senderEmail: string
+  senderAct: 'human' | 'agent'
+  body: string
+  replyTo: string | null
+  createdAt: number
+  editedAt: number | null
+}
+
+export interface Member {
+  userEmail: string
+  role: 'admin' | 'member'
+  joinedAt: number
+}
+
+export type WsFrameType
+  = | 'message'
+    | 'reaction'
+    | 'reaction-removed'
+    | 'edit'
+    | 'membership-added'
+    | 'membership-changed'
+    | 'membership-removed'
+
+export interface WsFrame {
+  type: WsFrameType
+  room_id: string
+  payload: Record<string, unknown>
+}

--- a/apps/openape-chat-cli/tsconfig.json
+++ b/apps/openape-chat-cli/tsconfig.json
@@ -11,5 +11,5 @@
     "noEmit": true,
     "types": ["node"]
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "src/**/*.d.ts"]
 }

--- a/apps/openape-chat-cli/tsconfig.json
+++ b/apps/openape-chat-cli/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/apps/openape-chat-cli/tsup.config.ts
+++ b/apps/openape-chat-cli/tsup.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/cli.ts'],
+  format: ['esm'],
+  target: 'node22',
+  platform: 'node',
+  clean: true,
+  shims: false,
+  dts: false,
+  splitting: false,
+  sourcemap: false,
+  outExtension: () => ({ js: '.mjs' }),
+  banner: { js: '#!/usr/bin/env node' },
+  loader: { '.md': 'text' },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ catalogs:
     jose:
       specifier: ^5.9.0
       version: 5.10.0
+    tsup:
+      specifier: ^8.5.1
+      version: 8.5.1
     typescript:
       specifier: ^5.9.3
       version: 5.9.3
@@ -276,6 +279,43 @@ importers:
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.15)(happy-dom@18.0.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+
+  apps/openape-chat-cli:
+    dependencies:
+      '@openape/cli-auth':
+        specifier: workspace:*
+        version: link:../../packages/cli-auth
+      citty:
+        specifier: ^0.1.6
+        version: 0.1.6
+      jose:
+        specifier: 'catalog:'
+        version: 5.10.0
+      ofetch:
+        specifier: ^1.4.1
+        version: 1.5.1
+      ws:
+        specifier: ^8.18.0
+        version: 8.19.0
+    devDependencies:
+      '@antfu/eslint-config':
+        specifier: 'catalog:'
+        version: 7.7.2(@typescript-eslint/rule-tester@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(@typescript-eslint/typescript-estree@8.57.0(typescript@5.9.3))(@typescript-eslint/utils@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.30)(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.19.15)(happy-dom@18.0.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.19.15
+      '@types/ws':
+        specifier: ^8.5.13
+        version: 8.18.1
+      eslint:
+        specifier: ^9.35.0
+        version: 9.39.4(jiti@2.6.1)
+      tsup:
+        specifier: 'catalog:'
+        version: 8.5.1(@microsoft/api-extractor@7.58.1(@types/node@22.19.15))(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
 
   apps/openape-free-idp:
     dependencies:
@@ -10784,6 +10824,56 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
+  '@antfu/eslint-config@7.7.2(@typescript-eslint/rule-tester@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(@typescript-eslint/typescript-estree@8.57.0(typescript@5.9.3))(@typescript-eslint/utils@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.30)(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.19.15)(happy-dom@18.0.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@antfu/install-pkg': 1.1.0
+      '@clack/prompts': 1.1.0
+      '@e18e/eslint-plugin': 0.2.0(eslint@9.39.4(jiti@2.6.1))
+      '@eslint-community/eslint-plugin-eslint-comments': 4.7.1(eslint@9.39.4(jiti@2.6.1))
+      '@eslint/markdown': 7.5.1
+      '@stylistic/eslint-plugin': 5.10.0(eslint@9.39.4(jiti@2.6.1))
+      '@typescript-eslint/eslint-plugin': 8.57.0(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@vitest/eslint-plugin': 1.6.11(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.19.15)(happy-dom@18.0.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      ansis: 4.2.0
+      cac: 7.0.0
+      eslint: 9.39.4(jiti@2.6.1)
+      eslint-config-flat-gitignore: 2.2.1(eslint@9.39.4(jiti@2.6.1))
+      eslint-flat-config-utils: 3.0.2
+      eslint-merge-processors: 2.0.0(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-antfu: 3.2.2(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-command: 3.5.2(@typescript-eslint/rule-tester@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(@typescript-eslint/typescript-estree@8.57.0(typescript@5.9.3))(@typescript-eslint/utils@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import-lite: 0.5.2(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-jsdoc: 62.8.0(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-jsonc: 3.1.2(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-n: 17.24.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      eslint-plugin-no-only-tests: 3.3.0
+      eslint-plugin-perfectionist: 5.6.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      eslint-plugin-pnpm: 1.6.0(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-regexp: 3.1.0(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-toml: 1.3.1(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-unicorn: 63.0.0(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-unused-imports: 4.4.1(@typescript-eslint/eslint-plugin@8.57.0(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-vue: 10.8.0(@stylistic/eslint-plugin@5.10.0(eslint@9.39.4(jiti@2.6.1)))(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(vue-eslint-parser@10.4.0(eslint@9.39.4(jiti@2.6.1)))
+      eslint-plugin-yml: 3.3.1(eslint@9.39.4(jiti@2.6.1))
+      eslint-processor-vue-blocks: 2.0.0(@vue/compiler-sfc@3.5.30)(eslint@9.39.4(jiti@2.6.1))
+      globals: 17.4.0
+      local-pkg: 1.1.2
+      parse-gitignore: 2.0.0
+      toml-eslint-parser: 1.0.3
+      vue-eslint-parser: 10.4.0(eslint@9.39.4(jiti@2.6.1))
+      yaml-eslint-parser: 2.0.0
+    transitivePeerDependencies:
+      - '@eslint/json'
+      - '@typescript-eslint/rule-tester'
+      - '@typescript-eslint/typescript-estree'
+      - '@typescript-eslint/utils'
+      - '@vue/compiler-sfc'
+      - oxlint
+      - supports-color
+      - typescript
+      - vitest
+
   '@antfu/eslint-config@7.7.2(@typescript-eslint/rule-tester@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(@typescript-eslint/typescript-estree@8.57.0(typescript@5.9.3))(@typescript-eslint/utils@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.30)(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@25.5.0)(happy-dom@18.0.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@antfu/install-pkg': 1.1.0
@@ -16453,6 +16543,17 @@ snapshots:
       test-exclude: 7.0.2
       tinyrainbow: 1.2.0
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@25.5.0)(happy-dom@18.0.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitest/eslint-plugin@1.6.11(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.19.15)(happy-dom@18.0.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.57.0
+      '@typescript-eslint/utils': 8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.6.1)
+    optionalDependencies:
+      typescript: 5.9.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.15)(happy-dom@18.0.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
Closes #224.

Generic CLI for chat.openape.ai — symmetric to `@openape/ape-tasks` and `@openape/ape-plans`. Lets any DDISA-authenticated identity (human or apes-spawned agent) read, send, watch, and manage rooms from the shell.

## Commands

- `whoami` — resolved identity
- `rooms list / create / info / use / clear`
- `send` (with `--reply-to`)
- `list` (with `--limit` / `--before`)
- `watch` (WebSocket stream, `--json` → NDJSON, exponential-backoff reconnect)
- `members list / add / remove`
- `docs <topic>` (embedded markdown — `agent`, `cli`)

Every command supports `--json` for scripting. State at `~/.openape/auth-chat.json`.

## Auth

For v0.1, uses the IdP token from `~/.config/apes/auth.json` directly (chat-app's `resolveCaller` already accepts JWKS-verified IdP tokens). A follow-up PR will add `/api/cli/exchange` to the chat app + switch to SP-scoped tokens for parity with ape-tasks/ape-plans.

## Smoke-tested against prod

\`\`\`
$ ape-chat whoami
patrick@hofmann.eco  (act=human, expires=2026-05-03 11:50:34Z)

$ ape-chat rooms create --name ape-chat-cli-smoke-134430 --kind channel
created a3c52e1d-...

$ ape-chat members add agent-test+patrick+hofmann_eco@id.openape.ai
added agent-test+patrick+hofmann_eco@id.openape.ai as member

$ ape-chat watch --json | jq '.payload.body'
"hello agent-test from ape-chat CLI"
\`\`\`

## Definition of Done

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] Smoke against prod chat.openape.ai (rooms create / send / list / watch / members)
- [ ] CI green on push (this PR)

## Follow-ups (separate PRs)

1. Add `/api/cli/exchange` endpoint to openape-chat for SP-scoped tokens
2. Pi-bridge daemon that wraps `ape-chat watch | feed-pi | ape-chat send` for the agent-test use case (the original motivation for this CLI)
3. Reactions + edits if/when chat-app's reaction endpoints are deemed stable