### PR TITLE
fix(apes): stamp OPENAPE_OWNER_EMAIL in plist + surface apes-login errors

### DIFF
--- a/.changeset/spawn-stamp-owner-email-plist.md
+++ b/.changeset/spawn-stamp-owner-email-plist.md
@@ -1,0 +1,7 @@
+---
+'@openape/apes': minor
+---
+
+`apes agents spawn --bridge` now stamps `OPENAPE_OWNER_EMAIL` into the bridge daemon's launchd plist `EnvironmentVariables` block, plus its start.sh logs the actual `apes login` failure to stderr instead of silently swallowing it.
+
+Together these mean a freshly-spawned agent is robust to the cli-auth merge bug from the previous patch: the bridge can resolve its owner from the env var even if `auth.json` ever gets clobbered, and any login refresh failure is debuggable from the daemon's stderr log without an interactive grant approval.

--- a/packages/apes/src/commands/agents/spawn.ts
+++ b/packages/apes/src/commands/agents/spawn.ts
@@ -166,7 +166,7 @@ export const spawnAgentCommand = defineCommand({
             return {
               plistLabel: bridgePlistLabel(name),
               plistPath: bridgePlistPath(name),
-              plistContent: buildBridgePlist(name, homeDir),
+              plistContent: buildBridgePlist(name, homeDir, auth.email),
               startScript: buildBridgeStartScript(),
               envFile: buildBridgeEnvFile(cfg),
             }

--- a/packages/apes/src/lib/llm-bridge.ts
+++ b/packages/apes/src/lib/llm-bridge.ts
@@ -117,8 +117,15 @@ except Exception: sys.exit(1)" 2>/dev/null || true)
 try: print(json.load(open(os.path.expanduser('~/.config/apes/auth.json')))['idp'])
 except Exception: sys.exit(1)" 2>/dev/null || true)
   if [ -n "$agent_email" ] && [ -n "$agent_idp" ]; then
-    apes login "$agent_email" --idp "$agent_idp" >/dev/null 2>&1 \\
-      || echo "warn: apes login failed for $agent_email; continuing with cached token"
+    # Capture full output so the failure mode is debuggable from logs
+    # without needing an interactive grant approval. apes-login should
+    # succeed with the SSH key under ~/.ssh/id_ed25519 written by spawn;
+    # if it doesn't, the cached token carries us until expiry (~1h) and
+    # the daemon will retry on the next launchd restart.
+    login_output=$(apes login "$agent_email" --idp "$agent_idp" 2>&1) || {
+      echo "warn: apes login failed for $agent_email; continuing with cached token" >&2
+      echo "$login_output" | sed 's/^/  apes-login: /' >&2
+    }
   fi
 fi
 
@@ -172,8 +179,14 @@ exec openape-chat-bridge
  * it automatically and respawns on crash via KeepAlive. UserName ensures
  * launchd starts the process as the agent (not root), even though the
  * plist itself is root-owned.
+ *
+ * `OPENAPE_OWNER_EMAIL` is stamped into the daemon environment as a
+ * defense-in-depth fallback for the chat-bridge identity check: the
+ * canonical source is `owner_email` in `~/.config/apes/auth.json`
+ * (written by spawn), but if a future `apes login` ever clobbers that
+ * field the bridge can still resolve its owner from this env var.
  */
-export function buildBridgePlist(agentName: string, homeDir: string): string {
+export function buildBridgePlist(agentName: string, homeDir: string, ownerEmail: string): string {
   const startScript = `${homeDir}/Library/Application Support/openape/bridge/start.sh`
   const stdoutLog = `${homeDir}/Library/Logs/openape-chat-bridge.log`
   const stderrLog = `${homeDir}/Library/Logs/openape-chat-bridge.err.log`
@@ -208,6 +221,8 @@ export function buildBridgePlist(agentName: string, homeDir: string): string {
         <string>${homeDir}</string>
         <key>PATH</key>
         <string>${homeDir}/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <key>OPENAPE_OWNER_EMAIL</key>
+        <string>${ownerEmail}</string>
     </dict>
 </dict>
 </plist>

--- a/packages/apes/test/agents-llm-bridge.test.ts
+++ b/packages/apes/test/agents-llm-bridge.test.ts
@@ -125,7 +125,7 @@ describe('llm-bridge — pure helpers', () => {
   })
 
   it('buildBridgePlist embeds agent name as label + UserName + paths + KeepAlive', () => {
-    const plist = buildBridgePlist('agent-x', '/Users/agent-x')
+    const plist = buildBridgePlist('agent-x', '/Users/agent-x', 'patrick@hofmann.eco')
     expect(plist).toContain('<string>eco.hofmann.apes.bridge.agent-x</string>')
     expect(plist).toContain('<key>UserName</key>')
     expect(plist).toContain('<string>agent-x</string>')
@@ -134,6 +134,15 @@ describe('llm-bridge — pure helpers', () => {
     expect(plist).toContain('<key>KeepAlive</key>')
     expect(plist).toContain('<key>RunAtLoad</key>')
     expect(plist).toContain('<key>HOME</key>')
+  })
+
+  it('buildBridgePlist stamps OPENAPE_OWNER_EMAIL in EnvironmentVariables', () => {
+    const plist = buildBridgePlist('agent-x', '/Users/agent-x', 'patrick@hofmann.eco')
+    // Defense-in-depth: bridge falls back to this env var when auth.json
+    // lacks owner_email (e.g. an old `apes login` clobbered it). Without
+    // this the daemon would crash-loop on "missing 'owner_email'".
+    expect(plist).toContain('<key>OPENAPE_OWNER_EMAIL</key>')
+    expect(plist).toContain('<string>patrick@hofmann.eco</string>')
   })
 
   it('bridgePlistLabel + bridgePlistPath include agent name', () => {


### PR DESCRIPTION
## Summary

Two related defense-in-depth fixes for the bridge daemon spawn path:

1. **`buildBridgePlist` now stamps `OPENAPE_OWNER_EMAIL`** into the launchd plist's `EnvironmentVariables` block. The chat-bridge already falls back to this env var when `owner_email` is missing from `auth.json` (added in the previous patch). Now the env var is written by spawn itself, so freshly-spawned agents are robust regardless of any future cli-auth churn.
2. **`buildBridgeStartScript` no longer swallows apes-login errors.** Output is captured and prefixed-logged to stderr on failure, so the daemon's stderr log shows what actually went wrong — root-causing the auth-refresh path no longer requires an interactive grant approval.

Both changes mean a freshly-spawned agent doesn't need any of the manual workarounds applied to `agent-bot3` (PlistBuddy patch, in-place `auth.json` re-stamping). Existing agents already in production can be retrofitted with one PlistBuddy call to add `OPENAPE_OWNER_EMAIL`.

## Test plan

- [x] `pnpm --filter @openape/apes lint typecheck` clean
- [x] 13 tests in `agents-llm-bridge.test.ts` pass, including the new env-var assertion
- [ ] After release, next `apes agents spawn` produces a plist with `OPENAPE_OWNER_EMAIL` already populated.