### PR TITLE
feat(chat-bridge): pi-bridge daemon for chat.openape.ai

### DIFF
--- a/apps/openape-chat-bridge/README.md
+++ b/apps/openape-chat-bridge/README.md
@@ -1,0 +1,83 @@
+# `@openape/chat-bridge`
+
+Long-running daemon that lets a local LLM CLI (default: `pi-coding-agent`)
+answer chat.openape.ai messages on behalf of an apes-spawned agent.
+
+The bridge connects to chat via WebSocket using the agent's IdP token
+(same path `ape-chat watch` uses), spawns the configured LLM CLI per
+inbound message in `--print` mode, and posts the captured stdout back
+into the same room as a reply.
+
+## Topology
+
+```
+chat.openape.ai
+    ↓ WS frames
+chat-bridge daemon          (under agent-test)
+    ↓ pi --print "<msg>"
+pi-coding-agent             (extension: litellm)
+    ↓ /v1/chat/completions
+litellm proxy 4000          (under patrickhofmann)
+    ↓ /codex/responses
+ChatGPT subscription
+```
+
+## Setup (per agent user)
+
+```bash
+apes login <agent-email>                           # once, for the agent
+bun add -g @mariozechner/pi-coding-agent           # or whatever LLM CLI
+# pi extension that points at your model proxy: see openape/agent-copy-test
+bun add -g @openape/chat-bridge                    # the daemon
+openape-chat-bridge                                # foreground; ^C to stop
+```
+
+## Configuration (env vars)
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `APE_CHAT_ENDPOINT` | `https://chat.openape.ai` | Chat API host |
+| `APE_CHAT_BRIDGE_CMD` | `pi` | Executable to spawn per message |
+| `APE_CHAT_BRIDGE_ARGS` | `--provider litellm --model gpt-5.4 --print` | Extra args |
+| `APE_CHAT_BRIDGE_ROOM` | (none → all rooms) | Restrict to one room id |
+| `APE_CHAT_BRIDGE_TIMEOUT_MS` | `60000` | Max time per LLM call |
+
+## Behavior
+
+- Agent-side filter: ignores its own messages (no infinite loop).
+- One process per inbound message — slow LLM calls don't block other rooms.
+- Errors from the LLM are surfaced as a chat reply prefixed with `(bridge error …)`.
+- Reconnects on WebSocket disconnect with exponential backoff (1s → 30s).
+- Logs to stderr, stdout is reserved for the LLM CLI's output.
+
+## Smoke-tested
+
+```text
+12:01:42  patrick → chat: "What is 2+2? Answer in one word."
+12:01:42  bridge in (room ...c99): What is 2+2? Answer in one word.
+12:01:46  bridge out (room ...c99): 4
+12:01:46  chat.openape.ai shows: [agent] agent-test+...: 4
+```
+
+Latency dominated by the LLM call (~4s for ChatGPT-5.4-Subscription on
+"trivial" math). Round-trip from chat WS frame → reply posted: < 5s.
+
+## Build
+
+```bash
+pnpm install --filter @openape/chat-bridge...
+pnpm --filter @openape/chat-bridge build
+node apps/openape-chat-bridge/dist/bridge.mjs   # foreground daemon
+```
+
+## Limitations / future work
+
+- **One-shot calls only.** Each message triggers a fresh `pi --print` run
+  with no memory of prior turns in the room. Stateful sessions (pi RPC mode,
+  or a per-room rolling-context file) would be a v0.2 follow-up.
+- **No tool-call routing.** If pi triggers a bash/edit tool, the result
+  stays inside pi's process — only the final stdout is posted to chat.
+- **No slash-command routing.** A future iteration could intercept
+  `/help`, `/reset`, `/model X` etc. before forwarding to pi.
+- **No identity-verification per message.** The bridge replies to anything
+  not from itself, including other agents in the same room.

--- a/apps/openape-chat-bridge/package.json
+++ b/apps/openape-chat-bridge/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@openape/chat-bridge",
+  "version": "0.1.0",
+  "description": "Bridge daemon: forwards chat.openape.ai messages to a local LLM CLI (default: pi) and posts replies back as the agent",
+  "type": "module",
+  "license": "MIT",
+  "private": false,
+  "bin": {
+    "openape-chat-bridge": "./dist/bridge.mjs"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix"
+  },
+  "dependencies": {
+    "@openape/cli-auth": "workspace:*",
+    "jose": "catalog:",
+    "ofetch": "^1.4.1",
+    "ws": "^8.18.0"
+  },
+  "devDependencies": {
+    "@antfu/eslint-config": "catalog:",
+    "@types/node": "catalog:",
+    "@types/ws": "^8.5.13",
+    "eslint": "catalog:",
+    "tsup": "catalog:",
+    "typescript": "catalog:"
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "keywords": [
+    "openape",
+    "chat",
+    "bridge",
+    "agent",
+    "pi"
+  ]
+}

--- a/apps/openape-chat-bridge/src/bridge.ts
+++ b/apps/openape-chat-bridge/src/bridge.ts
@@ -1,0 +1,239 @@
+// openape-chat-bridge
+//
+// Long-running daemon. Listens to chat.openape.ai via a WebSocket using the
+// caller's IdP token (same path ape-chat watch uses), and for every inbound
+// message that wasn't sent by the caller itself, shells out to a local LLM
+// CLI (default: pi-coding-agent in --print mode), capturing its stdout and
+// posting it back into the same room as a reply.
+//
+// Designed to run as an apes-spawned agent user that has done `apes login`
+// once. The proxy / model config sits inside the LLM CLI extension — this
+// bridge only knows about chat I/O and how to launch the CLI.
+//
+// Env knobs (all optional):
+//   APE_CHAT_ENDPOINT      override https://chat.openape.ai
+//   APE_CHAT_BRIDGE_CMD    LLM command to invoke (default: 'pi')
+//   APE_CHAT_BRIDGE_ARGS   space-separated extra args (default:
+//                          '--provider litellm --model gpt-5.4 --print')
+//   APE_CHAT_BRIDGE_ROOM   restrict to one room id (default: all rooms the
+//                          agent is a member of)
+//   APE_CHAT_BRIDGE_TIMEOUT_MS  CLI timeout per message (default: 60000)
+
+import { spawn } from 'node:child_process'
+import process from 'node:process'
+import { ensureFreshIdpAuth, NotLoggedInError } from '@openape/cli-auth'
+import { decodeJwt } from 'jose'
+import { ofetch } from 'ofetch'
+import WebSocket from 'ws'
+
+const DEFAULT_ENDPOINT = 'https://chat.openape.ai'
+const DEFAULT_CMD = 'pi'
+const DEFAULT_ARGS = '--provider litellm --model gpt-5.4 --print'
+const DEFAULT_TIMEOUT_MS = 60_000
+
+const PING_INTERVAL_MS = 30_000
+const RECONNECT_BASE_MS = 1000
+const RECONNECT_MAX_MS = 30_000
+
+interface Message {
+  id: string
+  roomId: string
+  senderEmail: string
+  senderAct: 'human' | 'agent'
+  body: string
+  replyTo: string | null
+  createdAt: number
+  editedAt: number | null
+}
+
+interface WsFrame {
+  type: string
+  room_id: string
+  payload: Record<string, unknown>
+}
+
+interface BridgeConfig {
+  endpoint: string
+  cmd: string
+  args: string[]
+  roomFilter?: string
+  timeoutMs: number
+}
+
+function readConfig(): BridgeConfig {
+  const argsRaw = process.env.APE_CHAT_BRIDGE_ARGS ?? DEFAULT_ARGS
+  return {
+    endpoint: (process.env.APE_CHAT_ENDPOINT ?? DEFAULT_ENDPOINT).replace(/\/$/, ''),
+    cmd: process.env.APE_CHAT_BRIDGE_CMD ?? DEFAULT_CMD,
+    args: argsRaw.split(/\s+/).filter(Boolean),
+    roomFilter: process.env.APE_CHAT_BRIDGE_ROOM,
+    timeoutMs: Number.parseInt(process.env.APE_CHAT_BRIDGE_TIMEOUT_MS ?? '', 10) || DEFAULT_TIMEOUT_MS,
+  }
+}
+
+async function getIdentity(): Promise<{ email: string, bearer: string }> {
+  const idp = await ensureFreshIdpAuth()
+  const claims = decodeJwt(idp.access_token) as { sub?: string }
+  if (!claims.sub) {
+    throw new NotLoggedInError('IdP token has no sub claim — re-run `apes login` for this user.')
+  }
+  return { email: claims.sub, bearer: idp.access_token }
+}
+
+async function postMessage(
+  cfg: BridgeConfig,
+  bearer: string,
+  roomId: string,
+  body: string,
+  replyTo?: string,
+): Promise<void> {
+  const url = `${cfg.endpoint}/api/rooms/${encodeURIComponent(roomId)}/messages`
+  await ofetch(url, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${bearer}` },
+    body: replyTo ? { body, reply_to: replyTo } : { body },
+  })
+}
+
+function runLlm(cfg: BridgeConfig, prompt: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cfg.cmd, [...cfg.args, prompt], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: process.env,
+    })
+    let stdout = ''
+    let stderr = ''
+    const killer = setTimeout(() => child.kill('SIGKILL'), cfg.timeoutMs)
+    child.stdout.on('data', (b: Buffer) => { stdout += b.toString('utf8') })
+    child.stderr.on('data', (b: Buffer) => { stderr += b.toString('utf8') })
+    child.on('error', (err) => {
+      clearTimeout(killer)
+      reject(err)
+    })
+    child.on('close', (code) => {
+      clearTimeout(killer)
+      if (code !== 0) {
+        reject(new Error(`${cfg.cmd} exited ${code}: ${stderr.trim() || stdout.trim()}`))
+        return
+      }
+      resolve(stdout.trim())
+    })
+  })
+}
+
+async function handleMessage(
+  cfg: BridgeConfig,
+  selfEmail: string,
+  bearer: string,
+  msg: Message,
+): Promise<void> {
+  if (msg.senderEmail === selfEmail) return
+  if (!msg.body.trim()) return
+  if (cfg.roomFilter && msg.roomId !== cfg.roomFilter) return
+
+  log(`[${msg.roomId}] in: ${truncate(msg.body, 80)}`)
+
+  let reply: string
+  try {
+    reply = await runLlm(cfg, msg.body)
+  }
+  catch (err) {
+    const errMsg = err instanceof Error ? err.message : String(err)
+    log(`[${msg.roomId}] LLM error: ${errMsg}`)
+    reply = `(bridge error invoking ${cfg.cmd}: ${truncate(errMsg, 200)})`
+  }
+
+  if (!reply) {
+    log(`[${msg.roomId}] empty reply, skipping`)
+    return
+  }
+
+  try {
+    await postMessage(cfg, bearer, msg.roomId, reply, msg.id)
+    log(`[${msg.roomId}] out: ${truncate(reply, 80)}`)
+  }
+  catch (err) {
+    const errMsg = err instanceof Error ? err.message : String(err)
+    log(`[${msg.roomId}] post error: ${errMsg}`)
+  }
+}
+
+function truncate(s: string, n: number): string {
+  if (s.length <= n) return s
+  return `${s.slice(0, n - 1)}…`
+}
+
+function log(line: string): void {
+  process.stderr.write(`${new Date().toISOString()}  ${line}\n`)
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function pumpOnce(
+  cfg: BridgeConfig,
+  identity: { email: string, bearer: string },
+): Promise<void> {
+  const wsUrl = `${cfg.endpoint.replace(/^http/, 'ws')}/api/ws?token=${encodeURIComponent(identity.bearer)}`
+  const ws = new WebSocket(wsUrl)
+
+  return new Promise<void>((resolve, reject) => {
+    let pingTimer: NodeJS.Timeout | undefined
+
+    ws.on('open', () => {
+      log(`connected as ${identity.email} → ${cfg.endpoint}`)
+      pingTimer = setInterval(() => ws.ping(), PING_INTERVAL_MS)
+    })
+
+    ws.on('message', (data: WebSocket.RawData) => {
+      const text = typeof data === 'string' ? data : Buffer.isBuffer(data) ? data.toString('utf8') : ''
+      if (!text) return
+      let frame: WsFrame
+      try { frame = JSON.parse(text) as WsFrame }
+      catch { return }
+      if (frame.type !== 'message') return
+      // Don't await — handle messages concurrently so a slow LLM call doesn't
+      // block other rooms. Errors are logged inside handleMessage.
+      void handleMessage(cfg, identity.email, identity.bearer, frame.payload as unknown as Message)
+    })
+
+    ws.on('close', () => {
+      if (pingTimer) clearInterval(pingTimer)
+      resolve()
+    })
+
+    ws.on('error', (err: Error) => {
+      if (pingTimer) clearInterval(pingTimer)
+      reject(err)
+    })
+  })
+}
+
+async function main(): Promise<void> {
+  const cfg = readConfig()
+  const identity = await getIdentity()
+
+  log(`bridge starting — cmd=${cfg.cmd} args=[${cfg.args.join(' ')}] room=${cfg.roomFilter ?? '*'}`)
+
+  let attempt = 0
+  while (true) {
+    try {
+      await pumpOnce(cfg, identity)
+      attempt = 0
+    }
+    catch (err) {
+      const delay = Math.min(RECONNECT_BASE_MS * 2 ** attempt, RECONNECT_MAX_MS)
+      attempt++
+      const msg = err instanceof Error ? err.message : String(err)
+      log(`disconnected (${msg}) — reconnecting in ${Math.round(delay / 1000)}s`)
+      await sleep(delay)
+    }
+  }
+}
+
+main().catch((err: unknown) => {
+  const msg = err instanceof Error ? err.message : String(err)
+  process.stderr.write(`fatal: ${msg}\n`)
+  process.exit(1)
+})

--- a/apps/openape-chat-bridge/tsconfig.json
+++ b/apps/openape-chat-bridge/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/apps/openape-chat-bridge/tsup.config.ts
+++ b/apps/openape-chat-bridge/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/bridge.ts'],
+  format: ['esm'],
+  target: 'node22',
+  platform: 'node',
+  clean: true,
+  shims: false,
+  dts: false,
+  splitting: false,
+  sourcemap: false,
+  outExtension: () => ({ js: '.mjs' }),
+  banner: { js: '#!/usr/bin/env node' },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ catalogs:
     jose:
       specifier: ^5.9.0
       version: 5.10.0
+    tsup:
+      specifier: ^8.5.1
+      version: 8.5.1
     typescript:
       specifier: ^5.9.3
       version: 5.9.3
@@ -276,6 +279,40 @@ importers:
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.15)(happy-dom@18.0.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+
+  apps/openape-chat-bridge:
+    dependencies:
+      '@openape/cli-auth':
+        specifier: workspace:*
+        version: link:../../packages/cli-auth
+      jose:
+        specifier: 'catalog:'
+        version: 5.10.0
+      ofetch:
+        specifier: ^1.4.1
+        version: 1.5.1
+      ws:
+        specifier: ^8.18.0
+        version: 8.19.0
+    devDependencies:
+      '@antfu/eslint-config':
+        specifier: 'catalog:'
+        version: 7.7.2(@typescript-eslint/rule-tester@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(@typescript-eslint/typescript-estree@8.57.0(typescript@5.9.3))(@typescript-eslint/utils@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.30)(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.19.15)(happy-dom@18.0.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.19.15
+      '@types/ws':
+        specifier: ^8.5.13
+        version: 8.18.1
+      eslint:
+        specifier: ^9.35.0
+        version: 9.39.4(jiti@2.6.1)
+      tsup:
+        specifier: 'catalog:'
+        version: 8.5.1(@microsoft/api-extractor@7.58.1(@types/node@22.19.15))(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
 
   apps/openape-free-idp:
     dependencies:
@@ -10784,6 +10821,56 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
+  '@antfu/eslint-config@7.7.2(@typescript-eslint/rule-tester@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(@typescript-eslint/typescript-estree@8.57.0(typescript@5.9.3))(@typescript-eslint/utils@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.30)(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.19.15)(happy-dom@18.0.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@antfu/install-pkg': 1.1.0
+      '@clack/prompts': 1.1.0
+      '@e18e/eslint-plugin': 0.2.0(eslint@9.39.4(jiti@2.6.1))
+      '@eslint-community/eslint-plugin-eslint-comments': 4.7.1(eslint@9.39.4(jiti@2.6.1))
+      '@eslint/markdown': 7.5.1
+      '@stylistic/eslint-plugin': 5.10.0(eslint@9.39.4(jiti@2.6.1))
+      '@typescript-eslint/eslint-plugin': 8.57.0(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@vitest/eslint-plugin': 1.6.11(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.19.15)(happy-dom@18.0.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      ansis: 4.2.0
+      cac: 7.0.0
+      eslint: 9.39.4(jiti@2.6.1)
+      eslint-config-flat-gitignore: 2.2.1(eslint@9.39.4(jiti@2.6.1))
+      eslint-flat-config-utils: 3.0.2
+      eslint-merge-processors: 2.0.0(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-antfu: 3.2.2(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-command: 3.5.2(@typescript-eslint/rule-tester@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(@typescript-eslint/typescript-estree@8.57.0(typescript@5.9.3))(@typescript-eslint/utils@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import-lite: 0.5.2(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-jsdoc: 62.8.0(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-jsonc: 3.1.2(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-n: 17.24.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      eslint-plugin-no-only-tests: 3.3.0
+      eslint-plugin-perfectionist: 5.6.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      eslint-plugin-pnpm: 1.6.0(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-regexp: 3.1.0(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-toml: 1.3.1(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-unicorn: 63.0.0(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-unused-imports: 4.4.1(@typescript-eslint/eslint-plugin@8.57.0(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-vue: 10.8.0(@stylistic/eslint-plugin@5.10.0(eslint@9.39.4(jiti@2.6.1)))(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(vue-eslint-parser@10.4.0(eslint@9.39.4(jiti@2.6.1)))
+      eslint-plugin-yml: 3.3.1(eslint@9.39.4(jiti@2.6.1))
+      eslint-processor-vue-blocks: 2.0.0(@vue/compiler-sfc@3.5.30)(eslint@9.39.4(jiti@2.6.1))
+      globals: 17.4.0
+      local-pkg: 1.1.2
+      parse-gitignore: 2.0.0
+      toml-eslint-parser: 1.0.3
+      vue-eslint-parser: 10.4.0(eslint@9.39.4(jiti@2.6.1))
+      yaml-eslint-parser: 2.0.0
+    transitivePeerDependencies:
+      - '@eslint/json'
+      - '@typescript-eslint/rule-tester'
+      - '@typescript-eslint/typescript-estree'
+      - '@typescript-eslint/utils'
+      - '@vue/compiler-sfc'
+      - oxlint
+      - supports-color
+      - typescript
+      - vitest
+
   '@antfu/eslint-config@7.7.2(@typescript-eslint/rule-tester@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(@typescript-eslint/typescript-estree@8.57.0(typescript@5.9.3))(@typescript-eslint/utils@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.30)(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@25.5.0)(happy-dom@18.0.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@antfu/install-pkg': 1.1.0
@@ -16453,6 +16540,17 @@ snapshots:
       test-exclude: 7.0.2
       tinyrainbow: 1.2.0
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@25.5.0)(happy-dom@18.0.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitest/eslint-plugin@1.6.11(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.19.15)(happy-dom@18.0.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.57.0
+      '@typescript-eslint/utils': 8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.6.1)
+    optionalDependencies:
+      typescript: 5.9.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.15)(happy-dom@18.0.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
Closes #226. Builds on #225 (ape-chat CLI).

Long-running daemon under an apes-spawned agent. Connects to chat.openape.ai via WebSocket, spawns the configured LLM CLI (default \`pi --provider litellm --model gpt-5.4 --print\`) per inbound message, posts the reply back into the same room with \`reply_to\` set.

## Smoke (verified end-to-end against prod)

\`\`\`text
12:01:42  patrick  → chat: "What is 2+2? Answer in one word."
12:01:42  bridge       in: "What is 2+2? Answer in one word."
12:01:46  bridge      out: "4"
12:01:46  chat shows: [agent] agent-test+...: 4
\`\`\`

Topology: chat WS → bridge → pi → litellm-proxy → ChatGPT subscription → reply.

## Configuration (env)

| Var | Default |
|---|---|
| \`APE_CHAT_ENDPOINT\` | \`https://chat.openape.ai\` |
| \`APE_CHAT_BRIDGE_CMD\` | \`pi\` |
| \`APE_CHAT_BRIDGE_ARGS\` | \`--provider litellm --model gpt-5.4 --print\` |
| \`APE_CHAT_BRIDGE_ROOM\` | (none → all rooms) |
| \`APE_CHAT_BRIDGE_TIMEOUT_MS\` | \`60000\` |

## Behavior

- Skips own messages (no infinite loop)
- Concurrent — slow LLM calls don't block other rooms
- Reconnects on WS disconnect (exp backoff 1s → 30s)
- Errors surfaced as a chat reply prefixed with \`(bridge error …)\`
- Logs to stderr; stdout reserved for LLM stdout (which is captured)

## Definition of Done

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] Smoke against prod chat + ChatGPT subscription
- [ ] CI green

## Follow-ups

- Stateful per-room sessions (pi RPC mode or rolling context window)
- Slash-command routing (\`/reset\`, \`/model X\`)
- Tool-call observability — surface intermediate tool runs as chat events