### PR TITLE
chore(release): ape-chat + chat-bridge 0.1.0

### DIFF
--- a/.changeset/initial-chat-cli-and-bridge.md
+++ b/.changeset/initial-chat-cli-and-bridge.md
@@ -1,0 +1,6 @@
+---
+"@openape/ape-chat": minor
+"@openape/chat-bridge": minor
+---
+
+Initial release of `@openape/ape-chat` (CLI for chat.openape.ai) and `@openape/chat-bridge` (daemon that lets a local LLM CLI like pi answer chat messages on behalf of an apes-spawned agent). See each package's README for setup and usage.

--- a/apps/openape-chat-bridge/package.json
+++ b/apps/openape-chat-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openape/chat-bridge",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "description": "Bridge daemon: forwards chat.openape.ai messages to a local LLM CLI (default: pi) and posts replies back as the agent",
   "type": "module",
   "license": "MIT",

--- a/apps/openape-chat-cli/package.json
+++ b/apps/openape-chat-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openape/ape-chat",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "description": "CLI for chat.openape.ai — shared rooms for humans and agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
First release of the two new chat-side packages.

| Package | New version | What it does |
|---|---|---|
| `@openape/ape-chat` | 0.1.0 | CLI for chat.openape.ai — symmetric to ape-tasks/ape-plans |
| `@openape/chat-bridge` | 0.1.0 | Daemon that forwards chat messages to a local LLM CLI (default: pi) and posts replies as the agent |

Once merged the Changesets bot opens the standard "Version Packages" PR; merging that publishes both to npm with provenance via the existing release workflow.