### PR TITLE
fix(chat): lower-case caller.email at resolveCaller boundary (#282)

### DIFF
--- a/.changeset/fix-chat-email-case.md
+++ b/.changeset/fix-chat-email-case.md
@@ -1,0 +1,9 @@
+---
+'@openape/chat': patch
+---
+
+Canonicalise email casing in `resolveCaller` (closes #282).
+
+Contacts canonicalised to lowercase but `messages.senderEmail`, `memberships.userEmail`, and edit-ownership checks (`existing.senderEmail !== caller.email`) used `caller.email` as-is from the JWT `sub`. If two casings of the same address ever co-existed (different IdP behaviour, re-issued accounts), they'd be treated as separate identities — `Foo@x.com` user added to a room would appear next to a `foo@x.com` contact, the bridge allowlist (lower-cased) would diverge from server-side membership rows, and authz checks would silently disagree.
+
+`resolveCaller` now lower-cases the email exactly once at the boundary — every downstream comparison sees the same string regardless of how the IdP emitted the casing. Two regression tests for the cookie + bearer paths.

--- a/apps/openape-chat/server/utils/auth.ts
+++ b/apps/openape-chat/server/utils/auth.ts
@@ -52,7 +52,11 @@ export async function resolveCaller(event: H3Event): Promise<Caller> {
     throw createError({ statusCode: 401, statusMessage: 'Not authenticated' })
   }
   return {
-    email: claims.sub,
+    // Lower-case once at the boundary so every downstream comparison
+    // (membership rows, message ownership, contacts canonicalisation,
+    // bridge allowlist) sees the same string regardless of how the IdP
+    // emitted the casing — see #282.
+    email: claims.sub.toLowerCase(),
     act: claims.act === 'agent' ? 'agent' : 'human',
     source: 'cookie',
   }
@@ -98,7 +102,7 @@ async function verifyBearer(token: string): Promise<Caller> {
     if (!cli) {
       throw createError({ statusCode: 401, statusMessage: 'Invalid CLI token' })
     }
-    return { email: cli.email, act: cli.act, source: 'bearer' }
+    return { email: cli.email.toLowerCase(), act: cli.act, source: 'bearer' }
   }
 
   try {
@@ -108,7 +112,7 @@ async function verifyBearer(token: string): Promise<Caller> {
       throw createError({ statusCode: 401, statusMessage: 'Token missing sub' })
     }
     return {
-      email,
+      email: email.toLowerCase(),
       act: payload.act === 'agent' ? 'agent' : 'human',
       source: 'bearer',
     }

--- a/apps/openape-chat/tests/auth-canonicalisation.test.ts
+++ b/apps/openape-chat/tests/auth-canonicalisation.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest'
+
+// Pin the email-case canonicalisation in resolveCaller (#282). The
+// identity returned to every downstream handler is lower-cased exactly
+// once at this boundary; if it ever stops, contacts-canonicalisation +
+// memberships + bridge allowlist drift apart and authz checks
+// silently disagree on whether `Foo@x.com` and `foo@x.com` are the
+// same user.
+
+vi.mock('h3', () => ({
+  defineEventHandler: (fn: any) => fn,
+  createError: (opts: any) =>
+    Object.assign(new Error(opts.statusMessage), { statusCode: opts.statusCode }),
+}))
+
+// Auto-imported globals in nuxt-server land — stub them so the module
+// can be imported under vitest.
+;(globalThis as any).getHeader = vi.fn().mockReturnValue(null)
+;(globalThis as any).getQuery = vi.fn().mockReturnValue({})
+;(globalThis as any).getSpSession = vi.fn()
+;(globalThis as any).createError = (opts: any) =>
+  Object.assign(new Error(opts.statusMessage), { statusCode: opts.statusCode })
+;(globalThis as any).useRuntimeConfig = () => ({ public: { idpUrl: 'https://id.openape.ai' } })
+
+vi.mock('@openape/core', () => ({
+  createRemoteJWKS: vi.fn(),
+  verifyJWT: vi.fn(async () => ({ payload: { sub: 'Foo@X.com', act: 'human' } })),
+}))
+
+vi.mock('jose', () => ({
+  decodeProtectedHeader: vi.fn(() => ({ alg: 'EdDSA' })),
+}))
+
+vi.mock('../server/utils/cli-token', () => ({
+  verifyCliToken: vi.fn(async () => ({ email: 'Foo@X.com', act: 'human' })),
+}))
+
+describe('resolveCaller email canonicalisation (#282)', () => {
+  it('lower-cases the cookie-session sub claim', async () => {
+    ;(globalThis as any).getSpSession = vi.fn(async () => ({
+      data: { claims: { sub: 'Foo@X.com', act: 'human' } },
+    }))
+    const { resolveCaller } = await import('../server/utils/auth')
+    const caller = await resolveCaller({} as any)
+    expect(caller.email).toBe('foo@x.com')
+    expect(caller.source).toBe('cookie')
+  })
+
+  it('lower-cases the bearer-JWT sub claim', async () => {
+    ;(globalThis as any).getHeader = vi.fn((_event, name: string) =>
+      name.toLowerCase() === 'authorization' ? 'Bearer eyJhbGciOiJFZERTQSJ9.fake' : null,
+    )
+    ;(globalThis as any).getQuery = vi.fn(() => ({}))
+    const { resolveCaller } = await import('../server/utils/auth')
+    const caller = await resolveCaller({} as any)
+    expect(caller.email).toBe('foo@x.com')
+    expect(caller.source).toBe('bearer')
+  })
+})


### PR DESCRIPTION
Closes #282. Contacts canonicalise but other paths (memberships, message ownership, bridge allowlist) used the JWT sub as-is. Single lower-case at the boundary fixes the latent authz divergence.