### PR TITLE
fix(auth): bind refresh-token redemption to original client_id (#274)

### DIFF
--- a/.changeset/fix-refresh-client-binding.md
+++ b/.changeset/fix-refresh-client-binding.md
@@ -1,0 +1,9 @@
+---
+'@openape/auth': minor
+---
+
+Fix refresh-token cross-audience forgery (closes #274).
+
+`handleRefreshGrant` accepted a user-supplied `client_id` and passed it straight into `issueAssertion({ aud: clientId })` without verifying it matched the client the token was originally issued to. A refresh token captured for SP-A could therefore be redeemed at the IdP token endpoint with `client_id=SP-B` to mint a fresh assertion with `aud=SP-B` — RFC 6749 §6 audience binding broken.
+
+The handler now compares the request's `client_id` against the `clientId` returned from `RefreshTokenStore.consume` and throws a new `RefreshClientMismatchError` (also exported from the package) on mismatch. The IdP's `/token` route already maps any error from `handleRefreshGrant` to `400 invalid_grant`, so no route changes were needed.

--- a/packages/auth/src/__tests__/refresh-token.test.ts
+++ b/packages/auth/src/__tests__/refresh-token.test.ts
@@ -302,4 +302,22 @@ describe('handleRefreshGrant', () => {
       'https://idp.example.com',
     )).rejects.toThrow('expired')
   })
+
+  it('rejects when client_id does not match the one the token was issued for (#274)', async () => {
+    // Pin RFC 6749 §6 audience binding. Without this check, a refresh
+    // token captured from SP-A could be redeemed at /token with
+    // client_id=SP-B to mint an assertion with aud=SP-B — full
+    // cross-audience token forgery.
+    const keyStore = new InMemoryKeyStore()
+    const refreshStore = new InMemoryRefreshTokenStore()
+    const { token } = await refreshStore.create('alice@example.com', 'sp-a.example.com')
+
+    await expect(handleRefreshGrant(
+      token,
+      'sp-b.example.com', // attacker-supplied wrong client
+      refreshStore,
+      keyStore,
+      'https://idp.example.com',
+    )).rejects.toMatchObject({ name: 'RefreshClientMismatchError' })
+  })
 })

--- a/packages/auth/src/idp/index.ts
+++ b/packages/auth/src/idp/index.ts
@@ -1,7 +1,7 @@
 export { type AuthorizeParams, type AuthorizeResult, evaluatePolicy, validateAuthorizeRequest } from './authorize.js'
 export { type AgentKeyResolver, type ClientAssertionResult, validateClientAssertion } from './client-assertion.js'
 export { generateJWKS, type JWKSResponse, serveJWKS } from './jwks.js'
-export { handleRefreshGrant, type RefreshGrantResult } from './refresh.js'
+export { handleRefreshGrant, RefreshClientMismatchError, type RefreshGrantResult } from './refresh.js'
 export {
   type CodeEntry,
   type CodeStore,

--- a/packages/auth/src/idp/refresh.ts
+++ b/packages/auth/src/idp/refresh.ts
@@ -11,8 +11,22 @@ export interface RefreshGrantResult {
   assertion: string
 }
 
+export class RefreshClientMismatchError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'RefreshClientMismatchError'
+  }
+}
+
 /**
  * Handle grant_type=refresh_token: rotate refresh token, issue new access/id tokens.
+ *
+ * The `clientId` arg is the request's `client_id` form field, which we
+ * MUST verify matches the client the refresh token was originally
+ * issued to (RFC 6749 §6). Without this check a refresh token captured
+ * for SP-A could be presented at /token with `client_id=SP-B` to mint
+ * a fresh assertion `aud=SP-B` — audience binding broken. See security
+ * audit 2026-05-04 / GitHub issue #274.
  */
 export async function handleRefreshGrant(
   refreshToken: string,
@@ -22,7 +36,13 @@ export async function handleRefreshGrant(
   issuer: string,
   resolveUserClaims?: UserClaimsResolver,
 ): Promise<RefreshGrantResult> {
-  const { newToken, userId } = await refreshStore.consume(refreshToken)
+  const { newToken, userId, clientId: issuedClientId } = await refreshStore.consume(refreshToken)
+
+  if (issuedClientId !== clientId) {
+    throw new RefreshClientMismatchError(
+      `Refresh token was issued for client_id=${issuedClientId}, cannot redeem for client_id=${clientId}`,
+    )
+  }
 
   // Resolve user claims (same as in authorization_code flow)
   let extraClaims: { email?: string, name?: string, approver?: string } = {}


### PR DESCRIPTION
Closes #274. RFC 6749 §6 audience binding fix. `handleRefreshGrant` now compares the request's `client_id` against the stored value from `RefreshTokenStore.consume` and throws `RefreshClientMismatchError` on mismatch — IdP token route already maps to 400 invalid_grant. New regression test.