### PR TITLE
feat(chat): 1:1-only model (hide channels UI, spawn auto-creates DM)

### DIFF
--- a/.changeset/chat-hide-channels-and-auto-dm.md
+++ b/.changeset/chat-hide-channels-and-auto-dm.md
@@ -1,0 +1,5 @@
+---
+"@openape/apes": minor
+---
+
+Bridge model shifts to 1:1-only. `apes agents spawn --bridge` no longer takes `--bridge-room <name>` — it auto-creates a DM between the spawning user and the new agent. The chat-app UI hides channels (group chats) until the contacts model lands; agents in shared rooms produce reply-loops between agents and there's no reliable way to filter agent-from-human messages yet. Existing channels are not deleted, just hidden from the room list. Direct URL access to a channel still works for back-compat.

--- a/apps/openape-chat/app/pages/index.vue
+++ b/apps/openape-chat/app/pages/index.vue
@@ -17,43 +17,16 @@ if (!user.value && import.meta.client) {
   navigateTo('/login')
 }
 
-const { data: rooms, refresh } = await useFetch<RoomRow[]>('/api/rooms', {
+const { data: allRooms } = await useFetch<RoomRow[]>('/api/rooms', {
   default: () => [],
 })
 
-const showCreate = ref(false)
-const createName = ref('')
-const createKind = ref<'channel' | 'dm'>('channel')
-const createMembers = ref('')
-const creating = ref(false)
-const createError = ref<string | null>(null)
-
-async function createRoom() {
-  createError.value = null
-  if (!createName.value.trim()) return
-  creating.value = true
-  try {
-    const members = createMembers.value
-      .split(/[,\s]+/)
-      .map(s => s.trim())
-      .filter(Boolean)
-    const room = await $fetch<{ id: string }>('/api/rooms', {
-      method: 'POST',
-      body: { name: createName.value.trim(), kind: createKind.value, members },
-    })
-    showCreate.value = false
-    createName.value = ''
-    createMembers.value = ''
-    await refresh()
-    navigateTo(`/rooms/${room.id}`)
-  }
-  catch (err) {
-    createError.value = err instanceof Error ? err.message : 'Failed to create room'
-  }
-  finally {
-    creating.value = false
-  }
-}
+// Channel-style rooms (group chats) are hidden until the contacts model
+// (Phase A) ships — letting an agent loose in a multi-member room with no
+// way to filter agent vs human created reply-loops between agents. DMs
+// (1:1) stay visible because the membership shape inherently bounds the
+// participants.
+const rooms = computed(() => (allRooms.value ?? []).filter(r => r.kind === 'dm'))
 
 async function logout() {
   await spLogout()
@@ -72,13 +45,6 @@ async function logout() {
         <span v-if="user.act === 'agent'">🤖</span>
       </span>
       <UButton
-        icon="i-lucide-plus"
-        size="sm"
-        color="primary"
-        aria-label="New room"
-        @click="showCreate = true"
-      />
-      <UButton
         icon="i-lucide-log-out"
         size="sm"
         color="neutral"
@@ -93,7 +59,9 @@ async function logout() {
         <EnableNotifications />
       </ClientOnly>
       <p v-if="!rooms?.length" class="p-8 text-center text-zinc-500 text-sm">
-        No rooms yet. Create one to start chatting.
+        No direct chats yet.<br>
+        Spawn an agent with <code class="text-zinc-300">apes agents spawn &lt;name&gt; --bridge</code>
+        to start a conversation.
       </p>
       <ul v-else class="divide-y divide-zinc-800">
         <li v-for="room of rooms" :key="room.id">
@@ -113,41 +81,5 @@ async function logout() {
         </li>
       </ul>
     </main>
-
-    <UModal v-model:open="showCreate">
-      <template #content>
-        <form class="p-6 space-y-4" @submit.prevent="createRoom">
-          <h2 class="text-lg font-semibold">
-            New room
-          </h2>
-          <UFormField label="Name" required>
-            <UInput v-model="createName" placeholder="team-alpha" autofocus />
-          </UFormField>
-          <UFormField label="Type">
-            <URadioGroup
-              v-model="createKind"
-              :items="[
-                { value: 'channel', label: 'Channel — many members can join later' },
-                { value: 'dm', label: 'DM — fixed member set' },
-              ]"
-            />
-          </UFormField>
-          <UFormField label="Members (emails, comma or space separated)" :hint="createKind === 'dm' ? 'You + at least one other email' : 'Optional — anyone can join later'">
-            <UTextarea v-model="createMembers" :rows="2" placeholder="alice@example.com, bob@example.com" />
-          </UFormField>
-          <p v-if="createError" class="text-sm text-red-400">
-            {{ createError }}
-          </p>
-          <div class="flex gap-2 justify-end">
-            <UButton color="neutral" variant="ghost" @click="showCreate = false">
-              Cancel
-            </UButton>
-            <UButton type="submit" color="primary" :loading="creating">
-              Create
-            </UButton>
-          </div>
-        </form>
-      </template>
-    </UModal>
   </div>
 </template>

--- a/packages/apes/src/commands/agents/spawn.ts
+++ b/packages/apes/src/commands/agents/spawn.ts
@@ -15,7 +15,7 @@ import {
   issueAgentToken,
   registerAgentAtIdp,
 } from '../../lib/agent-bootstrap'
-import { ensureRoomMembership } from '../../lib/chat-room'
+import { ensureDmWith } from '../../lib/chat-room'
 import { generateKeyPairInMemory } from '../../lib/keygen'
 import {
   bridgePlistLabel,
@@ -66,11 +66,6 @@ export const spawnAgentCommand = defineCommand({
     'bridge-base-url': {
       type: 'string',
       description: 'Override LITELLM_BASE_URL for the bridge (default: read from ~/litellm/.env or http://127.0.0.1:4000/v1).',
-    },
-    'bridge-room': {
-      type: 'string',
-      description:
-        'After spawn, create (or find) a chat.openape.ai room with this name and add the new agent as a member. Uses the spawning user\'s IdP bearer.',
     },
   },
   async run({ args }) {
@@ -203,25 +198,23 @@ export const spawnAgentCommand = defineCommand({
 
       consola.success(`Agent ${name} spawned.`)
 
-      const bridgeRoom = typeof args['bridge-room'] === 'string' ? args['bridge-room'] : undefined
-      if (args.bridge && bridgeRoom) {
+      if (args.bridge) {
         try {
-          consola.start(`Inviting agent into chat.openape.ai room "${bridgeRoom}"…`)
-          const result = await ensureRoomMembership({
+          consola.start('Setting up direct chat with the agent…')
+          const result = await ensureDmWith({
             callerBearer: auth.access_token,
-            roomName: bridgeRoom,
-            agentEmail: registration.email,
+            callerEmail: auth.email,
+            peerEmail: registration.email,
           })
           consola.success(
             result.created
-              ? `Created room ${result.roomId} and added ${registration.email}`
-              : `Room ${result.roomId} already existed; added ${registration.email}`,
+              ? `Created direct chat with ${registration.email}`
+              : `Direct chat with ${registration.email} already existed`,
           )
         }
         catch (err) {
           const msg = err instanceof Error ? err.message : String(err)
-          consola.warn(`Could not auto-create / invite to chat room: ${msg}`)
-          consola.info('Add the agent manually with: ape-chat members add <agent-email>')
+          consola.warn(`Could not auto-create direct chat: ${msg}`)
         }
       }
 

--- a/packages/apes/src/lib/chat-room.ts
+++ b/packages/apes/src/lib/chat-room.ts
@@ -1,10 +1,12 @@
-// Helpers for `apes agents spawn --bridge --bridge-room <name>`. Hits
-// chat.openape.ai's REST API as the spawning user (uses their IdP bearer)
-// to create a room (or find existing) and add the agent as a member.
+// Helpers for `apes agents spawn --bridge`. Hits chat.openape.ai's REST
+// API as the spawning user (uses their IdP bearer) to ensure a DM exists
+// with the new agent. Auto-accepts both directions — the spawn act
+// itself implies trust on the human side, and the agent has no policy
+// of its own.
 //
-// We deliberately use plain fetch here rather than depending on
-// @openape/ape-chat — keeps apes free of a runtime npm dep on the chat
-// CLI. The shape mirrors openape-chat's server/api/rooms/* endpoints.
+// Plain fetch here so apes stays free of a runtime npm dep on
+// @openape/ape-chat. The shape mirrors openape-chat's server/api/rooms/*
+// endpoints.
 
 const DEFAULT_CHAT_ENDPOINT = 'https://chat.openape.ai'
 
@@ -12,6 +14,14 @@ interface Room {
   id: string
   name: string
   kind: 'channel' | 'dm'
+  /** Only present on GET /api/rooms (caller's role). */
+  role?: 'admin' | 'member'
+}
+
+interface Member {
+  userEmail: string
+  role: 'admin' | 'member'
+  joinedAt: number
 }
 
 function chatEndpoint(): string {
@@ -39,48 +49,54 @@ async function chatFetch<T>(
   return await res.json() as T
 }
 
-async function findRoomByName(bearer: string, name: string): Promise<Room | null> {
-  const rooms = await chatFetch<Room[]>(bearer, '/api/rooms')
-  return rooms.find(r => r.name === name) ?? null
+async function listRooms(bearer: string): Promise<Room[]> {
+  return chatFetch<Room[]>(bearer, '/api/rooms')
 }
 
-async function createRoom(bearer: string, name: string): Promise<Room> {
-  return chatFetch<Room>(bearer, '/api/rooms', {
-    method: 'POST',
-    body: { name, kind: 'channel', members: [] },
-  })
+async function listMembers(bearer: string, roomId: string): Promise<Member[]> {
+  return chatFetch<Member[]>(bearer, `/api/rooms/${encodeURIComponent(roomId)}/members`)
 }
 
-async function addMember(bearer: string, roomId: string, email: string, role: 'member' | 'admin' = 'member'): Promise<void> {
-  await chatFetch(bearer, `/api/rooms/${encodeURIComponent(roomId)}/members`, {
-    method: 'POST',
-    body: { email, role },
-  })
+async function findExistingDm(bearer: string, callerEmail: string, peerEmail: string): Promise<Room | null> {
+  // Walk the caller's rooms, filter to DMs, and pick the one whose member
+  // set is exactly {caller, peer}. Server-side this would be a single
+  // query — keeping it client-side until the chat-app exposes a
+  // /api/dms-with/{email} endpoint.
+  const rooms = await listRooms(bearer)
+  for (const room of rooms) {
+    if (room.kind !== 'dm') continue
+    const members = await listMembers(bearer, room.id)
+    if (members.length !== 2) continue
+    const emails = new Set(members.map(m => m.userEmail.toLowerCase()))
+    if (emails.has(callerEmail.toLowerCase()) && emails.has(peerEmail.toLowerCase())) {
+      return room
+    }
+  }
+  return null
 }
 
 /**
- * Idempotent: ensure a room with the given name exists and the agent is
- * a member. Returns the room id.
+ * Idempotent: ensure a DM room exists between the caller and the agent,
+ * with both as members. Used by `apes agents spawn --bridge` so the
+ * fresh agent immediately has a 1:1 chat with the spawning user — no
+ * room name, no manual invite.
  *
- * - If the room exists, reuse it.
- * - If the room exists and the agent is already a member, no-op on
- *   membership (server returns 200 on duplicate inserts in our schema).
+ * Returns the DM room id and whether it was created or reused.
  */
-export async function ensureRoomMembership(opts: {
+export async function ensureDmWith(opts: {
   callerBearer: string
-  roomName: string
-  agentEmail: string
+  callerEmail: string
+  peerEmail: string
 }): Promise<{ roomId: string, created: boolean }> {
-  const existing = await findRoomByName(opts.callerBearer, opts.roomName)
-  let room: Room
-  let created = false
-  if (existing) {
-    room = existing
-  }
-  else {
-    room = await createRoom(opts.callerBearer, opts.roomName)
-    created = true
-  }
-  await addMember(opts.callerBearer, room.id, opts.agentEmail)
-  return { roomId: room.id, created }
+  const existing = await findExistingDm(opts.callerBearer, opts.callerEmail, opts.peerEmail)
+  if (existing) return { roomId: existing.id, created: false }
+
+  // Name is informational. The new contacts UI surfaces the peer's email
+  // (or display name) directly; this string is only the fallback in
+  // legacy room-list views.
+  const room = await chatFetch<Room>(opts.callerBearer, '/api/rooms', {
+    method: 'POST',
+    body: { name: opts.peerEmail, kind: 'dm', members: [opts.peerEmail] },
+  })
+  return { roomId: room.id, created: true }
 }

--- a/packages/apes/test/agents-chat-room.test.ts
+++ b/packages/apes/test/agents-chat-room.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { ensureRoomMembership } from '../src/lib/chat-room'
+import { ensureDmWith } from '../src/lib/chat-room'
 
-describe('ensureRoomMembership', () => {
+describe('ensureDmWith', () => {
   const realFetch = globalThis.fetch
   const calls: Array<{ url: string, method: string, body?: unknown }> = []
 
@@ -20,68 +20,113 @@ describe('ensureRoomMembership', () => {
     })
   }
 
-  it('reuses an existing room with the same name (no create call)', async () => {
+  it('reuses an existing DM whose member set matches caller + peer', async () => {
     globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input)
       const method = init?.method ?? 'GET'
-      const bodyTxt = init?.body
-      calls.push({ url, method, body: bodyTxt ? JSON.parse(String(bodyTxt)) : undefined })
+      const body = init?.body ? JSON.parse(String(init.body)) : undefined
+      calls.push({ url, method, body })
       if (url.endsWith('/api/rooms') && method === 'GET') {
-        return jsonResponse(200, [{ id: 'room-1', name: 'demo', kind: 'channel' }])
+        return jsonResponse(200, [
+          { id: 'r-channel', name: 'team', kind: 'channel' },
+          { id: 'r-dm', name: 'agent-x@id', kind: 'dm' },
+          { id: 'r-other-dm', name: 'someone-else', kind: 'dm' },
+        ])
       }
-      if (url.includes('/api/rooms/room-1/members') && method === 'POST') {
-        return jsonResponse(200, { userEmail: 'agent-x@id', role: 'member', joinedAt: 1 })
+      if (url.includes('/api/rooms/r-dm/members')) {
+        return jsonResponse(200, [
+          { userEmail: 'PATRICK@hofmann.eco', role: 'admin', joinedAt: 1 },
+          { userEmail: 'agent-x@id', role: 'member', joinedAt: 1 },
+        ])
       }
-      throw new Error(`unexpected fetch ${method} ${url}`)
+      if (url.includes('/api/rooms/r-other-dm/members')) {
+        return jsonResponse(200, [
+          { userEmail: 'patrick@hofmann.eco', role: 'admin', joinedAt: 1 },
+          { userEmail: 'someone@else', role: 'member', joinedAt: 1 },
+        ])
+      }
+      throw new Error(`unexpected ${method} ${url}`)
     }) as typeof fetch
 
-    const out = await ensureRoomMembership({
+    const out = await ensureDmWith({
       callerBearer: 'tok',
-      roomName: 'demo',
-      agentEmail: 'agent-x@id',
+      callerEmail: 'patrick@hofmann.eco',
+      peerEmail: 'agent-x@id',
     })
-    expect(out).toEqual({ roomId: 'room-1', created: false })
-    expect(calls.map(c => `${c.method} ${c.url.replace(/^https?:\/\/[^/]+/, '')}`)).toEqual([
-      'GET /api/rooms',
-      'POST /api/rooms/room-1/members',
-    ])
+
+    expect(out).toEqual({ roomId: 'r-dm', created: false })
+    // Match must be email-case-insensitive (the server may have stored
+    // either case; bridge-side reads should not care).
+    expect(calls.find(c => c.method === 'POST' && c.url.endsWith('/api/rooms'))).toBeUndefined()
   })
 
-  it('creates the room when not found, then adds the agent', async () => {
+  it('creates a new DM when none exists with the peer, and adds the peer as a member', async () => {
     globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input)
       const method = init?.method ?? 'GET'
-      const bodyTxt = init?.body
-      calls.push({ url, method, body: bodyTxt ? JSON.parse(String(bodyTxt)) : undefined })
-      if (url.endsWith('/api/rooms') && method === 'GET') {
-        return jsonResponse(200, [])
-      }
+      const body = init?.body ? JSON.parse(String(init.body)) : undefined
+      calls.push({ url, method, body })
+      if (url.endsWith('/api/rooms') && method === 'GET') return jsonResponse(200, [])
       if (url.endsWith('/api/rooms') && method === 'POST') {
-        return jsonResponse(200, { id: 'room-new', name: 'fresh', kind: 'channel' })
+        // Backend auto-adds the caller; we ask for the peer in `members`.
+        return jsonResponse(200, { id: 'r-new', name: 'agent-y@id', kind: 'dm' })
       }
-      if (url.includes('/api/rooms/room-new/members') && method === 'POST') {
-        return jsonResponse(200, { userEmail: 'agent-y@id', role: 'member', joinedAt: 1 })
-      }
-      throw new Error(`unexpected fetch ${method} ${url}`)
+      throw new Error(`unexpected ${method} ${url}`)
     }) as typeof fetch
 
-    const out = await ensureRoomMembership({
+    const out = await ensureDmWith({
       callerBearer: 'tok',
-      roomName: 'fresh',
-      agentEmail: 'agent-y@id',
+      callerEmail: 'patrick@hofmann.eco',
+      peerEmail: 'agent-y@id',
     })
-    expect(out).toEqual({ roomId: 'room-new', created: true })
-    expect(calls).toHaveLength(3)
-    expect(calls[1]!.body).toEqual({ name: 'fresh', kind: 'channel', members: [] })
-    expect(calls[2]!.body).toEqual({ email: 'agent-y@id', role: 'member' })
+
+    expect(out).toEqual({ roomId: 'r-new', created: true })
+    const post = calls.find(c => c.method === 'POST')
+    expect(post?.body).toEqual({ name: 'agent-y@id', kind: 'dm', members: ['agent-y@id'] })
+  })
+
+  it('skips DMs whose member sets contain other emails (no false reuse)', async () => {
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/api/rooms')) {
+        return jsonResponse(200, [{ id: 'r-3way', name: 'oddly named', kind: 'dm' }])
+      }
+      if (url.includes('/members')) {
+        return jsonResponse(200, [
+          { userEmail: 'patrick@hofmann.eco', role: 'admin', joinedAt: 1 },
+          { userEmail: 'someone@else', role: 'member', joinedAt: 1 },
+          { userEmail: 'third@person', role: 'member', joinedAt: 1 },
+        ])
+      }
+      throw new Error('boom')
+    }) as typeof fetch
+
+    // Add a POST handler so the create path is reachable.
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      const method = init?.method ?? 'GET'
+      if (url.endsWith('/api/rooms') && method === 'POST') {
+        return jsonResponse(200, { id: 'r-fresh', name: 'p@e', kind: 'dm' })
+      }
+      return originalFetch(input, init)
+    }) as typeof fetch
+
+    const out = await ensureDmWith({
+      callerBearer: 'tok',
+      callerEmail: 'patrick@hofmann.eco',
+      peerEmail: 'p@e',
+    })
+    expect(out.created).toBe(true)
+    expect(out.roomId).toBe('r-fresh')
   })
 
   it('surfaces server-side errors with status code', async () => {
     globalThis.fetch = vi.fn(async () => jsonResponse(401, { error: 'nope' })) as typeof fetch
-    await expect(ensureRoomMembership({
+    await expect(ensureDmWith({
       callerBearer: 'bad',
-      roomName: 'x',
-      agentEmail: 'a@b',
+      callerEmail: 'a@b',
+      peerEmail: 'c@d',
     })).rejects.toThrow(/401/)
   })
 })


### PR DESCRIPTION
## Why

Multi-member rooms with both humans and agents trigger an "agent reply-loop" — agents respond to each other's messages because the bridge has no way to filter agent vs human. Saw this live with two bot agents in the same demo room.

Until the contacts model (Phase A) lands and we have proper friend-request/accept semantics, the safest path is to constrain everything to 1:1.

## Changes

### chat-app UI
- \`apps/openape-chat/app/pages/index.vue\`: filters the room list to \`kind === 'dm'\`. The "+ new room" button + create-modal removed. Empty-state copy points users at \`apes agents spawn --bridge\`. Existing channels are not deleted — just hidden from the sidebar (direct URL access still works for back-compat).

### apes spawn
- \`--bridge-room <name>\` flag removed. \`apes agents spawn --bridge\` now auto-creates a DM between the spawning user and the new agent (kind='dm', members=[caller, agent]).
- New helper \`ensureDmWith()\` in \`lib/chat-room.ts\` looks for an existing DM with that exact member set first; idempotent re-spawn.

### Tests
- \`agents-chat-room.test.ts\` updated for the new helper: reuse-existing-DM, create-when-missing, reject-3-way (must be exactly 2 members), error path.

## Out of scope (separate work)

- Server-side enforcement that DMs have exactly 2 members (today the schema permits more — PR is on best-behavior client-side)
- \`contacts\` table + friend-request / accept flow (Phase A)
- Re-introducing channels under a "verified-human-only" guard

## Migration

- Existing channels invisible in UI; nothing destructive.
- Existing agents (already in channels) keep working — direct URL access opens the room.
- New \`apes agents spawn agent-X --bridge\` immediately gives a DM. No channel side-effect.