### PR TITLE
fix(idp): close passkey-graft via unauthenticated add-credential (#291)

### DIFF
--- a/.changeset/fix-passkey-graft.md
+++ b/.changeset/fix-passkey-graft.md
@@ -1,0 +1,15 @@
+---
+'@openape/nuxt-auth-idp': minor
+---
+
+Close the passkey-graft account-takeover path (closes #291).
+
+The unauthenticated `POST /api/webauthn/register/verify` flow used to APPEND a credential to a user that already had passkeys. Anyone with read-access to the user's mailbox (transient compromise, leaked dump, recycled provider, kiosk session) could therefore mail themselves a registration token, register their own passkey, and gain permanent first-class control of the account — surviving every password-reset / recovery flow because the attacker's passkey IS itself a first-class credential.
+
+The verify endpoint now refuses to register a credential when the user already has at least one passkey and the request comes through the unauthenticated mail-token path. Legitimate flows continue to work:
+
+- **First-time enrolment** (no user yet, or user but zero credentials): unchanged — the mail token is the only trust anchor possible when no credential exists.
+- **Add a device while authenticated**: was already a separate endpoint (`POST /api/webauthn/credentials/add/verify`) that requires a fresh assertion against an existing credential.
+- **Lost-everything recovery**: tracked in #297 — 72h email-hold flow with single-token semantics + push-broadcast, separate code path.
+
+Four regression tests pin the gate.

--- a/modules/nuxt-auth-idp/src/runtime/server/api/webauthn/register/verify.post.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/api/webauthn/register/verify.post.ts
@@ -37,8 +37,42 @@ export default defineEventHandler(async (event) => {
     credential.name = body.deviceName
   }
 
-  // Create user if not exists
   const existingUser = await userStore.findByEmail(regUrl.email)
+
+  // SECURITY GATE — close the passkey-graft path (#291).
+  //
+  // Before this gate, the unauthenticated mail-token-only flow let
+  // anyone with read-access to the user's mailbox (transient, leaked
+  // dump, recycled provider) APPEND a fresh credential to an account
+  // that already had passkeys. That credential then survives every
+  // password-reset / recovery flow because there is no password — the
+  // attacker's passkey is itself a first-class credential.
+  //
+  // First-time enrolment (no user yet, or user but zero credentials)
+  // stays self-service here — the mail token is the only trust anchor
+  // possible when no credentials exist yet. Add-device for users who
+  // already have credentials goes through the authenticated
+  // POST /api/webauthn/credentials/add/verify path (requires a fresh
+  // assertion against an existing credential). Recovery for users who
+  // lost everything goes through the new 72h-mail-hold flow specified
+  // in #297.
+  if (existingUser) {
+    const existingCredentials = await credentialStore.findByUser(regUrl.email)
+    if (existingCredentials.length > 0) {
+      throw createProblemError({
+        status: 409,
+        title: 'Account already has passkeys — sign in to add a new device',
+        detail:
+          'This email is already enrolled. To add a new device, sign in '
+          + 'on a device that already has a passkey and use Account → '
+          + 'Add device. If you have lost access to all your devices, '
+          + 'use the recovery flow. Self-service appending of '
+          + 'credentials via the mail-token path is no longer permitted '
+          + 'because it allowed account takeover via mailbox compromise.',
+      })
+    }
+  }
+
   if (!existingUser) {
     await userStore.create({ email: regUrl.email, name: regUrl.name, isActive: true, createdAt: Math.floor(Date.now() / 1000) })
   }

--- a/modules/nuxt-auth-idp/test/webauthn-register-verify.test.ts
+++ b/modules/nuxt-auth-idp/test/webauthn-register-verify.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Pin the security gate added in PR for #291: the unauthenticated
+// mail-token-only register flow refuses to APPEND credentials to a
+// user that already has passkeys. The remaining legitimate use is
+// first-time enrolment only.
+
+const readBodyMock = vi.fn()
+const findRegUrlMock = vi.fn()
+const consumeRegUrlMock = vi.fn()
+const consumeChallengeMock = vi.fn()
+const findUserByEmailMock = vi.fn()
+const createUserMock = vi.fn()
+const findCredentialsByUserMock = vi.fn()
+const saveCredentialMock = vi.fn()
+const updateSessionMock = vi.fn()
+const verifyRegistrationMock = vi.fn()
+
+vi.mock('h3', () => ({
+  defineEventHandler: (fn: any) => fn,
+  readBody: (...args: any[]) => readBodyMock(...args),
+}))
+
+vi.mock('@openape/auth', () => ({
+  verifyRegistration: (...args: any[]) => verifyRegistrationMock(...args),
+}))
+
+vi.mock('../src/runtime/server/utils/session', () => ({
+  getAppSession: vi.fn(async () => ({ update: updateSessionMock })),
+}))
+
+vi.mock('../src/runtime/server/utils/rp-config', () => ({
+  getRPConfig: () => ({ rpID: 'id.openape.ai' }),
+}))
+
+vi.mock('../src/runtime/server/utils/stores', () => ({
+  useIdpStores: () => ({
+    registrationUrlStore: {
+      find: findRegUrlMock,
+      consume: consumeRegUrlMock,
+    },
+    challengeStore: {
+      consume: consumeChallengeMock,
+    },
+    credentialStore: {
+      findByUser: findCredentialsByUserMock,
+      save: saveCredentialMock,
+    },
+    userStore: {
+      findByEmail: findUserByEmailMock,
+      create: createUserMock,
+    },
+  }),
+}))
+
+vi.mock('../src/runtime/server/utils/problem', () => ({
+  createProblemError: (opts: any) =>
+    Object.assign(new Error(opts.title), { statusCode: opts.status, data: opts }),
+}))
+
+beforeEach(() => {
+  readBodyMock.mockReset().mockResolvedValue({
+    token: 'reg-tok',
+    challengeToken: 'chal-tok',
+    response: { id: 'cred', rawId: 'cred', type: 'public-key', response: {} },
+  })
+  findRegUrlMock.mockReset().mockResolvedValue({
+    token: 'reg-tok', email: 'patrick@hofmann.eco', name: 'Patrick',
+  })
+  consumeRegUrlMock.mockReset()
+  consumeChallengeMock.mockReset().mockResolvedValue({
+    challenge: 'abc', rpId: 'id.openape.ai',
+  })
+  findUserByEmailMock.mockReset()
+  createUserMock.mockReset()
+  findCredentialsByUserMock.mockReset()
+  saveCredentialMock.mockReset()
+  updateSessionMock.mockReset()
+  verifyRegistrationMock.mockReset().mockResolvedValue({
+    verified: true,
+    credential: { credentialId: 'cred-id' },
+  })
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+async function importHandler() {
+  return (await import('../src/runtime/server/api/webauthn/register/verify.post')).default
+}
+
+describe('webauthn register verify — security gate (#291)', () => {
+  it('allows first-time enrolment (no existing user)', async () => {
+    findUserByEmailMock.mockResolvedValue(null)
+    findCredentialsByUserMock.mockResolvedValue([])
+
+    const handler = await importHandler()
+    const result = await handler({} as any)
+
+    expect(result).toMatchObject({ ok: true, email: 'patrick@hofmann.eco' })
+    expect(createUserMock).toHaveBeenCalled()
+    expect(saveCredentialMock).toHaveBeenCalled()
+    expect(consumeRegUrlMock).toHaveBeenCalledWith('reg-tok')
+  })
+
+  it('allows enrolment for an existing user with zero credentials (legacy import case)', async () => {
+    // A user record imported from another provider may exist before any
+    // credential is enrolled. That's still first-time enrolment for the
+    // passkey itself, so we let it through.
+    findUserByEmailMock.mockResolvedValue({ email: 'patrick@hofmann.eco' })
+    findCredentialsByUserMock.mockResolvedValue([])
+
+    const handler = await importHandler()
+    const result = await handler({} as any)
+
+    expect(result.ok).toBe(true)
+    expect(saveCredentialMock).toHaveBeenCalled()
+  })
+
+  it('REFUSES adding a credential to an account that already has passkeys', async () => {
+    // The passkey-graft path: attacker holds a registration token (got
+    // it via mailbox compromise), tries to attach their key to the
+    // victim's account. Now blocked at 409 — they have to either go
+    // through the authenticated add-device flow (impossible without a
+    // session) or the recovery flow (72h cooldown, broadcast to all
+    // existing devices).
+    findUserByEmailMock.mockResolvedValue({ email: 'patrick@hofmann.eco' })
+    findCredentialsByUserMock.mockResolvedValue([
+      { credentialId: 'existing-cred-1', rpId: 'id.openape.ai' },
+    ])
+
+    const handler = await importHandler()
+    await expect(handler({} as any)).rejects.toMatchObject({ statusCode: 409 })
+
+    expect(saveCredentialMock).not.toHaveBeenCalled()
+    expect(consumeRegUrlMock).not.toHaveBeenCalled() // token stays valid
+    expect(updateSessionMock).not.toHaveBeenCalled() // no session minted
+  })
+
+  it('refuses even with a single existing credential (no minimum threshold)', async () => {
+    findUserByEmailMock.mockResolvedValue({ email: 'patrick@hofmann.eco' })
+    findCredentialsByUserMock.mockResolvedValue([
+      { credentialId: 'lone-cred', rpId: 'someother-rp.example' },
+    ])
+
+    const handler = await importHandler()
+    await expect(handler({} as any)).rejects.toMatchObject({ statusCode: 409 })
+    expect(saveCredentialMock).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Closes #291. Recovery flow specified in #297 follows up.

Unauthenticated mail-token register/verify used to append credentials to existing-user accounts → mailbox compromise = permanent account takeover via attacker's own passkey. Verify endpoint now refuses when existing credentials present. First-time enrolment unchanged. Authenticated add-device path (`/api/webauthn/credentials/add/verify`) is unaffected. 4 new regression tests, 119 total.