### PR TITLE
fix(apes): bridge PATH $HOME/.bun/bin (not install/global/bin)

### DIFF
--- a/.changeset/bridge-bun-bin-path-fix.md
+++ b/.changeset/bridge-bun-bin-path-fix.md
@@ -1,0 +1,5 @@
+---
+"@openape/apes": patch
+---
+
+Fix bridge PATH on apes 0.26.0: bun symlinks live in `~/.bun/bin/` not `~/.bun/install/global/bin/`, so launchd's `exec openape-chat-bridge` was failing with "command not found" and crashlooping. One-char fix in plist + start.sh. Existing agents need their plist+start.sh patched in place (or destroy + re-spawn).

--- a/packages/apes/src/lib/llm-bridge.ts
+++ b/packages/apes/src/lib/llm-bridge.ts
@@ -103,7 +103,7 @@ export function buildBridgeStartScript(): string {
 # Slim launcher — install stack lives in spawn, not here.
 set -euo pipefail
 
-export PATH="$HOME/.bun/install/global/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+export PATH="$HOME/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
 
 # Refresh IdP token. Agents auth via SSH-key signing — the cached IdP
 # token has no refresh_token and expires after ~1h. Re-running apes
@@ -207,7 +207,7 @@ export function buildBridgePlist(agentName: string, homeDir: string): string {
         <key>HOME</key>
         <string>${homeDir}</string>
         <key>PATH</key>
-        <string>${homeDir}/.bun/install/global/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <string>${homeDir}/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
     </dict>
 </dict>
 </plist>

--- a/packages/apes/test/agents-llm-bridge.test.ts
+++ b/packages/apes/test/agents-llm-bridge.test.ts
@@ -106,8 +106,9 @@ describe('llm-bridge — pure helpers', () => {
     expect(sh).toContain('"$EXT_DIR/litellm.ts"')
     expect(sh).toContain('. "$HOME/.pi/agent/.env"')
     expect(sh).toContain('exec openape-chat-bridge')
-    // PATH includes the bun global bin dir where the installer landed.
-    expect(sh).toContain('$HOME/.bun/install/global/bin')
+    // PATH includes the bun global bin dir where the installer landed
+    // (bun symlinks live in ~/.bun/bin, NOT ~/.bun/install/global/bin).
+    expect(sh).toContain('$HOME/.bun/bin')
   })
 
   it('buildBridgeStartScript refreshes IdP token before exec (1h expiry workaround)', () => {


### PR DESCRIPTION
Hotfix on top of #247.

bun symlinks live in \`~/.bun/bin/\`, not \`~/.bun/install/global/bin/\` (verified from \`/Users/agent-bot2/.bun/\` after a real \`bun add -g\` install). The fast-boot PR's plist + start.sh PATH pointed at the latter. Result: launchd starts the bridge → \`exec openape-chat-bridge\` → \`command not found\` → KeepAlive crashloop.

One-char path fix in \`buildBridgePlist\` and \`buildBridgeStartScript\`. Test asserts the correct path.

Verified live by patching agent-bot2's plist + start.sh in-place + bootstrap → bridge connected + replied to a chat message in <2s.

Existing agent-bot1 / agent-bot2 still work post-merge because their plists were already patched in place. Future fresh \`spawn --bridge\` calls will get the correct path from the start.