### PR TITLE
fix(apes): destroy uses sudo + silent password (drop DDISA grant)

### DIFF
--- a/.changeset/destroy-sudo-silent.md
+++ b/.changeset/destroy-sudo-silent.md
@@ -1,0 +1,5 @@
+---
+"@openape/apes": minor
+---
+
+`apes agents destroy` now uses sudo + a silent password prompt instead of `apes run --as root` + a visible password prompt. One credential, one interaction. The DDISA grant approval was redundant: sysadminctl required the local admin password regardless. The previous `consola.prompt({ mask: '*' })` showed the password in plaintext on terminals (Warp, etc.) where the mask option is ignored — replaced with native raw-mode stdin that disables echo entirely. `APES_ADMIN_PASSWORD` env var still works for non-interactive use.

--- a/packages/apes/src/commands/agents/destroy.ts
+++ b/packages/apes/src/commands/agents/destroy.ts
@@ -9,6 +9,7 @@ import { CliError, CliExit } from '../../errors'
 import { apiFetch } from '../../http'
 import { AGENT_NAME_REGEX, buildDestroyTeardownScript } from '../../lib/agent-bootstrap'
 import { isDarwin, readMacOSUser, whichBinary } from '../../lib/macos-user'
+import { readPasswordSilent } from '../../lib/silent-password'
 
 interface IdpUser {
   email: string
@@ -95,10 +96,10 @@ export const destroyAgentCommand = defineCommand({
       }
     }
 
-    // IdP-side first: while the parent's bearer is still fresh from preflight.
-    // The escapes step below blocks for human approval, which can take longer
-    // than the token's TTL — running the IdP DELETE after that wait would
-    // surface a stale-token error and leave the agent record orphaned.
+    // IdP-side first so the parent's bearer is still fresh. The sudo step
+    // below blocks for the password prompt, which the user might take a
+    // moment to complete — running the IdP DELETE after a stale-token
+    // window would leave the agent record orphaned.
     if (idpExists) {
       const id = encodeURIComponent(idpAgent!.email)
       if (args.soft) {
@@ -115,38 +116,33 @@ export const destroyAgentCommand = defineCommand({
     }
 
     if (osUserExists) {
-      const apes = whichBinary('apes')
-      if (!apes) {
-        throw new CliError('`apes` not found on PATH. Install @openape/apes globally first.')
-      }
-      const escapes = whichBinary('escapes')
-      if (!escapes) {
-        throw new CliError('`escapes` not found on PATH; OS teardown requires escapes.')
+      // OS teardown runs via plain sudo + the local admin password. The
+      // previous flow wrapped this in `apes run --as root` (DDISA grant
+      // approval) but the password was needed regardless because
+      // sysadminctl -deleteUser refuses without explicit -adminUser/
+      // -adminPassword in escapes' setuid-root context. Two prompts for
+      // one operation: dropped the grant, kept the password (#239).
+      const sudo = whichBinary('sudo')
+      if (!sudo) {
+        throw new CliError('`sudo` not found on PATH; required for OS teardown.')
       }
 
-      // The teardown script runs in escapes' setuid-root context, which
-      // has no audit/PAM session attached. Bare `sysadminctl -deleteUser`
-      // and `dscl . -delete` hang ~5min then fail with -14987 from there.
-      // sysadminctl with explicit -adminUser/-adminPassword bypasses that
-      // path, so we collect the local admin password here and pipe it to
-      // the script via stdin (never as argv — it would show up in `ps`
-      // and in escapes' audit log).
       const adminUser = userInfo().username
-      const adminPassword = await collectAdminPassword({ adminUser, force: !!args.force })
+      const adminPassword = await collectAdminPassword({ adminUser })
 
       const scratch = mkdtempSync(join(tmpdir(), `apes-destroy-${name}-`))
       const scriptPath = join(scratch, 'teardown.sh')
       try {
         const script = buildDestroyTeardownScript({ name, homeDir: `/Users/${name}`, adminUser })
         writeFileSync(scriptPath, script, { mode: 0o700 })
-        consola.start('Running teardown as root via `apes run --as root --wait`…')
-        consola.info('You will be asked to approve the as=root grant in your DDISA inbox; this command blocks until you do.')
-        // --wait makes the call synchronous; without it `apes run --as root`
-        // returns exit 75 (pending) immediately, leaving a dangling grant.
-        // input + stdio[0]='pipe' streams the password into bash's stdin
-        // so the teardown's `read -r ADMIN_PASSWORD` consumes it.
-        execFileSync(apes, ['run', '--as', 'root', '--wait', '--', 'bash', scriptPath], {
-          input: `${adminPassword}\n`,
+        consola.start('Running teardown via sudo…')
+        // sudo -S reads its own password from the first stdin line and
+        // consumes the trailing newline; the rest of stdin is connected
+        // to the child. The teardown script's `read -r ADMIN_PASSWORD`
+        // then picks up the second line for sysadminctl. Same secret
+        // serves both — the user typed it once.
+        execFileSync(sudo, ['-S', '--prompt=', '--', 'bash', scriptPath], {
+          input: `${adminPassword}\n${adminPassword}\n`,
           stdio: ['pipe', 'inherit', 'inherit'],
         })
       }
@@ -163,38 +159,19 @@ export const destroyAgentCommand = defineCommand({
 })
 
 /**
- * Collect the local admin password used for the `sysadminctl -deleteUser
- * -adminUser <u> -adminPassword <p>` call inside the teardown script.
+ * Resolve the local admin password used for sudo + `sysadminctl
+ * -deleteUser`. Single secret, single prompt:
  *
- * Resolution order:
- *   1. `APES_ADMIN_PASSWORD` env var (always preferred — lets CI and
- *      orchestrators script the destroy without a TTY).
- *   2. Interactive prompt (silent) when stdin is a TTY.
- *   3. Refuse with a clear hint when neither is available.
- *
- * `--force` skips the confirmation prompt earlier in the flow but does
- * NOT skip this step: there's no safe non-interactive default for an
- * admin credential, and silent failure here would be a regression
- * compared to the prior `sudo -n` attempt that at least surfaced an
- * error.
+ *   1. `APES_ADMIN_PASSWORD` env var (CI / orchestrators)
+ *   2. Silent terminal prompt (raw-mode stdin, no echo, no mask)
+ *   3. Refuse with a clear hint when neither is available
  */
-async function collectAdminPassword(opts: { adminUser: string, force: boolean }): Promise<string> {
+async function collectAdminPassword(opts: { adminUser: string }): Promise<string> {
   const fromEnv = process.env.APES_ADMIN_PASSWORD
   if (fromEnv && fromEnv.length > 0) return fromEnv
-
-  if (!process.stdin.isTTY) {
-    throw new CliError(
-      `Admin password required for sysadminctl -deleteUser. No TTY available `
-      + `for the silent prompt; set APES_ADMIN_PASSWORD in the environment `
-      + `(local admin password for ${opts.adminUser}). The teardown reads it `
-      + `from stdin and never stores it.`,
-    )
-  }
-
-  consola.info(`Local admin password for ${opts.adminUser} (used for sysadminctl -deleteUser; not stored):`)
-  const pw = await consola.prompt('Admin password', { type: 'text', mask: '*' })
-  if (typeof pw === 'symbol' || !pw || pw.length === 0) {
+  const pw = await readPasswordSilent(`Password for ${opts.adminUser}: `)
+  if (pw.length === 0) {
     throw new CliExit(0)
   }
-  return pw as string
+  return pw
 }

--- a/packages/apes/src/lib/silent-password.ts
+++ b/packages/apes/src/lib/silent-password.ts
@@ -1,0 +1,69 @@
+// Silent password input using raw-mode stdin. consola.prompt's `mask`
+// option is honoured by some terminals (iTerm, Terminal.app) but ignored
+// by others (Warp, some VT-emulator wrappers) — falling back to plain
+// echoed text. Native readline with raw mode + manual character handling
+// works uniformly: stdin is muted (no echo) and we render exactly what
+// the user has come to expect from `sudo` / `ssh-keygen -p` / etc — the
+// prompt label, no mask, just the trailing newline once Enter is hit.
+
+import { CliError } from '../errors'
+
+/**
+ * Prompt for a password without echoing keystrokes. Resolves with the
+ * typed string (without trailing newline). Throws `CliError` on Ctrl-C
+ * / Ctrl-D / non-TTY stdin.
+ */
+export function readPasswordSilent(prompt: string): Promise<string> {
+  if (!process.stdin.isTTY) {
+    return Promise.reject(new CliError(
+      'No TTY available for the silent password prompt. '
+      + 'Set APES_ADMIN_PASSWORD in the environment instead.',
+    ))
+  }
+  return new Promise<string>((resolve, reject) => {
+    process.stdout.write(prompt)
+    const wasRaw = process.stdin.isRaw ?? false
+    process.stdin.setRawMode(true)
+    process.stdin.resume()
+    process.stdin.setEncoding('utf8')
+
+    let buf = ''
+    let cleanupFn: (() => void) | undefined
+    const cleanup = () => cleanupFn?.()
+    const onData = (chunk: string) => {
+      for (const ch of chunk) {
+        const code = ch.charCodeAt(0)
+        if (ch === '\r' || ch === '\n') {
+          cleanup()
+          process.stdout.write('\n')
+          resolve(buf)
+          return
+        }
+        if (code === 3) { // Ctrl-C
+          cleanup()
+          process.stdout.write('\n')
+          reject(new CliError('Aborted by user (Ctrl-C).'))
+          return
+        }
+        if (code === 4 && buf.length === 0) { // Ctrl-D on empty
+          cleanup()
+          process.stdout.write('\n')
+          reject(new CliError('Aborted by user (Ctrl-D).'))
+          return
+        }
+        if (code === 0x7F || code === 8) { // DEL / backspace
+          if (buf.length > 0) buf = buf.slice(0, -1)
+          continue
+        }
+        if (code < 32) continue // ignore other control chars
+        buf += ch
+      }
+    }
+    cleanupFn = () => {
+      process.stdin.removeListener('data', onData)
+      process.stdin.setRawMode(wasRaw)
+      process.stdin.pause()
+    }
+    process.stdin.on('data', onData)
+  })
+}

--- a/packages/apes/test/agents-destroy.test.ts
+++ b/packages/apes/test/agents-destroy.test.ts
@@ -131,7 +131,7 @@ describe('apes agents destroy', () => {
     }
   })
 
-  it('--keep-os-user skips the privileged escapes call entirely', async () => {
+  it('--keep-os-user skips the privileged sudo call entirely', async () => {
     const { apiFetch } = await import('../src/http.js')
     const { execFileSync } = await import('node:child_process')
     vi.mocked(apiFetch)
@@ -146,7 +146,7 @@ describe('apes agents destroy', () => {
     expect(apiFetch).toHaveBeenCalledTimes(2)
   })
 
-  it('runs the teardown script via apes run --as root when OS user exists', async () => {
+  it('runs the teardown script via sudo -S when OS user exists', async () => {
     const { apiFetch } = await import('../src/http.js')
     const { execFileSync } = await import('node:child_process')
     vi.mocked(apiFetch)
@@ -159,11 +159,12 @@ describe('apes agents destroy', () => {
 
     expect(execFileSync).toHaveBeenCalledTimes(1)
     const [bin, argv, opts] = vi.mocked(execFileSync).mock.calls[0]!
-    expect(bin).toBe('/usr/local/bin/apes')
-    expect(argv).toEqual(['run', '--as', 'root', '--wait', '--', 'bash', '/tmp/apes-destroy-test/teardown.sh'])
+    expect(bin).toBe('/usr/local/bin/sudo')
+    expect(argv).toEqual(['-S', '--prompt=', '--', 'bash', '/tmp/apes-destroy-test/teardown.sh'])
     // Password must be piped via stdin, never as argv (would leak via
-    // ps and the escapes audit log).
-    expect(opts).toMatchObject({ input: 'test-admin-pw\n', stdio: ['pipe', 'inherit', 'inherit'] })
+    // ps). Two newline-terminated copies: first for sudo -S, second for
+    // the teardown script's `read -r ADMIN_PASSWORD`.
+    expect(opts).toMatchObject({ input: 'test-admin-pw\ntest-admin-pw\n', stdio: ['pipe', 'inherit', 'inherit'] })
     expect(argv).not.toContain('test-admin-pw')
   })
 
@@ -181,14 +182,14 @@ describe('apes agents destroy', () => {
       const { destroyAgentCommand } = await import('../src/commands/agents/destroy.js')
       await expect((destroyAgentCommand as any).run({
         args: { name: 'agent-a', force: true },
-      })).rejects.toThrow(/APES_ADMIN_PASSWORD/)
+      })).rejects.toThrow(/APES_ADMIN_PASSWORD|silent password prompt/)
     }
     finally {
       Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true })
     }
   })
 
-  it('issues IdP DELETE before the long-blocking escapes call (token-fresh order)', async () => {
+  it('issues IdP DELETE before the long-blocking sudo call (token-fresh order)', async () => {
     const { apiFetch } = await import('../src/http.js')
     const { execFileSync } = await import('node:child_process')
     const callOrder: string[] = []
@@ -198,7 +199,7 @@ describe('apes agents destroy', () => {
       return { ok: true }
     })
     vi.mocked(execFileSync).mockImplementation(((..._args: any[]) => {
-      callOrder.push('execFileSync:apes-run-as-root')
+      callOrder.push('execFileSync:sudo')
       return Buffer.alloc(0)
     }) as any)
     macosUserMock.readMacOSUser.mockReturnValue({ name: 'agent-a', uid: 250, shell: '/usr/local/bin/ape-shell' })
@@ -207,8 +208,8 @@ describe('apes agents destroy', () => {
     await (destroyAgentCommand as any).run({ args: { name: 'agent-a', force: true } })
 
     const deleteIdx = callOrder.findIndex(c => c.includes('DELETE:/api/my-agents/'))
-    const escapesIdx = callOrder.findIndex(c => c === 'execFileSync:apes-run-as-root')
+    const sudoIdx = callOrder.findIndex(c => c === 'execFileSync:sudo')
     expect(deleteIdx).toBeGreaterThanOrEqual(0)
-    expect(escapesIdx).toBeGreaterThan(deleteIdx)
+    expect(sudoIdx).toBeGreaterThan(deleteIdx)
   })
 })

--- a/packages/apes/test/silent-password.test.ts
+++ b/packages/apes/test/silent-password.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest'
+import { readPasswordSilent } from '../src/lib/silent-password'
+
+describe('readPasswordSilent', () => {
+  it('rejects with a CliError when stdin has no TTY', async () => {
+    // Vitest workers run without a controlling terminal, so stdin.isTTY is
+    // already undefined/false. The helper must surface a clear hint that
+    // points at APES_ADMIN_PASSWORD instead of stalling on the prompt.
+    await expect(readPasswordSilent('Password: ')).rejects.toThrow(/APES_ADMIN_PASSWORD/)
+  })
+})


### PR DESCRIPTION
Closes #239.

Two UX issues with \`apes agents destroy\`:

1. **Two credentials for one operation.** \`apes run --as root\` (DDISA grant approval in browser) PLUS local admin password (terminal). The grant gave root execution but sysadminctl rejected it — the password was needed regardless. So the grant was redundant.
2. **Password not actually silent.** \`consola.prompt({ type: 'text', mask: '*' })\` displays mask characters in some terminals but in others (Warp, some VT-emulator wrappers) the password ends up in plaintext on screen and scrolled into history.

## Changes

- **Drop the grant.** \`destroy\` now invokes \`sudo -S --prompt= -- bash <teardown>\` and pipes the admin password twice on stdin: first line for sudo, second for the teardown's \`read -r ADMIN_PASSWORD\` (used by sysadminctl). One secret, one user interaction.
- **Silent password input.** New \`lib/silent-password.ts\` uses raw-mode stdin and explicitly disables echo. No mask characters, just the prompt label and the trailing newline once Enter is hit. Matches \`sudo\` / \`ssh-keygen\` UX.
- \`escapes\` no longer required for destroy (still required for spawn).
- \`APES_ADMIN_PASSWORD\` env var still works for non-interactive use.

## Tests

- 1 new vitest in \`silent-password.test.ts\` (rejects without TTY)
- All existing destroy tests updated for the sudo invocation; mocks now expect \`sudo -S --prompt= --\` and the password piped twice
- All 616 apes tests pass; coverage threshold met

## Manual smoke

\`\`\`text
$ apes agents destroy agent-demo2
About to destroy "agent-demo2":
• Remove macOS user agent-demo2 and rm -rf /Users/agent-demo2
• Hard-delete IdP agent agent-demo2+...@id.openape.ai and all its SSH keys
✔ Proceed? yes
✔ Deleted IdP agent agent-demo2+...
ℹ Running teardown via sudo…
Password for patrickhofmann:        # silent, no mask, single prompt
✔ Destroyed agent-demo2.
\`\`\`