### PR TITLE
fix(core): validate DDISA idp= URL — block DNS-poisoning IdP takeover (#281)

### DIFF
--- a/.changeset/fix-ddisa-idp-validation.md
+++ b/.changeset/fix-ddisa-idp-validation.md
@@ -1,0 +1,16 @@
+---
+'@openape/core': minor
+---
+
+Validate the DDISA `idp=` URL on parse (closes #281).
+
+`parseDDISARecord` previously accepted any string after `idp=`: `http://`, `javascript:`, IDN homograph hostnames, paths with embedded credentials. The IdP URL is the trust anchor for the entire DDISA flow — every SP that resolves it fetches JWKS from there and accepts the resulting assertions, so a poisoned DNS record (cache poisoning, on-path attacker, hostile registrar/registrant for a sub-tenant, dev environments without DNSSEC) redirected every login through an attacker IdP that the SP would happily trust.
+
+The parser now rejects records whose `idp=` value isn't:
+
+- a parseable URL,
+- with `https:` protocol (or `http:` when `OPENAPE_DDISA_ALLOW_HTTP=1` is set — strictly a dev escape hatch),
+- without embedded credentials (`user:pass@`),
+- printable-ASCII only (defends against IDN homographs + RTL-override + null-byte injection — punycode hostnames are fine, they're already ASCII).
+
+Five new tests pin each rejection class plus the dev-env escape hatch. Existing-record happy-path tests are unchanged: the original input string is returned untouched (no URL re-normalisation), so a record that was being read correctly before is still being read correctly.

--- a/packages/core/src/__tests__/parser.test.ts
+++ b/packages/core/src/__tests__/parser.test.ts
@@ -74,6 +74,44 @@ describe('parseDDISARecord', () => {
     expect(result?.mode).toBe('open')
   })
 
+  it('rejects an idp= URL that is not https:// (#281)', () => {
+    // DNS poisoning attack vector: a TXT record claiming
+    // `idp=http://attacker.example` — every SP downstream would
+    // then fetch JWKS over plaintext from a hostile origin.
+    expect(parseDDISARecord('v=ddisa1 idp=http://idp.example.com')).toBeNull()
+    expect(parseDDISARecord('v=ddisa1 idp=javascript:alert(1)')).toBeNull()
+    expect(parseDDISARecord('v=ddisa1 idp=ftp://idp.example.com')).toBeNull()
+    expect(parseDDISARecord('v=ddisa1 idp=not-a-url')).toBeNull()
+  })
+
+  it('rejects an empty idp= value', () => {
+    expect(parseDDISARecord('v=ddisa1 idp=')).toBeNull()
+  })
+
+  it('rejects an idp= URL with embedded credentials', () => {
+    // `https://attacker:x@idp.victim.com` — the credentials travel
+    // with whatever consumer copies the raw string forward.
+    expect(parseDDISARecord('v=ddisa1 idp=https://attacker:secret@idp.victim.com')).toBeNull()
+  })
+
+  it('rejects an idp= URL with non-ASCII hostnames (IDN homograph defence)', () => {
+    // `idp.example` looks legit but the `а` is Cyrillic U+0430.
+    expect(parseDDISARecord('v=ddisa1 idp=https://idp.exаmple.com')).toBeNull()
+  })
+
+  it('accepts http:// only when OPENAPE_DDISA_ALLOW_HTTP=1 is set (dev escape hatch)', () => {
+    const orig = process.env.OPENAPE_DDISA_ALLOW_HTTP
+    try {
+      process.env.OPENAPE_DDISA_ALLOW_HTTP = '1'
+      const r = parseDDISARecord('v=ddisa1 idp=http://localhost:3000')
+      expect(r?.idp).toBe('http://localhost:3000')
+    }
+    finally {
+      if (orig === undefined) delete process.env.OPENAPE_DDISA_ALLOW_HTTP
+      else process.env.OPENAPE_DDISA_ALLOW_HTTP = orig
+    }
+  })
+
   it('returns null for empty string', () => {
     expect(parseDDISARecord('')).toBeNull()
   })

--- a/packages/core/src/dns/parser.ts
+++ b/packages/core/src/dns/parser.ts
@@ -4,6 +4,70 @@ const VALID_MODES: PolicyMode[] = ['open', 'allowlist-admin', 'allowlist-user', 
 const DDISA_VERSION = 'ddisa1'
 
 /**
+ * Validate a DDISA `idp=` URL.
+ *
+ * The IdP URL is the trust anchor for the entire DDISA flow — every
+ * SP that resolves it will fetch JWKS from there and accept the
+ * resulting assertions. A poisoned DNS record can therefore redirect
+ * every login through an attacker IdP. To make that harder we reject
+ * URLs that don't pass these tests:
+ *
+ *   - parseable URL
+ *   - protocol = `https:` (production); `http:` allowed only when
+ *     `OPENAPE_DDISA_ALLOW_HTTP=1` is set in the env (dev shortcut)
+ *   - hostname has no embedded credentials (`user:pass@`)
+ *   - hostname has no IDN homograph confusables (must round-trip
+ *     identically through `URL` parsing — defends against right-to-left
+ *     override + homoglyph spoofs)
+ *
+ * No host allow-list — that's an SP-side concern (#280 / per-deploy
+ * config). Here we just ensure the URL is structurally trustworthy.
+ *
+ * Returns `null` on rejection so the caller treats the record as
+ * absent.
+ */
+function isValidIdpUrl(value: string): string | null {
+  if (!value) return null
+
+  let url: URL
+  try {
+    url = new URL(value)
+  }
+  catch {
+    return null
+  }
+
+  const allowHttp = process.env.OPENAPE_DDISA_ALLOW_HTTP === '1'
+  const httpsOnly = url.protocol === 'https:'
+  const httpAcceptable = allowHttp && url.protocol === 'http:'
+  if (!httpsOnly && !httpAcceptable) return null
+
+  // Reject embedded credentials — `https://attacker:x@idp.victim.com`
+  // would let `idp.victim.com` host JWKS but the URL stamps the raw
+  // string into auth.json on the SP side; if any consumer fetches
+  // without sanitising, the credentials travel with it.
+  if (url.username || url.password) return null
+
+  // IDN homograph defence: reject the URL when the original input
+  // string contains any non-ASCII character. URL parsing punycode-
+  // converts hostnames so url.hostname is always ASCII; the check
+  // has to happen against the raw input. A legitimate punycode label
+  // (`xn--…`) is unaffected because it's pure ASCII to begin with.
+  // Reject any non-printable-ASCII characters in the input. Anything
+  // outside U+0020..U+007E (and a few whitespace controls) is a homograph
+  // / RTL-override / null-byte injection vector.
+  for (let i = 0; i < value.length; i++) {
+    const c = value.charCodeAt(i)
+    if (c !== 0x09 && (c < 0x20 || c > 0x7E)) return null
+  }
+
+  // Return the original input rather than `url.toString()` so we
+  // don't normalise a trailing slash onto operator-specified records
+  // — preserving exact byte-for-byte forwarding to SPs.
+  return value
+}
+
+/**
  * Parse a DDISA DNS TXT record string.
  * Format: "v=ddisa1 idp=https://idp.example.com; mode=open; priority=10"
  *
@@ -35,9 +99,11 @@ export function parseDDISARecord(txt: string): DDISARecord | null {
     const value = part.slice(eqIndex + 1).trim()
 
     switch (key) {
-      case 'idp':
-        record.idp = value
+      case 'idp': {
+        const validated = isValidIdpUrl(value)
+        if (validated) record.idp = validated
         break
+      }
       case 'mode':
         if (VALID_MODES.includes(value as PolicyMode)) {
           record.mode = value as PolicyMode


### PR DESCRIPTION
Closes #281. Parser now rejects non-`https://`, embedded creds, IDN homographs / RTL-override. `OPENAPE_DDISA_ALLOW_HTTP=1` opens `http://` for dev. Original input string preserved when valid (no URL re-normalisation). 5 new tests + 1 coverage.