### PR TITLE
feat(chat): Phase B — multiple threads per DM

### DIFF
--- a/.changeset/phase-b-threads.md
+++ b/.changeset/phase-b-threads.md
@@ -1,0 +1,12 @@
+---
+'@openape/chat': minor
+'@openape/ape-chat': minor
+'@openape/chat-bridge': minor
+---
+
+Phase B: multiple parallel threads per chat room (ChatGPT-style sessions per contact).
+
+- Server: new `threads` table + `messages.thread_id` column. New endpoints `GET/POST /api/rooms/:id/threads`, `PATCH/DELETE /api/threads/:id`. `messages.get` accepts `thread_id` filter; `messages.post` accepts `thread_id` and falls back to a lazily-created `main` thread for back-compat with existing rooms. Contacts auto-create the main thread on DM creation.
+- Bridge: pi-RPC sessions are now keyed by `(roomId, threadId)` so parallel conversations with the same human stay in independent contexts. Inbound messages without `threadId` are dropped (server guarantees the field).
+- CLI: new `ape-chat threads {list|new|use|rename|archive}` command, plus `--thread` flags on `send` and `list`. Active thread is remembered per-room in `~/.openape/auth-chat.json`.
+- Webapp: thread switcher tabs in the room view (mobile-first horizontal scroll), `+` to create a thread inline, messages and outgoing posts scoped to the active thread.

--- a/apps/openape-chat-bridge/src/bridge.ts
+++ b/apps/openape-chat-bridge/src/bridge.ts
@@ -21,7 +21,7 @@ import WebSocket from 'ws'
 import { ChatApi } from './chat-api'
 import { readAgentIdentity, readAllowlist, shouldAutoAccept } from './identity'
 import { PiRpcSession } from './pi-rpc'
-import { RoomSession } from './room-session'
+import { ThreadSession } from './thread-session'
 
 const DEFAULT_ENDPOINT = 'https://chat.openape.ai'
 const DEFAULT_PI_BIN = 'pi'
@@ -36,6 +36,7 @@ const ALLOWLIST_POLL_INTERVAL_MS = 30_000
 interface Message {
   id: string
   roomId: string
+  threadId: string
   senderEmail: string
   senderAct: 'human' | 'agent'
   body: string
@@ -90,7 +91,10 @@ function truncate(s: string, n: number): string {
 }
 
 class Bridge {
-  private rooms = new Map<string, RoomSession>()
+  // Sessions keyed by `${roomId}:${threadId}` — Phase B keeps an
+  // independent pi context per chat thread so parallel conversations
+  // with the same human contact don't bleed into each other.
+  private threads = new Map<string, ThreadSession>()
   private chat: ChatApi
   private bearer: () => Promise<string>
 
@@ -164,30 +168,39 @@ class Bridge {
     if (msg.senderEmail === this.selfEmail) return
     if (!msg.body.trim()) return
     if (this.cfg.roomFilter && msg.roomId !== this.cfg.roomFilter) return
+    // Phase-B-aware servers always include `threadId`; for resilience
+    // against an older server (or a stray pre-Phase-B frame) we'd have
+    // no good fallback — the server now refuses thread-less inserts.
+    if (!msg.threadId) {
+      log(`[${msg.roomId}] dropping message ${msg.id} without threadId — server too old?`)
+      return
+    }
 
-    log(`[${msg.roomId}] in: ${truncate(msg.body, 80)}`)
-    const session = this.getOrCreateRoom(msg.roomId)
+    log(`[${msg.roomId}/${msg.threadId.slice(0, 8)}] in: ${truncate(msg.body, 80)}`)
+    const session = this.getOrCreateThread(msg.roomId, msg.threadId)
     session.enqueue(msg.body, msg.id)
   }
 
-  private getOrCreateRoom(roomId: string): RoomSession {
-    let s = this.rooms.get(roomId)
+  private getOrCreateThread(roomId: string, threadId: string): ThreadSession {
+    const key = `${roomId}:${threadId}`
+    let s = this.threads.get(key)
     if (s) return s
     const pi = new PiRpcSession({
       binary: this.cfg.piBin,
       args: ['--provider', this.cfg.provider, '--model', this.cfg.model, '--no-session'],
     })
     pi.onExit((code) => {
-      log(`[${roomId}] pi exited code=${code} — recreating on next message`)
-      this.rooms.delete(roomId)
+      log(`[${roomId}/${threadId.slice(0, 8)}] pi exited code=${code} — recreating on next message`)
+      this.threads.delete(key)
     })
-    s = new RoomSession({
+    s = new ThreadSession({
       roomId,
+      threadId,
       chat: this.chat,
       pi,
       log,
     })
-    this.rooms.set(roomId, s)
+    this.threads.set(key, s)
     return s
   }
 

--- a/apps/openape-chat-bridge/src/chat-api.ts
+++ b/apps/openape-chat-bridge/src/chat-api.ts
@@ -7,6 +7,7 @@ import { ofetch } from 'ofetch'
 export interface PostedMessage {
   id: string
   roomId: string
+  threadId: string
   body: string
   createdAt: number
 }
@@ -24,13 +25,20 @@ const MAX_BODY = 10_000
 export class ChatApi {
   constructor(private endpoint: string, private bearer: () => Promise<string>) {}
 
-  async postMessage(roomId: string, body: string, replyTo?: string): Promise<PostedMessage> {
+  async postMessage(
+    roomId: string,
+    body: string,
+    opts: { replyTo?: string, threadId?: string } = {},
+  ): Promise<PostedMessage> {
     const trimmed = clamp(body, MAX_BODY)
     const url = `${this.endpoint}/api/rooms/${encodeURIComponent(roomId)}/messages`
+    const payload: Record<string, unknown> = { body: trimmed }
+    if (opts.replyTo) payload.reply_to = opts.replyTo
+    if (opts.threadId) payload.thread_id = opts.threadId
     const result = await ofetch<PostedMessage>(url, {
       method: 'POST',
       headers: { Authorization: await this.bearer() },
-      body: replyTo ? { body: trimmed, reply_to: replyTo } : { body: trimmed },
+      body: payload,
     })
     return result
   }

--- a/apps/openape-chat-bridge/src/thread-session.ts
+++ b/apps/openape-chat-bridge/src/thread-session.ts
@@ -1,7 +1,12 @@
-// One RoomSession per chat room. Owns a long-lived pi RPC subprocess,
-// a queue of pending prompts, and the placeholder message id for the
-// in-flight turn. Streams pi text deltas back into the chat by
-// PATCHing the placeholder.
+// One ThreadSession per (room, thread). Owns a long-lived pi RPC
+// subprocess, a queue of pending prompts, and the placeholder message
+// id for the in-flight turn. Streams pi text deltas back into the chat
+// by PATCHing the placeholder.
+//
+// Phase B: each chat thread is an isolated pi conversation. The bridge
+// keeps one of these per (roomId, threadId) so the agent can hold
+// parallel ChatGPT-style sessions with the same human contact without
+// cross-contamination.
 
 import type { ChatApi } from './chat-api'
 import type { PiEvent, PiRpcSession } from './pi-rpc'
@@ -17,19 +22,20 @@ interface ActiveTurn {
   replyToMessageId: string
 }
 
-export interface RoomSessionDeps {
+export interface ThreadSessionDeps {
   roomId: string
+  threadId: string
   chat: ChatApi
   pi: PiRpcSession
   /** Logger sink — bridge typically forwards to stderr. */
   log: (line: string) => void
 }
 
-export class RoomSession {
+export class ThreadSession {
   private active: ActiveTurn | undefined
   private queue: Array<{ body: string, replyToMessageId: string }> = []
 
-  constructor(private deps: RoomSessionDeps) {
+  constructor(private deps: ThreadSessionDeps) {
     this.deps.pi.on(event => this.onPiEvent(event))
   }
 
@@ -43,14 +49,14 @@ export class RoomSession {
   }
 
   private async startTurn(body: string, replyToMessageId: string): Promise<void> {
-    const placeholder = await this.deps.chat.postMessage(this.deps.roomId, '…', replyToMessageId)
+    const placeholder = await this.deps.chat.postMessage(this.deps.roomId, '…', {
+      replyTo: replyToMessageId,
+      threadId: this.deps.threadId,
+    })
     const turn: ActiveTurn = {
       placeholderId: placeholder.id,
       accumulated: '',
       replyToMessageId,
-      // The throttle rebinds to `turn` via closure — when the turn ends
-      // we cancel before clearing `this.active`, so the captured ref is
-      // never used after teardown.
       throttle: createThrottle(async () => {
         if (!this.active || this.active.placeholderId !== placeholder.id) return
         const text = this.active.accumulated || '…'
@@ -58,7 +64,7 @@ export class RoomSession {
           await this.deps.chat.patchMessage(placeholder.id, text)
         }
         catch (err) {
-          this.deps.log(`patch failed (room=${this.deps.roomId}): ${err instanceof Error ? err.message : String(err)}`)
+          this.deps.log(`patch failed (room=${this.deps.roomId} thread=${this.deps.threadId}): ${err instanceof Error ? err.message : String(err)}`)
         }
       }, PATCH_INTERVAL_MS),
     }
@@ -76,17 +82,14 @@ export class RoomSession {
           this.active.accumulated += inner.delta
           this.active.throttle.schedule()
         }
-        // thinking_delta / toolcall_delta / tool_execution_* → ignored in
-        // v1. Hooks live here for the next milestone.
         break
       }
       case 'agent_end':
         this.endTurn()
         break
       case 'response':
-        // RPC responses to our `prompt` command — surfaced for failure cases.
         if (event.success === false) {
-          this.deps.log(`pi rpc error (room=${this.deps.roomId}): ${event.error ?? 'unknown'}`)
+          this.deps.log(`pi rpc error (room=${this.deps.roomId} thread=${this.deps.threadId}): ${event.error ?? 'unknown'}`)
           this.failTurn(`(pi rpc error: ${event.error ?? 'unknown'})`)
         }
         break
@@ -98,8 +101,6 @@ export class RoomSession {
     if (!turn) return
     turn.throttle.flush()
     this.active = undefined
-    // Drain the queue. Doing this synchronously in event order means
-    // queued prompts run sequentially in the same conversation context.
     const next = this.queue.shift()
     if (next) {
       void this.startTurn(next.body, next.replyToMessageId)

--- a/apps/openape-chat-cli/src/api.ts
+++ b/apps/openape-chat-cli/src/api.ts
@@ -1,7 +1,7 @@
 import { ofetch } from 'ofetch'
 import { getChatBearer } from './auth'
 import { getEndpoint } from './config'
-import type { Member, Message, Room } from './types'
+import type { Member, Message, Room, Thread } from './types'
 
 export class ApiError extends Error {
   constructor(
@@ -67,23 +67,60 @@ export function getRoom(id: string, opts?: { endpoint?: string }): Promise<Room>
 
 export function listMessages(
   roomId: string,
-  query?: { limit?: number, before?: number },
+  query?: { limit?: number, before?: number, threadId?: string },
   opts?: { endpoint?: string },
 ): Promise<Message[]> {
   return request<Message[]>(`/api/rooms/${encodeURIComponent(roomId)}/messages`, {
-    query: { limit: query?.limit, before: query?.before },
+    query: { limit: query?.limit, before: query?.before, thread_id: query?.threadId },
     endpoint: opts?.endpoint,
   })
 }
 
 export function sendMessage(
   roomId: string,
-  body: { body: string, reply_to?: string },
+  body: { body: string, reply_to?: string, thread_id?: string },
   opts?: { endpoint?: string },
 ): Promise<Message> {
   return request<Message>(`/api/rooms/${encodeURIComponent(roomId)}/messages`, {
     method: 'POST',
     body,
+    endpoint: opts?.endpoint,
+  })
+}
+
+export function listThreads(roomId: string, opts?: { endpoint?: string }): Promise<Thread[]> {
+  return request<Thread[]>(`/api/rooms/${encodeURIComponent(roomId)}/threads`, {
+    endpoint: opts?.endpoint,
+  })
+}
+
+export function createThread(
+  roomId: string,
+  body: { name: string },
+  opts?: { endpoint?: string },
+): Promise<Thread> {
+  return request<Thread>(`/api/rooms/${encodeURIComponent(roomId)}/threads`, {
+    method: 'POST',
+    body,
+    endpoint: opts?.endpoint,
+  })
+}
+
+export function patchThread(
+  threadId: string,
+  body: { name?: string, archived?: boolean },
+  opts?: { endpoint?: string },
+): Promise<Thread> {
+  return request<Thread>(`/api/threads/${encodeURIComponent(threadId)}`, {
+    method: 'PATCH',
+    body,
+    endpoint: opts?.endpoint,
+  })
+}
+
+export function archiveThread(threadId: string, opts?: { endpoint?: string }): Promise<void> {
+  return request<void>(`/api/threads/${encodeURIComponent(threadId)}`, {
+    method: 'DELETE',
     endpoint: opts?.endpoint,
   })
 }

--- a/apps/openape-chat-cli/src/cli.ts
+++ b/apps/openape-chat-cli/src/cli.ts
@@ -6,6 +6,7 @@ import { listCommand } from './commands/list'
 import { membersCommand } from './commands/members'
 import { roomsCommand } from './commands/rooms'
 import { sendCommand } from './commands/send'
+import { threadsCommand } from './commands/threads'
 import { watchCommand } from './commands/watch'
 import { whoamiCommand } from './commands/whoami'
 
@@ -21,6 +22,7 @@ const main = defineCommand({
     whoami: whoamiCommand,
     contacts: contactsCommand,
     rooms: roomsCommand,
+    threads: threadsCommand,
     send: sendCommand,
     list: listCommand,
     watch: watchCommand,

--- a/apps/openape-chat-cli/src/commands/list.ts
+++ b/apps/openape-chat-cli/src/commands/list.ts
@@ -1,12 +1,13 @@
 import { defineCommand } from 'citty'
 import { listMessages } from '../api'
-import { getDefaultRoomId } from '../config'
+import { getDefaultRoomId, getDefaultThreadId } from '../config'
 import { fmtTime, printJson, printLine } from '../output'
 
 export const listCommand = defineCommand({
   meta: { name: 'list', description: 'Show recent messages in a room' },
   args: {
     room: { type: 'string', description: 'Room id (defaults to `ape-chat rooms use <id>`)' },
+    thread: { type: 'string', description: 'Thread id (defaults to active thread for the room; pass "all" for every thread)' },
     limit: { type: 'string', description: 'Max messages to fetch (1-200)', default: '50' },
     before: { type: 'string', description: 'Unix seconds — fetch only messages older than this' },
     json: { type: 'boolean', default: false },
@@ -21,7 +22,13 @@ export const listCommand = defineCommand({
       throw new Error('--limit must be an integer between 1 and 200')
     }
     const before = args.before ? Number.parseInt(args.before, 10) : undefined
-    const messages = await listMessages(roomId, { limit, before })
+    // `--thread all` is the explicit escape hatch for "show me every
+    // thread"; without it, fall back to the room's active thread (if
+    // set) so per-thread context is the default reading mode.
+    const threadId = args.thread === 'all'
+      ? undefined
+      : getDefaultThreadId(roomId, args.thread)
+    const messages = await listMessages(roomId, { limit, before, threadId })
     if (args.json) {
       printJson(messages)
       return

--- a/apps/openape-chat-cli/src/commands/send.ts
+++ b/apps/openape-chat-cli/src/commands/send.ts
@@ -1,6 +1,6 @@
 import { defineCommand } from 'citty'
 import { sendMessage } from '../api'
-import { getDefaultRoomId } from '../config'
+import { getDefaultRoomId, getDefaultThreadId } from '../config'
 import { fmtTime, printJson, printLine } from '../output'
 
 export const sendCommand = defineCommand({
@@ -8,6 +8,7 @@ export const sendCommand = defineCommand({
   args: {
     body: { type: 'positional', required: true, description: 'Message body (use quotes)' },
     room: { type: 'string', description: 'Room id (defaults to `ape-chat rooms use <id>`)' },
+    thread: { type: 'string', description: 'Thread id (defaults to active thread for the room → main)' },
     'reply-to': { type: 'string', description: 'Message id to reply to' },
     json: { type: 'boolean', default: false },
   },
@@ -16,9 +17,11 @@ export const sendCommand = defineCommand({
     if (!roomId) {
       throw new Error('No room specified. Pass --room <id> or run `ape-chat rooms use <id>` first.')
     }
+    const threadId = getDefaultThreadId(roomId, args.thread)
     const message = await sendMessage(roomId, {
       body: args.body,
       ...(args['reply-to'] ? { reply_to: args['reply-to'] } : {}),
+      ...(threadId ? { thread_id: threadId } : {}),
     })
     if (args.json) {
       printJson(message)

--- a/apps/openape-chat-cli/src/commands/threads.ts
+++ b/apps/openape-chat-cli/src/commands/threads.ts
@@ -1,0 +1,116 @@
+import { defineCommand } from 'citty'
+import { archiveThread, createThread, listThreads, patchThread } from '../api'
+import { getDefaultRoomId, getDefaultThreadId, setDefaultThreadId } from '../config'
+import { fmtTime, printJson, printLine } from '../output'
+
+function requireRoom(arg?: string | null): string {
+  const roomId = getDefaultRoomId(arg)
+  if (!roomId) {
+    throw new Error('No room specified. Pass --room <id> or run `ape-chat rooms use <id>` first.')
+  }
+  return roomId
+}
+
+const listSub = defineCommand({
+  meta: { name: 'list', description: 'List threads in a room' },
+  args: {
+    room: { type: 'string', description: 'Room id (defaults to active room)' },
+    json: { type: 'boolean', default: false },
+  },
+  async run({ args }) {
+    const roomId = requireRoom(args.room)
+    const threads = await listThreads(roomId)
+    if (args.json) {
+      printJson(threads)
+      return
+    }
+    if (threads.length === 0) {
+      printLine('(no threads)')
+      return
+    }
+    const active = getDefaultThreadId(roomId)
+    for (const t of threads) {
+      const marker = active === t.id ? '* ' : '  '
+      const archived = t.archivedAt ? ' [archived]' : ''
+      printLine(`${marker}${t.id.slice(0, 8)}  ${t.name}${archived}  (created ${fmtTime(t.createdAt)})`)
+    }
+  },
+})
+
+const newSub = defineCommand({
+  meta: { name: 'new', description: 'Create a new thread in a room' },
+  args: {
+    name: { type: 'positional', required: true, description: 'Thread name' },
+    room: { type: 'string', description: 'Room id (defaults to active room)' },
+    use: { type: 'boolean', default: true, description: 'Make this the active thread for the room' },
+    json: { type: 'boolean', default: false },
+  },
+  async run({ args }) {
+    const roomId = requireRoom(args.room)
+    const thread = await createThread(roomId, { name: args.name })
+    if (args.use) setDefaultThreadId(roomId, thread.id)
+    if (args.json) {
+      printJson(thread)
+      return
+    }
+    printLine(`created ${thread.id} (${thread.name})${args.use ? ' — now active' : ''}`)
+  },
+})
+
+const useSub = defineCommand({
+  meta: { name: 'use', description: 'Set the active thread for a room' },
+  args: {
+    thread: { type: 'positional', required: false, description: 'Thread id (omit + --clear to unset)' },
+    room: { type: 'string', description: 'Room id (defaults to active room)' },
+    clear: { type: 'boolean', default: false, description: 'Unset the active thread for the room' },
+  },
+  async run({ args }) {
+    const roomId = requireRoom(args.room)
+    if (args.clear || !args.thread) {
+      setDefaultThreadId(roomId, null)
+      printLine(`active thread cleared for room ${roomId}`)
+      return
+    }
+    setDefaultThreadId(roomId, args.thread)
+    printLine(`active thread for room ${roomId} → ${args.thread}`)
+  },
+})
+
+const renameSub = defineCommand({
+  meta: { name: 'rename', description: 'Rename a thread' },
+  args: {
+    thread: { type: 'positional', required: true, description: 'Thread id' },
+    name: { type: 'positional', required: true, description: 'New name' },
+    json: { type: 'boolean', default: false },
+  },
+  async run({ args }) {
+    const updated = await patchThread(args.thread, { name: args.name })
+    if (args.json) {
+      printJson(updated)
+      return
+    }
+    printLine(`renamed ${updated.id} → ${updated.name}`)
+  },
+})
+
+const archiveSub = defineCommand({
+  meta: { name: 'archive', description: 'Archive a thread (soft-delete; history preserved)' },
+  args: {
+    thread: { type: 'positional', required: true, description: 'Thread id' },
+  },
+  async run({ args }) {
+    await archiveThread(args.thread)
+    printLine(`archived ${args.thread}`)
+  },
+})
+
+export const threadsCommand = defineCommand({
+  meta: { name: 'threads', description: 'List, create, switch and archive threads inside a room' },
+  subCommands: {
+    list: listSub,
+    new: newSub,
+    use: useSub,
+    rename: renameSub,
+    archive: archiveSub,
+  },
+})

--- a/apps/openape-chat-cli/src/config.ts
+++ b/apps/openape-chat-cli/src/config.ts
@@ -7,6 +7,13 @@ const DEFAULT_ENDPOINT = 'https://chat.openape.ai'
 interface CliState {
   endpoint?: string
   defaultRoomId?: string
+  /**
+   * Per-room active thread. Phase B: rooms can have N threads, and the
+   * CLI remembers which thread the user has `ape-chat threads use`d
+   * inside each room so subsequent `send`/`list` calls land in the
+   * intended thread without forcing a `--thread` flag every time.
+   */
+  defaultThreadByRoom?: Record<string, string>
 }
 
 function configPath(): string {
@@ -54,5 +61,21 @@ export function setDefaultRoomId(roomId: string | null): void {
   const state = loadState()
   if (roomId) state.defaultRoomId = roomId
   else delete state.defaultRoomId
+  saveState(state)
+}
+
+export function getDefaultThreadId(roomId: string, override?: string | null): string | undefined {
+  if (override) return override
+  const env = process.env.APE_CHAT_THREAD
+  if (env) return env
+  return loadState().defaultThreadByRoom?.[roomId]
+}
+
+export function setDefaultThreadId(roomId: string, threadId: string | null): void {
+  const state = loadState()
+  const map = { ...(state.defaultThreadByRoom ?? {}) }
+  if (threadId) map[roomId] = threadId
+  else delete map[roomId]
+  state.defaultThreadByRoom = map
   saveState(state)
 }

--- a/apps/openape-chat-cli/src/docs/cli.md
+++ b/apps/openape-chat-cli/src/docs/cli.md
@@ -19,8 +19,13 @@ ape-chat rooms use <id>     # set default room
 | `rooms info <id>` | Show one room's metadata |
 | `rooms use <id>` | Persist a default room id |
 | `rooms clear` | Forget the default room |
-| `send "..."` `[--room <id>] [--reply-to <msg-id>]` | Post a message |
-| `list` `[--room <id>] [--limit N] [--before <unix-s>]` | Show recent history |
+| `threads list` `[--room <id>]` | List threads in a room (★ marks active) |
+| `threads new "<name>"` `[--room <id>] [--no-use]` | Create a thread (active by default) |
+| `threads use <id>` `[--room <id>] [--clear]` | Switch active thread for a room |
+| `threads rename <id> "<name>"` | Rename a thread |
+| `threads archive <id>` | Soft-archive a thread (history preserved) |
+| `send "..."` `[--room <id>] [--thread <id>] [--reply-to <msg-id>]` | Post a message (defaults to active thread) |
+| `list` `[--room <id>] [--thread <id>\|all] [--limit N] [--before <unix-s>]` | Show recent history (active thread by default) |
 | `watch` `[--room <id>] [--json]` | Stream live events via WebSocket |
 | `members list` `[--room <id>]` | Members + roles |
 | `members add <email>` `[--role member\|admin] [--room <id>]` | Invite (admins only) |
@@ -42,6 +47,7 @@ configuration commands).
 |---|---|
 | `APE_CHAT_ENDPOINT` | Override the chat host |
 | `APE_CHAT_ROOM` | Override the default room id |
+| `APE_CHAT_THREAD` | Override the default thread id (applies to whichever room is active) |
 
 ## Exit codes
 

--- a/apps/openape-chat-cli/src/types.ts
+++ b/apps/openape-chat-cli/src/types.ts
@@ -15,12 +15,22 @@ export interface Room {
 export interface Message {
   id: string
   roomId: string
+  threadId: string
   senderEmail: string
   senderAct: 'human' | 'agent'
   body: string
   replyTo: string | null
   createdAt: number
   editedAt: number | null
+}
+
+export interface Thread {
+  id: string
+  roomId: string
+  name: string
+  createdByEmail: string
+  createdAt: number
+  archivedAt: number | null
 }
 
 export interface Member {

--- a/apps/openape-chat/app/pages/rooms/[id].vue
+++ b/apps/openape-chat/app/pages/rooms/[id].vue
@@ -4,6 +4,7 @@ import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 interface Message {
   id: string
   roomId: string
+  threadId: string
   senderEmail: string
   senderAct: 'human' | 'agent'
   body: string
@@ -17,6 +18,15 @@ interface Reaction {
   userEmail: string
   emoji: string
   createdAt: number
+}
+
+interface Thread {
+  id: string
+  roomId: string
+  name: string
+  createdByEmail: string
+  createdAt: number
+  archivedAt: number | null
 }
 
 const route = useRoute()
@@ -42,10 +52,11 @@ const scrollEl = ref<HTMLElement>()
 const roomInfo = ref<RoomInfo | null>(null)
 const roomError = ref<string | null>(null)
 const membersOpen = ref(false)
+const threads = ref<Thread[]>([])
+const activeThreadId = ref<string | null>(null)
+const newThreadName = ref('')
+const showNewThread = ref(false)
 
-// Per-page title — falls back to a generic placeholder while the
-// metadata loads, then updates to the room name. The titleTemplate
-// from nuxt.config appends " — OpenApe Chat".
 useHead({
   title: () => roomInfo.value?.name ?? 'Room',
 })
@@ -58,9 +69,6 @@ async function loadRoomInfo() {
   catch (err) {
     const status = (err as { statusCode?: number })?.statusCode
     if (status === 404) {
-      // The server returns 404 both for "room doesn't exist" and "you're
-      // not a member" — this is intentional, non-members should not be
-      // able to discover that a room exists at all.
       roomError.value = 'Raum für diesen User nicht verfügbar.'
     }
     else if (status === 401) {
@@ -73,15 +81,33 @@ async function loadRoomInfo() {
   }
 }
 
-async function loadMessages() {
+async function loadThreads(): Promise<void> {
   if (!roomInfo.value) {
+    threads.value = []
+    activeThreadId.value = null
+    return
+  }
+  // Server lazily creates a "main" thread on first GET for legacy rooms,
+  // so the result is guaranteed non-empty for any room the caller is in.
+  const rows = await $fetch<Thread[]>(`/api/rooms/${roomId.value}/threads`)
+  threads.value = rows
+  if (!activeThreadId.value || !rows.some(t => t.id === activeThreadId.value)) {
+    const firstOpen = rows.find(t => !t.archivedAt) ?? rows[0]
+    activeThreadId.value = firstOpen?.id ?? null
+  }
+}
+
+async function loadMessages() {
+  if (!roomInfo.value || !activeThreadId.value) {
     messages.value = []
     loading.value = false
     return
   }
   loading.value = true
   try {
-    const rows = await $fetch<Message[]>(`/api/rooms/${roomId.value}/messages?limit=50`)
+    const rows = await $fetch<Message[]>(`/api/rooms/${roomId.value}/messages`, {
+      query: { limit: 50, thread_id: activeThreadId.value },
+    })
     messages.value = rows
   }
   finally {
@@ -93,6 +119,7 @@ async function loadMessages() {
 
 async function loadInitial() {
   await loadRoomInfo()
+  await loadThreads()
   await loadMessages()
 }
 
@@ -106,7 +133,7 @@ function addReactionLocal(r: Reaction) {
   if (!list.some(x => x.userEmail === r.userEmail && x.emoji === r.emoji)) {
     list.push(r)
     reactions.value.set(r.messageId, list)
-    reactions.value = new Map(reactions.value) // trigger reactivity
+    reactions.value = new Map(reactions.value)
   }
 }
 
@@ -123,16 +150,17 @@ const chat = useChat()
 let off: (() => void) | undefined
 
 onMounted(async () => {
-  // Connect WS first so the live indicator updates regardless of whether
-  // we can read messages. Non-members watching a Join screen still get
-  // a fresh socket — when they join, broadcasts start flowing immediately
-  // without a reconnect dance.
   chat.connect()
   await loadInitial()
   off = chat.on((frame) => {
     if (frame.room_id !== roomId.value) return
     if (frame.type === 'message') {
       const m = frame.payload as Message
+      // Only append messages that belong to the currently-viewed thread.
+      // Other threads still get the broadcast (so a future "unread badge"
+      // hook can pick it up here without server changes), but the active
+      // message list stays scoped.
+      if (m.threadId && m.threadId !== activeThreadId.value) return
       if (!messages.value.some(x => x.id === m.id)) {
         messages.value.push(m)
         nextTick(() => scrollToBottom())
@@ -151,19 +179,32 @@ onMounted(async () => {
       removeReactionLocal(p.messageId, p.userEmail, p.emoji)
     }
     else if (frame.type === 'membership-removed') {
-      const p = frame.payload as { roomId: string, userEmail: string }
-      // If I'm the one being removed, kick myself out of the room view.
-      // The next loadRoomInfo would 404 anyway; this just makes the
-      // transition immediate instead of waiting for the next interaction.
+      const p = frame.payload as { roomId: string, userEmail: string, thread?: Thread }
+      // Two flavours: (a) a member was removed from the room — if it's
+      // me, navigate out; (b) a thread was archived — refresh the
+      // thread list so the tab disappears (or moves to "Archived").
+      if (p.thread) {
+        void loadThreads()
+        return
+      }
       if (p.userEmail === user.value?.sub) {
         navigateTo('/')
       }
     }
     else if (frame.type === 'membership-changed') {
-      const p = frame.payload as { roomId: string, userEmail: string, role: 'member' | 'admin' }
-      // Refresh local role so the admin UI flips when someone promotes
-      // or demotes me without requiring a page reload.
-      if (p.userEmail === user.value?.sub && roomInfo.value) {
+      const p = frame.payload as {
+        roomId: string
+        userEmail?: string
+        role?: 'member' | 'admin'
+        thread?: Thread
+      }
+      // Either a role change for a member (existing v1 behaviour) or a
+      // new/renamed thread (Phase B). Disambiguate via payload shape.
+      if (p.thread) {
+        void loadThreads()
+        return
+      }
+      if (p.userEmail === user.value?.sub && p.role && roomInfo.value) {
         roomInfo.value = { ...roomInfo.value, role: p.role }
       }
     }
@@ -175,13 +216,14 @@ onBeforeUnmount(() => {
 })
 
 watch(roomId, loadInitial)
+watch(activeThreadId, () => { void loadMessages() })
 
 async function send(body: string) {
+  if (!activeThreadId.value) return
   await $fetch(`/api/rooms/${roomId.value}/messages`, {
     method: 'POST',
-    body: { body },
+    body: { body, thread_id: activeThreadId.value },
   })
-  // Server will broadcast via WS; the inbound frame appends + scrolls.
 }
 
 async function react(messageId: string, emoji: string) {
@@ -215,6 +257,26 @@ function reactionsFor(messageId: string) {
   }
   return Array.from(counts.entries(), ([emoji, c]) => ({ emoji, ...c }))
 }
+
+const visibleThreads = computed(() => threads.value.filter(t => !t.archivedAt))
+
+async function selectThread(id: string): Promise<void> {
+  if (activeThreadId.value === id) return
+  activeThreadId.value = id
+}
+
+async function createThread(): Promise<void> {
+  const name = newThreadName.value.trim()
+  if (!name) return
+  const created = await $fetch<Thread>(`/api/rooms/${roomId.value}/threads`, {
+    method: 'POST',
+    body: { name },
+  })
+  newThreadName.value = ''
+  showNewThread.value = false
+  await loadThreads()
+  activeThreadId.value = created.id
+}
 </script>
 
 <template>
@@ -244,6 +306,57 @@ function reactionsFor(messageId: string) {
         {{ chat.connected.value ? '● live' : '○ offline' }}
       </span>
     </header>
+
+    <nav
+      v-if="roomInfo && visibleThreads.length"
+      class="sticky top-[52px] z-10 flex items-center gap-1 px-2 py-1 border-b border-zinc-800 bg-zinc-950/95 backdrop-blur overflow-x-auto"
+      aria-label="Threads"
+    >
+      <button
+        v-for="t of visibleThreads"
+        :key="t.id"
+        type="button"
+        class="shrink-0 px-3 py-1.5 rounded-full text-sm whitespace-nowrap transition-colors"
+        :class="activeThreadId === t.id
+          ? 'bg-emerald-500/20 text-emerald-300 border border-emerald-500/40'
+          : 'text-zinc-400 border border-transparent hover:bg-zinc-900'"
+        @click="selectThread(t.id)"
+      >
+        {{ t.name }}
+      </button>
+      <button
+        type="button"
+        class="shrink-0 px-3 py-1.5 rounded-full text-sm text-zinc-400 border border-zinc-800 hover:bg-zinc-900"
+        aria-label="New thread"
+        @click="showNewThread = !showNewThread"
+      >
+        +
+      </button>
+    </nav>
+
+    <div
+      v-if="showNewThread"
+      class="px-3 py-2 border-b border-zinc-800 flex gap-2"
+    >
+      <UInput
+        v-model="newThreadName"
+        placeholder="Thread name…"
+        size="sm"
+        class="flex-1"
+        @keydown.enter="createThread"
+      />
+      <UButton size="sm" color="primary" :disabled="!newThreadName.trim()" @click="createThread">
+        Create
+      </UButton>
+      <UButton
+        size="sm"
+        color="neutral"
+        variant="ghost"
+        @click="showNewThread = false; newThreadName = ''"
+      >
+        Cancel
+      </UButton>
+    </div>
 
     <main ref="scrollEl" class="flex-1 overflow-y-auto px-3 py-3 space-y-3">
       <div v-if="roomError" class="max-w-sm mx-auto py-12 text-center space-y-3">
@@ -275,7 +388,7 @@ function reactionsFor(messageId: string) {
       </template>
     </main>
 
-    <SendBox v-if="roomInfo" @send="send" />
+    <SendBox v-if="roomInfo && activeThreadId" @send="send" />
 
     <MemberManager
       v-if="roomInfo"

--- a/apps/openape-chat/server/api/rooms/[id]/messages.get.ts
+++ b/apps/openape-chat/server/api/rooms/[id]/messages.get.ts
@@ -8,6 +8,7 @@ import { assertMember } from '../../../utils/membership'
 const querySchema = z.object({
   before: z.coerce.number().int().positive().optional(),
   limit: z.coerce.number().int().min(1).max(200).default(50),
+  thread_id: z.string().uuid().optional(),
 })
 
 export default defineEventHandler(async (event) => {
@@ -23,14 +24,17 @@ export default defineEventHandler(async (event) => {
   }
 
   const db = useDb()
-  const where = parsed.data.before
-    ? and(eq(messages.roomId, id), lt(messages.createdAt, parsed.data.before))
-    : eq(messages.roomId, id)
+  // Phase B filter: when a thread_id is provided, scope to that thread;
+  // otherwise return all room messages (back-compat). The webapp + CLI
+  // pass the thread_id once they know which thread the user is viewing.
+  const conds = [eq(messages.roomId, id)]
+  if (parsed.data.thread_id) conds.push(eq(messages.threadId, parsed.data.thread_id))
+  if (parsed.data.before) conds.push(lt(messages.createdAt, parsed.data.before))
 
   const rows = await db
     .select()
     .from(messages)
-    .where(where)
+    .where(and(...conds))
     .orderBy(desc(messages.createdAt))
     .limit(parsed.data.limit)
 

--- a/apps/openape-chat/server/api/rooms/[id]/messages.post.ts
+++ b/apps/openape-chat/server/api/rooms/[id]/messages.post.ts
@@ -6,10 +6,15 @@ import { resolveCaller } from '../../../utils/auth'
 import { assertMember } from '../../../utils/membership'
 import { notifyRoomMembers } from '../../../utils/push'
 import { broadcastToRoom } from '../../../utils/realtime'
+import { ensureMainThread, findThreadById } from '../../../utils/threads'
 
 const bodySchema = z.object({
   body: z.string().trim().min(1).max(10_000),
   reply_to: z.string().uuid().optional(),
+  // Optional in v1: when omitted, the message lands in the room's main
+  // thread (auto-created on first use). Phase-B-aware clients pass the
+  // active thread id explicitly.
+  thread_id: z.string().uuid().optional(),
 })
 
 export default defineEventHandler(async (event) => {
@@ -24,9 +29,29 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: parsed.error.message })
   }
 
+  // Resolve thread: explicit thread_id (validated to belong to this
+  // room) OR fall back to the room's main thread (lazy-create for
+  // legacy rooms).
+  let threadId: string
+  if (parsed.data.thread_id) {
+    const thread = await findThreadById(parsed.data.thread_id)
+    if (!thread || thread.roomId !== id) {
+      throw createError({ statusCode: 400, statusMessage: 'thread_id does not belong to this room' })
+    }
+    if (thread.archivedAt) {
+      throw createError({ statusCode: 400, statusMessage: 'Cannot post to an archived thread' })
+    }
+    threadId = thread.id
+  }
+  else {
+    const main = await ensureMainThread({ roomId: id, createdByEmail: caller.email })
+    threadId = main.id
+  }
+
   const message = {
     id: randomUUID(),
     roomId: id,
+    threadId,
     senderEmail: caller.email,
     senderAct: caller.act,
     body: parsed.data.body,

--- a/apps/openape-chat/server/api/rooms/[id]/threads/index.get.ts
+++ b/apps/openape-chat/server/api/rooms/[id]/threads/index.get.ts
@@ -1,0 +1,20 @@
+import { resolveCaller } from '../../../../utils/auth'
+import { assertMember } from '../../../../utils/membership'
+import { ensureMainThread, listThreadsInRoom } from '../../../../utils/threads'
+
+export default defineEventHandler(async (event) => {
+  const caller = await resolveCaller(event)
+  const id = getRouterParam(event, 'id')
+  if (!id) throw createError({ statusCode: 400, statusMessage: 'Missing room id' })
+  await assertMember(id, caller.email)
+
+  // Lazy backfill for legacy rooms (created before Phase B): if there
+  // are no threads, materialise a "main" thread that absorbs any
+  // existing thread-less messages.
+  const existing = await listThreadsInRoom(id)
+  if (existing.length === 0) {
+    await ensureMainThread({ roomId: id, createdByEmail: caller.email })
+    return await listThreadsInRoom(id)
+  }
+  return existing
+})

--- a/apps/openape-chat/server/api/rooms/[id]/threads/index.post.ts
+++ b/apps/openape-chat/server/api/rooms/[id]/threads/index.post.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod'
+import { resolveCaller } from '../../../../utils/auth'
+import { assertMember } from '../../../../utils/membership'
+import { createThread } from '../../../../utils/threads'
+import { broadcastToRoom } from '../../../../utils/realtime'
+
+const bodySchema = z.object({
+  name: z.string().trim().min(1).max(100),
+})
+
+export default defineEventHandler(async (event) => {
+  const caller = await resolveCaller(event)
+  const id = getRouterParam(event, 'id')
+  if (!id) throw createError({ statusCode: 400, statusMessage: 'Missing room id' })
+  await assertMember(id, caller.email)
+
+  const parsed = bodySchema.safeParse(await readBody(event))
+  if (!parsed.success) {
+    throw createError({ statusCode: 400, statusMessage: parsed.error.message })
+  }
+
+  const thread = await createThread({
+    roomId: id,
+    name: parsed.data.name,
+    createdByEmail: caller.email,
+  })
+  // Reuse the existing membership-* event channel so peers refresh
+  // their thread list without polling.
+  await broadcastToRoom(id, { type: 'membership-changed', room_id: id, payload: { thread } })
+  setResponseStatus(event, 201)
+  return thread
+})

--- a/apps/openape-chat/server/api/threads/[id].delete.ts
+++ b/apps/openape-chat/server/api/threads/[id].delete.ts
@@ -1,0 +1,26 @@
+import { resolveCaller } from '../../utils/auth'
+import { assertMember } from '../../utils/membership'
+import { findThreadById, updateThread } from '../../utils/threads'
+import { broadcastToRoom } from '../../utils/realtime'
+
+// Soft-delete: archive only. Preserves message history (so a user can
+// re-open and read past context). Hard-delete is intentionally not
+// exposed in v1 to avoid accidental loss.
+export default defineEventHandler(async (event) => {
+  const caller = await resolveCaller(event)
+  const id = getRouterParam(event, 'id')
+  if (!id) throw createError({ statusCode: 400, statusMessage: 'Missing thread id' })
+  const existing = await findThreadById(id)
+  if (!existing) throw createError({ statusCode: 404, statusMessage: 'Thread not found' })
+  await assertMember(existing.roomId, caller.email)
+  const updated = await updateThread(id, { archived: true })
+  if (updated) {
+    await broadcastToRoom(existing.roomId, {
+      type: 'membership-removed',
+      room_id: existing.roomId,
+      payload: { thread: updated },
+    })
+  }
+  setResponseStatus(event, 204)
+  return null
+})

--- a/apps/openape-chat/server/api/threads/[id].patch.ts
+++ b/apps/openape-chat/server/api/threads/[id].patch.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod'
+import { resolveCaller } from '../../utils/auth'
+import { assertMember } from '../../utils/membership'
+import { findThreadById, updateThread } from '../../utils/threads'
+import { broadcastToRoom } from '../../utils/realtime'
+
+const bodySchema = z.object({
+  name: z.string().trim().min(1).max(100).optional(),
+  archived: z.boolean().optional(),
+}).refine(b => b.name !== undefined || b.archived !== undefined, {
+  message: 'Provide at least one of name, archived',
+})
+
+export default defineEventHandler(async (event) => {
+  const caller = await resolveCaller(event)
+  const id = getRouterParam(event, 'id')
+  if (!id) throw createError({ statusCode: 400, statusMessage: 'Missing thread id' })
+  const existing = await findThreadById(id)
+  if (!existing) throw createError({ statusCode: 404, statusMessage: 'Thread not found' })
+  await assertMember(existing.roomId, caller.email)
+
+  const parsed = bodySchema.safeParse(await readBody(event))
+  if (!parsed.success) {
+    throw createError({ statusCode: 400, statusMessage: parsed.error.message })
+  }
+
+  const updated = await updateThread(id, parsed.data)
+  if (updated) {
+    await broadcastToRoom(existing.roomId, {
+      type: 'membership-changed',
+      room_id: existing.roomId,
+      payload: { thread: updated },
+    })
+  }
+  return updated
+})

--- a/apps/openape-chat/server/database/schema.ts
+++ b/apps/openape-chat/server/database/schema.ts
@@ -21,6 +21,10 @@ export const memberships = sqliteTable('memberships', {
 export const messages = sqliteTable('messages', {
   id: text('id').primaryKey(),
   roomId: text('room_id').notNull(),
+  // Phase B: each room has one or more threads; messages live on a
+  // thread. Nullable for back-compat with rows written before Phase B —
+  // those get treated as the room's "main" thread by query-side joins.
+  threadId: text('thread_id'),
   senderEmail: text('sender_email').notNull(),
   // 'human' or 'agent' — purely a display hint, not a permission boundary in v1
   senderAct: text('sender_act', { enum: ['human', 'agent'] }).notNull(),
@@ -28,6 +32,19 @@ export const messages = sqliteTable('messages', {
   replyTo: text('reply_to'),
   createdAt: integer('created_at').notNull(),
   editedAt: integer('edited_at'),
+})
+
+// Phase B: parallel sessions inside a single 1:1 contact (= room).
+// Each thread has its own bridge pi-RPC session — context is isolated.
+// Default "main" thread is auto-created on contact-accept (or lazy-
+// created on first GET for legacy rooms).
+export const threads = sqliteTable('threads', {
+  id: text('id').primaryKey(),
+  roomId: text('room_id').notNull(),
+  name: text('name').notNull(),
+  createdByEmail: text('created_by_email').notNull(),
+  createdAt: integer('created_at').notNull(),
+  archivedAt: integer('archived_at'),
 })
 
 export const reactions = sqliteTable('reactions', {
@@ -80,4 +97,6 @@ export type NewMessage = typeof messages.$inferInsert
 export type Reaction = typeof reactions.$inferSelect
 export type Contact = typeof contacts.$inferSelect
 export type NewContact = typeof contacts.$inferInsert
+export type Thread = typeof threads.$inferSelect
+export type NewThread = typeof threads.$inferInsert
 export type PushSubscription = typeof pushSubscriptions.$inferSelect

--- a/apps/openape-chat/server/plugins/02.database.ts
+++ b/apps/openape-chat/server/plugins/02.database.ts
@@ -31,6 +31,7 @@ export default defineNitroPlugin(async () => {
     await db.run(sql`CREATE TABLE IF NOT EXISTS messages (
       id TEXT PRIMARY KEY,
       room_id TEXT NOT NULL,
+      thread_id TEXT,
       sender_email TEXT NOT NULL,
       sender_act TEXT NOT NULL,
       body TEXT NOT NULL,
@@ -38,7 +39,26 @@ export default defineNitroPlugin(async () => {
       created_at INTEGER NOT NULL,
       edited_at INTEGER
     )`)
+    // ALTER for existing prod rows (CREATE TABLE IF NOT EXISTS skips when
+    // table exists; the new column has to be added separately).
+    try {
+      await db.run(sql`ALTER TABLE messages ADD COLUMN thread_id TEXT`)
+    }
+    catch {
+      // Already added in a prior boot — sqlite throws on duplicate column.
+    }
     await db.run(sql`CREATE INDEX IF NOT EXISTS idx_messages_room_created ON messages(room_id, created_at)`)
+    await db.run(sql`CREATE INDEX IF NOT EXISTS idx_messages_thread_created ON messages(thread_id, created_at)`)
+
+    await db.run(sql`CREATE TABLE IF NOT EXISTS threads (
+      id TEXT PRIMARY KEY,
+      room_id TEXT NOT NULL,
+      name TEXT NOT NULL,
+      created_by_email TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      archived_at INTEGER
+    )`)
+    await db.run(sql`CREATE INDEX IF NOT EXISTS idx_threads_room ON threads(room_id, created_at)`)
 
     await db.run(sql`CREATE TABLE IF NOT EXISTS reactions (
       message_id TEXT NOT NULL,

--- a/apps/openape-chat/server/utils/contacts.ts
+++ b/apps/openape-chat/server/utils/contacts.ts
@@ -10,6 +10,7 @@ import { and, eq, or } from 'drizzle-orm'
 import { useDb } from '../database/drizzle'
 import { contacts, memberships, rooms } from '../database/schema'
 import type { Contact } from '../database/schema'
+import { ensureMainThread } from './threads'
 
 export interface ContactView {
   /** Other party's email. */
@@ -87,6 +88,9 @@ export async function ensureDmRoomFor(row: Contact): Promise<string> {
     }).onConflictDoNothing()
   }
   await db.update(contacts).set({ roomId: id }).where(eq(contacts.id, row.id))
+  // Auto-create the room's "main" thread so any first message has
+  // somewhere to land — Phase B threads model.
+  await ensureMainThread({ roomId: id, createdByEmail: row.emailA })
   return id
 }
 

--- a/apps/openape-chat/server/utils/threads.ts
+++ b/apps/openape-chat/server/utils/threads.ts
@@ -1,0 +1,98 @@
+// Helpers for the threads model. A thread is a parallel sub-conversation
+// inside a 1:1 contact (= room). Each room has exactly one "main" thread
+// auto-created on contact-accept; the user can spin up additional named
+// threads for separate concerns (e.g. "Email-Triage", "Code-Review").
+
+import { randomUUID } from 'node:crypto'
+import { and, asc, eq, isNull } from 'drizzle-orm'
+import { useDb } from '../database/drizzle'
+import { messages, threads } from '../database/schema'
+import type { Thread } from '../database/schema'
+
+export const MAIN_THREAD_NAME = 'main'
+
+export async function listThreadsInRoom(roomId: string): Promise<Thread[]> {
+  const db = useDb()
+  return await db
+    .select()
+    .from(threads)
+    .where(eq(threads.roomId, roomId))
+    .orderBy(asc(threads.createdAt))
+    .all()
+}
+
+export async function findThreadById(id: string): Promise<Thread | null> {
+  const db = useDb()
+  const row = await db.select().from(threads).where(eq(threads.id, id)).get()
+  return row ?? null
+}
+
+/**
+ * Ensure a "main" thread exists for the room. Idempotent — returns the
+ * existing one if already there. Used both by contact-accept (eager
+ * creation) and by GET /api/rooms/{id}/threads (lazy backfill for legacy
+ * rooms that pre-date the threads table).
+ */
+export async function ensureMainThread(opts: { roomId: string, createdByEmail: string }): Promise<Thread> {
+  const db = useDb()
+  const existing = await db
+    .select()
+    .from(threads)
+    .where(and(eq(threads.roomId, opts.roomId), eq(threads.name, MAIN_THREAD_NAME), isNull(threads.archivedAt)))
+    .get()
+  if (existing) return existing
+  const id = randomUUID()
+  const now = Math.floor(Date.now() / 1000)
+  await db.insert(threads).values({
+    id,
+    roomId: opts.roomId,
+    name: MAIN_THREAD_NAME,
+    createdByEmail: opts.createdByEmail,
+    createdAt: now,
+  })
+  // Also backfill: any existing room messages without a thread_id get
+  // attributed to this main thread. Safe one-time op since main is the
+  // only thread that could absorb them at this point.
+  await db
+    .update(messages)
+    .set({ threadId: id })
+    .where(and(eq(messages.roomId, opts.roomId), isNull(messages.threadId)))
+  return (await db.select().from(threads).where(eq(threads.id, id)).get())!
+}
+
+export async function createThread(opts: {
+  roomId: string
+  name: string
+  createdByEmail: string
+}): Promise<Thread> {
+  const db = useDb()
+  const id = randomUUID()
+  const now = Math.floor(Date.now() / 1000)
+  await db.insert(threads).values({
+    id,
+    roomId: opts.roomId,
+    name: opts.name.trim().slice(0, 100),
+    createdByEmail: opts.createdByEmail,
+    createdAt: now,
+  })
+  return (await db.select().from(threads).where(eq(threads.id, id)).get())!
+}
+
+export async function updateThread(
+  id: string,
+  patch: { name?: string, archived?: boolean },
+): Promise<Thread | null> {
+  const db = useDb()
+  const updates: Partial<Thread> = {}
+  if (typeof patch.name === 'string') {
+    updates.name = patch.name.trim().slice(0, 100)
+  }
+  if (typeof patch.archived === 'boolean') {
+    updates.archivedAt = patch.archived ? Math.floor(Date.now() / 1000) : null
+  }
+  if (Object.keys(updates).length === 0) {
+    return await findThreadById(id)
+  }
+  await db.update(threads).set(updates).where(eq(threads.id, id))
+  return await findThreadById(id)
+}

--- a/apps/openape-chat/tests/schema.test.ts
+++ b/apps/openape-chat/tests/schema.test.ts
@@ -2,7 +2,7 @@ import { createClient } from '@libsql/client'
 import { eq, sql } from 'drizzle-orm'
 import { drizzle } from 'drizzle-orm/libsql'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { memberships, messages, pushSubscriptions, reactions, rooms } from '../server/database/schema'
+import { memberships, messages, pushSubscriptions, reactions, rooms, threads } from '../server/database/schema'
 
 // Smoke test for the chat DB schema: spin up an in-memory SQLite, run the
 // same CREATE TABLE statements the production startup plugin runs, and
@@ -10,17 +10,18 @@ import { memberships, messages, pushSubscriptions, reactions, rooms } from '../s
 // migration script. This file is intentionally low-level — route-handler
 // behaviour gets covered by integration tests once the WS layer lands.
 
-let db: ReturnType<typeof drizzle<{ rooms: typeof rooms, memberships: typeof memberships, messages: typeof messages, reactions: typeof reactions, pushSubscriptions: typeof pushSubscriptions }>>
+let db: ReturnType<typeof drizzle<{ rooms: typeof rooms, memberships: typeof memberships, messages: typeof messages, reactions: typeof reactions, pushSubscriptions: typeof pushSubscriptions, threads: typeof threads }>>
 
 beforeEach(async () => {
   const client = createClient({ url: ':memory:' })
-  db = drizzle(client, { schema: { rooms, memberships, messages, reactions, pushSubscriptions } })
+  db = drizzle(client, { schema: { rooms, memberships, messages, reactions, pushSubscriptions, threads } })
 
   await db.run(sql`CREATE TABLE rooms (id TEXT PRIMARY KEY, name TEXT NOT NULL, kind TEXT NOT NULL, created_by_email TEXT NOT NULL, created_at INTEGER NOT NULL)`)
   await db.run(sql`CREATE TABLE memberships (room_id TEXT NOT NULL, user_email TEXT NOT NULL, role TEXT NOT NULL DEFAULT 'member', joined_at INTEGER NOT NULL, PRIMARY KEY (room_id, user_email))`)
-  await db.run(sql`CREATE TABLE messages (id TEXT PRIMARY KEY, room_id TEXT NOT NULL, sender_email TEXT NOT NULL, sender_act TEXT NOT NULL, body TEXT NOT NULL, reply_to TEXT, created_at INTEGER NOT NULL, edited_at INTEGER)`)
+  await db.run(sql`CREATE TABLE messages (id TEXT PRIMARY KEY, room_id TEXT NOT NULL, thread_id TEXT, sender_email TEXT NOT NULL, sender_act TEXT NOT NULL, body TEXT NOT NULL, reply_to TEXT, created_at INTEGER NOT NULL, edited_at INTEGER)`)
   await db.run(sql`CREATE TABLE reactions (message_id TEXT NOT NULL, user_email TEXT NOT NULL, emoji TEXT NOT NULL, created_at INTEGER NOT NULL, PRIMARY KEY (message_id, user_email, emoji))`)
   await db.run(sql`CREATE TABLE push_subscriptions (endpoint TEXT PRIMARY KEY, user_email TEXT NOT NULL, p256dh TEXT NOT NULL, auth TEXT NOT NULL, created_at INTEGER NOT NULL)`)
+  await db.run(sql`CREATE TABLE threads (id TEXT PRIMARY KEY, room_id TEXT NOT NULL, name TEXT NOT NULL, created_by_email TEXT NOT NULL, created_at INTEGER NOT NULL, archived_at INTEGER)`)
 })
 
 afterEach(() => {
@@ -82,6 +83,19 @@ describe('chat schema', () => {
     await expect(db.insert(pushSubscriptions).values({ ...sub, userEmail: 'q@x' })).rejects.toThrow()
     const got = await db.select().from(pushSubscriptions).where(eq(pushSubscriptions.endpoint, sub.endpoint)).get()
     expect(got?.userEmail).toBe('p@x')
+  })
+
+  it('scopes messages to a thread when thread_id is set', async () => {
+    await db.insert(rooms).values({ id: 'r1', name: 'r', kind: 'dm', createdByEmail: 'p@x', createdAt: 1 })
+    await db.insert(threads).values({ id: 't1', roomId: 'r1', name: 'main', createdByEmail: 'p@x', createdAt: 1 })
+    await db.insert(threads).values({ id: 't2', roomId: 'r1', name: 'side', createdByEmail: 'p@x', createdAt: 2 })
+    await db.insert(messages).values({ id: 'm1', roomId: 'r1', threadId: 't1', senderEmail: 'p@x', senderAct: 'human', body: 'main', createdAt: 1 })
+    await db.insert(messages).values({ id: 'm2', roomId: 'r1', threadId: 't2', senderEmail: 'p@x', senderAct: 'human', body: 'side', createdAt: 2 })
+
+    const inT1 = await db.select().from(messages).where(eq(messages.threadId, 't1'))
+    const inT2 = await db.select().from(messages).where(eq(messages.threadId, 't2'))
+    expect(inT1.map(r => r.id)).toEqual(['m1'])
+    expect(inT2.map(r => r.id)).toEqual(['m2'])
   })
 
   it('lists memberships joined to rooms (the GET /api/rooms shape)', async () => {


### PR DESCRIPTION
## Summary

Phase B closes #255: ChatGPT-style parallel threads inside each 1:1 contact, so a human and an agent (or two humans) can run independent, isolated conversations side-by-side without context bleed.

- **Server** (`@openape/chat`): `threads` table + `messages.thread_id`, REST endpoints (`GET/POST /api/rooms/:id/threads`, `PATCH/DELETE /api/threads/:id`), thread-scoped `messages.get`/`post`. Lazy `main`-thread backfill for pre-Phase-B rooms. `ensureDmRoomFor` auto-creates the main thread on contact accept.
- **Bridge** (`@openape/chat-bridge`): pi-RPC sessions keyed by `(roomId, threadId)` — `room-session.ts` → `thread-session.ts`. Inbound `Message` carries `threadId`.
- **CLI** (`@openape/ape-chat`): `ape-chat threads {list|new|use|rename|archive}` subcommand. `--thread` flag on `send`/`list`. Active thread persisted per-room in `~/.openape/auth-chat.json`. Docs updated.
- **Webapp**: horizontal scrollable thread tabs in the room view (mobile-first), inline `+` to create, messages and outgoing posts scoped to the active thread, WS frames refresh the thread list reactively.
- **Changeset**: `minor` for all three packages.

## Test plan

- [x] `pnpm --filter @openape/chat lint typecheck test` (7 schema tests, including new per-thread isolation test)
- [x] `pnpm --filter @openape/chat-bridge lint typecheck test` (17 tests)
- [x] `pnpm --filter @openape/ape-chat lint typecheck`
- [ ] Smoke after deploy: open chat.openape.ai, contact view shows the `main` tab; create a side thread, switch tabs, send a message in each; verify agent answers land in the right tab.