### PR TITLE
fix(apes): bridge start.sh refreshes IdP token (drops 1h crashloop)

### DIFF
--- a/.changeset/bridge-token-refresh.md
+++ b/.changeset/bridge-token-refresh.md
@@ -1,0 +1,5 @@
+---
+"@openape/apes": patch
+---
+
+Fix bridge crashloop on 1h agent IdP token expiry. Agents auth via SSH-key signing — the resulting IdP token has no refresh_token and dies after ~1h. The bridge then crashloops because launchd's KeepAlive restarts it but the cached token is still expired. Fix: spawn `--bridge` start.sh now installs `@openape/apes` and runs `apes login <email> --idp <idp>` (key-based, non-interactive) before exec'ing the bridge — every launchd boot produces a fresh ~1h token, recovery gap on the hourly mark drops to ~10s instead of permanent breakage.

--- a/packages/apes/src/lib/llm-bridge.ts
+++ b/packages/apes/src/lib/llm-bridge.ts
@@ -108,8 +108,33 @@ mkdir -p "$NPM_CONFIG_PREFIX"
 # upgrades on the next launchctl restart instead of needing manual touch.
 npm install -g --silent @openape/chat-bridge@latest
 
+# apes is needed to refresh the agent's IdP token before each boot —
+# agents auth via SSH key signing, the resulting token has no
+# refresh_token and expires after ~1h. Without re-running 'apes login'
+# the bridge would crashloop after the first hour. KeepAlive's 10s
+# throttle then bounds the recovery gap to ~10s.
+if ! command -v apes >/dev/null 2>&1; then
+  npm install -g --silent @openape/apes
+fi
+
 if ! command -v pi >/dev/null 2>&1; then
   npm install -g --silent @mariozechner/pi-coding-agent
+fi
+
+# Refresh IdP token. Read the agent's own email + idp out of the auth
+# file spawn wrote, then re-sign via the registered SSH key. python3 is
+# always available on macOS — avoids a jq dep.
+if [ -f "$HOME/.config/apes/auth.json" ]; then
+  agent_email=$(python3 -c "import json,os,sys
+try: print(json.load(open(os.path.expanduser('~/.config/apes/auth.json')))['email'])
+except Exception: sys.exit(1)" 2>/dev/null || true)
+  agent_idp=$(python3 -c "import json,os,sys
+try: print(json.load(open(os.path.expanduser('~/.config/apes/auth.json')))['idp'])
+except Exception: sys.exit(1)" 2>/dev/null || true)
+  if [ -n "$agent_email" ] && [ -n "$agent_idp" ]; then
+    apes login "$agent_email" --idp "$agent_idp" >/dev/null 2>&1 \\
+      || echo "warn: apes login failed for $agent_email; continuing with cached token"
+  fi
 fi
 
 EXT_DIR="$HOME/.pi/agent/extensions"

--- a/packages/apes/test/agents-llm-bridge.test.ts
+++ b/packages/apes/test/agents-llm-bridge.test.ts
@@ -107,6 +107,22 @@ describe('llm-bridge — pure helpers', () => {
     expect(sh).toContain('exec openape-chat-bridge')
   })
 
+  it('buildBridgeStartScript installs apes + refreshes IdP token before exec (1h expiry workaround)', () => {
+    const sh = buildBridgeStartScript()
+    // apes is required to re-sign the agent's IdP token via SSH key.
+    expect(sh).toContain('npm install -g --silent @openape/apes')
+    // The script must read the agent's own email and idp out of auth.json
+    // and call `apes login` BEFORE exec'ing the bridge — otherwise the
+    // bridge picks up the (potentially expired) cached token and crashes.
+    expect(sh).toContain('~/.config/apes/auth.json')
+    expect(sh).toContain('apes login "$agent_email" --idp "$agent_idp"')
+    // Order: login must come before exec.
+    const loginIdx = sh.indexOf('apes login')
+    const execIdx = sh.indexOf('exec openape-chat-bridge')
+    expect(loginIdx).toBeGreaterThan(0)
+    expect(execIdx).toBeGreaterThan(loginIdx)
+  })
+
   it('buildBridgePlist embeds agent name as label + UserName + paths + KeepAlive', () => {
     const plist = buildBridgePlist('agent-x', '/Users/agent-x')
     expect(plist).toContain('<string>eco.hofmann.apes.bridge.agent-x</string>')


### PR DESCRIPTION
Closes #244.

Agents auth via SSH-key signing — the resulting IdP token has no refresh_token and expires ~1h later. \`@openape/cli-auth\`'s \`ensureFreshIdpAuth\` then throws \`Not logged in\`. The bridge inherits this and dies. With launchd \`KeepAlive: true\` the bridge restarts every 10s, but \`start.sh\` doesn't re-authenticate, so the new instance hits the same expired token and crashes again. Permanent crashloop.

We hit this trying to verify chat-bridge v0.2 against \`agent-test\` whose IdP token had aged out.

## Fix

\`start.sh\` now:

1. \`npm install -g @openape/apes\` (next to chat-bridge + pi)
2. Reads agent's \`email\` and \`idp\` out of \`~/.config/apes/auth.json\` via \`python3\` (always available on macOS — no jq dep)
3. Runs \`apes login <email> --idp <idp>\` before exec'ing the bridge — key-based, non-interactive, idempotent

Every launchd boot produces a fresh ~1h token. With KeepAlive's 10s throttle, agents recover from the hourly token expiry within ~10s instead of permanently breaking.

## Tests

- New unit test asserts start.sh runs \`apes login\` BEFORE \`exec openape-chat-bridge\` and reads agent_email/agent_idp from auth.json.
- Pre-existing test \`shell-login-integration.test.ts\` flakes on local (10s tsup-build hook timeout) on this branch AND on main — unrelated.

## Out of scope (follow-up)

In-process token refresh inside the bridge so the 10s KeepAlive gap on the hour-mark goes away entirely.