### PR TITLE
feat(chat): /api/cli/exchange + ape-chat on SP-scoped tokens

### DIFF
--- a/.changeset/chat-cli-exchange.md
+++ b/.changeset/chat-cli-exchange.md
@@ -1,0 +1,6 @@
+---
+"@openape/chat": patch
+"@openape/ape-chat": patch
+---
+
+Add `/api/cli/exchange` to chat-app for RFC 8693-style token exchange (parity with ape-tasks/ape-plans). `@openape/ape-chat` now prefers SP-scoped tokens (cached 30 days at `~/.config/apes/sp-tokens/chat.openape.ai.json`) but falls back gracefully to raw IdP tokens when talking to a chat deployment that pre-dates the exchange endpoint.

--- a/apps/openape-chat-cli/src/auth.ts
+++ b/apps/openape-chat-cli/src/auth.ts
@@ -1,13 +1,8 @@
-import { ensureFreshIdpAuth, NotLoggedInError } from '@openape/cli-auth'
+import { AuthError, ensureFreshIdpAuth, getAuthorizedBearer, NotLoggedInError } from '@openape/cli-auth'
 import { decodeJwt } from 'jose'
+import { getEndpoint } from './config'
 
-// chat.openape.ai's `resolveCaller` accepts JWKS-verified IdP tokens
-// directly (see apps/openape-chat/server/utils/auth.ts). There is currently
-// no SP-scoped exchange endpoint at /api/cli/exchange on chat. We use the
-// raw IdP access_token until we add SP-token exchange to the chat-app in a
-// follow-up PR — at that point this file becomes a `getAuthorizedBearer`
-// call against `aud: 'chat.openape.ai'` and the change is invisible to
-// command code.
+const AUDIENCE = 'chat.openape.ai'
 
 export interface CallerIdentity {
   email: string
@@ -16,11 +11,33 @@ export interface CallerIdentity {
   expires_at: number
 }
 
+/**
+ * Returns an `Authorization: Bearer …` header valid for chat.openape.ai.
+ *
+ * Prefers SP-scoped tokens minted by `${endpoint}/api/cli/exchange` (cached
+ * 30 days at `~/.config/apes/sp-tokens/chat.openape.ai.json`). Falls back to
+ * the raw IdP access_token if the chat-app deployment is older than the
+ * exchange endpoint — chat's `resolveCaller` accepts both shapes.
+ */
 export async function getChatBearer(): Promise<string> {
-  const idp = await ensureFreshIdpAuth()
-  return `Bearer ${idp.access_token}`
+  try {
+    return await getAuthorizedBearer({ endpoint: getEndpoint(null), aud: AUDIENCE })
+  }
+  catch (err) {
+    if (err instanceof AuthError && err.status === 404) {
+      // Pre-exchange deployment — use the raw IdP token directly.
+      const idp = await ensureFreshIdpAuth()
+      return `Bearer ${idp.access_token}`
+    }
+    throw err
+  }
 }
 
+/**
+ * Identity is read from the IdP token (not the SP-scoped chat token) so we
+ * always show the fully-qualified user/agent identity even when the
+ * SP-token's claims have been pruned.
+ */
 export async function getChatCaller(): Promise<CallerIdentity> {
   const idp = await ensureFreshIdpAuth()
   const claims = decodeJwt(idp.access_token) as { sub?: string, act?: string, exp?: number }

--- a/apps/openape-chat/server/api/cli/exchange.post.ts
+++ b/apps/openape-chat/server/api/cli/exchange.post.ts
@@ -1,0 +1,86 @@
+import type { JWTPayload } from 'jose'
+import { createRemoteJWKSet, jwtVerify } from 'jose'
+import { signCliToken } from '../../utils/cli-token'
+
+interface ExchangeBody {
+  subject_token?: string
+  scopes?: string[]
+}
+
+const EXPECTED_AUD = 'apes-cli'
+
+let _idpJwks: ReturnType<typeof createRemoteJWKSet> | null = null
+let _idpJwksUrl = ''
+
+function getIdpJwks(idpUrl: string): ReturnType<typeof createRemoteJWKSet> {
+  const url = new URL('/.well-known/jwks.json', idpUrl).toString()
+  if (!_idpJwks || _idpJwksUrl !== url) {
+    _idpJwks = createRemoteJWKSet(new URL(url))
+    _idpJwksUrl = url
+  }
+  return _idpJwks
+}
+
+/**
+ * POST /api/cli/exchange — RFC 8693-style token exchange.
+ *
+ * Accepts an IdP-issued subject_token (signed by id.openape.ai with
+ * `aud='apes-cli'`), verifies it via JWKS, and mints an HS256 SP-scoped
+ * token for chat.openape.ai. The CLI side (`@openape/cli-auth`
+ * `getAuthorizedBearer`) caches the result at
+ * ~/.config/apes/sp-tokens/chat.openape.ai.json so subsequent ape-chat
+ * commands skip this endpoint until the SP-token expires (30 days).
+ *
+ * Body:    `{ subject_token: <jwt>, scopes?: string[] }`
+ * Response (201): `{ access_token, token_type: "Bearer", expires_at, aud, scopes? }`
+ */
+export default defineEventHandler(async (event) => {
+  const body = await readBody<ExchangeBody>(event)
+  if (!body?.subject_token || typeof body.subject_token !== 'string') {
+    throw createError({ statusCode: 400, statusMessage: 'subject_token required' })
+  }
+
+  const idpUrl = useRuntimeConfig().public.idpUrl as string
+  if (!idpUrl) {
+    throw createError({ statusCode: 500, statusMessage: 'IdP URL not configured' })
+  }
+
+  let claims: JWTPayload
+  try {
+    const verified = await jwtVerify(body.subject_token, getIdpJwks(idpUrl), {
+      issuer: idpUrl,
+      audience: EXPECTED_AUD,
+    })
+    claims = verified.payload
+  }
+  catch (err) {
+    const detail = err instanceof Error ? err.message : 'verify failed'
+    throw createError({
+      statusCode: 401,
+      statusMessage: 'Invalid subject_token',
+      data: { detail: `Token must be issued by ${idpUrl} with aud=${EXPECTED_AUD}. ${detail}` },
+    })
+  }
+
+  const sub = claims.sub
+  if (typeof sub !== 'string' || !sub.includes('@')) {
+    throw createError({
+      statusCode: 401,
+      statusMessage: 'subject_token has no usable subject claim',
+      data: { detail: 'Expected sub to be an email address.' },
+    })
+  }
+
+  const act = (claims as { act?: string }).act === 'agent' ? 'agent' : 'human'
+
+  const { token, expiresAt } = await signCliToken({ email: sub, act })
+
+  setResponseStatus(event, 201)
+  return {
+    access_token: token,
+    token_type: 'Bearer' as const,
+    expires_at: expiresAt,
+    aud: 'chat.openape.ai',
+    ...(Array.isArray(body.scopes) ? { scopes: body.scopes } : {}),
+  }
+})

--- a/apps/openape-chat/server/utils/auth.ts
+++ b/apps/openape-chat/server/utils/auth.ts
@@ -1,5 +1,7 @@
 import type { H3Event } from 'h3'
 import { createRemoteJWKS, verifyJWT } from '@openape/core'
+import { decodeProtectedHeader } from 'jose'
+import { verifyCliToken } from './cli-token'
 
 // `getSpSession`, `createError`, `getHeader`, `getQuery`, and `useRuntimeConfig`
 // are all auto-imported by Nuxt 4 (the SP module + nitro), so we don't import
@@ -80,6 +82,25 @@ function extractBearer(event: H3Event): string | null {
 }
 
 async function verifyBearer(token: string): Promise<Caller> {
+  // Dispatch on alg in the protected header. HS256 = SP-scoped CLI token
+  // minted by /api/cli/exchange (verified locally with the session secret).
+  // Anything else (RS256/ES256/EdDSA) goes through the IdP JWKS path.
+  let alg: string | undefined
+  try {
+    alg = decodeProtectedHeader(token).alg
+  }
+  catch {
+    throw createError({ statusCode: 401, statusMessage: 'Malformed bearer token' })
+  }
+
+  if (alg === 'HS256') {
+    const cli = await verifyCliToken(token)
+    if (!cli) {
+      throw createError({ statusCode: 401, statusMessage: 'Invalid CLI token' })
+    }
+    return { email: cli.email, act: cli.act, source: 'bearer' }
+  }
+
   try {
     const { payload } = await verifyJWT<DDISAClaims>(token, getJwks())
     const email = payload.sub

--- a/apps/openape-chat/server/utils/cli-token.ts
+++ b/apps/openape-chat/server/utils/cli-token.ts
@@ -1,0 +1,61 @@
+import { jwtVerify, SignJWT } from 'jose'
+
+const ISSUER = 'chat.openape.ai'
+const AUDIENCE = 'chat.openape.ai'
+
+export interface CliTokenPayload {
+  iss: 'chat.openape.ai'
+  aud: 'chat.openape.ai'
+  typ: 'cli'
+  sub: string
+  email: string
+  act: 'human' | 'agent'
+  iat: number
+  exp: number
+}
+
+function secret(): Uint8Array {
+  const s = (useRuntimeConfig().openapeSp?.sessionSecret as string) || ''
+  if (!s || s.length < 32) {
+    throw createError({ statusCode: 500, statusMessage: 'CLI token secret not configured (openapeSp.sessionSecret < 32 chars)' })
+  }
+  return new TextEncoder().encode(s)
+}
+
+/**
+ * Mint an HS256 SP-scoped CLI token. 30-day lifetime by default; clients
+ * cache it at ~/.config/apes/sp-tokens/chat.openape.ai.json. Issued from
+ * the /api/cli/exchange endpoint after the IdP-issued subject_token has
+ * been verified via JWKS.
+ */
+export async function signCliToken(params: {
+  email: string
+  act: 'human' | 'agent'
+  ttlSeconds?: number
+}): Promise<{ token: string, expiresAt: number }> {
+  const ttl = params.ttlSeconds ?? 30 * 24 * 3600
+  const now = Math.floor(Date.now() / 1000)
+  const exp = now + ttl
+  const payload = { typ: 'cli', sub: params.email, email: params.email, act: params.act }
+  const token = await new SignJWT(payload)
+    .setProtectedHeader({ alg: 'HS256' })
+    .setIssuer(ISSUER)
+    .setAudience(AUDIENCE)
+    .setIssuedAt()
+    .setExpirationTime(exp)
+    .sign(secret())
+  return { token, expiresAt: exp }
+}
+
+export async function verifyCliToken(token: string): Promise<CliTokenPayload | null> {
+  try {
+    const { payload } = await jwtVerify(token, secret(), { issuer: ISSUER, audience: AUDIENCE })
+    if (payload.typ !== 'cli') return null
+    if (typeof payload.sub !== 'string' || typeof payload.email !== 'string') return null
+    if (payload.act !== 'human' && payload.act !== 'agent') return null
+    return payload as unknown as CliTokenPayload
+  }
+  catch {
+    return null
+  }
+}


### PR DESCRIPTION
Closes #233.

Adds RFC 8693-style token exchange to the chat-app and switches \`@openape/ape-chat\` to consume SP-scoped tokens — parity with ape-tasks/ape-plans.

## Server changes

- \`apps/openape-chat/server/api/cli/exchange.post.ts\` — POST endpoint that verifies an IdP-issued subject_token (\`aud=apes-cli\`) via JWKS, mints an HS256 SP-scoped token (\`aud=chat.openape.ai\`, 30-day TTL) using \`openapeSp.sessionSecret\`.
- \`apps/openape-chat/server/utils/cli-token.ts\` — \`signCliToken\` / \`verifyCliToken\` helpers (mirrors openape-tasks's pattern).
- \`apps/openape-chat/server/utils/auth.ts\` — \`verifyBearer\` now dispatches on the JWT alg: HS256 → local cli-token verification, anything else → existing IdP JWKS path. Both flows produce the same \`Caller\` shape so route handlers don't branch.

## Client changes

- \`@openape/ape-chat\` \`getChatBearer()\` calls \`getAuthorizedBearer({ aud: 'chat.openape.ai' })\` from \`@openape/cli-auth\`. Result cached at \`~/.config/apes/sp-tokens/chat.openape.ai.json\` for 30 days.
- Smart fallback: if the exchange endpoint returns 404 (chat deployment older than this PR), the client falls back to passing the raw IdP token. So the rollout order doesn't matter — client can ship before or after server.

## Smoke test

Live against current prod (which still 404s on \`/api/cli/exchange\`):

\`\`\`text
$ ape-chat whoami
patrick@hofmann.eco  (act=human, expires=...)
$ ape-chat rooms list
4efd51f2-...  channel  [admin]   team-a
a3c52e1d-...  channel  [admin]   ape-chat-cli-smoke-...
\`\`\`

Once chat-app deploys, the next \`ape-chat\` invocation hits the exchange endpoint, caches the SP-token, and subsequent calls within 30 days skip the IdP roundtrip entirely.

## Definition of Done

- [x] \`pnpm typecheck\` clean (apes-chat-cli + chat-app server via nuxt tsconfig)
- [x] \`pnpm lint\` clean
- [x] Live smoke against current prod (fallback path)
- [ ] Live smoke against this branch's deploy (SP-token path) — verify after merge + deploy