### PR TITLE
feat(cli-auth+apes): in-process Ed25519 refresh for agent tokens

### DIFF
--- a/.changeset/in-process-agent-refresh.md
+++ b/.changeset/in-process-agent-refresh.md
@@ -1,0 +1,12 @@
+---
+'@openape/cli-auth': minor
+'@openape/apes': minor
+---
+
+In-process Ed25519 challenge-response refresh for agent IdP tokens (closes #259).
+
+Agent tokens have no `refresh_token` — the IdP's `/agent/authenticate` endpoint deliberately doesn't issue one. Before this change, `ensureFreshIdpAuth` threw `NotLoggedInError` when an agent token expired, which left the chat-bridge daemon in a 1-hour crash-restart loop: launchd's KeepAlive bounced the process every time the cached token aged out, the start.sh shell-out re-ran `apes login` to mint a fresh one, and the cycle repeated.
+
+- **`@openape/cli-auth`** now refreshes agent tokens in-process. When `auth.json.refresh_token` is missing but `key_path` (or `~/.ssh/id_ed25519`) is present, `ensureFreshIdpAuth` signs a new challenge against the IdP's `/agent/challenge` + `/agent/authenticate` endpoints — same flow `apes login --key` uses — and persists the rotated token. The chat-bridge daemon now stays connected across the 1h expiry boundary.
+- **`@openape/apes`**: `apes login` and `apes agents spawn` write `key_path` into auth.json so any cli-auth consumer (chat-bridge, ape-tasks, ape-plans, …) inherits the in-process refresh capability for free. `saveAuth` merges with existing fields so older spawns retain `owner_email` across logins (mirrors PR #257's cli-auth fix). `start.sh` no longer shells out to `apes login` at boot — the install is now ~3-5s instead of doing the legacy refresh dance.
+- **`@openape/cli-auth`** new public types: `IdpAuth.key_path` (optional, absolute path to the Ed25519 signing key).

--- a/packages/apes/src/commands/agents/spawn.ts
+++ b/packages/apes/src/commands/agents/spawn.ts
@@ -148,6 +148,7 @@ export const spawnAgentCommand = defineCommand({
         accessToken: token,
         email: registration.email,
         expiresAt: Math.floor(Date.now() / 1000) + expiresIn,
+        keyPath: `${homeDir}/.ssh/id_ed25519`,
         ownerEmail: auth.email,
       })
 

--- a/packages/apes/src/commands/auth/login.ts
+++ b/packages/apes/src/commands/auth/login.ts
@@ -284,17 +284,17 @@ async function loginWithKey(idp: string, keyPath: string, agentEmail: string) {
 
   const { token, expires_in } = await authResp.json() as { token: string, expires_in: number }
 
+  // Persist the absolute key path on auth.json so any cli-auth consumer
+  // (chat-bridge, ape-tasks, ape-plans, …) can refresh the agent token
+  // in-process without shelling out to `apes login`. See issue #259.
+  const absoluteKeyPath = resolvePath(keyPath.replace(/^~/, homedir()))
   saveAuth({
     idp,
     access_token: token,
     email: agentEmail,
     expires_at: Math.floor(Date.now() / 1000) + (expires_in || 3600),
+    key_path: absoluteKeyPath,
   })
-
-  // Persist the resolved key path + email to config.toml so future apes/ape-shell
-  // invocations can auto-refresh via Ed25519 challenge-response without a new
-  // `apes login`. Merge with existing config so [defaults] is preserved.
-  const absoluteKeyPath = resolvePath(keyPath.replace(/^~/, homedir()))
   const existingConfig = loadConfig()
   saveConfig({
     ...existingConfig,

--- a/packages/apes/src/config.ts
+++ b/packages/apes/src/config.ts
@@ -8,6 +8,18 @@ export interface AuthData {
   refresh_token?: string
   email: string
   expires_at: number
+  /**
+   * Set by `apes login --key …` (and `apes agents spawn`), absolute
+   * path to the Ed25519 key the agent signs challenges with. Lets
+   * `@openape/cli-auth` refresh agent tokens in-process; see #259.
+   */
+  key_path?: string
+  /**
+   * Email of the human who owns this agent — written by
+   * `apes agents spawn`. The chat-bridge reads it for owner-only
+   * contact handshakes. Optional for human auth.json files.
+   */
+  owner_email?: string
 }
 
 export interface ApesConfig {
@@ -89,7 +101,29 @@ export function loadAuth(): AuthData | null {
 
 export function saveAuth(data: AuthData): void {
   ensureDir()
-  writeFileSync(AUTH_FILE, JSON.stringify(data, null, 2), { mode: 0o600 })
+  // Preserve unmodelled fields from any prior version of auth.json
+  // (e.g. older installs of this package, or fields a sibling CLI
+  // wrote). Symmetric with cli-auth's saveIdpAuth — see #257 for the
+  // bridge crash-loop the bare overwrite caused before.
+  let extra: Record<string, unknown> = {}
+  if (existsSync(AUTH_FILE)) {
+    try {
+      const raw = readFileSync(AUTH_FILE, 'utf-8')
+      if (raw.trim()) {
+        const prev = JSON.parse(raw) as Record<string, unknown>
+        for (const key of Object.keys(prev)) {
+          if (!(key in (data as unknown as Record<string, unknown>))) {
+            extra[key] = prev[key]
+          }
+        }
+      }
+    }
+    catch {
+      extra = {}
+    }
+  }
+  const merged = { ...extra, ...data }
+  writeFileSync(AUTH_FILE, JSON.stringify(merged, null, 2), { mode: 0o600 })
 }
 
 export function clearAuth(): void {

--- a/packages/apes/src/lib/agent-bootstrap.ts
+++ b/packages/apes/src/lib/agent-bootstrap.ts
@@ -364,6 +364,13 @@ export interface AuthJsonInput {
   email: string
   expiresAt: number
   /**
+   * Absolute path to the agent's Ed25519 private key on its own home
+   * directory. Lets `@openape/cli-auth` refresh the access token in
+   * process via challenge-response — see #259. Spawn writes the key
+   * to `${homeDir}/.ssh/id_ed25519` so the path is deterministic.
+   */
+  keyPath: string
+  /**
    * Email of the human owner who spawned this agent. Persisted so the
    * bridge daemon can (a) send the initial contact request to the right
    * person and (b) seed its allowlist with the only peer it should
@@ -378,6 +385,7 @@ export function buildAgentAuthJson(input: AuthJsonInput): string {
     access_token: input.accessToken,
     email: input.email,
     expires_at: input.expiresAt,
+    key_path: input.keyPath,
     owner_email: input.ownerEmail,
   }, null, 2)}\n`
 }

--- a/packages/apes/src/lib/llm-bridge.ts
+++ b/packages/apes/src/lib/llm-bridge.ts
@@ -87,12 +87,16 @@ LITELLM_API_KEY=${cfg.apiKey}
  * start.sh content. Slim — assumes the bridge stack (chat-bridge + apes
  * + pi) was already bun-installed during spawn. Each launchd boot only:
  *
- *   1. Refreshes the agent's IdP token via `apes login` (key-based,
- *      ~1h expiry workaround — agent tokens have no refresh_token).
- *   2. Drops the litellm pi extension if missing (idempotent).
- *   3. Sources the proxy env + execs the bridge.
+ *   1. Drops the litellm pi extension if missing (idempotent).
+ *   2. Sources the proxy env + execs the bridge.
  *
  * Boot time goes from ~75s (with installs) to ~3-5s.
+ *
+ * Token refresh: handled in-process by `@openape/cli-auth`, which
+ * does its own Ed25519 challenge-response when the cached IdP token
+ * expires (`auth.json.key_path` points at `~/.ssh/id_ed25519`). No
+ * `apes login` shell-out needed at boot — the daemon stays connected
+ * across the 1h expiry boundary instead of crash-restarting. See #259.
  *
  * To upgrade an agent's bridge after a new release:
  *   apes run --as <name> -- bun update -g @openape/chat-bridge
@@ -105,29 +109,10 @@ set -euo pipefail
 
 export PATH="$HOME/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
 
-# Refresh IdP token. Agents auth via SSH-key signing — the cached IdP
-# token has no refresh_token and expires after ~1h. Re-running apes
-# login re-signs against the registered key. Soft-fails to leave the
-# bridge usable on cached token if the IdP is briefly unreachable.
-if [ -f "$HOME/.config/apes/auth.json" ] && command -v apes >/dev/null 2>&1; then
-  agent_email=$(python3 -c "import json,os,sys
-try: print(json.load(open(os.path.expanduser('~/.config/apes/auth.json')))['email'])
-except Exception: sys.exit(1)" 2>/dev/null || true)
-  agent_idp=$(python3 -c "import json,os,sys
-try: print(json.load(open(os.path.expanduser('~/.config/apes/auth.json')))['idp'])
-except Exception: sys.exit(1)" 2>/dev/null || true)
-  if [ -n "$agent_email" ] && [ -n "$agent_idp" ]; then
-    # Capture full output so the failure mode is debuggable from logs
-    # without needing an interactive grant approval. apes-login should
-    # succeed with the SSH key under ~/.ssh/id_ed25519 written by spawn;
-    # if it doesn't, the cached token carries us until expiry (~1h) and
-    # the daemon will retry on the next launchd restart.
-    login_output=$(apes login "$agent_email" --idp "$agent_idp" 2>&1) || {
-      echo "warn: apes login failed for $agent_email; continuing with cached token" >&2
-      echo "$login_output" | sed 's/^/  apes-login: /' >&2
-    }
-  fi
-fi
+# Token refresh is in-process via @openape/cli-auth's challenge-response
+# path (auth.json.key_path -> ~/.ssh/id_ed25519). No "apes login" needed
+# at boot — keeping start.sh slim avoids the rate-limit dance the old
+# refresh hit when KeepAlive crash-restarted the daemon every 1h.
 
 EXT_DIR="$HOME/.pi/agent/extensions"
 mkdir -p "$EXT_DIR"

--- a/packages/apes/test/agents-bootstrap.test.ts
+++ b/packages/apes/test/agents-bootstrap.test.ts
@@ -57,12 +57,14 @@ describe('shQuote', () => {
 })
 
 describe('buildAgentAuthJson', () => {
-  it('emits a stable, parseable auth.json', () => {
+  it('emits a stable, parseable auth.json with key_path + owner_email', () => {
     const out = buildAgentAuthJson({
       idp: 'https://id.openape.ai',
       accessToken: 'tok',
       email: 'agent-a+patrick+hofmann_eco@id.openape.ai',
       expiresAt: 1234567890,
+      keyPath: '/Users/agent-a/.ssh/id_ed25519',
+      ownerEmail: 'patrick@hofmann.eco',
     })
     const parsed = JSON.parse(out)
     expect(parsed).toEqual({
@@ -70,6 +72,11 @@ describe('buildAgentAuthJson', () => {
       access_token: 'tok',
       email: 'agent-a+patrick+hofmann_eco@id.openape.ai',
       expires_at: 1234567890,
+      // key_path lets cli-auth refresh in-process via challenge-response
+      // (#259) — without this the daemon would crash-restart hourly.
+      key_path: '/Users/agent-a/.ssh/id_ed25519',
+      // owner_email backs the contact handshake — see #257.
+      owner_email: 'patrick@hofmann.eco',
     })
     expect(out.endsWith('\n')).toBe(true)
   })

--- a/packages/apes/test/agents-llm-bridge.test.ts
+++ b/packages/apes/test/agents-llm-bridge.test.ts
@@ -111,17 +111,18 @@ describe('llm-bridge — pure helpers', () => {
     expect(sh).toContain('$HOME/.bun/bin')
   })
 
-  it('buildBridgeStartScript refreshes IdP token before exec (1h expiry workaround)', () => {
+  it('buildBridgeStartScript no longer invokes `apes login` — refresh is in-process via cli-auth (#259)', () => {
     const sh = buildBridgeStartScript()
-    // The script must read the agent's own email and idp out of auth.json
-    // and call `apes login` BEFORE exec'ing the bridge — otherwise the
-    // bridge picks up the (potentially expired) cached token and crashes.
-    expect(sh).toContain('~/.config/apes/auth.json')
-    expect(sh).toContain('apes login "$agent_email" --idp "$agent_idp"')
-    const loginIdx = sh.indexOf('apes login')
-    const execIdx = sh.indexOf('exec openape-chat-bridge')
-    expect(loginIdx).toBeGreaterThan(0)
-    expect(execIdx).toBeGreaterThan(loginIdx)
+    // Token refresh moved into @openape/cli-auth's challenge-response
+    // path. start.sh used to invoke `apes login` on every daemon boot
+    // as a workaround for the 1h agent-token expiry; now cli-auth
+    // handles it without shelling out, so the daemon stays connected
+    // across expiry instead of crash-restarting.
+    //
+    // Match the actual command invocation (whitespace-bracketed) instead
+    // of the bare substring — comments still mention the historical
+    // command name.
+    expect(sh).not.toMatch(/(^|[\s;|&])apes\s+login\b/m)
   })
 
   it('buildBridgePlist embeds agent name as label + UserName + paths + KeepAlive', () => {

--- a/packages/cli-auth/src/agent-refresh.ts
+++ b/packages/cli-auth/src/agent-refresh.ts
@@ -1,0 +1,152 @@
+import { Buffer } from 'node:buffer'
+import { sign } from 'node:crypto'
+import { existsSync, readFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { ofetch } from 'ofetch'
+import { loadEd25519PrivateKey } from './ssh-key.js'
+import type { IdpAuth } from './types.js'
+
+interface DiscoveryDocument {
+  ddisa_agent_challenge_endpoint?: string
+  ddisa_agent_authenticate_endpoint?: string
+}
+
+interface ChallengeResponse {
+  challenge: string
+}
+
+interface AuthenticateResponse {
+  token: string
+  expires_in: number
+}
+
+async function getEndpoints(idp: string): Promise<{ challenge: string, authenticate: string }> {
+  let disco: DiscoveryDocument = {}
+  try {
+    disco = await ofetch<DiscoveryDocument>(`${idp}/.well-known/openid-configuration`)
+  }
+  catch {
+    // Fall through to convention-based paths — the IdP usually exposes both,
+    // but a missing discovery doc shouldn't block a key-based refresh.
+  }
+  return {
+    challenge: disco.ddisa_agent_challenge_endpoint ?? `${idp}/api/agent/challenge`,
+    authenticate: disco.ddisa_agent_authenticate_endpoint ?? `${idp}/api/agent/authenticate`,
+  }
+}
+
+function resolveKeyPath(p: string): string {
+  if (p.startsWith('~')) return join(homedir(), p.slice(1))
+  return p
+}
+
+/**
+ * Resolve the signing key for an agent refresh.
+ *
+ * Order:
+ *   1. `auth.key_path` (set by `apes login --key …` once it persists)
+ *   2. `~/.ssh/id_ed25519` if present (default for `apes agents spawn`,
+ *      which writes the agent's keypair there).
+ *
+ * Returns `null` when no key is available — caller falls back to
+ * `NotLoggedInError` so the consuming CLI can surface the right hint.
+ */
+function findSigningKey(auth: IdpAuth): { keyPath: string, keyContent: string } | null {
+  const candidates: string[] = []
+  if (auth.key_path) candidates.push(resolveKeyPath(auth.key_path))
+  candidates.push(join(homedir(), '.ssh', 'id_ed25519'))
+
+  for (const p of candidates) {
+    if (existsSync(p)) {
+      try {
+        return { keyPath: p, keyContent: readFileSync(p, 'utf-8') }
+      }
+      catch {
+        // Permission denied / unreadable — try the next candidate.
+      }
+    }
+  }
+  return null
+}
+
+/**
+ * Refresh an agent's IdP token via Ed25519 challenge-response.
+ *
+ * Why this exists: agent IdP tokens are minted by the IdP's
+ * `/agent/authenticate` endpoint and have **no** refresh_token (the
+ * spec deliberately keeps agent auth challenge-only — no long-lived
+ * bearer to leak). The OAuth refresh-token grant in
+ * `ensureFreshIdpAuth` therefore can't recover an expired agent token,
+ * which left the chat-bridge daemon in a 1-hour crash-restart loop
+ * (see issue #259). This function plugs the gap by re-running the
+ * same challenge-response flow `apes login --key` does — entirely
+ * in-process, no `apes` shell-out, no daemon restart.
+ *
+ * Returns `null` when refresh isn't possible (no key on disk, IdP
+ * rejected, network error). The caller is `ensureFreshIdpAuth`,
+ * which then falls back to `NotLoggedInError`.
+ */
+export async function refreshAgentToken(
+  auth: IdpAuth,
+  now: number = Math.floor(Date.now() / 1000),
+): Promise<IdpAuth | null> {
+  const key = findSigningKey(auth)
+  if (!key) return null
+
+  let privateKey
+  try {
+    privateKey = loadEd25519PrivateKey(key.keyContent)
+  }
+  catch {
+    return null
+  }
+
+  let endpoints
+  try {
+    endpoints = await getEndpoints(auth.idp)
+  }
+  catch {
+    return null
+  }
+
+  let challenge: string
+  try {
+    const resp = await ofetch<ChallengeResponse>(endpoints.challenge, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: { agent_id: auth.email },
+    })
+    challenge = resp.challenge
+  }
+  catch {
+    return null
+  }
+
+  let signature: string
+  try {
+    signature = sign(null, Buffer.from(challenge), privateKey).toString('base64')
+  }
+  catch {
+    return null
+  }
+
+  let authResp: AuthenticateResponse
+  try {
+    authResp = await ofetch<AuthenticateResponse>(endpoints.authenticate, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: { agent_id: auth.email, challenge, signature },
+    })
+  }
+  catch {
+    return null
+  }
+
+  return {
+    ...auth,
+    access_token: authResp.token,
+    expires_at: now + (authResp.expires_in || 3600),
+    key_path: auth.key_path ?? key.keyPath,
+  }
+}

--- a/packages/cli-auth/src/refresh.ts
+++ b/packages/cli-auth/src/refresh.ts
@@ -1,4 +1,5 @@
 import { ofetch } from 'ofetch'
+import { refreshAgentToken } from './agent-refresh.js'
 import { loadIdpAuth, saveIdpAuth } from './storage.js'
 import { AuthError, NotLoggedInError  } from './types.js'
 import type { IdpAuth } from './types.js'
@@ -50,7 +51,17 @@ export async function ensureFreshIdpAuth(now: number = Math.floor(Date.now() / 1
     return auth
   }
 
+  // Agent path: no refresh_token (the IdP doesn't issue one for
+  // /agent/authenticate) but we may have a signing key on disk.
+  // Re-run the same challenge-response flow `apes login --key` does
+  // and persist the refreshed token. See packages/cli-auth/src/agent-refresh.ts
+  // for the rationale and #259 for the daemon crash loop this prevents.
   if (!auth.refresh_token) {
+    const refreshed = await refreshAgentToken(auth, now)
+    if (refreshed) {
+      saveIdpAuth(refreshed)
+      return refreshed
+    }
     throw new NotLoggedInError(
       `IdP token expired at ${new Date(auth.expires_at * 1000).toISOString()} and no refresh_token is stored. Run \`apes login\` again.`,
     )

--- a/packages/cli-auth/src/ssh-key.ts
+++ b/packages/cli-auth/src/ssh-key.ts
@@ -1,0 +1,85 @@
+import { Buffer } from 'node:buffer'
+import { createPrivateKey  } from 'node:crypto'
+import type { KeyObject } from 'node:crypto'
+
+const OPENSSH_MAGIC = 'openssh-key-v1\0'
+
+/**
+ * Parse an OpenSSH Ed25519 private key file and return a Node.js KeyObject.
+ *
+ * Supports both OpenSSH format (`-----BEGIN OPENSSH PRIVATE KEY-----`)
+ * and PKCS8 PEM format (`-----BEGIN PRIVATE KEY-----`). Mirrors the
+ * loader in `@openape/apes` — duplicated here so cli-auth can do its
+ * own challenge-response refresh without taking an apes dependency.
+ */
+export function loadEd25519PrivateKey(pem: string): KeyObject {
+  if (pem.includes('BEGIN OPENSSH PRIVATE KEY')) {
+    return parseOpenSSHEd25519(pem)
+  }
+  return createPrivateKey(pem)
+}
+
+function parseOpenSSHEd25519(pem: string): KeyObject {
+  const b64 = pem
+    .replace(/-----BEGIN OPENSSH PRIVATE KEY-----/, '')
+    .replace(/-----END OPENSSH PRIVATE KEY-----/, '')
+    .replace(/\s/g, '')
+
+  const buf = Buffer.from(b64, 'base64')
+  let offset = 0
+
+  const magic = buf.subarray(0, OPENSSH_MAGIC.length).toString('ascii')
+  if (magic !== OPENSSH_MAGIC) {
+    throw new Error('Not an OpenSSH private key')
+  }
+  offset += OPENSSH_MAGIC.length
+
+  const cipherLen = buf.readUInt32BE(offset); offset += 4
+  const cipher = buf.subarray(offset, offset + cipherLen).toString(); offset += cipherLen
+  if (cipher !== 'none') {
+    throw new Error(`Encrypted keys not supported (cipher: ${cipher}). Decrypt first with: ssh-keygen -p -f <key>`)
+  }
+
+  const kdfLen = buf.readUInt32BE(offset); offset += 4
+  offset += kdfLen
+
+  const kdfOptsLen = buf.readUInt32BE(offset); offset += 4
+  offset += kdfOptsLen
+
+  const numKeys = buf.readUInt32BE(offset); offset += 4
+  if (numKeys !== 1) {
+    throw new Error(`Expected 1 key, got ${numKeys}`)
+  }
+
+  const pubSectionLen = buf.readUInt32BE(offset); offset += 4
+  offset += pubSectionLen
+
+  const privSectionLen = buf.readUInt32BE(offset); offset += 4
+  const privSection = buf.subarray(offset, offset + privSectionLen)
+  let pOffset = 0
+
+  const check1 = privSection.readUInt32BE(pOffset); pOffset += 4
+  const check2 = privSection.readUInt32BE(pOffset); pOffset += 4
+  if (check1 !== check2) {
+    throw new Error('Check integers mismatch — key may be corrupted or encrypted')
+  }
+
+  const keyTypeLen = privSection.readUInt32BE(pOffset); pOffset += 4
+  const keyType = privSection.subarray(pOffset, pOffset + keyTypeLen).toString(); pOffset += keyTypeLen
+  if (keyType !== 'ssh-ed25519') {
+    throw new Error(`Expected ssh-ed25519, got ${keyType}`)
+  }
+
+  const pubKeyLen = privSection.readUInt32BE(pOffset); pOffset += 4
+  const pubKey = privSection.subarray(pOffset, pOffset + pubKeyLen); pOffset += pubKeyLen
+
+  const privKeyLen = privSection.readUInt32BE(pOffset); pOffset += 4
+  const privKeyData = privSection.subarray(pOffset, pOffset + privKeyLen)
+
+  const seed = privKeyData.subarray(0, 32)
+
+  return createPrivateKey({
+    key: { kty: 'OKP', crv: 'Ed25519', d: seed.toString('base64url'), x: pubKey.toString('base64url') },
+    format: 'jwk',
+  })
+}

--- a/packages/cli-auth/src/types.ts
+++ b/packages/cli-auth/src/types.ts
@@ -10,6 +10,15 @@ export interface IdpAuth {
   refresh_token?: string
   email: string
   expires_at: number
+  /**
+   * Absolute path to an Ed25519 private key, set when the original
+   * `apes login` was key-based (i.e. agent login). Lets `cli-auth`
+   * refresh the access token in-process by signing a fresh challenge
+   * — replaces the per-hour daemon restart cycle that was needed
+   * before this field existed. Optional: human (PKCE) logins leave
+   * it unset and continue to use the OAuth `refresh_token` path.
+   */
+  key_path?: string
 }
 
 /**

--- a/packages/cli-auth/test/refresh.test.ts
+++ b/packages/cli-auth/test/refresh.test.ts
@@ -38,7 +38,7 @@ describe('ensureFreshIdpAuth', () => {
     expect(result.access_token).toBe('still-good')
   })
 
-  it('throws NotLoggedInError when token expired and no refresh_token', async () => {
+  it('throws NotLoggedInError when token expired and no refresh_token AND no key_path', async () => {
     saveIdpAuth({
       idp: 'https://id.openape.ai',
       access_token: 'expired',
@@ -46,6 +46,81 @@ describe('ensureFreshIdpAuth', () => {
       expires_at: 100,
     })
     await expect(ensureFreshIdpAuth(2000)).rejects.toThrow(NotLoggedInError)
+  })
+
+  it('refreshes an agent token via key challenge-response when refresh_token is missing (#259)', async () => {
+    // Write a real Ed25519 PKCS8 key to disk so the in-process signing works.
+    const { generateKeyPairSync } = await import('node:crypto')
+    const { writeFileSync } = await import('node:fs')
+    const { keyObject: priv } = { keyObject: generateKeyPairSync('ed25519').privateKey }
+    const pem = priv.export({ format: 'pem', type: 'pkcs8' }).toString()
+    const keyPath = join(tmpHome, 'agent-key.pem')
+    writeFileSync(keyPath, pem)
+
+    saveIdpAuth({
+      idp: 'https://id.openape.ai',
+      access_token: 'expired',
+      email: 'agent-x+patrick+hofmann_eco@id.openape.ai',
+      expires_at: 100,
+      key_path: keyPath,
+    })
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      const u = String(url)
+      if (u.endsWith('/.well-known/openid-configuration')) {
+        return new Response(JSON.stringify({}), { status: 200, headers: { 'Content-Type': 'application/json' } })
+      }
+      if (u.endsWith('/api/agent/challenge')) {
+        return new Response(JSON.stringify({ challenge: 'YWJj' }), {
+          status: 200, headers: { 'Content-Type': 'application/json' },
+        })
+      }
+      if (u.endsWith('/api/agent/authenticate')) {
+        return new Response(JSON.stringify({ token: 'fresh-agent-token', expires_in: 3600 }), {
+          status: 200, headers: { 'Content-Type': 'application/json' },
+        })
+      }
+      throw new Error(`unexpected fetch ${u}`)
+    })
+
+    const refreshed = await ensureFreshIdpAuth(2000)
+    expect(refreshed.access_token).toBe('fresh-agent-token')
+    expect(refreshed.expires_at).toBe(2000 + 3600)
+    expect(loadIdpAuth()?.access_token).toBe('fresh-agent-token')
+    // key_path stays — needed for the next refresh
+    expect(loadIdpAuth()?.key_path).toBe(keyPath)
+
+    fetchSpy.mockRestore()
+  })
+
+  it('falls back to NotLoggedInError when agent challenge endpoint rejects', async () => {
+    const { generateKeyPairSync } = await import('node:crypto')
+    const { writeFileSync } = await import('node:fs')
+    const priv = generateKeyPairSync('ed25519').privateKey
+    const pem = priv.export({ format: 'pem', type: 'pkcs8' }).toString()
+    const keyPath = join(tmpHome, 'agent-key.pem')
+    writeFileSync(keyPath, pem)
+
+    saveIdpAuth({
+      idp: 'https://id.openape.ai',
+      access_token: 'expired',
+      email: 'agent-x@example',
+      expires_at: 100,
+      key_path: keyPath,
+    })
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      const u = String(url)
+      if (u.endsWith('/.well-known/openid-configuration')) {
+        return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } })
+      }
+      // IdP rejects the challenge request — refresh path returns null,
+      // ensureFreshIdpAuth surfaces the original NotLoggedInError.
+      return new Response('rate limited', { status: 429 })
+    })
+
+    await expect(ensureFreshIdpAuth(2000)).rejects.toThrow(NotLoggedInError)
+    fetchSpy.mockRestore()
   })
 
   it('refreshes via OIDC and persists the new token', async () => {


### PR DESCRIPTION
Closes #259.

## Summary

Removes the chat-bridge's hourly crash-restart loop. Before this change, agent IdP tokens (which have no `refresh_token`) expired every hour, `ensureFreshIdpAuth` threw `NotLoggedInError`, the bridge crashed, launchd's `KeepAlive` restarted it, `start.sh` shelled out to `apes login`, and the cycle repeated every 60 minutes.

After this change the bridge stays connected across the expiry boundary — token refresh happens in-process via the same Ed25519 challenge-response flow `apes login --key` uses.

## Changes

### `@openape/cli-auth`

- **`agent-refresh.ts`** (new): mints a fresh agent token by signing a `/agent/challenge` against `/agent/authenticate`. Returns `null` on any failure (no key on disk, IdP rejected, network error) so the caller falls back to `NotLoggedInError`.
- **`ssh-key.ts`** (new): self-contained Ed25519 OpenSSH/PKCS8 loader. Mirrors the apes copy — duplicated rather than imported because `cli-auth` has no `apes` dependency by design.
- **`types.IdpAuth`**: new optional `key_path` field, set when the original login was key-based.
- **`refresh.ensureFreshIdpAuth`**: when `refresh_token` is missing, tries `refreshAgentToken` before throwing.

### `@openape/apes`

- **`apes login --key …`** persists the absolute key path into `auth.json.key_path`.
- **`apes agents spawn --bridge`** writes `key_path: ${homeDir}/.ssh/id_ed25519` into the agent's auth.json on first boot.
- **`saveAuth`** merges with existing fields (mirrors the PR #257 cli-auth fix), so `owner_email` and `key_path` survive across logins.
- **`start.sh`**: no longer shells out to `apes login` at boot. The token refresh is now cli-auth's responsibility.

## Test plan

- [x] `pnpm --filter @openape/cli-auth lint typecheck test` (3 new tests: real-Ed25519 refresh, IdP rejection fallback, no-refresh-token+no-key-path NotLoggedInError)
- [x] `pnpm --filter @openape/apes lint typecheck test` (615 tests + 3 skipped, including updated buildAgentAuthJson + start.sh assertions)
- [x] `pnpm --filter @openape/chat-bridge typecheck test` (17 tests)
- [ ] After release: bump bridge on agent-bot3 (or freshly spawn an agent), observe the daemon stays connected for >2h without `launchctl list` showing restart count incrementing.