### PR TITLE
fix(apes): destroy uses sysadminctl -adminUser/-adminPassword to avoid 5min hang and -14987

### DIFF
--- a/.changeset/destroy-sysadminctl-admincreds.md
+++ b/.changeset/destroy-sysadminctl-admincreds.md
@@ -1,0 +1,9 @@
+---
+"@openape/apes": patch
+---
+
+Fix: `apes agents destroy` no longer hangs ~5min and fails with `eUndefinedError -14987` from `DSRecord.m`.
+
+Root cause: the teardown script ran inside `escapes`' setuid-root context, which has no audit/PAM session attached (`AUDIT_SESSION_ID=unset`). Plain `sysadminctl -deleteUser` and `dscl . -delete` both made an implicit "is current session admin?" check via opendirectoryd; with no session bound, the lookup hung 5min and exited `-14987`.
+
+Fix: pass `-adminUser/-adminPassword` to `sysadminctl` so it authenticates against DirectoryService directly instead of probing the session. The local admin password is collected from `APES_ADMIN_PASSWORD` (preferred) or a silent prompt, then piped via stdin into the teardown script — never as an argv element (would leak via `ps` and the escapes audit log). With this change the user record delete completes in ~1s.

--- a/packages/apes/src/commands/agents/destroy.ts
+++ b/packages/apes/src/commands/agents/destroy.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from 'node:child_process'
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { tmpdir, userInfo } from 'node:os'
 import { join } from 'node:path'
 import { defineCommand } from 'citty'
 import consola from 'consola'
@@ -123,16 +123,32 @@ export const destroyAgentCommand = defineCommand({
       if (!escapes) {
         throw new CliError('`escapes` not found on PATH; OS teardown requires escapes.')
       }
+
+      // The teardown script runs in escapes' setuid-root context, which
+      // has no audit/PAM session attached. Bare `sysadminctl -deleteUser`
+      // and `dscl . -delete` hang ~5min then fail with -14987 from there.
+      // sysadminctl with explicit -adminUser/-adminPassword bypasses that
+      // path, so we collect the local admin password here and pipe it to
+      // the script via stdin (never as argv — it would show up in `ps`
+      // and in escapes' audit log).
+      const adminUser = userInfo().username
+      const adminPassword = await collectAdminPassword({ adminUser, force: !!args.force })
+
       const scratch = mkdtempSync(join(tmpdir(), `apes-destroy-${name}-`))
       const scriptPath = join(scratch, 'teardown.sh')
       try {
-        const script = buildDestroyTeardownScript({ name, homeDir: `/Users/${name}` })
+        const script = buildDestroyTeardownScript({ name, homeDir: `/Users/${name}`, adminUser })
         writeFileSync(scriptPath, script, { mode: 0o700 })
         consola.start('Running teardown as root via `apes run --as root --wait`…')
         consola.info('You will be asked to approve the as=root grant in your DDISA inbox; this command blocks until you do.')
         // --wait makes the call synchronous; without it `apes run --as root`
         // returns exit 75 (pending) immediately, leaving a dangling grant.
-        execFileSync(apes, ['run', '--as', 'root', '--wait', '--', 'bash', scriptPath], { stdio: 'inherit' })
+        // input + stdio[0]='pipe' streams the password into bash's stdin
+        // so the teardown's `read -r ADMIN_PASSWORD` consumes it.
+        execFileSync(apes, ['run', '--as', 'root', '--wait', '--', 'bash', scriptPath], {
+          input: `${adminPassword}\n`,
+          stdio: ['pipe', 'inherit', 'inherit'],
+        })
       }
       finally {
         rmSync(scratch, { recursive: true, force: true })
@@ -145,3 +161,40 @@ export const destroyAgentCommand = defineCommand({
     consola.success(`Destroyed ${name}.`)
   },
 })
+
+/**
+ * Collect the local admin password used for the `sysadminctl -deleteUser
+ * -adminUser <u> -adminPassword <p>` call inside the teardown script.
+ *
+ * Resolution order:
+ *   1. `APES_ADMIN_PASSWORD` env var (always preferred — lets CI and
+ *      orchestrators script the destroy without a TTY).
+ *   2. Interactive prompt (silent) when stdin is a TTY.
+ *   3. Refuse with a clear hint when neither is available.
+ *
+ * `--force` skips the confirmation prompt earlier in the flow but does
+ * NOT skip this step: there's no safe non-interactive default for an
+ * admin credential, and silent failure here would be a regression
+ * compared to the prior `sudo -n` attempt that at least surfaced an
+ * error.
+ */
+async function collectAdminPassword(opts: { adminUser: string, force: boolean }): Promise<string> {
+  const fromEnv = process.env.APES_ADMIN_PASSWORD
+  if (fromEnv && fromEnv.length > 0) return fromEnv
+
+  if (!process.stdin.isTTY) {
+    throw new CliError(
+      `Admin password required for sysadminctl -deleteUser. No TTY available `
+      + `for the silent prompt; set APES_ADMIN_PASSWORD in the environment `
+      + `(local admin password for ${opts.adminUser}). The teardown reads it `
+      + `from stdin and never stores it.`,
+    )
+  }
+
+  consola.info(`Local admin password for ${opts.adminUser} (used for sysadminctl -deleteUser; not stored):`)
+  const pw = await consola.prompt('Admin password', { type: 'text', mask: '*' })
+  if (typeof pw === 'symbol' || !pw || pw.length === 0) {
+    throw new CliExit(0)
+  }
+  return pw as string
+}

--- a/packages/apes/src/lib/agent-bootstrap.ts
+++ b/packages/apes/src/lib/agent-bootstrap.ts
@@ -201,10 +201,11 @@ echo "OK $NAME uid=$NEXT_UID home=$HOME_DIR"
 export interface DestroyTeardownScriptInput {
   name: string
   homeDir: string
+  adminUser: string
 }
 
 export function buildDestroyTeardownScript(input: DestroyTeardownScriptInput): string {
-  const { name, homeDir } = input
+  const { name, homeDir, adminUser } = input
   return `#!/bin/bash
 # Best-effort teardown. set -u catches typos; we deliberately do NOT use -e
 # because pkill / launchctl are allowed to fail when the user has no live
@@ -213,6 +214,16 @@ set -u
 
 NAME=${shQuote(name)}
 HOME_DIR=${shQuote(homeDir)}
+ADMIN_USER=${shQuote(adminUser)}
+
+# Read the admin password from stdin (line 1). The caller pipes it in.
+# We never accept it as an argv element so it can't show up in process
+# listings or escapes' audit log.
+read -r ADMIN_PASSWORD
+if [ -z "$ADMIN_PASSWORD" ]; then
+  echo "ERROR: no admin password on stdin (expected one line)." >&2
+  exit 2
+fi
 
 UID_OF=$(dscl . -read "/Users/$NAME" UniqueID 2>/dev/null | awk '/UniqueID:/ {print $2}')
 
@@ -225,25 +236,32 @@ if [ -d "$HOME_DIR" ] && [ "$HOME_DIR" != "/" ] && [ "$HOME_DIR" != "" ]; then
   rm -rf "$HOME_DIR"
 fi
 
-# Delete the user record. \`sysadminctl -deleteUser\` is the canonical macOS
-# API and removes Open Directory metadata that \`dscl . -delete\` leaves
-# behind. Fall back to dscl if sysadminctl isn't available or rejects the
-# user. Surface a clear error if both fail — silent failure here is what
-# left orphaned dscl records on previous spawn/destroy round-trips.
-if command -v sysadminctl >/dev/null 2>&1; then
-  if sysadminctl -deleteUser "$NAME" 2>/dev/null; then
-    :
-  elif dscl . -read "/Users/$NAME" >/dev/null 2>&1; then
-    dscl . -delete "/Users/$NAME" || {
-      echo "ERROR: failed to delete user record /Users/$NAME" >&2
-      exit 1
-    }
-  fi
-elif dscl . -read "/Users/$NAME" >/dev/null 2>&1; then
-  dscl . -delete "/Users/$NAME" || {
-    echo "ERROR: failed to delete user record /Users/$NAME" >&2
-    exit 1
-  }
+# \`escapes\` is a plain setuid binary — opendirectoryd sees no audit/PAM
+# session attached (AUDIT_SESSION_ID=unset) and rejects DirectoryService
+# writes from this context: a bare \`sysadminctl -deleteUser\` or
+# \`dscl . -delete\` hangs ~5 minutes and exits with eUndefinedError -14987
+# at DSRecord.m:563. Passing explicit -adminUser/-adminPassword bypasses
+# opendirectoryd's implicit "is current session admin?" check and
+# authenticates against DirectoryService directly — the delete then
+# completes in ~1 second.
+if ! command -v sysadminctl >/dev/null 2>&1; then
+  echo "ERROR: sysadminctl not available; cannot delete user record." >&2
+  exit 1
+fi
+
+sysadminctl \\
+  -deleteUser "$NAME" \\
+  -adminUser "$ADMIN_USER" \\
+  -adminPassword "$ADMIN_PASSWORD"
+SYSAD_EC=$?
+unset ADMIN_PASSWORD
+
+if [ $SYSAD_EC -ne 0 ]; then
+  echo "ERROR: sysadminctl -deleteUser failed (exit=$SYSAD_EC)." >&2
+  echo "       Common causes: wrong admin password, admin user '$ADMIN_USER'" >&2
+  echo "       not in admin group, or target user '$NAME' is the last secure" >&2
+  echo "       token holder (run \\\`sysadminctl -secureTokenStatus $NAME\\\`)." >&2
+  exit 1
 fi
 
 # Verify the record is actually gone.

--- a/packages/apes/test/agents-bootstrap.test.ts
+++ b/packages/apes/test/agents-bootstrap.test.ts
@@ -165,24 +165,35 @@ describe('buildSpawnSetupScript', () => {
 
 describe('buildDestroyTeardownScript', () => {
   it('produces a script that deletes the user and home dir', () => {
-    const script = buildDestroyTeardownScript({ name: 'agent-a', homeDir: '/Users/agent-a' })
+    const script = buildDestroyTeardownScript({ name: 'agent-a', homeDir: '/Users/agent-a', adminUser: 'patrickhofmann' })
     expect(script).toContain(`NAME='agent-a'`)
     expect(script).toContain(`HOME_DIR='/Users/agent-a'`)
+    expect(script).toContain(`ADMIN_USER='patrickhofmann'`)
     expect(script).toContain('launchctl bootout "user/$UID_OF"')
     expect(script).toContain('pkill -9 -u "$UID_OF"')
     expect(script).toContain('rm -rf "$HOME_DIR"')
-    expect(script).toContain('sysadminctl -deleteUser "$NAME"')
-    expect(script).toContain('dscl . -delete "/Users/$NAME"')
+    expect(script).toContain('sysadminctl \\')
+    expect(script).toContain('-deleteUser "$NAME"')
+    expect(script).toContain('-adminUser "$ADMIN_USER"')
+    expect(script).toContain('-adminPassword "$ADMIN_PASSWORD"')
+  })
+
+  it('reads the admin password from stdin (never as argv) and unsets it after use', () => {
+    const script = buildDestroyTeardownScript({ name: 'agent-a', homeDir: '/Users/agent-a', adminUser: 'patrickhofmann' })
+    expect(script).toContain('read -r ADMIN_PASSWORD')
+    expect(script).toContain('unset ADMIN_PASSWORD')
+    // The literal password must never be embedded in the script.
+    expect(script).not.toMatch(/-adminPassword\s+["'][^"'$]/)
   })
 
   it('post-verifies the user record is actually gone (no silent failure)', () => {
-    const script = buildDestroyTeardownScript({ name: 'agent-a', homeDir: '/Users/agent-a' })
+    const script = buildDestroyTeardownScript({ name: 'agent-a', homeDir: '/Users/agent-a', adminUser: 'patrickhofmann' })
     expect(script).toContain('still exists after teardown')
     expect(script).toContain('exit 1')
   })
 
   it('guards against empty/root home', () => {
-    const script = buildDestroyTeardownScript({ name: 'agent-a', homeDir: '/Users/agent-a' })
+    const script = buildDestroyTeardownScript({ name: 'agent-a', homeDir: '/Users/agent-a', adminUser: 'patrickhofmann' })
     expect(script).toContain('"$HOME_DIR" != "/"')
   })
 })

--- a/packages/apes/test/agents-destroy.test.ts
+++ b/packages/apes/test/agents-destroy.test.ts
@@ -45,11 +45,16 @@ describe('apes agents destroy', () => {
     vi.spyOn(console, 'log').mockImplementation(() => {})
     macosUserMock.readMacOSUser.mockReturnValue(null)
     macosUserMock.isDarwin.mockReturnValue(true)
+    // The OS-teardown path collects the local admin password; CI never
+    // has a TTY so we set the env-var resolution path explicitly. Tests
+    // that exercise the "no password" failure case delete this first.
+    process.env.APES_ADMIN_PASSWORD = 'test-admin-pw'
   })
 
   afterEach(() => {
     vi.restoreAllMocks()
     vi.resetModules()
+    delete process.env.APES_ADMIN_PASSWORD
   })
 
   it('rejects an invalid agent name', async () => {
@@ -153,9 +158,34 @@ describe('apes agents destroy', () => {
     await (destroyAgentCommand as any).run({ args: { name: 'agent-a', force: true } })
 
     expect(execFileSync).toHaveBeenCalledTimes(1)
-    const [bin, argv] = vi.mocked(execFileSync).mock.calls[0]!
+    const [bin, argv, opts] = vi.mocked(execFileSync).mock.calls[0]!
     expect(bin).toBe('/usr/local/bin/apes')
     expect(argv).toEqual(['run', '--as', 'root', '--wait', '--', 'bash', '/tmp/apes-destroy-test/teardown.sh'])
+    // Password must be piped via stdin, never as argv (would leak via
+    // ps and the escapes audit log).
+    expect(opts).toMatchObject({ input: 'test-admin-pw\n', stdio: ['pipe', 'inherit', 'inherit'] })
+    expect(argv).not.toContain('test-admin-pw')
+  })
+
+  it('refuses with a clear hint when --force is set but APES_ADMIN_PASSWORD is missing and there is no TTY', async () => {
+    delete process.env.APES_ADMIN_PASSWORD
+    const { apiFetch } = await import('../src/http.js')
+    vi.mocked(apiFetch)
+      .mockResolvedValueOnce([AGENT] as any)
+      .mockResolvedValueOnce({ ok: true } as any)
+    macosUserMock.readMacOSUser.mockReturnValue({ name: 'agent-a', uid: 250, shell: '/usr/local/bin/ape-shell' })
+
+    const originalIsTTY = process.stdin.isTTY
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true })
+    try {
+      const { destroyAgentCommand } = await import('../src/commands/agents/destroy.js')
+      await expect((destroyAgentCommand as any).run({
+        args: { name: 'agent-a', force: true },
+      })).rejects.toThrow(/APES_ADMIN_PASSWORD/)
+    }
+    finally {
+      Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true })
+    }
   })
 
   it('issues IdP DELETE before the long-blocking escapes call (token-fresh order)', async () => {


### PR DESCRIPTION
## Summary

`apes agents destroy` previously hung ~5 minutes inside the teardown step and exited with `eUndefinedError -14987` from `DSRecord.m:563`, leaving an orphan dscl record behind.

**Root cause:** the teardown script runs in `escapes`' setuid-root context, which has no audit/PAM session attached (`AUDIT_SESSION_ID=unset`). Plain `sysadminctl -deleteUser` and `dscl . -delete` make an implicit "is current session admin?" lookup via opendirectoryd; with no session bound, that lookup hangs and eventually fails.

**Fix:** pass `-adminUser/-adminPassword` to `sysadminctl` so it authenticates against DirectoryService directly instead of probing the session. The local admin password is collected from `APES_ADMIN_PASSWORD` (preferred for CI) or a silent prompt, then piped into the script via stdin — never as an argv element (would leak via `ps` and the escapes audit log).

Result on the test box: `sysadminctl -deleteUser` completes in ~1s instead of 303s.

## Test plan

- [x] `pnpm --filter @openape/apes typecheck`
- [x] `pnpm --filter @openape/apes test agents-bootstrap agents-destroy` (13/13 pass; new tests cover stdin-only password, env-var fallback, no-TTY hint)
- [x] E2E on macOS: `apes agents spawn agentb` → `apes run --as agentb -- whoami` → `apes agents destroy agentb` — all three approvals + 1 admin-pwd prompt, destroy completes in seconds with `OK destroyed agentb` and `id agentb` returns "no such user".

## Notes

- Existing `--force` path now also requires `APES_ADMIN_PASSWORD` in env (no safe non-interactive default for an admin credential). Surfaces a clear error instead of silently failing in CI.
- Tried `sudo -n` from already-root first; it doesn't bind a console-bound audit session and didn't help. The `-adminUser/-adminPassword` route is the documented sysadminctl scripting path and is what works.