### PR TITLE
fix(cli-auth): preserve owner_email across saveIdpAuth + bridge env fallback

### DIFF
--- a/.changeset/auth-preserve-owner-email.md
+++ b/.changeset/auth-preserve-owner-email.md
@@ -1,0 +1,9 @@
+---
+'@openape/cli-auth': patch
+'@openape/chat-bridge': patch
+---
+
+Fix bridge crash-loop "auth.json missing 'owner_email'" after `apes login`.
+
+- `@openape/cli-auth`: `saveIdpAuth` now merges with existing fields instead of overwriting wholesale. `apes login` (called from the bridge's `start.sh` on every daemon boot) used to silently drop `owner_email` written by `apes agents spawn`, leaving the bridge in a fatal restart loop until the auth.json was manually re-stamped. The merge preserves any unknown keys in the file across logins.
+- `@openape/chat-bridge`: `readAgentIdentity` falls back to `OPENAPE_OWNER_EMAIL` env var when `owner_email` is missing from auth.json, so an old agent (spawned before the Phase A migration) can be unblocked by adding one line to its launchd plist.

--- a/apps/openape-chat-bridge/src/identity.ts
+++ b/apps/openape-chat-bridge/src/identity.ts
@@ -38,10 +38,12 @@ function allowlistPath(): string {
  * Read the agent's identity from auth.json. Throws if the file is
  * missing or has no `email` — both indicate a botched spawn.
  *
- * `ownerEmail` is optional in the file shape (older spawns didn't write
- * it) but the bridge requires it for the new contact-handshake flow;
- * when missing, we throw so the daemon refuses to start rather than
- * accepting from random peers.
+ * `owner_email` is normally written by `apes agents spawn`. If it's
+ * missing we fall back to `OPENAPE_OWNER_EMAIL` from the environment
+ * (set by the launchd plist) so an old auth.json that pre-dates the
+ * Phase A migration doesn't strand the bridge in a crash loop. If both
+ * are missing we throw — the bridge requires it for the contact
+ * handshake.
  */
 export function readAgentIdentity(): AgentIdentity {
   const path = authPath()
@@ -51,13 +53,15 @@ export function readAgentIdentity(): AgentIdentity {
   const raw = readFileSync(path, 'utf8')
   const parsed = JSON.parse(raw) as AuthFile
   if (!parsed.email) throw new Error(`auth.json at ${path} missing 'email'`)
-  if (!parsed.owner_email) {
+  if (!parsed.idp) throw new Error(`auth.json at ${path} missing 'idp'`)
+  const ownerEmail = parsed.owner_email ?? process.env.OPENAPE_OWNER_EMAIL
+  if (!ownerEmail) {
     throw new Error(
-      `auth.json at ${path} missing 'owner_email' — re-spawn the agent with @openape/apes >= 0.28 so the owner can be tracked`,
+      `auth.json at ${path} missing 'owner_email' and no OPENAPE_OWNER_EMAIL env var set — `
+      + 're-spawn the agent with @openape/apes >= 0.28 or add OPENAPE_OWNER_EMAIL to the launchd plist',
     )
   }
-  if (!parsed.idp) throw new Error(`auth.json at ${path} missing 'idp'`)
-  return { email: parsed.email, ownerEmail: parsed.owner_email, idp: parsed.idp }
+  return { email: parsed.email, ownerEmail, idp: parsed.idp }
 }
 
 /**

--- a/packages/cli-auth/src/storage.ts
+++ b/packages/cli-auth/src/storage.ts
@@ -53,7 +53,32 @@ export function loadIdpAuth(): IdpAuth | null {
 
 export function saveIdpAuth(auth: IdpAuth): void {
   ensureConfigDir()
-  writeFileSync(getAuthFile(), JSON.stringify(auth, null, 2), { mode: 0o600 })
+  // Preserve fields the IdpAuth type doesn't model — primarily
+  // `owner_email`, written by `apes agents spawn` so the bridge can
+  // tell who the agent belongs to. Without this merge, every call to
+  // `apes login` (e.g. from the bridge's start.sh on each daemon boot)
+  // would silently drop owner_email and the bridge would crash-loop
+  // with "auth.json missing 'owner_email'".
+  const file = getAuthFile()
+  let extra: Record<string, unknown> = {}
+  if (existsSync(file)) {
+    try {
+      const raw = readFileSync(file, 'utf-8')
+      if (raw.trim()) {
+        const prev = JSON.parse(raw) as Record<string, unknown>
+        for (const key of Object.keys(prev)) {
+          if (!(key in (auth as unknown as Record<string, unknown>))) {
+            extra[key] = prev[key]
+          }
+        }
+      }
+    }
+    catch {
+      extra = {}
+    }
+  }
+  const merged = { ...extra, ...auth }
+  writeFileSync(file, JSON.stringify(merged, null, 2), { mode: 0o600 })
 }
 
 export function clearIdpAuth(): void {

--- a/packages/cli-auth/test/storage.test.ts
+++ b/packages/cli-auth/test/storage.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync as fsWriteFileSync } from 'node:fs'
+import { mkdtempSync, readFileSync as fsReadFileSync, rmSync, writeFileSync as fsWriteFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
@@ -64,6 +64,31 @@ describe('IdP auth roundtrip', () => {
     })
     clearIdpAuth()
     expect(loadIdpAuth()).toBeNull()
+  })
+
+  it('preserves unmodelled fields like owner_email across saveIdpAuth calls', () => {
+    // Simulate `apes agents spawn` writing auth.json with owner_email,
+    // followed by a later `apes login` (which only knows about IdpAuth
+    // fields). Without the merge, owner_email would be silently dropped
+    // and the bridge's startup check would crash-loop.
+    fsWriteFileSync(getAuthFile(), JSON.stringify({
+      idp: 'https://id.openape.ai',
+      access_token: 'old',
+      email: 'agent-bot3+patrick+hofmann_eco@id.openape.ai',
+      expires_at: 1,
+      owner_email: 'patrick@hofmann.eco',
+    }), { mode: 0o600 })
+
+    saveIdpAuth({
+      idp: 'https://id.openape.ai',
+      access_token: 'fresh',
+      email: 'agent-bot3+patrick+hofmann_eco@id.openape.ai',
+      expires_at: 2,
+    })
+
+    const reread = JSON.parse(fsReadFileSync(getAuthFile(), 'utf-8')) as Record<string, unknown>
+    expect(reread.access_token).toBe('fresh')
+    expect(reread.owner_email).toBe('patrick@hofmann.eco')
   })
 
   it('returns null on corrupted JSON instead of throwing', () => {


### PR DESCRIPTION
## Problem

The chat-bridge daemon for `agent-bot3` was crash-looping with `auth.json missing 'owner_email'`. Root cause: bridge's `start.sh` runs `apes login` on every boot to refresh the token, and `cli-auth`'s `saveIdpAuth` writes the IdpAuth blob wholesale — silently dropping `owner_email` that `apes agents spawn` wrote next to it.

## Fix

- **`@openape/cli-auth`**: `saveIdpAuth` now reads the existing file and merges any unknown keys (primarily `owner_email`) before writing. New roundtrip test covers the spawn → login sequence.
- **`@openape/chat-bridge`**: `readAgentIdentity` falls back to `OPENAPE_OWNER_EMAIL` env var when `owner_email` is missing, so an old/clobbered auth.json can be unblocked from the launchd plist without a full re-spawn.

## Test plan

- [x] `pnpm --filter @openape/cli-auth lint typecheck test` (21 tests, +1 new)
- [x] `pnpm --filter @openape/chat-bridge lint typecheck test` (17 tests)
- [ ] After merge + release: bump bridge on agent-bot3, restart daemon, confirm bridge stays connected (no crash loop).