### PR TITLE
fix(idp): close grant self-approve bypass — agents can no longer mint own authz_jwt

### DIFF
--- a/.changeset/fix-grant-self-approve.md
+++ b/.changeset/fix-grant-self-approve.md
@@ -1,0 +1,15 @@
+---
+'@openape/nuxt-auth-idp': patch
+---
+
+Fix grant approval bypass: agents could self-approve their own grants regardless of approver policy.
+
+`approve.post.ts` previously had an `isRequester` short-circuit that let any caller approve a grant whose `requester === bearer.sub`. An agent armed with only its 1h IdP token could therefore mint authz_jwt for arbitrary audiences without the human owner ever being involved — defeating the entire DDISA delegation model.
+
+The handler now resolves the approver policy correctly per the User type convention (`approver === undefined` means "owner, or self when there is no owner"):
+
+- explicit approver set → only that approver (or owner) may approve
+- approver unset, owner set → owner is the implicit approver (sub-user / agent path)
+- approver unset, owner unset → top-level human, self-approval is implicit
+
+Surfaced in the security audit on 2026-05-04.

--- a/modules/nuxt-auth-idp/src/runtime/server/api/grants/[id]/approve.post.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/api/grants/[id]/approve.post.ts
@@ -37,17 +37,33 @@ export default defineEventHandler(async (event) => {
     throw createProblemError({ status: 404, title: 'Grant not found', type: 'https://openape.org/errors/grant_not_found' })
   }
 
-  // Management token bypasses authorization check
+  // Management token bypasses authorization check.
   const isManagement = email === '_management_'
-  // Allow if the logged-in user is the requester themselves
-  const isRequester = grant.request.requester === email
-  if (!isManagement && !isRequester) {
+  if (!isManagement) {
     const requesterUser = await userStore.findByEmail(grant.request.requester)
     if (!requesterUser) {
       throw createProblemError({ status: 403, title: 'Requester not found for this grant' })
     }
-    const isOwnerOrApprover = requesterUser.owner === email || requesterUser.approver === email
-    if (!isOwnerOrApprover) {
+    // Approver-policy resolution. Per the User type convention
+    // (`packages/auth/src/idp/stores.ts:320`), `approver === undefined`
+    // means "defaults to owner, or self when there is no owner". So:
+    //
+    //   approver explicitly set    -> only that approver (and the owner) may approve.
+    //   approver unset, owner set  -> owner is the implicit approver (sub-user / agent).
+    //   approver unset, owner unset -> top-level human, self-approval is implicit.
+    //
+    // The previous `isRequester` shortcut allowed *every* requester to
+    // self-approve regardless of policy — that bypassed the entire
+    // delegation model: an agent with only its 1h IdP token could mint
+    // itself authz_jwt for arbitrary audiences without the human owner
+    // ever being involved. See security audit 2026-05-04.
+    const isOwner = requesterUser.owner !== undefined && requesterUser.owner === email
+    const isExplicitApprover = requesterUser.approver !== undefined && requesterUser.approver === email
+    const isImplicitSelfApprove
+      = requesterUser.approver === undefined
+      && requesterUser.owner === undefined
+      && requesterUser.email === email
+    if (!isOwner && !isExplicitApprover && !isImplicitSelfApprove) {
       throw createProblemError({ status: 403, title: 'Only the owner or approver can approve this grant' })
     }
   }

--- a/modules/nuxt-auth-idp/test/grants-approve-authz.test.ts
+++ b/modules/nuxt-auth-idp/test/grants-approve-authz.test.ts
@@ -1,0 +1,196 @@
+import type { OpenApeCliAuthorizationDetail, OpenApeGrant } from '@openape/core'
+import { InMemoryGrantStore } from '@openape/grants'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Approver-policy regression suite. Surfaced in the security audit on
+// 2026-05-04 (issue #275-area): the previous `isRequester` short-circuit
+// in approve.post.ts let any requester self-approve, so an agent armed
+// with only its 1h IdP token could mint authz_jwt for arbitrary audiences
+// without the human owner's consent. These tests pin the corrected
+// approver-policy resolution: explicit approver / owner / implicit-self
+// (top-level human only) — never "requester == bearer".
+
+let grantStore = new InMemoryGrantStore()
+const readBodyMock = vi.fn()
+const routerParamMock = vi.fn()
+let mockRequireAuthEmail = 'admin@example.com'
+const usersInStore: Map<string, { email: string, owner?: string, approver?: string }> = new Map()
+
+vi.mock('h3', () => ({
+  defineEventHandler: (fn: any) => fn,
+  readBody: (...args: any[]) => readBodyMock(...args),
+  getRouterParam: (...args: any[]) => routerParamMock(...args),
+  getRequestHeader: vi.fn(),
+  setResponseHeader: vi.fn(),
+  setResponseStatus: vi.fn(),
+  createError: (opts: any) =>
+    Object.assign(new Error(opts.statusMessage), { statusCode: opts.statusCode, data: opts.data }),
+}))
+
+vi.mock('../src/runtime/server/utils/admin', () => ({
+  requireAuth: vi.fn(async () => mockRequireAuthEmail),
+}))
+
+vi.mock('../src/runtime/server/utils/grant-stores', () => ({
+  useGrantStores: () => ({ grantStore }),
+}))
+
+vi.mock('../src/runtime/server/utils/stores', () => ({
+  getIdpIssuer: () => 'https://id.openape.at',
+  useIdpStores: () => ({
+    userStore: {
+      findByEmail: async (email: string) => usersInStore.get(email),
+    },
+    keyStore: {
+      getSigningKey: async () => {
+        const keyPair = await crypto.subtle.generateKey(
+          { name: 'Ed25519', namedCurve: 'Ed25519' } as unknown as EcKeyGenParams,
+          true,
+          ['sign', 'verify'],
+        )
+        return { kid: 'test-kid', privateKey: keyPair.privateKey, publicKey: keyPair.publicKey }
+      },
+    },
+  }),
+}))
+
+vi.mock('nitropack/runtime', () => ({
+  useRuntimeConfig: () => ({ openapeIdp: {} }),
+  useEvent: vi.fn(),
+  useStorage: vi.fn(),
+}))
+
+function detail(): OpenApeCliAuthorizationDetail {
+  return {
+    type: 'openape_cli',
+    cli_id: 'rm',
+    operation_id: 'rm.delete',
+    resource_chain: [{ resource: 'filesystem', selector: { path: '/tmp/x' } }],
+    action: 'delete',
+    permission: 'rm.filesystem[path=/tmp/x]#delete',
+    display: 'Remove /tmp/x',
+    risk: 'medium',
+  }
+}
+
+async function createGrantBy(requester: string): Promise<OpenApeGrant> {
+  const g: OpenApeGrant = {
+    id: 'grant-approver-test',
+    status: 'pending',
+    created_at: Math.floor(Date.now() / 1000),
+    request: {
+      requester,
+      target_host: 'macmini',
+      audience: 'shapes',
+      grant_type: 'once',
+      authorization_details: [detail()],
+      command: ['rm', '/tmp/x'],
+      cmd_hash: 'SHA-256:dummy',
+    },
+  }
+  await grantStore.save(g)
+  return g
+}
+
+async function importHandler() {
+  return (await import('../src/runtime/server/api/grants/[id]/approve.post')).default
+}
+
+describe('approve.post authorization', () => {
+  beforeEach(() => {
+    grantStore = new InMemoryGrantStore()
+    usersInStore.clear()
+    readBodyMock.mockReset().mockResolvedValue({})
+    routerParamMock.mockReset().mockReturnValue('grant-approver-test')
+  })
+
+  it('rejects an agent that tries to self-approve its own grant', async () => {
+    // Sub-user with an explicit owner (the human) and no separate approver.
+    // The agent presents its own bearer (sub === requester); previously the
+    // `isRequester` shortcut bypassed the policy and let it self-approve.
+    usersInStore.set('agent@example.com', {
+      email: 'agent@example.com',
+      owner: 'patrick@hofmann.eco',
+      approver: undefined,
+    })
+    await createGrantBy('agent@example.com')
+    mockRequireAuthEmail = 'agent@example.com'
+
+    const handler = await importHandler()
+    await expect(handler({} as any)).rejects.toMatchObject({ statusCode: 403 })
+  })
+
+  it('lets the explicit approver approve a sub-user grant', async () => {
+    usersInStore.set('agent@example.com', {
+      email: 'agent@example.com',
+      owner: 'patrick@hofmann.eco',
+      approver: 'security@example.com',
+    })
+    await createGrantBy('agent@example.com')
+    mockRequireAuthEmail = 'security@example.com'
+
+    const handler = await importHandler()
+    const result = await handler({} as any)
+    expect(result.grant.status).toBe('approved')
+  })
+
+  it('lets the owner approve a sub-user grant when approver is unset', async () => {
+    // Approver undefined => owner is the implicit approver.
+    usersInStore.set('agent@example.com', {
+      email: 'agent@example.com',
+      owner: 'patrick@hofmann.eco',
+      approver: undefined,
+    })
+    await createGrantBy('agent@example.com')
+    mockRequireAuthEmail = 'patrick@hofmann.eco'
+
+    const handler = await importHandler()
+    const result = await handler({} as any)
+    expect(result.grant.status).toBe('approved')
+  })
+
+  it('lets a top-level human approve their own grant (no owner, no approver)', async () => {
+    // Implicit-self path: when both owner and approver are undefined the
+    // user IS the policy's terminal authority, so self-approval is fine.
+    usersInStore.set('patrick@hofmann.eco', {
+      email: 'patrick@hofmann.eco',
+      owner: undefined,
+      approver: undefined,
+    })
+    await createGrantBy('patrick@hofmann.eco')
+    mockRequireAuthEmail = 'patrick@hofmann.eco'
+
+    const handler = await importHandler()
+    const result = await handler({} as any)
+    expect(result.grant.status).toBe('approved')
+  })
+
+  it('rejects approval by an unrelated party', async () => {
+    usersInStore.set('agent@example.com', {
+      email: 'agent@example.com',
+      owner: 'patrick@hofmann.eco',
+      approver: undefined,
+    })
+    await createGrantBy('agent@example.com')
+    mockRequireAuthEmail = 'random@stranger.example'
+
+    const handler = await importHandler()
+    await expect(handler({} as any)).rejects.toMatchObject({ statusCode: 403 })
+  })
+
+  it('still allows the management token to approve regardless of approver-policy', async () => {
+    // The management bypass is intentional; a deployment with a known
+    // management secret can short-circuit the policy.
+    usersInStore.set('agent@example.com', {
+      email: 'agent@example.com',
+      owner: 'patrick@hofmann.eco',
+      approver: undefined,
+    })
+    await createGrantBy('agent@example.com')
+    mockRequireAuthEmail = '_management_'
+
+    const handler = await importHandler()
+    const result = await handler({} as any)
+    expect(result.grant.status).toBe('approved')
+  })
+})


### PR DESCRIPTION
Closes the critical finding from the 2026-05-04 security audit.

## Problem

`modules/nuxt-auth-idp/src/runtime/server/api/grants/[id]/approve.post.ts:42-44` had a short-circuit:

\`\`\`ts
const isRequester = grant.request.requester === email
if (!isManagement && !isRequester) {
  // … approver-policy check
}
\`\`\`

An agent armed with only its 1h IdP token could:
1. POST `/api/grants` with arbitrary `authorization_details` — bearer = agent — record stamps `requester = agent.email`
2. POST `/api/grants/{id}/approve` with the same agent bearer — `isRequester` = true, **policy check bypassed** — grant approved
3. Mint `authz_jwt` for arbitrary audiences via the existing token endpoint

The human owner was never involved. The entire DDISA delegation model was defeated.

## Fix

Drop the `isRequester` short-circuit. Resolve the approver policy correctly per the `User` type convention (`packages/auth/src/idp/stores.ts:320` — `approver === undefined` means "owner, or self when there is no owner"):

| user.approver | user.owner | who can approve |
|---|---|---|
| set | any | the explicit approver, plus the owner |
| unset | set | the owner (implicit approver — sub-user / agent path) |
| unset | unset | the user themselves (top-level human, implicit self-approval) |

The previous behaviour where ANY requester could self-approve regardless of policy is gone.

## Test plan

- [x] Six new regression tests in `grants-approve-authz.test.ts` pinning every branch — agent self-approve rejected (403), owner approves agent grant (200), explicit approver approves (200), top-level human self-approves (200), unrelated party rejected (403), management token still bypasses (200)
- [x] `pnpm --filter @openape/nuxt-auth-idp test` — 102 pass (was 96)
- [x] `pnpm --filter @openape/nuxt-auth-idp lint typecheck` clean

## Follow-up issues

The audit surfaced 8 more findings tracked in #273 #274 #276 #277 #279 #280 #281 #282 #283.