### PR TITLE
feat(chat-bridge): pi RPC mode + streaming text_delta

### DIFF
--- a/.changeset/bridge-pi-rpc-streaming.md
+++ b/.changeset/bridge-pi-rpc-streaming.md
@@ -1,0 +1,8 @@
+---
+"@openape/chat-bridge": minor
+"@openape/apes": patch
+---
+
+`@openape/chat-bridge` rewritten to drive pi via its RPC mode (`pi --mode rpc`) instead of one-shot `pi --print` per message. One long-lived pi subprocess per chat room means the conversation now has memory across messages — "what's 7×6?" then "and ×2?" produces "84" not a confused "what do you mean ×2?". The agent's reply also visibly grows in real time as pi streams `text_delta` events: bridge posts a placeholder message and PATCHes it progressively (throttled ~300ms).
+
+`@openape/apes`: bridge `start.sh` now always pulls `@openape/chat-bridge@latest` on boot, so restarting the launchd daemon picks up new bridge versions without manual intervention. Pi extension setup unchanged.

--- a/apps/openape-chat-bridge/package.json
+++ b/apps/openape-chat-bridge/package.json
@@ -20,7 +20,8 @@
     "dev": "tsup --watch",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",
-    "lint:fix": "eslint . --fix"
+    "lint:fix": "eslint . --fix",
+    "test": "vitest run"
   },
   "dependencies": {
     "@openape/cli-auth": "workspace:*",
@@ -34,7 +35,8 @@
     "@types/ws": "^8.5.13",
     "eslint": "catalog:",
     "tsup": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   },
   "engines": {
     "node": ">=22"

--- a/apps/openape-chat-bridge/src/bridge.ts
+++ b/apps/openape-chat-bridge/src/bridge.ts
@@ -1,35 +1,31 @@
 // openape-chat-bridge
 //
-// Long-running daemon. Listens to chat.openape.ai via a WebSocket using the
-// caller's IdP token (same path ape-chat watch uses), and for every inbound
-// message that wasn't sent by the caller itself, shells out to a local LLM
-// CLI (default: pi-coding-agent in --print mode), capturing its stdout and
-// posting it back into the same room as a reply.
-//
-// Designed to run as an apes-spawned agent user that has done `apes login`
-// once. The proxy / model config sits inside the LLM CLI extension — this
-// bridge only knows about chat I/O and how to launch the CLI.
+// Long-running daemon. Connects to chat.openape.ai via WebSocket using
+// the agent's IdP token. For each inbound message that wasn't sent by
+// the agent itself, forwards into a long-lived pi RPC subprocess for
+// the room. Streams pi's `text_delta` events back as progressive PATCH
+// updates on a placeholder chat message — so the human sees the agent
+// "type" in real time, with memory across messages in the same room.
 //
 // Env knobs (all optional):
-//   APE_CHAT_ENDPOINT      override https://chat.openape.ai
-//   APE_CHAT_BRIDGE_CMD    LLM command to invoke (default: 'pi')
-//   APE_CHAT_BRIDGE_ARGS   space-separated extra args (default:
-//                          '--provider litellm --model gpt-5.4 --print')
-//   APE_CHAT_BRIDGE_ROOM   restrict to one room id (default: all rooms the
-//                          agent is a member of)
-//   APE_CHAT_BRIDGE_TIMEOUT_MS  CLI timeout per message (default: 60000)
+//   APE_CHAT_ENDPOINT            override https://chat.openape.ai
+//   APE_CHAT_BRIDGE_PI_BIN       pi binary path (default: 'pi' on PATH)
+//   APE_CHAT_BRIDGE_PROVIDER     pi --provider (default: 'litellm')
+//   APE_CHAT_BRIDGE_MODEL        pi --model    (default: 'gpt-5.4')
+//   APE_CHAT_BRIDGE_ROOM         restrict to one room id
 
-import { spawn } from 'node:child_process'
 import process from 'node:process'
 import { ensureFreshIdpAuth, NotLoggedInError } from '@openape/cli-auth'
 import { decodeJwt } from 'jose'
-import { ofetch } from 'ofetch'
 import WebSocket from 'ws'
+import { ChatApi } from './chat-api'
+import { PiRpcSession } from './pi-rpc'
+import { RoomSession } from './room-session'
 
 const DEFAULT_ENDPOINT = 'https://chat.openape.ai'
-const DEFAULT_CMD = 'pi'
-const DEFAULT_ARGS = '--provider litellm --model gpt-5.4 --print'
-const DEFAULT_TIMEOUT_MS = 60_000
+const DEFAULT_PI_BIN = 'pi'
+const DEFAULT_PROVIDER = 'litellm'
+const DEFAULT_MODEL = 'gpt-5.4'
 
 const PING_INTERVAL_MS = 30_000
 const RECONNECT_BASE_MS = 1000
@@ -54,113 +50,29 @@ interface WsFrame {
 
 interface BridgeConfig {
   endpoint: string
-  cmd: string
-  args: string[]
+  piBin: string
+  provider: string
+  model: string
   roomFilter?: string
-  timeoutMs: number
 }
 
 function readConfig(): BridgeConfig {
-  const argsRaw = process.env.APE_CHAT_BRIDGE_ARGS ?? DEFAULT_ARGS
   return {
     endpoint: (process.env.APE_CHAT_ENDPOINT ?? DEFAULT_ENDPOINT).replace(/\/$/, ''),
-    cmd: process.env.APE_CHAT_BRIDGE_CMD ?? DEFAULT_CMD,
-    args: argsRaw.split(/\s+/).filter(Boolean),
+    piBin: process.env.APE_CHAT_BRIDGE_PI_BIN ?? DEFAULT_PI_BIN,
+    provider: process.env.APE_CHAT_BRIDGE_PROVIDER ?? DEFAULT_PROVIDER,
+    model: process.env.APE_CHAT_BRIDGE_MODEL ?? DEFAULT_MODEL,
     roomFilter: process.env.APE_CHAT_BRIDGE_ROOM,
-    timeoutMs: Number.parseInt(process.env.APE_CHAT_BRIDGE_TIMEOUT_MS ?? '', 10) || DEFAULT_TIMEOUT_MS,
   }
 }
 
-async function getIdentity(): Promise<{ email: string, bearer: string }> {
+async function getIdentity(): Promise<{ email: string }> {
   const idp = await ensureFreshIdpAuth()
   const claims = decodeJwt(idp.access_token) as { sub?: string }
   if (!claims.sub) {
     throw new NotLoggedInError('IdP token has no sub claim — re-run `apes login` for this user.')
   }
-  return { email: claims.sub, bearer: idp.access_token }
-}
-
-async function postMessage(
-  cfg: BridgeConfig,
-  bearer: string,
-  roomId: string,
-  body: string,
-  replyTo?: string,
-): Promise<void> {
-  const url = `${cfg.endpoint}/api/rooms/${encodeURIComponent(roomId)}/messages`
-  await ofetch(url, {
-    method: 'POST',
-    headers: { Authorization: `Bearer ${bearer}` },
-    body: replyTo ? { body, reply_to: replyTo } : { body },
-  })
-}
-
-function runLlm(cfg: BridgeConfig, prompt: string): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const child = spawn(cfg.cmd, [...cfg.args, prompt], {
-      stdio: ['ignore', 'pipe', 'pipe'],
-      env: process.env,
-    })
-    let stdout = ''
-    let stderr = ''
-    const killer = setTimeout(() => child.kill('SIGKILL'), cfg.timeoutMs)
-    child.stdout.on('data', (b: Buffer) => { stdout += b.toString('utf8') })
-    child.stderr.on('data', (b: Buffer) => { stderr += b.toString('utf8') })
-    child.on('error', (err) => {
-      clearTimeout(killer)
-      reject(err)
-    })
-    child.on('close', (code) => {
-      clearTimeout(killer)
-      if (code !== 0) {
-        reject(new Error(`${cfg.cmd} exited ${code}: ${stderr.trim() || stdout.trim()}`))
-        return
-      }
-      resolve(stdout.trim())
-    })
-  })
-}
-
-async function handleMessage(
-  cfg: BridgeConfig,
-  selfEmail: string,
-  bearer: string,
-  msg: Message,
-): Promise<void> {
-  if (msg.senderEmail === selfEmail) return
-  if (!msg.body.trim()) return
-  if (cfg.roomFilter && msg.roomId !== cfg.roomFilter) return
-
-  log(`[${msg.roomId}] in: ${truncate(msg.body, 80)}`)
-
-  let reply: string
-  try {
-    reply = await runLlm(cfg, msg.body)
-  }
-  catch (err) {
-    const errMsg = err instanceof Error ? err.message : String(err)
-    log(`[${msg.roomId}] LLM error: ${errMsg}`)
-    reply = `(bridge error invoking ${cfg.cmd}: ${truncate(errMsg, 200)})`
-  }
-
-  if (!reply) {
-    log(`[${msg.roomId}] empty reply, skipping`)
-    return
-  }
-
-  try {
-    await postMessage(cfg, bearer, msg.roomId, reply, msg.id)
-    log(`[${msg.roomId}] out: ${truncate(reply, 80)}`)
-  }
-  catch (err) {
-    const errMsg = err instanceof Error ? err.message : String(err)
-    log(`[${msg.roomId}] post error: ${errMsg}`)
-  }
-}
-
-function truncate(s: string, n: number): string {
-  if (s.length <= n) return s
-  return `${s.slice(0, n - 1)}…`
+  return { email: claims.sub }
 }
 
 function log(line: string): void {
@@ -171,55 +83,101 @@ function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms))
 }
 
-async function pumpOnce(
-  cfg: BridgeConfig,
-  identity: { email: string, bearer: string },
-): Promise<void> {
-  const wsUrl = `${cfg.endpoint.replace(/^http/, 'ws')}/api/ws?token=${encodeURIComponent(identity.bearer)}`
-  const ws = new WebSocket(wsUrl)
+function truncate(s: string, n: number): string {
+  return s.length <= n ? s : `${s.slice(0, n - 1)}…`
+}
 
-  return new Promise<void>((resolve, reject) => {
-    let pingTimer: NodeJS.Timeout | undefined
+class Bridge {
+  private rooms = new Map<string, RoomSession>()
+  private chat: ChatApi
+  private bearer: () => Promise<string>
 
-    ws.on('open', () => {
-      log(`connected as ${identity.email} → ${cfg.endpoint}`)
-      pingTimer = setInterval(() => ws.ping(), PING_INTERVAL_MS)
+  constructor(private cfg: BridgeConfig, private selfEmail: string) {
+    this.bearer = async () => {
+      const idp = await ensureFreshIdpAuth()
+      return `Bearer ${idp.access_token}`
+    }
+    this.chat = new ChatApi(this.cfg.endpoint, this.bearer)
+  }
+
+  handleInbound(msg: Message): void {
+    if (msg.senderEmail === this.selfEmail) return
+    if (!msg.body.trim()) return
+    if (this.cfg.roomFilter && msg.roomId !== this.cfg.roomFilter) return
+
+    log(`[${msg.roomId}] in: ${truncate(msg.body, 80)}`)
+    const session = this.getOrCreateRoom(msg.roomId)
+    session.enqueue(msg.body, msg.id)
+  }
+
+  private getOrCreateRoom(roomId: string): RoomSession {
+    let s = this.rooms.get(roomId)
+    if (s) return s
+    const pi = new PiRpcSession({
+      binary: this.cfg.piBin,
+      args: ['--provider', this.cfg.provider, '--model', this.cfg.model, '--no-session'],
     })
-
-    ws.on('message', (data: WebSocket.RawData) => {
-      const text = typeof data === 'string' ? data : Buffer.isBuffer(data) ? data.toString('utf8') : ''
-      if (!text) return
-      let frame: WsFrame
-      try { frame = JSON.parse(text) as WsFrame }
-      catch { return }
-      if (frame.type !== 'message') return
-      // Don't await — handle messages concurrently so a slow LLM call doesn't
-      // block other rooms. Errors are logged inside handleMessage.
-      void handleMessage(cfg, identity.email, identity.bearer, frame.payload as unknown as Message)
+    pi.onExit((code) => {
+      log(`[${roomId}] pi exited code=${code} — recreating on next message`)
+      this.rooms.delete(roomId)
     })
-
-    ws.on('close', () => {
-      if (pingTimer) clearInterval(pingTimer)
-      resolve()
+    s = new RoomSession({
+      roomId,
+      chat: this.chat,
+      pi,
+      log,
     })
+    this.rooms.set(roomId, s)
+    return s
+  }
 
-    ws.on('error', (err: Error) => {
-      if (pingTimer) clearInterval(pingTimer)
-      reject(err)
+  async pumpOnce(): Promise<void> {
+    const bearer = await this.bearer()
+    const wsUrl = `${this.cfg.endpoint.replace(/^http/, 'ws')}/api/ws?token=${encodeURIComponent(bearer.replace(/^Bearer\s+/i, ''))}`
+    const ws = new WebSocket(wsUrl)
+    return new Promise<void>((resolve, reject) => {
+      let pingTimer: NodeJS.Timeout | undefined
+
+      ws.on('open', () => {
+        log(`connected as ${this.selfEmail} → ${this.cfg.endpoint}`)
+        pingTimer = setInterval(() => ws.ping(), PING_INTERVAL_MS)
+      })
+
+      ws.on('message', (data: WebSocket.RawData) => {
+        const text = typeof data === 'string'
+          ? data
+          : Buffer.isBuffer(data) ? data.toString('utf8') : ''
+        if (!text) return
+        let frame: WsFrame
+        try { frame = JSON.parse(text) as WsFrame }
+        catch { return }
+        if (frame.type !== 'message') return
+        this.handleInbound(frame.payload as unknown as Message)
+      })
+
+      ws.on('close', () => {
+        if (pingTimer) clearInterval(pingTimer)
+        resolve()
+      })
+      ws.on('error', (err: Error) => {
+        if (pingTimer) clearInterval(pingTimer)
+        reject(err)
+      })
     })
-  })
+  }
 }
 
 async function main(): Promise<void> {
   const cfg = readConfig()
   const identity = await getIdentity()
 
-  log(`bridge starting — cmd=${cfg.cmd} args=[${cfg.args.join(' ')}] room=${cfg.roomFilter ?? '*'}`)
+  log(`bridge starting — pi=${cfg.piBin} provider=${cfg.provider} model=${cfg.model} room=${cfg.roomFilter ?? '*'}`)
 
+  const bridge = new Bridge(cfg, identity.email)
   let attempt = 0
   while (true) {
     try {
-      await pumpOnce(cfg, identity)
+      await bridge.pumpOnce()
       attempt = 0
     }
     catch (err) {

--- a/apps/openape-chat-bridge/src/chat-api.ts
+++ b/apps/openape-chat-bridge/src/chat-api.ts
@@ -1,0 +1,51 @@
+// Thin chat.openape.ai REST client used by the bridge to post + edit
+// messages on behalf of the agent. Authenticates with the bearer the
+// daemon's WebSocket already uses (refreshed by @openape/cli-auth).
+
+import { ofetch } from 'ofetch'
+
+export interface PostedMessage {
+  id: string
+  roomId: string
+  body: string
+  createdAt: number
+}
+
+const MAX_BODY = 10_000
+
+export class ChatApi {
+  constructor(private endpoint: string, private bearer: () => Promise<string>) {}
+
+  async postMessage(roomId: string, body: string, replyTo?: string): Promise<PostedMessage> {
+    const trimmed = clamp(body, MAX_BODY)
+    const url = `${this.endpoint}/api/rooms/${encodeURIComponent(roomId)}/messages`
+    const result = await ofetch<PostedMessage>(url, {
+      method: 'POST',
+      headers: { Authorization: await this.bearer() },
+      body: replyTo ? { body: trimmed, reply_to: replyTo } : { body: trimmed },
+    })
+    return result
+  }
+
+  async patchMessage(messageId: string, body: string): Promise<void> {
+    const trimmed = clamp(body, MAX_BODY)
+    const url = `${this.endpoint}/api/messages/${encodeURIComponent(messageId)}`
+    await ofetch(url, {
+      method: 'PATCH',
+      headers: { Authorization: await this.bearer() },
+      body: { body: trimmed },
+    })
+  }
+}
+
+function clamp(s: string, max: number): string {
+  // The chat-app rejects empty (after trim) and > 10kB bodies. Hard floor
+  // at one printable char so the placeholder PATCH path can still send "…"
+  // updates; ceiling at the schema limit so progressive accumulation
+  // doesn't fail at message N when a later N+1 turn would have succeeded.
+  if (s.trim().length === 0) return '…'
+  if (s.length <= max) return s
+  return `${s.slice(0, max - 1)}…`
+}
+
+export { clamp as _clampBodyForTest }

--- a/apps/openape-chat-bridge/src/pi-rpc.ts
+++ b/apps/openape-chat-bridge/src/pi-rpc.ts
@@ -1,0 +1,166 @@
+// Long-lived pi RPC subprocess per chat conversation.
+//
+// Pi's RPC protocol (https://pi.dev/docs/latest/rpc): launch with
+// `--mode rpc`, send commands as JSON lines on stdin, receive events
+// + responses as JSON lines on stdout. The protocol is strict about
+// only splitting on `\n` — Node's readline must NOT be used because it
+// also splits on U+2028 / U+2029.
+
+import { spawn } from 'node:child_process'
+import type { ChildProcessWithoutNullStreams } from 'node:child_process'
+
+export interface PiRpcOptions {
+  binary: string
+  args: string[]
+  env?: NodeJS.ProcessEnv
+}
+
+export interface AssistantMessageDelta {
+  type: 'text_delta' | 'thinking_delta' | 'toolcall_delta' | 'done'
+  delta?: string
+  contentIndex?: number
+  [k: string]: unknown
+}
+
+/**
+ * Pi RPC event shape. We only model the fields the bridge actually reads;
+ * unknown event kinds still flow through (the `type` field is always a
+ * string) but pattern-matching code should `switch (event.type)` and ignore
+ * non-handled cases.
+ */
+export interface PiEvent {
+  type: string
+  // message_update payload
+  assistantMessageEvent?: AssistantMessageDelta
+  // agent_end / message_end / message_start payload
+  messages?: unknown[]
+  message?: unknown
+  // tool_execution_* payload
+  toolCallId?: string
+  toolName?: string
+  args?: unknown
+  partialResult?: unknown
+  result?: unknown
+  isError?: boolean
+  // RPC response shape
+  id?: string
+  command?: string
+  success?: boolean
+  error?: string
+  // catch-all
+  [k: string]: unknown
+}
+
+/**
+ * Buffer-based JSONL splitter that treats only `\n` as a record terminator.
+ * Returns the parsed records and keeps any trailing partial line for the
+ * next chunk. Exported for unit testing.
+ */
+export function pumpJsonl(buffer: string, chunk: string): { events: unknown[], rest: string } {
+  const combined = buffer + chunk
+  const lines = combined.split('\n')
+  const rest = lines.pop() ?? ''
+  const events: unknown[] = []
+  for (const line of lines) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+    try {
+      events.push(JSON.parse(trimmed))
+    }
+    catch {
+      // ignore malformed line — pi guarantees valid JSON per the spec,
+      // so if we see a bad line it's likely a stderr leak we can drop.
+    }
+  }
+  return { events, rest }
+}
+
+export class PiRpcSession {
+  private proc: ChildProcessWithoutNullStreams
+  private stdoutBuffer = ''
+  private stderrBuffer = ''
+  private listeners: Array<(event: PiEvent) => void> = []
+  private exitListeners: Array<(code: number | null) => void> = []
+  private exited = false
+
+  constructor(opts: PiRpcOptions) {
+    this.proc = spawn(opts.binary, ['--mode', 'rpc', ...opts.args], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: opts.env ?? process.env,
+    })
+
+    this.proc.stdout.setEncoding('utf8')
+    this.proc.stdout.on('data', (chunk: string) => {
+      const { events, rest } = pumpJsonl(this.stdoutBuffer, chunk)
+      this.stdoutBuffer = rest
+      for (const ev of events) {
+        for (const fn of this.listeners) {
+          try { fn(ev as PiEvent) }
+          catch (err) {
+            process.stderr.write(`pi-rpc listener threw: ${err instanceof Error ? err.message : String(err)}\n`)
+          }
+        }
+      }
+    })
+
+    this.proc.stderr.setEncoding('utf8')
+    this.proc.stderr.on('data', (chunk: string) => {
+      this.stderrBuffer += chunk
+      // Surface every line of stderr as it arrives — pi prints diagnostic
+      // info there. Keep a rolling tail in stderrBuffer so a crash report
+      // can include the last few lines.
+      process.stderr.write(`[pi] ${chunk}`)
+      if (this.stderrBuffer.length > 8192) {
+        this.stderrBuffer = this.stderrBuffer.slice(-4096)
+      }
+    })
+
+    this.proc.on('exit', (code) => {
+      this.exited = true
+      for (const fn of this.exitListeners) {
+        try { fn(code) }
+        catch {
+          // listener errors must not mask the exit
+        }
+      }
+    })
+  }
+
+  isAlive(): boolean {
+    return !this.exited
+  }
+
+  recentStderr(): string {
+    return this.stderrBuffer.slice(-4096)
+  }
+
+  send(command: Record<string, unknown>): void {
+    if (this.exited) {
+      throw new Error('pi-rpc subprocess has exited')
+    }
+    this.proc.stdin.write(`${JSON.stringify(command)}\n`)
+  }
+
+  prompt(message: string, opts?: { id?: string }): void {
+    this.send({ type: 'prompt', message, ...(opts?.id ? { id: opts.id } : {}) })
+  }
+
+  on(listener: (event: PiEvent) => void): () => void {
+    this.listeners.push(listener)
+    return () => {
+      this.listeners = this.listeners.filter(l => l !== listener)
+    }
+  }
+
+  onExit(listener: (code: number | null) => void): void {
+    this.exitListeners.push(listener)
+  }
+
+  kill(signal: NodeJS.Signals = 'SIGTERM'): void {
+    if (this.exited) return
+    try { this.proc.kill(signal) }
+    catch {
+      // already gone
+    }
+  }
+}

--- a/apps/openape-chat-bridge/src/room-session.ts
+++ b/apps/openape-chat-bridge/src/room-session.ts
@@ -1,0 +1,120 @@
+// One RoomSession per chat room. Owns a long-lived pi RPC subprocess,
+// a queue of pending prompts, and the placeholder message id for the
+// in-flight turn. Streams pi text deltas back into the chat by
+// PATCHing the placeholder.
+
+import type { ChatApi } from './chat-api'
+import type { PiEvent, PiRpcSession } from './pi-rpc'
+import type { Throttle } from './throttle'
+import { createThrottle } from './throttle'
+
+const PATCH_INTERVAL_MS = 300
+
+interface ActiveTurn {
+  placeholderId: string
+  accumulated: string
+  throttle: Throttle
+  replyToMessageId: string
+}
+
+export interface RoomSessionDeps {
+  roomId: string
+  chat: ChatApi
+  pi: PiRpcSession
+  /** Logger sink — bridge typically forwards to stderr. */
+  log: (line: string) => void
+}
+
+export class RoomSession {
+  private active: ActiveTurn | undefined
+  private queue: Array<{ body: string, replyToMessageId: string }> = []
+
+  constructor(private deps: RoomSessionDeps) {
+    this.deps.pi.on(event => this.onPiEvent(event))
+  }
+
+  /** Forward an inbound chat message to pi. Queues if a turn is in flight. */
+  enqueue(body: string, replyToMessageId: string): void {
+    if (this.active) {
+      this.queue.push({ body, replyToMessageId })
+      return
+    }
+    void this.startTurn(body, replyToMessageId)
+  }
+
+  private async startTurn(body: string, replyToMessageId: string): Promise<void> {
+    const placeholder = await this.deps.chat.postMessage(this.deps.roomId, '…', replyToMessageId)
+    const turn: ActiveTurn = {
+      placeholderId: placeholder.id,
+      accumulated: '',
+      replyToMessageId,
+      // The throttle rebinds to `turn` via closure — when the turn ends
+      // we cancel before clearing `this.active`, so the captured ref is
+      // never used after teardown.
+      throttle: createThrottle(async () => {
+        if (!this.active || this.active.placeholderId !== placeholder.id) return
+        const text = this.active.accumulated || '…'
+        try {
+          await this.deps.chat.patchMessage(placeholder.id, text)
+        }
+        catch (err) {
+          this.deps.log(`patch failed (room=${this.deps.roomId}): ${err instanceof Error ? err.message : String(err)}`)
+        }
+      }, PATCH_INTERVAL_MS),
+    }
+    this.active = turn
+    this.deps.pi.prompt(body)
+  }
+
+  private onPiEvent(event: PiEvent): void {
+    if (!this.active) return
+    switch (event.type) {
+      case 'message_update': {
+        const inner = event.assistantMessageEvent
+        if (!inner) break
+        if (inner.type === 'text_delta' && typeof inner.delta === 'string') {
+          this.active.accumulated += inner.delta
+          this.active.throttle.schedule()
+        }
+        // thinking_delta / toolcall_delta / tool_execution_* → ignored in
+        // v1. Hooks live here for the next milestone.
+        break
+      }
+      case 'agent_end':
+        this.endTurn()
+        break
+      case 'response':
+        // RPC responses to our `prompt` command — surfaced for failure cases.
+        if (event.success === false) {
+          this.deps.log(`pi rpc error (room=${this.deps.roomId}): ${event.error ?? 'unknown'}`)
+          this.failTurn(`(pi rpc error: ${event.error ?? 'unknown'})`)
+        }
+        break
+    }
+  }
+
+  private endTurn(): void {
+    const turn = this.active
+    if (!turn) return
+    turn.throttle.flush()
+    this.active = undefined
+    // Drain the queue. Doing this synchronously in event order means
+    // queued prompts run sequentially in the same conversation context.
+    const next = this.queue.shift()
+    if (next) {
+      void this.startTurn(next.body, next.replyToMessageId)
+    }
+  }
+
+  private failTurn(message: string): void {
+    const turn = this.active
+    if (!turn) return
+    turn.accumulated = message
+    turn.throttle.flush()
+    this.active = undefined
+    const next = this.queue.shift()
+    if (next) {
+      void this.startTurn(next.body, next.replyToMessageId)
+    }
+  }
+}

--- a/apps/openape-chat-bridge/src/throttle.ts
+++ b/apps/openape-chat-bridge/src/throttle.ts
@@ -1,0 +1,60 @@
+// Trailing-edge throttle: invokes `fn` at most once per `intervalMs`,
+// always firing the latest `pending()` value (whatever is current at
+// fire time). Exposes `flush()` to force the trailing call and
+// `cancel()` to drop it.
+
+export interface Throttle {
+  schedule: () => void
+  flush: () => void
+  cancel: () => void
+}
+
+export function createThrottle(fn: () => void | Promise<void>, intervalMs: number): Throttle {
+  let timer: NodeJS.Timeout | undefined
+  let pendingFlush = false
+  let inFlight = false
+
+  const fire = async () => {
+    if (inFlight) {
+      pendingFlush = true
+      return
+    }
+    inFlight = true
+    pendingFlush = false
+    try {
+      await fn()
+    }
+    finally {
+      inFlight = false
+      if (pendingFlush) {
+        // Coalesce: if more schedule()s landed during the in-flight call,
+        // run once more. Avoids losing the latest accumulator state.
+        pendingFlush = false
+        await fn()
+      }
+    }
+  }
+
+  return {
+    schedule() {
+      if (timer) return
+      timer = setTimeout(() => {
+        timer = undefined
+        void fire()
+      }, intervalMs)
+    },
+    flush() {
+      if (timer) {
+        clearTimeout(timer)
+        timer = undefined
+      }
+      void fire()
+    },
+    cancel() {
+      if (timer) {
+        clearTimeout(timer)
+        timer = undefined
+      }
+    },
+  }
+}

--- a/apps/openape-chat-bridge/test/chat-api.test.ts
+++ b/apps/openape-chat-bridge/test/chat-api.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { _clampBodyForTest as clamp } from '../src/chat-api'
+
+describe('chat-api body clamp', () => {
+  it('returns the body untouched when within limits', () => {
+    expect(clamp('hello', 100)).toBe('hello')
+  })
+
+  it('replaces a whitespace-only body with "…" so PATCH passes the trim().min(1) check', () => {
+    expect(clamp('', 100)).toBe('…')
+    expect(clamp('   ', 100)).toBe('…')
+    expect(clamp('\n\t', 100)).toBe('…')
+  })
+
+  it('truncates over-long bodies to max-1 + ellipsis', () => {
+    const body = 'x'.repeat(200)
+    const clamped = clamp(body, 50)
+    expect(clamped.length).toBe(50)
+    expect(clamped.endsWith('…')).toBe(true)
+  })
+})

--- a/apps/openape-chat-bridge/test/pi-rpc.test.ts
+++ b/apps/openape-chat-bridge/test/pi-rpc.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { pumpJsonl } from '../src/pi-rpc'
+
+describe('pumpJsonl', () => {
+  it('returns one event per complete line, splitting on \\n only', () => {
+    const r = pumpJsonl('', '{"type":"agent_start"}\n{"type":"agent_end"}\n')
+    expect(r.events).toEqual([{ type: 'agent_start' }, { type: 'agent_end' }])
+    expect(r.rest).toBe('')
+  })
+
+  it('keeps a trailing partial line in `rest` for the next chunk', () => {
+    const r1 = pumpJsonl('', '{"type":"agent_start"}\n{"type":"messa')
+    expect(r1.events).toEqual([{ type: 'agent_start' }])
+    expect(r1.rest).toBe('{"type":"messa')
+
+    const r2 = pumpJsonl(r1.rest, 'ge_start"}\n')
+    expect(r2.events).toEqual([{ type: 'message_start' }])
+    expect(r2.rest).toBe('')
+  })
+
+  it('does NOT split on Unicode separators (U+2028 / U+2029)', () => {
+    // Per pi RPC spec these MUST be treated as ordinary characters inside
+    // the JSON payload. Node's readline would split here — pumpJsonl must
+    // not.
+    const sep = '\u2028'
+    const payload = `{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"line one${sep}line two"}}`
+    const r = pumpJsonl('', `${payload}\n`)
+    expect(r.events).toHaveLength(1)
+    expect((r.events[0] as { assistantMessageEvent: { delta: string } }).assistantMessageEvent.delta).toBe(`line one${sep}line two`)
+  })
+
+  it('drops malformed lines silently rather than crashing the stream', () => {
+    const r = pumpJsonl('', 'this is not json\n{"type":"agent_end"}\n')
+    expect(r.events).toEqual([{ type: 'agent_end' }])
+  })
+
+  it('ignores blank lines', () => {
+    const r = pumpJsonl('', '\n   \n{"type":"agent_start"}\n')
+    expect(r.events).toEqual([{ type: 'agent_start' }])
+  })
+})

--- a/apps/openape-chat-bridge/test/throttle.test.ts
+++ b/apps/openape-chat-bridge/test/throttle.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createThrottle } from '../src/throttle'
+
+describe('createThrottle', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('coalesces multiple schedule() calls into one trailing fire', async () => {
+    const fn = vi.fn(() => Promise.resolve())
+    const t = createThrottle(fn, 300)
+    t.schedule()
+    t.schedule()
+    t.schedule()
+    expect(fn).toHaveBeenCalledTimes(0)
+    await vi.advanceTimersByTimeAsync(300)
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('flush() forces immediate fire and clears the timer', async () => {
+    const fn = vi.fn(() => Promise.resolve())
+    const t = createThrottle(fn, 300)
+    t.schedule()
+    t.flush()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(fn).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(300)
+    // No second fire — the scheduled timer must have been cancelled.
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('cancel() drops a scheduled fire', async () => {
+    const fn = vi.fn(() => Promise.resolve())
+    const t = createThrottle(fn, 300)
+    t.schedule()
+    t.cancel()
+    await vi.advanceTimersByTimeAsync(300)
+    expect(fn).not.toHaveBeenCalled()
+  })
+
+  it('coalesces schedule() that arrives during an in-flight call', async () => {
+    let resolveFirst: (() => void) | null = null
+    const fn = vi.fn(() => new Promise<void>((resolve) => {
+      // First call hangs until we release it; subsequent calls resolve sync.
+      if (!resolveFirst) {
+        resolveFirst = resolve
+      }
+      else {
+        resolve()
+      }
+    }))
+    const t = createThrottle(fn, 100)
+    t.schedule()
+    await vi.advanceTimersByTimeAsync(100)
+    expect(fn).toHaveBeenCalledTimes(1) // first fire in flight
+
+    t.schedule()
+    await vi.advanceTimersByTimeAsync(100)
+    // The throttle should NOT start a second fire while the first is in
+    // flight; it marks pendingFlush and runs once after the first resolves.
+    expect(fn).toHaveBeenCalledTimes(1)
+
+    resolveFirst!()
+    await vi.runAllTimersAsync()
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/apes/src/lib/llm-bridge.ts
+++ b/packages/apes/src/lib/llm-bridge.ts
@@ -103,9 +103,10 @@ export NPM_CONFIG_PREFIX="$HOME/.npm-global"
 export PATH="$NPM_CONFIG_PREFIX/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
 mkdir -p "$NPM_CONFIG_PREFIX"
 
-if ! command -v openape-chat-bridge >/dev/null 2>&1; then
-  npm install -g --silent @openape/chat-bridge
-fi
+# Always pull @latest on boot. npm is cached so this is a no-op when the
+# global is already current; when a new version ships, the daemon auto-
+# upgrades on the next launchctl restart instead of needing manual touch.
+npm install -g --silent @openape/chat-bridge@latest
 
 if ! command -v pi >/dev/null 2>&1; then
   npm install -g --silent @mariozechner/pi-coding-agent

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -313,6 +313,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.15)(happy-dom@18.0.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   apps/openape-chat-cli:
     dependencies:


### PR DESCRIPTION
Closes #242.

Rewrites \`@openape/chat-bridge\` to drive pi via its RPC protocol (\`pi --mode rpc\`) instead of spawning a fresh \`pi --print\` per inbound message.

## Why

Today's bridge has no memory: every message starts a new pi process with no context. "Was ist 7×6?" → "42", then "und ×2?" → "What's ×2?" — confusing.

There's also no live-typing feel: the user waits 5–10s, then sees a complete reply pop in.

## What changes

- One long-lived pi RPC subprocess per chat room (lazy, started on first inbound).
- On inbound message: post a placeholder ("…") chat message, then forward to pi.
- Stream \`text_delta\` events into the placeholder via \`PATCH /api/messages/<id>\` (throttled ~300ms).
- Memory across messages in the same room is automatic — pi keeps the conversation in its own state.
- Tests cover JSONL framing (\\n only, never U+2028 / U+2029), throttle coalescing, body clamp.

\`@openape/apes\` start.sh now \`npm install -g @openape/chat-bridge@latest\` on every launchd boot — restarting the daemon picks up new bridge versions without touching the agent's home.

## Out of scope (separate PRs)

- Persistent pi sessions across bridge restarts (\`--session <id>\`)
- Thinking / tool-call rendering as separate chat blocks
- Threads (chat-app schema change)
- Autonomous triggers

## Live verification (after merge + publish)

\`\`\`text
patrick:  Was ist 7 mal 6?
agent:    [...] 42        # appears word-by-word as pi streams
patrick:  Und mal 2?
agent:    [...] 84        # answers from context, not "What do you mean ×2?"
\`\`\`