### PR TITLE
chore: complete publish-chain — add ape-chat, chat-bridge, vue-components

### DIFF
--- a/scripts/publish-chain.mjs
+++ b/scripts/publish-chain.mjs
@@ -23,6 +23,12 @@ import { resolve } from 'node:path'
 
 const ROOT = new URL('..', import.meta.url).pathname
 
+// Keep this in sync with the publishable (private:false) workspace
+// packages. New entries get appended in dependency order — leaf packages
+// (no other publishable depends on them) can go anywhere after their
+// own deps. The audit script below the file is the source of truth:
+//
+//   node -e "const fs=require('fs'),p=require('path');for(const r of ['packages','modules','apps']){for(const d of fs.readdirSync(r)){const f=p.join(r,d,'package.json');if(!fs.existsSync(f))continue;const j=JSON.parse(fs.readFileSync(f));if(j.private!==true)console.log(j.name,'→',r+'/'+d)}}"
 const PACKAGES = [
   { name: '@openape/core', dir: 'packages/core' },
   { name: '@openape/grants', dir: 'packages/grants' },
@@ -31,10 +37,13 @@ const PACKAGES = [
   { name: '@openape/proxy', dir: 'packages/proxy' },
   { name: '@openape/server', dir: 'packages/server' },
   { name: '@openape/browser', dir: 'packages/browser' },
+  { name: '@openape/vue-components', dir: 'packages/vue-components' },
   { name: '@openape/apes', dir: 'packages/apes' },
   { name: '@openape/unstorage-s3-driver', dir: 'packages/s3-driver' },
   { name: '@openape/nuxt-auth-sp', dir: 'modules/nuxt-auth-sp' },
   { name: '@openape/nuxt-auth-idp', dir: 'modules/nuxt-auth-idp' },
+  { name: '@openape/ape-chat', dir: 'apps/openape-chat-cli' },
+  { name: '@openape/chat-bridge', dir: 'apps/openape-chat-bridge' },
 ]
 
 const dryRun = process.argv.includes('--dry-run')


### PR DESCRIPTION
\`scripts/publish-chain.mjs\` had a hardcoded PACKAGES list that missed three publishable workspace packages, so \`pnpm release:local\` silently skipped them. We hit this with #229 (chat-cli + chat-bridge initial 0.1.0) — they had to be published by hand.

Audit:

\`\`\`
publishable workspace packages (private:false in package.json):
  @openape/apes                      packages/apes                ✓ in list
  @openape/auth                      packages/auth                ✓
  @openape/browser                   packages/browser             ✓
  @openape/cli-auth                  packages/cli-auth            ✓
  @openape/core                      packages/core                ✓
  @openape/grants                    packages/grants              ✓
  @openape/proxy                     packages/proxy               ✓
  @openape/unstorage-s3-driver       packages/s3-driver           ✓
  @openape/server                    packages/server              ✓
  @openape/vue-components            packages/vue-components      ✗ MISSING
  @openape/nuxt-auth-idp             modules/nuxt-auth-idp        ✓
  @openape/nuxt-auth-sp              modules/nuxt-auth-sp         ✓
  @openape/chat-bridge               apps/openape-chat-bridge     ✗ MISSING
  @openape/ape-chat                  apps/openape-chat-cli        ✗ MISSING
\`\`\`

Adds the three. Comment includes the one-liner audit script so future mismatches surface during review.

## Side-effect

Dry-run after merge will report \`@openape/vue-components@0.2.3\` as new — it's locally bumped but never released. Up to you whether to publish on the next \`release:local\` (this PR is just the script fix; doesn't publish anything).

\`\`\`
$ node scripts/publish-chain.mjs --dry-run
…
Would publish 1 package(s):
  - @openape/vue-components@0.2.3
\`\`\`