### PR TITLE
fix(idp): reject authorization_details in /authorize GET — CSRF auto-approve (#273)

### DIFF
--- a/.changeset/fix-authorize-csrf.md
+++ b/.changeset/fix-authorize-csrf.md
@@ -1,0 +1,9 @@
+---
+'@openape/nuxt-auth-idp': patch
+---
+
+Fix CSRF auto-approval of `authorization_details` in `/authorize` GET (closes #273).
+
+The `/authorize` GET handler used to parse RFC 9396 `authorization_details` from the query string and auto-approve them server-side, treating an existing IdP session as implicit consent. A crafted URL — `<a href="https://idp/authorize?…&authorization_details=[<broad cli grant>]">` — could therefore approve sweeping grants via top-level GET navigation (cookies are `SameSite=Lax` by default), bypassing the approver-policy entirely.
+
+Until a proper consent UI lands, the parameter is rejected. Callers must use the explicit grant API: `POST /api/grants` to create the grant pending, then `POST /api/grants/{id}/approve` (which enforces the approver-policy fixed in PR #284). No production caller in this repo relied on the old combo — verified via grep.

--- a/modules/nuxt-auth-idp/src/runtime/server/routes/authorize.get.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/routes/authorize.get.ts
@@ -4,7 +4,7 @@ import type { ActorType, DelegationActClaim, OpenApeAuthorizationDetail } from '
 import { defineEventHandler, getQuery, getRequestURL, sendRedirect } from 'h3'
 import { extractDomain, resolveDDISA } from '@openape/core'
 import { evaluatePolicy, validateAuthorizeRequest } from '@openape/auth'
-import { approveGrant, createGrant, useGrant, validateDelegation } from '@openape/grants'
+import { useGrant, validateDelegation } from '@openape/grants'
 import { tryBearerAuth } from '../utils/agent-auth'
 import { getAppSession } from '../utils/session'
 import { useIdpStores } from '../utils/stores'
@@ -143,33 +143,31 @@ export default defineEventHandler(async (event) => {
     return sendRedirect(event, redirectUrl.toString())
   }
 
-  // Parse and process authorization_details (RFC 9396)
-  const authzDetails = parseAuthorizationDetails(String(query.authorization_details ?? ''))
-  let approvedDetails: OpenApeAuthorizationDetail[] | undefined
-
-  if (authzDetails.length > 0) {
-    const { grantStore } = useGrantStores()
-    approvedDetails = []
-
-    for (const detail of authzDetails) {
-      const grant = await createGrant({
-        requester: bearerPayload ? bearerPayload.sub : userId,
-        target_host: params.client_id,
-        audience: params.client_id,
-        grant_type: detail.approval ?? 'once',
-        permissions: [detail.type === 'openape_cli' ? detail.permission : detail.action],
-        ...(detail.type === 'openape_cli' ? { authorization_details: [detail] } : {}),
-        reason: detail.reason,
-      }, grantStore)
-
-      // Auto-approve: user consents by authenticating in the authorize flow
-      const approved = await approveGrant(grant.id, userId, grantStore)
-      approvedDetails.push({
-        ...detail,
-        grant_id: approved.id,
-      })
-    }
+  // RFC 9396 `authorization_details` is intentionally NOT honoured in
+  // the /authorize GET path. The historical implementation auto-approved
+  // arbitrary grant details whenever the parameter was present, treating
+  // the user's existing IdP session as implicit consent. That meant a
+  // crafted URL — `<a href="https://idp/authorize?...&authorization_details=[<broad cli grant>]">` —
+  // could silently approve grants server-side via top-level GET navigation
+  // (cookies are SameSite=Lax by default), bypassing the approver-policy
+  // entirely. See security audit 2026-05-04 / GitHub issue #273.
+  //
+  // Until a proper consent UI lands (issue #273 follow-up), callers must
+  // use the explicit grant API: POST /api/grants to create the grant
+  // pending, then POST /api/grants/{id}/approve to approve it (which
+  // enforces the approver-policy as fixed in PR #284).
+  const rawAuthzDetails = String(query.authorization_details ?? '')
+  if (rawAuthzDetails.trim() && parseAuthorizationDetails(rawAuthzDetails).length > 0) {
+    throw createProblemError({
+      status: 400,
+      title: '`authorization_details` is not supported on /authorize',
+      detail:
+        'Use POST /api/grants to create the grant pending, then '
+        + 'POST /api/grants/{id}/approve via the approver-policy. '
+        + 'See https://github.com/openape-ai/openape/issues/273',
+    })
   }
+  const approvedDetails: OpenApeAuthorizationDetail[] | undefined = undefined
 
   const code = crypto.randomUUID()
   await codeStore.save({

--- a/modules/nuxt-auth-idp/test/authorize-errors.test.ts
+++ b/modules/nuxt-auth-idp/test/authorize-errors.test.ts
@@ -26,6 +26,7 @@ vi.mock('../src/runtime/server/utils/session', () => ({
 }))
 
 vi.mock('../src/runtime/server/utils/agent-auth', () => ({
+  tryBearerAuth: vi.fn().mockResolvedValue(null),
   tryAgentAuth: vi.fn().mockResolvedValue(null),
 }))
 
@@ -39,6 +40,12 @@ vi.mock('../src/runtime/server/utils/grant-stores', () => ({
 vi.mock('@openape/core', () => ({
   extractDomain: vi.fn(),
   resolveDDISA: vi.fn().mockResolvedValue(null),
+  createProblemDetails: (opts: any) => ({
+    type: opts.type ?? 'about:blank',
+    title: opts.title,
+    status: opts.status,
+    detail: opts.detail,
+  }),
 }))
 
 vi.mock('@openape/grants', () => ({
@@ -86,5 +93,71 @@ describe('authorize endpoint — error redirects (RFC 6749 §4.1.2.1)', () => {
     const { default: handler } = await import('../src/runtime/server/routes/authorize.get')
 
     await expect(handler({} as any)).rejects.toThrow()
+  })
+
+  it('rejects authorization_details on /authorize (CSRF-able auto-approve removed, #273)', async () => {
+    // Pin the security fix: the historical implementation auto-approved
+    // arbitrary RFC 9396 authorization_details whenever the parameter was
+    // present, treating an existing IdP session as implicit consent. A
+    // crafted URL could therefore approve broad CLI grants via top-level
+    // GET navigation. The handler now refuses the parameter outright;
+    // callers must use POST /api/grants + POST /api/grants/{id}/approve.
+    const { getQuery } = await import('h3')
+    ;(getQuery as any).mockReturnValue({
+      client_id: 'sp.example.com',
+      redirect_uri: REDIRECT_URI,
+      state: 'xyz',
+      code_challenge: 'abc'.repeat(15), // valid 43-char placeholder
+      code_challenge_method: 'S256',
+      nonce: 'n1',
+      response_type: 'code',
+      authorization_details: JSON.stringify([
+        {
+          type: 'openape_cli',
+          cli_id: 'rm',
+          operation_id: 'rm.delete',
+          permission: 'rm.filesystem[*]#delete',
+          action: 'delete',
+        },
+      ]),
+    })
+
+    // Authenticated session needed to reach the authorization_details
+    // gate (it sits AFTER session resolution + policy evaluation).
+    const { getAppSession } = await import('../src/runtime/server/utils/session')
+    ;(getAppSession as any).mockResolvedValue({
+      data: { userId: 'patrick@hofmann.eco' },
+      update: vi.fn(),
+    })
+
+    const { default: handler } = await import('../src/runtime/server/routes/authorize.get')
+
+    await expect(handler({} as any)).rejects.toMatchObject({ statusCode: 400 })
+  })
+
+  it('still passes through when authorization_details is empty/whitespace', async () => {
+    // Empty / whitespace-only must not fall into the rejection path —
+    // SPs that always include the parameter (with `[]`) should keep
+    // working. Validation error on missing code_challenge fires first,
+    // proving the authorize flow itself was reached.
+    const { getQuery } = await import('h3')
+    ;(getQuery as any).mockReturnValue({
+      client_id: 'sp.example.com',
+      redirect_uri: REDIRECT_URI,
+      state: 'xyz',
+      code_challenge: '', // triggers earlier validation redirect
+      code_challenge_method: 'S256',
+      nonce: 'n1',
+      response_type: 'code',
+      authorization_details: '   ',
+    })
+
+    mockSendRedirect.mockClear()
+    const { default: handler } = await import('../src/runtime/server/routes/authorize.get')
+    await handler({} as any)
+
+    expect(mockSendRedirect).toHaveBeenCalled()
+    const redirectUrl = new URL(mockSendRedirect.mock.calls[0][1])
+    expect(redirectUrl.searchParams.get('error')).toBe('invalid_request')
   })
 })


### PR DESCRIPTION
Closes #273.

Quick fix while a proper consent UI is designed: reject the RFC 9396 `authorization_details` parameter on `/authorize` GET (was auto-approving regardless of approver-policy via top-level navigation). Callers route through the explicit grant API now — `POST /api/grants` then `POST /api/grants/{id}/approve`.

Verified no production caller uses the old combo (grep across packages/apps/examples). Two regression tests added; 104 total tests pass.