### PR TITLE
feat(chat): Phase A frontend + CLI — contacts UI, ape-chat contacts, apes agents allow

### DIFF
--- a/.changeset/phase-a-frontend-cli.md
+++ b/.changeset/phase-a-frontend-cli.md
@@ -1,0 +1,12 @@
+---
+"@openape/apes": minor
+"@openape/ape-chat": minor
+"@openape/chat-bridge": patch
+---
+
+Phase A frontend + CLI:
+
+- chat.openape.ai webapp shows contacts (incoming pending, connected, outgoing pending) with accept/decline/cancel actions and an "Add contact" dialog. Mobile-first. Live-updates via WS membership-* frames.
+- `@openape/ape-chat`: new `contacts list / add / accept / remove` subcommand.
+- `@openape/apes`: new `apes agents allow <agent> <peer-email>` — adds peer to the agent's bridge-allowlist file so the bridge auto-accepts that peer's contact request.
+- chat-bridge polls the allowlist + pending contacts every 30s while connected, so an `apes agents allow` change takes effect within half a minute without a daemon restart.

--- a/apps/openape-chat-bridge/src/bridge.ts
+++ b/apps/openape-chat-bridge/src/bridge.ts
@@ -31,6 +31,7 @@ const DEFAULT_MODEL = 'gpt-5.4'
 const PING_INTERVAL_MS = 30_000
 const RECONNECT_BASE_MS = 1000
 const RECONNECT_MAX_MS = 30_000
+const ALLOWLIST_POLL_INTERVAL_MS = 30_000
 
 interface Message {
   id: string
@@ -196,6 +197,7 @@ class Bridge {
     const ws = new WebSocket(wsUrl)
     return new Promise<void>((resolve, reject) => {
       let pingTimer: NodeJS.Timeout | undefined
+      let allowlistTimer: NodeJS.Timeout | undefined
 
       ws.on('open', () => {
         log(`connected as ${this.selfEmail} → ${this.cfg.endpoint}`)
@@ -211,6 +213,14 @@ class Bridge {
         void this.acceptAllowedPendingContacts().catch((err) => {
           log(`accept-pending-contacts failed: ${err instanceof Error ? err.message : String(err)}`)
         })
+        // Re-poll the allowlist + pending contacts every 30s so an
+        // `apes agents allow <agent> <peer>` call gets picked up within
+        // half a minute without a daemon restart.
+        allowlistTimer = setInterval(() => {
+          void this.acceptAllowedPendingContacts().catch((err) => {
+            log(`allowlist re-poll failed: ${err instanceof Error ? err.message : String(err)}`)
+          })
+        }, ALLOWLIST_POLL_INTERVAL_MS)
       })
 
       ws.on('message', (data: WebSocket.RawData) => {
@@ -227,10 +237,12 @@ class Bridge {
 
       ws.on('close', () => {
         if (pingTimer) clearInterval(pingTimer)
+        if (allowlistTimer) clearInterval(allowlistTimer)
         resolve()
       })
       ws.on('error', (err: Error) => {
         if (pingTimer) clearInterval(pingTimer)
+        if (allowlistTimer) clearInterval(allowlistTimer)
         reject(err)
       })
     })

--- a/apps/openape-chat-cli/src/api.ts
+++ b/apps/openape-chat-cli/src/api.ts
@@ -116,3 +116,7 @@ export function removeMember(
     { method: 'DELETE', endpoint: opts?.endpoint },
   )
 }
+
+// Exported for new command modules (contacts.ts) that POST/DELETE
+// arbitrary chat-app paths without a dedicated wrapper.
+export { request as _request }

--- a/apps/openape-chat-cli/src/cli.ts
+++ b/apps/openape-chat-cli/src/cli.ts
@@ -1,5 +1,6 @@
 import { defineCommand, runMain } from 'citty'
 import { ApiError } from './api'
+import { contactsCommand } from './commands/contacts'
 import { docsCommand } from './commands/docs'
 import { listCommand } from './commands/list'
 import { membersCommand } from './commands/members'
@@ -8,7 +9,7 @@ import { sendCommand } from './commands/send'
 import { watchCommand } from './commands/watch'
 import { whoamiCommand } from './commands/whoami'
 
-const VERSION = '0.1.0'
+const VERSION = '0.2.0'
 
 const main = defineCommand({
   meta: {
@@ -18,6 +19,7 @@ const main = defineCommand({
   },
   subCommands: {
     whoami: whoamiCommand,
+    contacts: contactsCommand,
     rooms: roomsCommand,
     send: sendCommand,
     list: listCommand,

--- a/apps/openape-chat-cli/src/commands/contacts.ts
+++ b/apps/openape-chat-cli/src/commands/contacts.ts
@@ -1,0 +1,128 @@
+import { defineCommand } from 'citty'
+import { ApiError, _request as request } from '../api'
+import { fmtTime, printJson, printLine } from '../output'
+
+interface ContactView {
+  peerEmail: string
+  myStatus: 'accepted' | 'pending' | 'blocked'
+  theirStatus: 'accepted' | 'pending' | 'blocked'
+  connected: boolean
+  roomId: string | null
+  requestedAt: number
+  acceptedAt: number | null
+}
+
+function listContactsApi(): Promise<ContactView[]> {
+  return request<ContactView[]>('/api/contacts')
+}
+function addContactApi(email: string): Promise<ContactView> {
+  return request<ContactView>('/api/contacts', { method: 'POST', body: { email } })
+}
+function acceptContactApi(email: string): Promise<ContactView> {
+  return request<ContactView>(`/api/contacts/${encodeURIComponent(email)}/accept`, { method: 'POST' })
+}
+function removeContactApi(email: string): Promise<{ ok: true }> {
+  return request<{ ok: true }>(`/api/contacts/${encodeURIComponent(email)}`, { method: 'DELETE' })
+}
+
+const listSub = defineCommand({
+  meta: { name: 'list', description: 'List contacts (connected, pending in/out)' },
+  args: {
+    json: { type: 'boolean', default: false },
+  },
+  async run({ args }) {
+    const all = await listContactsApi()
+    if (args.json) {
+      printJson(all)
+      return
+    }
+    if (all.length === 0) {
+      printLine('(no contacts — `ape-chat contacts add <email>` to send a request)')
+      return
+    }
+    for (const c of all) {
+      const tag = c.connected
+        ? 'connected '
+        : c.myStatus === 'pending'
+          ? 'incoming  '
+          : c.theirStatus === 'pending'
+            ? 'outgoing  '
+            : c.myStatus
+      const ts = c.acceptedAt ?? c.requestedAt
+      printLine(`${tag}  ${c.peerEmail.padEnd(44)}  ${fmtTime(ts)}`)
+    }
+  },
+})
+
+const addSub = defineCommand({
+  meta: { name: 'add', description: 'Send a contact request' },
+  args: {
+    email: { type: 'positional', required: true, description: 'Email of the peer' },
+    json: { type: 'boolean', default: false },
+  },
+  async run({ args }) {
+    const view = await addContactApi(args.email)
+    if (args.json) {
+      printJson(view)
+      return
+    }
+    if (view.connected) {
+      printLine(`✔ already connected to ${view.peerEmail}`)
+    }
+    else {
+      printLine(`✔ request sent to ${view.peerEmail} (waiting for accept)`)
+    }
+  },
+})
+
+const acceptSub = defineCommand({
+  meta: { name: 'accept', description: 'Accept a pending incoming request' },
+  args: {
+    email: { type: 'positional', required: true },
+    json: { type: 'boolean', default: false },
+  },
+  async run({ args }) {
+    try {
+      const view = await acceptContactApi(args.email)
+      if (args.json) {
+        printJson(view)
+        return
+      }
+      printLine(view.connected
+        ? `✔ accepted — connected to ${view.peerEmail}`
+        : `✔ marked accepted on your side; waiting for ${view.peerEmail}`)
+    }
+    catch (err) {
+      if (err instanceof ApiError && err.status === 404) {
+        throw new ApiError(404, `no pending request from ${args.email}`)
+      }
+      throw err
+    }
+  },
+})
+
+const removeSub = defineCommand({
+  meta: { name: 'remove', description: 'Unfriend (or cancel an outgoing request)' },
+  args: {
+    email: { type: 'positional', required: true },
+    json: { type: 'boolean', default: false },
+  },
+  async run({ args }) {
+    await removeContactApi(args.email)
+    if (args.json) {
+      printJson({ removed: args.email })
+      return
+    }
+    printLine(`✔ removed ${args.email}`)
+  },
+})
+
+export const contactsCommand = defineCommand({
+  meta: { name: 'contacts', description: 'List, add, accept, or remove 1:1 contacts' },
+  subCommands: {
+    list: listSub,
+    add: addSub,
+    accept: acceptSub,
+    remove: removeSub,
+  },
+})

--- a/apps/openape-chat/app/pages/index.vue
+++ b/apps/openape-chat/app/pages/index.vue
@@ -1,11 +1,14 @@
 <script setup lang="ts">
-interface RoomRow {
-  id: string
-  name: string
-  kind: 'channel' | 'dm'
-  createdByEmail: string
-  createdAt: number
-  role: 'member' | 'admin'
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+
+interface ContactRow {
+  peerEmail: string
+  myStatus: 'accepted' | 'pending' | 'blocked'
+  theirStatus: 'accepted' | 'pending' | 'blocked'
+  connected: boolean
+  roomId: string | null
+  requestedAt: number
+  acceptedAt: number | null
 }
 
 // Driven by the SP module's composable. `user` becomes null on 401, so a
@@ -17,20 +20,117 @@ if (!user.value && import.meta.client) {
   navigateTo('/login')
 }
 
-const { data: allRooms } = await useFetch<RoomRow[]>('/api/rooms', {
+const { data: contacts, refresh: refreshContacts } = await useFetch<ContactRow[]>('/api/contacts', {
   default: () => [],
 })
 
-// Channel-style rooms (group chats) are hidden until the contacts model
-// (Phase A) ships — letting an agent loose in a multi-member room with no
-// way to filter agent vs human created reply-loops between agents. DMs
-// (1:1) stay visible because the membership shape inherently bounds the
-// participants.
-const rooms = computed(() => (allRooms.value ?? []).filter(r => r.kind === 'dm'))
+// Three buckets — keeps the sidebar scannable. Sorted by most-recent
+// activity (acceptedAt for connected, requestedAt for pending).
+const incoming = computed(() => (contacts.value ?? [])
+  .filter(c => c.myStatus === 'pending' && c.theirStatus === 'accepted')
+  .sort((a, b) => b.requestedAt - a.requestedAt))
+const connected = computed(() => (contacts.value ?? [])
+  .filter(c => c.connected)
+  .sort((a, b) => (b.acceptedAt ?? 0) - (a.acceptedAt ?? 0)))
+const outgoing = computed(() => (contacts.value ?? [])
+  .filter(c => c.myStatus === 'accepted' && c.theirStatus === 'pending')
+  .sort((a, b) => b.requestedAt - a.requestedAt))
+
+const showAdd = ref(false)
+const addEmail = ref('')
+const adding = ref(false)
+const addError = ref<string | null>(null)
+
+async function addContact() {
+  addError.value = null
+  const email = addEmail.value.trim().toLowerCase()
+  if (!email) return
+  adding.value = true
+  try {
+    await $fetch('/api/contacts', { method: 'POST', body: { email } })
+    addEmail.value = ''
+    showAdd.value = false
+    await refreshContacts()
+  }
+  catch (err: unknown) {
+    addError.value = err instanceof Error ? err.message : 'Failed to add contact'
+  }
+  finally {
+    adding.value = false
+  }
+}
+
+const acting = ref<Set<string>>(new Set())
+function startAct(email: string) { acting.value = new Set([...acting.value, email]) }
+function endAct(email: string) {
+  const next = new Set(acting.value)
+  next.delete(email)
+  acting.value = next
+}
+
+async function acceptContact(email: string) {
+  startAct(email)
+  try {
+    await $fetch(`/api/contacts/${encodeURIComponent(email)}/accept`, { method: 'POST' })
+    await refreshContacts()
+  }
+  finally {
+    endAct(email)
+  }
+}
+
+async function removeContact(email: string) {
+  startAct(email)
+  try {
+    await $fetch(`/api/contacts/${encodeURIComponent(email)}`, { method: 'DELETE' })
+    await refreshContacts()
+  }
+  finally {
+    endAct(email)
+  }
+}
+
+// Live refresh on membership-* WS frames (peer accepted / contact change).
+// The chat-app already broadcasts these; we just consume them.
+let ws: WebSocket | null = null
+async function openLiveSocket() {
+  if (!import.meta.client) return
+  const tok = await $fetch<{ token: string }>('/api/ws-token')
+  const url = `${location.origin.replace(/^http/, 'ws')}/api/ws?token=${encodeURIComponent(tok.token)}`
+  ws = new WebSocket(url)
+  ws.addEventListener('message', (ev) => {
+    try {
+      const frame = JSON.parse(ev.data) as { type?: string }
+      if (frame.type?.startsWith('membership-')) {
+        void refreshContacts()
+      }
+    }
+    catch {
+      // ignore
+    }
+  })
+  ws.addEventListener('close', () => { ws = null })
+}
+
+onMounted(() => { void openLiveSocket() })
+onBeforeUnmount(() => { ws?.close() })
 
 async function logout() {
   await spLogout()
   navigateTo('/login')
+}
+
+function shortEmail(email: string): string {
+  // Agents are very long: agent-bot1+patrick+hofmann_eco@id.openape.ai →
+  // "agent-bot1". Humans stay full.
+  if (email.endsWith('@id.openape.ai') && email.includes('+')) {
+    return email.split('+')[0] ?? email
+  }
+  return email
+}
+
+function isAgent(email: string): boolean {
+  return email.endsWith('@id.openape.ai')
 }
 </script>
 
@@ -45,6 +145,13 @@ async function logout() {
         <span v-if="user.act === 'agent'">🤖</span>
       </span>
       <UButton
+        icon="i-lucide-user-plus"
+        size="sm"
+        color="primary"
+        aria-label="Add contact"
+        @click="showAdd = true"
+      />
+      <UButton
         icon="i-lucide-log-out"
         size="sm"
         color="neutral"
@@ -58,28 +165,155 @@ async function logout() {
       <ClientOnly>
         <EnableNotifications />
       </ClientOnly>
-      <p v-if="!rooms?.length" class="p-8 text-center text-zinc-500 text-sm">
-        No direct chats yet.<br>
-        Spawn an agent with <code class="text-zinc-300">apes agents spawn &lt;name&gt; --bridge</code>
+
+      <!-- Empty state -->
+      <p
+        v-if="!incoming.length && !connected.length && !outgoing.length"
+        class="p-8 text-center text-zinc-500 text-sm"
+      >
+        No contacts yet.<br>
+        Tap <UIcon name="i-lucide-user-plus" class="size-3 inline-block align-text-top" /> to add one,
+        or spawn an agent with
+        <code class="text-zinc-300">apes agents spawn &lt;name&gt; --bridge</code>
         to start a conversation.
       </p>
-      <ul v-else class="divide-y divide-zinc-800">
-        <li v-for="room of rooms" :key="room.id">
-          <NuxtLink
-            :to="`/rooms/${room.id}`"
-            class="block px-4 py-3 hover:bg-zinc-900 active:bg-zinc-800 transition-colors"
-          >
-            <div class="flex items-center gap-2">
-              <UIcon
-                :name="room.kind === 'dm' ? 'i-lucide-message-circle' : 'i-lucide-hash'"
-                class="text-zinc-500 size-4 shrink-0"
-              />
-              <span class="font-medium truncate">{{ room.name }}</span>
-              <span v-if="room.role === 'admin'" class="text-xs text-zinc-500 shrink-0">admin</span>
+
+      <!-- Incoming pending -->
+      <section v-if="incoming.length" class="border-b border-zinc-800">
+        <h2 class="px-4 pt-4 pb-2 text-xs font-medium uppercase tracking-wide text-zinc-500">
+          Pending requests · {{ incoming.length }}
+        </h2>
+        <ul class="divide-y divide-zinc-800">
+          <li v-for="c of incoming" :key="c.peerEmail" class="px-4 py-3 flex items-center gap-3">
+            <UIcon
+              :name="isAgent(c.peerEmail) ? 'i-lucide-bot' : 'i-lucide-user'"
+              class="text-zinc-500 size-5 shrink-0"
+            />
+            <div class="flex-1 min-w-0">
+              <div class="font-medium truncate">
+                {{ shortEmail(c.peerEmail) }}
+              </div>
+              <div class="text-xs text-zinc-500 truncate">
+                {{ c.peerEmail }}
+              </div>
             </div>
-          </NuxtLink>
-        </li>
-      </ul>
+            <UButton
+              size="sm"
+              color="primary"
+              :loading="acting.has(c.peerEmail)"
+              :disabled="acting.has(c.peerEmail)"
+              @click="acceptContact(c.peerEmail)"
+            >
+              Accept
+            </UButton>
+            <UButton
+              size="sm"
+              color="neutral"
+              variant="ghost"
+              icon="i-lucide-x"
+              aria-label="Decline"
+              :disabled="acting.has(c.peerEmail)"
+              @click="removeContact(c.peerEmail)"
+            />
+          </li>
+        </ul>
+      </section>
+
+      <!-- Connected contacts -->
+      <section v-if="connected.length">
+        <h2 class="px-4 pt-4 pb-2 text-xs font-medium uppercase tracking-wide text-zinc-500">
+          Contacts · {{ connected.length }}
+        </h2>
+        <ul class="divide-y divide-zinc-800">
+          <li v-for="c of connected" :key="c.peerEmail">
+            <NuxtLink
+              v-if="c.roomId"
+              :to="`/rooms/${c.roomId}`"
+              class="block px-4 py-3 hover:bg-zinc-900 active:bg-zinc-800 transition-colors"
+            >
+              <div class="flex items-center gap-3">
+                <UIcon
+                  :name="isAgent(c.peerEmail) ? 'i-lucide-bot' : 'i-lucide-user'"
+                  class="text-zinc-500 size-5 shrink-0"
+                />
+                <div class="flex-1 min-w-0">
+                  <div class="font-medium truncate">
+                    {{ shortEmail(c.peerEmail) }}
+                  </div>
+                  <div class="text-xs text-zinc-500 truncate">
+                    {{ c.peerEmail }}
+                  </div>
+                </div>
+              </div>
+            </NuxtLink>
+          </li>
+        </ul>
+      </section>
+
+      <!-- Outgoing pending -->
+      <section v-if="outgoing.length" class="border-t border-zinc-800">
+        <h2 class="px-4 pt-4 pb-2 text-xs font-medium uppercase tracking-wide text-zinc-500">
+          Waiting for · {{ outgoing.length }}
+        </h2>
+        <ul class="divide-y divide-zinc-800">
+          <li v-for="c of outgoing" :key="c.peerEmail" class="px-4 py-3 flex items-center gap-3">
+            <UIcon
+              :name="isAgent(c.peerEmail) ? 'i-lucide-bot' : 'i-lucide-user'"
+              class="text-zinc-500 size-5 shrink-0 opacity-50"
+            />
+            <div class="flex-1 min-w-0 opacity-70">
+              <div class="truncate">
+                {{ shortEmail(c.peerEmail) }}
+              </div>
+              <div class="text-xs text-zinc-500 truncate">
+                {{ c.peerEmail }} · pending
+              </div>
+            </div>
+            <UButton
+              size="sm"
+              color="neutral"
+              variant="ghost"
+              icon="i-lucide-x"
+              aria-label="Cancel request"
+              :disabled="acting.has(c.peerEmail)"
+              @click="removeContact(c.peerEmail)"
+            />
+          </li>
+        </ul>
+      </section>
     </main>
+
+    <UModal v-model:open="showAdd">
+      <template #content>
+        <form class="p-6 space-y-4" @submit.prevent="addContact">
+          <h2 class="text-lg font-semibold">
+            Add contact
+          </h2>
+          <p class="text-sm text-zinc-400">
+            Sends a friend request to the email below. Once they accept (or send a request back) you can chat.
+          </p>
+          <UFormField label="Email" required>
+            <UInput
+              v-model="addEmail"
+              type="email"
+              placeholder="alice@example.com"
+              autocomplete="email"
+              autofocus
+            />
+          </UFormField>
+          <p v-if="addError" class="text-sm text-red-400">
+            {{ addError }}
+          </p>
+          <div class="flex gap-2 justify-end">
+            <UButton color="neutral" variant="ghost" @click="showAdd = false">
+              Cancel
+            </UButton>
+            <UButton type="submit" color="primary" :loading="adding" :disabled="!addEmail.trim()">
+              Send request
+            </UButton>
+          </div>
+        </form>
+      </template>
+    </UModal>
   </div>
 </template>

--- a/packages/apes/src/commands/agents/allow.ts
+++ b/packages/apes/src/commands/agents/allow.ts
@@ -1,0 +1,82 @@
+import { execFileSync } from 'node:child_process'
+import { defineCommand } from 'citty'
+import consola from 'consola'
+import { CliError } from '../../errors'
+import { AGENT_NAME_REGEX } from '../../lib/agent-bootstrap'
+import { isDarwin, readMacOSUser, whichBinary } from '../../lib/macos-user'
+
+export const allowAgentCommand = defineCommand({
+  meta: {
+    name: 'allow',
+    description:
+      'Add a peer to the agent\'s contact-allowlist so the bridge auto-accepts that peer\'s contact request.',
+  },
+  args: {
+    agent: {
+      type: 'positional',
+      required: true,
+      description: 'Agent name (the macOS short username spawn created)',
+    },
+    email: {
+      type: 'positional',
+      required: true,
+      description: 'Peer email to allow (the address that will send the contact request)',
+    },
+  },
+  async run({ args }) {
+    const agent = args.agent as string
+    const email = (args.email as string).trim().toLowerCase()
+    if (!AGENT_NAME_REGEX.test(agent)) {
+      throw new CliError(`Invalid agent name "${agent}".`)
+    }
+    if (!email.includes('@')) {
+      throw new CliError(`Invalid email "${email}".`)
+    }
+    if (!isDarwin()) {
+      throw new CliError('`apes agents allow` is currently macOS-only.')
+    }
+    if (!readMacOSUser(agent)) {
+      throw new CliError(`No macOS user "${agent}" — has the agent been spawned?`)
+    }
+    const apes = whichBinary('apes')
+    if (!apes) throw new CliError('`apes` not found on PATH.')
+
+    // Update the allowlist file inside the agent's home. python3 is
+    // always present on macOS — avoids a jq dep. Idempotent: re-running
+    // for the same email is a no-op.
+    const script = `set -eu
+mkdir -p "$HOME/.config/openape"
+F="$HOME/.config/openape/bridge-allowlist.json"
+EMAIL=${shQuote(email)}
+python3 - "$F" "$EMAIL" <<'PY'
+import json, os, sys
+path, email = sys.argv[1], sys.argv[2].lower()
+data = {"emails": []}
+if os.path.exists(path):
+    try:
+        with open(path) as f:
+            data = json.load(f)
+        if not isinstance(data, dict) or not isinstance(data.get("emails"), list):
+            data = {"emails": []}
+    except Exception:
+        data = {"emails": []}
+emails = {e.lower() for e in data["emails"] if isinstance(e, str)}
+emails.add(email)
+data["emails"] = sorted(emails)
+with open(path, "w") as f:
+    json.dump(data, f, indent=2)
+    f.write("\\n")
+print("ok")
+PY
+chmod 600 "$F"
+`
+
+    consola.start(`Adding ${email} to ${agent}'s allowlist…`)
+    execFileSync(apes, ['run', '--as', agent, '--wait', '--', 'bash', '-c', script], { stdio: 'inherit' })
+    consola.success(`${agent} will auto-accept future contact requests from ${email} (within ~30s of next bridge connect).`)
+  },
+})
+
+function shQuote(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`
+}

--- a/packages/apes/src/commands/agents/index.ts
+++ b/packages/apes/src/commands/agents/index.ts
@@ -1,4 +1,5 @@
 import { defineCommand } from 'citty'
+import { allowAgentCommand } from './allow'
 import { destroyAgentCommand } from './destroy'
 import { listAgentsCommand } from './list'
 import { registerAgentCommand } from './register'
@@ -7,12 +8,13 @@ import { spawnAgentCommand } from './spawn'
 export const agentsCommand = defineCommand({
   meta: {
     name: 'agents',
-    description: 'Manage owned agents (register, spawn, list, destroy)',
+    description: 'Manage owned agents (register, spawn, list, destroy, allow)',
   },
   subCommands: {
     register: registerAgentCommand,
     spawn: spawnAgentCommand,
     list: listAgentsCommand,
     destroy: destroyAgentCommand,
+    allow: allowAgentCommand,
   },
 })


### PR DESCRIPTION
Closes #252.

User-facing side of #250. Backend lives since apes 0.28.0 + chat-bridge 0.2.1 + chat-app prod.

## Chat webapp

- Sidebar: incoming pending requests (accept / decline), connected contacts (tap to open), outgoing pending (cancel).
- "Add contact" toolbar button → modal with email input → POST /api/contacts.
- Live updates via existing WS membership-* frames.
- Mobile-first sections, comfortable tap targets.

## ape-chat CLI

- \`contacts list / add / accept / remove\` subcommand.

## apes

- \`apes agents allow <agent> <peer-email>\` — adds peer to the agent's bridge-allowlist (\`~/.config/openape/bridge-allowlist.json\` inside agent home). Future incoming contact requests from that peer get auto-accepted by the bridge within ~30s.

## Bridge

- 30s allowlist re-poll on top of the existing on-WS-connect check, so \`apes agents allow\` lands without a daemon restart.

## Tests

- All 17 chat-bridge + 614 apes tests still pass.
- chat-app has no test suite (pre-existing); manual verification post-deploy.