### PR TITLE
fix(idp): rate-limit XFF bypass — gate XFF trust on configured proxy CIDRs (#279)

### DIFF
--- a/.changeset/fix-rate-limit-xff-bypass.md
+++ b/.changeset/fix-rate-limit-xff-bypass.md
@@ -1,0 +1,11 @@
+---
+'@openape/nuxt-auth-idp': minor
+---
+
+Fix rate-limit bypass via spoofed `X-Forwarded-For` header (closes #279).
+
+The IdP rate-limit on `/api/(session|auth|agent|webauthn)`, `/authorize`, and `/token` was keyed on `getRequestIP(event, { xForwardedFor: true })`. h3 returns the **leftmost** XFF value, which is attacker-controllable on every deployment topology that doesn't strip incoming XFF — including Vercel in many configs. Rotating the header per request let attackers slip past the 10/min cap and brute-force agent challenges, WebAuthn assertions, and enrol endpoints.
+
+The plugin now keys on the socket peer by default. Operators behind a real proxy fleet opt in by setting `OPENAPE_RATE_LIMIT_TRUSTED_PROXIES` to a comma-separated CIDR list; when the request's direct peer is in that list the plugin walks the XFF chain right-to-left and returns the first non-trusted IP — the actual client. Attacker-injected leftmost values are now ignored.
+
+11 new unit tests pin CIDR matching + the right-to-left walk + the default-safe behaviour. The IPv4 CIDR matcher is small and inlined; IPv6 CIDR is a future improvement (matched literally for now).

--- a/modules/nuxt-auth-idp/src/runtime/server/plugins/rate-limit.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/plugins/rate-limit.ts
@@ -1,3 +1,4 @@
+import type { H3Event } from 'h3'
 import type { NitroApp } from 'nitropack'
 import { getRequestIP } from 'h3'
 
@@ -28,9 +29,96 @@ function cleanup() {
   }
 }
 
+// IPv4 CIDR membership. IPv6 ranges are matched literally (no
+// netmask) for now — most production proxy fleets are IPv4 anyway and
+// IPv6 CIDR is a rare config. Returns false on parse errors.
+function ipv4ToInt(ip: string): number | null {
+  const parts = ip.split('.')
+  if (parts.length !== 4) return null
+  let n = 0
+  for (const p of parts) {
+    const x = Number(p)
+    if (!Number.isInteger(x) || x < 0 || x > 255) return null
+    n = (n << 8) | x
+  }
+  // >>> 0 normalises to unsigned 32-bit so comparisons work after the
+  // sign-bit flip on octets > 127.
+  return n >>> 0
+}
+
+function ipMatches(ip: string, cidr: string): boolean {
+  if (cidr === ip) return true
+  if (!cidr.includes('/')) return false
+  const [base, prefixStr] = cidr.split('/')
+  if (!base || !prefixStr) return false
+  const prefix = Number(prefixStr)
+  if (!Number.isInteger(prefix) || prefix < 0 || prefix > 32) return false
+  const ipInt = ipv4ToInt(ip)
+  const baseInt = ipv4ToInt(base)
+  if (ipInt === null || baseInt === null) return false
+  if (prefix === 0) return true
+  const mask = ((1 << (32 - prefix)) - 1) ^ 0xFFFFFFFF
+  return (ipInt & mask) === (baseInt & mask)
+}
+
+function ipInTrustedList(ip: string, trusted: string[]): boolean {
+  return trusted.some(cidr => ipMatches(ip, cidr))
+}
+
+function parseTrustedProxies(): string[] {
+  // Operators behind a real proxy (Vercel, Cloudflare, NGINX) opt-in
+  // by setting OPENAPE_RATE_LIMIT_TRUSTED_PROXIES to a comma-separated
+  // CIDR list. The default is empty — XFF is ignored and rate-limiting
+  // keys on the socket peer. That's safe (a misconfigured deploy
+  // rate-limits per-proxy instead of per-client; never per attacker-
+  // chosen header value), and ahead of #279 we actively prefer this
+  // failure mode to letting attackers spoof XFF and skip the limit.
+  const raw = process.env.OPENAPE_RATE_LIMIT_TRUSTED_PROXIES
+  if (!raw) return []
+  return raw.split(',').map(s => s.trim()).filter(Boolean)
+}
+
+/**
+ * Resolve the rate-limit key IP. When the request's direct peer is in
+ * the trusted-proxy list, walk the X-Forwarded-For chain right-to-left
+ * skipping any IPs that are themselves trusted; the first untrusted
+ * value is the real client. Otherwise return the socket peer.
+ *
+ * Why right-to-left: XFF is "client, proxy1, proxy2, …" appended in
+ * arrival order. The closest hop (proxy2) is rightmost. If proxy2 is
+ * trusted we move left; if it's untrusted, an attacker has injected
+ * something or our proxy chain is misconfigured — bucket on that IP
+ * anyway so they can't escape rate-limiting by lying.
+ *
+ * Replaces the previous `xForwardedFor: true` blanket-trust which let
+ * attackers rotate the leftmost XFF value to bypass the auth-endpoint
+ * cap (see security audit 2026-05-04, #279).
+ */
+function resolveClientIp(event: H3Event, trustedProxies: string[]): string {
+  const peer = getRequestIP(event) || 'unknown'
+
+  if (trustedProxies.length === 0) return peer
+  if (peer === 'unknown') return peer
+  if (!ipInTrustedList(peer, trustedProxies)) return peer
+
+  const xff = event.node.req.headers['x-forwarded-for']
+  const xffStr = Array.isArray(xff) ? xff.join(',') : xff
+  if (!xffStr) return peer
+
+  const chain = xffStr.split(',').map(s => s.trim()).filter(Boolean)
+  for (let i = chain.length - 1; i >= 0; i--) {
+    const candidate = chain[i]!
+    if (!ipInTrustedList(candidate, trustedProxies)) return candidate
+  }
+  // Whole chain is trusted — fall back to peer.
+  return peer
+}
+
 export default (nitroApp: NitroApp) => {
   // Skip rate limiting entirely in E2E test mode
   if (process.env.OPENAPE_E2E === '1') return
+
+  const trustedProxies = parseTrustedProxies()
 
   nitroApp.hooks.hook('request', (event) => {
     const path = event.path || ''
@@ -38,7 +126,7 @@ export default (nitroApp: NitroApp) => {
 
     cleanup()
 
-    const ip = getRequestIP(event, { xForwardedFor: true }) || 'unknown'
+    const ip = resolveClientIp(event, trustedProxies)
     const key = `${ip}:auth`
     const now = Date.now()
 
@@ -69,3 +157,6 @@ export default (nitroApp: NitroApp) => {
     }
   })
 }
+
+// Exported for unit tests.
+export const _internals = { ipv4ToInt, ipMatches, ipInTrustedList, resolveClientIp }

--- a/modules/nuxt-auth-idp/test/rate-limit-trusted-proxies.test.ts
+++ b/modules/nuxt-auth-idp/test/rate-limit-trusted-proxies.test.ts
@@ -1,0 +1,107 @@
+import type { H3Event } from 'h3'
+import { describe, expect, it, vi } from 'vitest'
+import { _internals } from '../src/runtime/server/plugins/rate-limit'
+
+const { ipMatches, ipInTrustedList, resolveClientIp } = _internals
+
+vi.mock('h3', async () => {
+  const actual = await vi.importActual<any>('h3')
+  return {
+    ...actual,
+    getRequestIP: vi.fn(),
+  }
+})
+
+function makeEvent(socketIp: string | null, xff?: string | string[]): H3Event {
+  return {
+    node: {
+      req: {
+        headers: xff !== undefined ? { 'x-forwarded-for': xff } : {},
+      },
+    },
+  } as unknown as H3Event
+}
+
+async function setSocketIp(ip: string | null) {
+  const { getRequestIP } = await import('h3')
+  ;(getRequestIP as any).mockReturnValue(ip)
+}
+
+describe('rate-limit IP CIDR matching', () => {
+  it('matches IPs against /24 networks', () => {
+    expect(ipMatches('10.1.2.3', '10.1.2.0/24')).toBe(true)
+    expect(ipMatches('10.1.3.3', '10.1.2.0/24')).toBe(false)
+  })
+
+  it('matches single-host /32 entries (and bare IPs)', () => {
+    expect(ipMatches('10.0.0.1', '10.0.0.1/32')).toBe(true)
+    expect(ipMatches('10.0.0.1', '10.0.0.1')).toBe(true)
+    expect(ipMatches('10.0.0.2', '10.0.0.1/32')).toBe(false)
+  })
+
+  it('matches /0 (catch-all)', () => {
+    expect(ipMatches('1.2.3.4', '0.0.0.0/0')).toBe(true)
+  })
+
+  it('rejects malformed inputs', () => {
+    expect(ipMatches('not-an-ip', '10.0.0.0/24')).toBe(false)
+    expect(ipMatches('10.0.0.1', '10.0.0.0/33')).toBe(false)
+    expect(ipMatches('10.0.0.1', 'garbage')).toBe(false)
+  })
+
+  it('ipInTrustedList combines several CIDRs', () => {
+    const list = ['10.0.0.0/8', '192.168.0.0/16', '203.0.113.7']
+    expect(ipInTrustedList('10.5.5.5', list)).toBe(true)
+    expect(ipInTrustedList('192.168.42.99', list)).toBe(true)
+    expect(ipInTrustedList('203.0.113.7', list)).toBe(true)
+    expect(ipInTrustedList('1.2.3.4', list)).toBe(false)
+  })
+})
+
+describe('resolveClientIp (#279 — XFF only honoured behind trusted proxies)', () => {
+  it('returns socket peer when no trusted proxies configured (default safe)', async () => {
+    await setSocketIp('1.2.3.4')
+    // Even with attacker-controlled XFF the safe default is to ignore it.
+    const event = makeEvent('1.2.3.4', '6.6.6.6')
+    expect(resolveClientIp(event, [])).toBe('1.2.3.4')
+  })
+
+  it('returns socket peer when peer is NOT a trusted proxy', async () => {
+    await setSocketIp('1.2.3.4')
+    // Attacker connects directly with a forged XFF — peer is untrusted,
+    // so XFF is ignored and we bucket on the attacker's actual IP.
+    const event = makeEvent('1.2.3.4', '6.6.6.6')
+    expect(resolveClientIp(event, ['10.0.0.0/8'])).toBe('1.2.3.4')
+  })
+
+  it('walks XFF right-to-left when peer IS a trusted proxy', async () => {
+    await setSocketIp('10.0.0.5')
+    // chain = "real-client, public-proxy, our-proxy"
+    //         ^^^^ leftmost                  ^^^^ rightmost
+    // Walking right→left: 10.0.0.6 trusted (skip), 198.51.100.7 untrusted → that's the client.
+    const event = makeEvent('10.0.0.5', '203.0.113.99, 198.51.100.7, 10.0.0.6')
+    expect(resolveClientIp(event, ['10.0.0.0/8'])).toBe('198.51.100.7')
+  })
+
+  it('falls back to peer when whole XFF chain is trusted', async () => {
+    await setSocketIp('10.0.0.5')
+    const event = makeEvent('10.0.0.5', '10.0.0.7, 10.0.0.6')
+    expect(resolveClientIp(event, ['10.0.0.0/8'])).toBe('10.0.0.5')
+  })
+
+  it('returns peer when XFF header is missing', async () => {
+    await setSocketIp('10.0.0.5')
+    const event = makeEvent('10.0.0.5')
+    expect(resolveClientIp(event, ['10.0.0.0/8'])).toBe('10.0.0.5')
+  })
+
+  it('cannot be bypassed by a leftmost forged XFF entry', async () => {
+    // The original bug: getRequestIP({ xForwardedFor: true }) used to
+    // return '6.6.6.6' here (leftmost). With trusted-proxy gating an
+    // attacker connecting via a real proxy still has 198.51.100.7 as
+    // their actual hop and the leftmost spoof is ignored.
+    await setSocketIp('10.0.0.5')
+    const event = makeEvent('10.0.0.5', '6.6.6.6, 198.51.100.7, 10.0.0.6')
+    expect(resolveClientIp(event, ['10.0.0.0/8'])).toBe('198.51.100.7')
+  })
+})


### PR DESCRIPTION
Closes #279. `getRequestIP({ xForwardedFor: true })` returned the leftmost (attacker-controllable) XFF value. Now keys on socket peer by default; operators behind real proxies set `OPENAPE_RATE_LIMIT_TRUSTED_PROXIES` to a CIDR list and the plugin walks XFF right-to-left for the actual client. 11 new tests, 115 total.