### PR TITLE
fix(chat): no iOS auto-zoom on input focus

### DIFF
--- a/apps/openape-chat/app/assets/css/main.css
+++ b/apps/openape-chat/app/assets/css/main.css
@@ -1,2 +1,21 @@
 @import "tailwindcss";
 @import "@nuxt/ui";
+
+/*
+ * iOS Safari auto-zooms into form fields when the rendered font-size is
+ * below 16px on touch devices. The chat composer and the room-create
+ * dialogs use Nuxt UI's default input sizing which falls under that
+ * threshold on phones, so every keyboard summon nudges the layout.
+ *
+ * Lock all interactive form fields to >= 16px on touch-only viewports.
+ * Desktop keeps Nuxt UI's default scale via the (hover: hover) media
+ * guard, so the typography rhythm stays untouched there.
+ */
+@media (hover: none) and (pointer: coarse) {
+  input,
+  textarea,
+  select {
+    font-size: 16px;
+  }
+}
+


### PR DESCRIPTION
iPhone Safari auto-zooms into form fields when the rendered font-size is
below 16px on touch devices. Nuxt UI's default input/textarea/select
sizing falls under that threshold, so every keyboard summon (composer,
room-create dialogs) nudges the layout in.

Lock all interactive form fields to \`font-size: 16px\` on touch-only
viewports via a \`(hover: none) and (pointer: coarse)\` media guard.
Desktop keeps Nuxt UI's default typography untouched.

\`\`\`css
@media (hover: none) and (pointer: coarse) {
  input,
  textarea,
  select {
    font-size: 16px;
  }
}
\`\`\`