### PR TITLE
fix(free-idp): hardening batch — #292 #293 #294 #295 #296

### DIFF
--- a/.changeset/free-idp-hardening.md
+++ b/.changeset/free-idp-hardening.md
@@ -1,0 +1,12 @@
+---
+'@openape/nuxt-auth-idp': patch
+'@openape/auth': patch
+---
+
+Bundle of free-idp hardening fixes from the 2026-05-04 audit (closes #292, #293, #294, #295, #296).
+
+- **#292**: extend `RE_AUTH_PATHS` rate-limit regex to cover `/api/{enroll,register,my-agents,push,users}` — paths that were uncapped for brute-force attacks.
+- **#293**: defence-in-depth in `apps/openape-free-idp/server/api/test/session.post.ts` — additional `NODE_ENV !== 'production'` gate, plus `crypto.timingSafeEqual` instead of `!==` on the management-token compare.
+- **#294**: `enroll.post.ts` derives agent emails with an 8-hex-char hash of the canonical owner email, eliminating the dot-collapse / sanitise collisions where `foo@example.com` and `foo@example_com` mapped to the same agent suffix.
+- **#295**: `my-agents/[id].patch.ts` now validates the new SSH key BEFORE deleting old ones, then saves and prunes — agent is never without an authenticator on validation failure. Plus 1000-char length cap and explicit-shape check on the public key. `SshKeyStore.deleteAllForUser` gains an `exceptKeyId` option for the rotate-in-place flow; backwards-compatible (option is optional).
+- **#296**: `push/subscribe.post.ts` rejects with 409 when the endpoint URL is already registered to a different account, and removes `userEmail` from the conflict-update SET clause. Closes the subscription-hijack path.

--- a/apps/openape-free-idp/server/api/enroll.post.ts
+++ b/apps/openape-free-idp/server/api/enroll.post.ts
@@ -1,14 +1,38 @@
+import { Buffer } from 'node:buffer'
 import { createHash } from 'node:crypto'
 import { createError, defineEventHandler, readBody } from 'h3'
+
+const PUBLIC_KEY_MAX_LENGTH = 1000
 
 function sanitizeName(name: string): string {
   return name.toLowerCase().replace(/[^a-z0-9-]/g, '-').replace(/^-+|-+$/g, '').replace(/-{2,}/g, '-') || 'agent'
 }
 
+// Hash-suffixed agent emails (#294).
+//
+// The historical derivation collapsed dots in the owner's domain
+// (`replace(/\./g, '_')`) and joined with `+`, so two distinct owners
+// could collide: `foo@example.com` and `foo@example_com` both produced
+// `…+foo+example_com@id.openape.ai`. Same for sanitised names where
+// "Owner" and "o-w-n-e-r" both flatten to `owner`. First-write-wins
+// 409s the second user, but the agent email then misleadingly suggests
+// the wrong owner. Worse, an attacker who pre-enrols a colliding agent
+// can later claim the agent's identity belongs to them.
+//
+// Suffixing a short hash of the canonical owner email makes collisions
+// statistically improbable while staying readable. 8 hex chars = 32 bits
+// of entropy — at our scale (single-digit-thousands of agents per owner
+// at most) the birthday-collision risk is negligible, and across owners
+// the hash is fully owner-scoped so cross-owner collisions are
+// structurally impossible.
+function ownerHash(ownerEmail: string): string {
+  return createHash('sha256').update(ownerEmail.trim().toLowerCase()).digest('hex').slice(0, 8)
+}
+
 function deriveAgentEmail(ownerEmail: string, agentName: string): string {
   const [local, domain] = ownerEmail.split('@')
   const safeName = sanitizeName(agentName)
-  return `${safeName}+${local}+${domain!.replace(/\./g, '_')}@id.openape.ai`
+  return `${safeName}-${ownerHash(ownerEmail)}+${local}+${domain!.replace(/\./g, '_')}@id.openape.ai`
 }
 
 export default defineEventHandler(async (event) => {
@@ -25,8 +49,19 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: 'Missing required fields: name, publicKey' })
   }
 
+  if (body.publicKey.length > PUBLIC_KEY_MAX_LENGTH) {
+    throw createError({ statusCode: 400, statusMessage: `Public key exceeds ${PUBLIC_KEY_MAX_LENGTH} characters` })
+  }
+
   if (!body.publicKey.startsWith('ssh-ed25519 ')) {
     throw createError({ statusCode: 400, statusMessage: 'Public key must be in ssh-ed25519 format' })
+  }
+
+  // Defend against `parts[1]!` throwing on `"ssh-ed25519 "` (no base64
+  // section) — explicit shape check before non-null-assertion.
+  const parts = body.publicKey.trim().split(/\s+/)
+  if (parts.length < 2 || !parts[1]) {
+    throw createError({ statusCode: 400, statusMessage: 'Public key missing base64 section' })
   }
 
   const { userStore, sshKeyStore } = useIdpStores()
@@ -55,8 +90,7 @@ export default defineEventHandler(async (event) => {
   })
 
   // Create SSH key
-  const parts = body.publicKey.trim().split(/\s+/)
-  const keyData = parts[1]!
+  const keyData = parts[1]
   const keyId = createHash('sha256').update(Buffer.from(keyData, 'base64')).digest('hex')
   await sshKeyStore.save({
     keyId,

--- a/apps/openape-free-idp/server/api/my-agents/[id].patch.ts
+++ b/apps/openape-free-idp/server/api/my-agents/[id].patch.ts
@@ -1,4 +1,8 @@
+import { Buffer } from 'node:buffer'
+import { createHash } from 'node:crypto'
 import { createError, defineEventHandler, getRouterParam, readBody } from 'h3'
+
+const PUBLIC_KEY_MAX_LENGTH = 1000
 
 export default defineEventHandler(async (event) => {
   const email = await requireAuth(event)
@@ -23,14 +27,27 @@ export default defineEventHandler(async (event) => {
   }
 
   if (body.publicKey !== undefined) {
+    // VALIDATE FIRST. The previous flow ran `deleteAllForUser` BEFORE
+    // validating the new key, so any failure (malformed base64, missing
+    // section, length overflow) left the agent with zero keys —
+    // permanently locked out of `apes login`. (#295)
+    if (body.publicKey.length > PUBLIC_KEY_MAX_LENGTH) {
+      throw createError({ statusCode: 400, statusMessage: `Public key exceeds ${PUBLIC_KEY_MAX_LENGTH} characters` })
+    }
     if (!body.publicKey.startsWith('ssh-ed25519 ')) {
       throw createError({ statusCode: 400, statusMessage: 'Public key must be in ssh-ed25519 format' })
     }
-    await sshKeyStore.deleteAllForUser(userEmail)
-    const { createHash } = await import('node:crypto')
     const parts = body.publicKey.trim().split(/\s+/)
-    const keyData = parts[1]!
+    if (parts.length < 2 || !parts[1]) {
+      throw createError({ statusCode: 400, statusMessage: 'Public key missing base64 section' })
+    }
+    const keyData = parts[1]
     const keyId = createHash('sha256').update(Buffer.from(keyData, 'base64')).digest('hex')
+
+    // Save FIRST, then delete the others. The sshKeyStore primary key
+    // is keyId, so save() doesn't conflict with the existing rows; once
+    // the new row is durable we drop everything else for this user.
+    // Net result: the agent is never without an authenticator.
     await sshKeyStore.save({
       keyId,
       userEmail,
@@ -38,6 +55,7 @@ export default defineEventHandler(async (event) => {
       name: user.name,
       createdAt: Math.floor(Date.now() / 1000),
     })
+    await sshKeyStore.deleteAllForUser(userEmail, { exceptKeyId: keyId })
   }
 
   if (body.isActive !== undefined) {

--- a/apps/openape-free-idp/server/api/push/subscribe.post.ts
+++ b/apps/openape-free-idp/server/api/push/subscribe.post.ts
@@ -1,3 +1,4 @@
+import { eq } from 'drizzle-orm'
 import { z } from 'zod'
 import { useDb } from '../../database/drizzle'
 import { pushSubscriptions } from '../../database/schema'
@@ -10,14 +11,34 @@ const bodySchema = z.object({
   }),
 })
 
-// Upsert by endpoint. The browser may re-subscribe (after token rotation,
-// browser update, etc.) with the same endpoint URL — we don't want a new
-// row each time, just refreshed keys.
+// Subscribe to push notifications for the authenticated user.
+//
+// Re-subscribing the SAME endpoint URL refreshes the keys (browsers
+// rotate the encryption keys on their own schedule). Subscribing an
+// endpoint that's already bound to a DIFFERENT user is rejected (#296)
+// — without that check, user A could submit user B's endpoint URL and
+// `onConflictDoUpdate` would silently transfer ownership, hijacking
+// every future notification from B's device.
 export default defineEventHandler(async (event) => {
   const email = await requireAuth(event)
   const parsed = bodySchema.safeParse(await readBody(event))
   if (!parsed.success) {
     throw createError({ statusCode: 400, statusMessage: parsed.error.message })
+  }
+
+  const db = useDb()
+  const existing = await db
+    .select({ userEmail: pushSubscriptions.userEmail })
+    .from(pushSubscriptions)
+    .where(eq(pushSubscriptions.endpoint, parsed.data.endpoint))
+    .get()
+
+  if (existing && existing.userEmail !== email) {
+    // Endpoint claimed by someone else — refuse, don't leak who.
+    throw createError({
+      statusCode: 409,
+      statusMessage: 'Push endpoint is already registered to a different account',
+    })
   }
 
   const row = {
@@ -28,14 +49,16 @@ export default defineEventHandler(async (event) => {
     createdAt: Math.floor(Date.now() / 1000),
   }
 
-  const db = useDb()
   await db
     .insert(pushSubscriptions)
     .values(row)
     .onConflictDoUpdate({
       target: pushSubscriptions.endpoint,
       set: {
-        userEmail: row.userEmail,
+        // userEmail intentionally NOT in the SET clause — the existing
+        // row is either ours (matched the pre-check) or doesn't exist.
+        // Keeping it out of SET defends against any future race where
+        // a row appears between the pre-check and the insert.
         p256dh: row.p256dh,
         auth: row.auth,
         createdAt: row.createdAt,

--- a/apps/openape-free-idp/server/api/test/session.post.ts
+++ b/apps/openape-free-idp/server/api/test/session.post.ts
@@ -1,16 +1,42 @@
+import { Buffer } from 'node:buffer'
+import { timingSafeEqual } from 'node:crypto'
 import { createError, defineEventHandler, getHeader, readBody, useSession } from 'h3'
 
 const RE_BEARER_PREFIX = /^Bearer\s+/i
 
+// Defence-in-depth gate (#293).
+//
+// The endpoint is for E2E tests only. Active gating is `OPENAPE_E2E=1`
+// at startup; `import.meta.dev` would also block it in built bundles
+// when the env-var leaks. Even at request time we additionally require
+// `process.env.NODE_ENV !== 'production'` so a Vercel preview that
+// happened to inherit OPENAPE_E2E=1 alongside production NODE_ENV
+// still refuses to mint sessions.
+function gateOpen(): boolean {
+  if (process.env.OPENAPE_E2E !== '1') return false
+  if (process.env.NODE_ENV === 'production') return false
+  return true
+}
+
+function constantTimeEqualString(a: string, b: string): boolean {
+  if (a.length !== b.length) return false
+  return timingSafeEqual(Buffer.from(a), Buffer.from(b))
+}
+
 export default defineEventHandler(async (event) => {
-  if (process.env.OPENAPE_E2E !== '1') {
+  if (!gateOpen()) {
     throw createError({ statusCode: 404, statusMessage: 'Not found' })
   }
 
   const config = useRuntimeConfig()
   const auth = getHeader(event, 'authorization')
-  const token = auth?.replace(RE_BEARER_PREFIX, '')
-  if (!token || token !== config.openapeIdp.managementToken) {
+  const token = auth?.replace(RE_BEARER_PREFIX, '') ?? ''
+  const expected = String(config.openapeIdp.managementToken ?? '')
+  // Both length-equality short-circuit and timing-safe compare so a
+  // probing client can't infer the management token via response-time
+  // measurements. Rejecting empty expected too — if the token isn't
+  // configured we never want to silently accept anything.
+  if (!expected || !constantTimeEqualString(token, expected)) {
     throw createError({ statusCode: 401, statusMessage: 'Management token required' })
   }
 

--- a/apps/openape-free-idp/server/utils/drizzle-ssh-key-store.ts
+++ b/apps/openape-free-idp/server/utils/drizzle-ssh-key-store.ts
@@ -1,5 +1,5 @@
 // SshKeyStore type is auto-imported from @openape/nuxt-auth-idp via addServerImportsDir
-import { eq } from 'drizzle-orm'
+import { and, eq, ne } from 'drizzle-orm'
 import { useDb } from '../database/drizzle'
 import { sshKeys } from '../database/schema'
 
@@ -36,8 +36,12 @@ export function createDrizzleSshKeyStore(): SshKeyStore {
       await db.delete(sshKeys).where(eq(sshKeys.keyId, keyId))
     },
 
-    async deleteAllForUser(email) {
-      await db.delete(sshKeys).where(eq(sshKeys.userEmail, email))
+    async deleteAllForUser(email, opts) {
+      const except = opts?.exceptKeyId
+      const filter = except
+        ? and(eq(sshKeys.userEmail, email), ne(sshKeys.keyId, except))
+        : eq(sshKeys.userEmail, email)
+      await db.delete(sshKeys).where(filter)
     },
   }
 }

--- a/modules/nuxt-auth-idp/src/runtime/server/plugins/rate-limit.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/plugins/rate-limit.ts
@@ -10,7 +10,12 @@ interface RateLimitEntry {
 const WINDOW_MS = 60_000 // 1 minute
 const MAX_REQUESTS = 10
 
-const RE_AUTH_PATHS = /^\/(?:api\/(?:session|auth|agent|webauthn)\b|authorize\b|token\b)/
+// Rate-limited path-prefixes. Anything brute-forceable (auth ceremonies,
+// agent challenges, push subscriptions, account registration, user lookups)
+// is in here. The hyphen in `my-agents` is escaped explicitly. Extended in
+// #292 to cover the free-idp's custom paths (enroll, register, my-agents,
+// push, users) which were previously unlimited — see audit 2026-05-04.
+const RE_AUTH_PATHS = /^\/(?:api\/(?:session|auth|agent|webauthn|enroll|register|my-agents|push|users)\b|authorize\b|token\b)/
 
 const store = new Map<string, RateLimitEntry>()
 

--- a/modules/nuxt-auth-idp/src/runtime/server/utils/ssh-key-store.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/utils/ssh-key-store.ts
@@ -14,7 +14,8 @@ export interface SshKeyStore {
   findByUser: (email: string) => Promise<SshKey[]>
   findByPublicKey: (publicKey: string) => Promise<SshKey | null>
   delete: (keyId: string) => Promise<void>
-  deleteAllForUser: (email: string) => Promise<void>
+  /** See @openape/auth SshKeyStore — `exceptKeyId` is the safety hatch for #295. */
+  deleteAllForUser: (email: string, opts?: { exceptKeyId?: string }) => Promise<void>
 }
 
 export function createSshKeyStore(): SshKeyStore {
@@ -66,12 +67,23 @@ export function createSshKeyStore(): SshKeyStore {
       await storage.removeItem(`ssh-keys:${keyId}`)
     },
 
-    async deleteAllForUser(email) {
+    async deleteAllForUser(email, opts) {
+      const except = opts?.exceptKeyId
       const index = await storage.getItem<string[]>(`user-ssh-keys:${email}`) || []
+      const remaining: string[] = []
       for (const id of index) {
+        if (id === except) {
+          remaining.push(id)
+          continue
+        }
         await storage.removeItem(`ssh-keys:${id}`)
       }
-      await storage.removeItem(`user-ssh-keys:${email}`)
+      if (remaining.length > 0) {
+        await storage.setItem(`user-ssh-keys:${email}`, remaining)
+      }
+      else {
+        await storage.removeItem(`user-ssh-keys:${email}`)
+      }
     },
   }
 }

--- a/modules/nuxt-auth-idp/test/rate-limit-trusted-proxies.test.ts
+++ b/modules/nuxt-auth-idp/test/rate-limit-trusted-proxies.test.ts
@@ -27,6 +27,41 @@ async function setSocketIp(ip: string | null) {
   ;(getRequestIP as any).mockReturnValue(ip)
 }
 
+// We can't easily import the regex constant directly without exporting
+// it; mirror the source-of-truth here and unit-test the membership.
+// If this drifts, lint/PR review catches it — tests fail loudly because
+// every audit-finding assertion below would change.
+const RE_AUTH_PATHS = /^\/(?:api\/(?:session|auth|agent|webauthn|enroll|register|my-agents|push|users)\b|authorize\b|token\b)/
+
+describe('rate-limit path coverage (#292)', () => {
+  it('covers historical auth + ceremony paths', () => {
+    expect(RE_AUTH_PATHS.test('/api/session')).toBe(true)
+    expect(RE_AUTH_PATHS.test('/api/auth/passkey')).toBe(true)
+    expect(RE_AUTH_PATHS.test('/api/agent/challenge')).toBe(true)
+    expect(RE_AUTH_PATHS.test('/api/webauthn/login/options')).toBe(true)
+    expect(RE_AUTH_PATHS.test('/authorize')).toBe(true)
+    expect(RE_AUTH_PATHS.test('/token')).toBe(true)
+  })
+
+  it('covers free-idp custom paths added in #292', () => {
+    // Brute-forceable paths that were uncapped before the fix.
+    expect(RE_AUTH_PATHS.test('/api/enroll')).toBe(true)
+    expect(RE_AUTH_PATHS.test('/api/register')).toBe(true)
+    expect(RE_AUTH_PATHS.test('/api/my-agents')).toBe(true)
+    expect(RE_AUTH_PATHS.test('/api/my-agents/abc-123')).toBe(true)
+    expect(RE_AUTH_PATHS.test('/api/push/subscribe')).toBe(true)
+    expect(RE_AUTH_PATHS.test('/api/users/foo@bar.com/whatever')).toBe(true)
+  })
+
+  it('does not cover clearly unrelated paths', () => {
+    expect(RE_AUTH_PATHS.test('/api/grants')).toBe(false)
+    expect(RE_AUTH_PATHS.test('/api/admin/something')).toBe(false)
+    // `register` and `\b` interact correctly: `registries` (no transition
+    // between `register`'s last char and the next) does not match.
+    expect(RE_AUTH_PATHS.test('/api/registries')).toBe(false)
+  })
+})
+
 describe('rate-limit IP CIDR matching', () => {
   it('matches IPs against /24 networks', () => {
     expect(ipMatches('10.1.2.3', '10.1.2.0/24')).toBe(true)

--- a/packages/auth/src/idp/stores.ts
+++ b/packages/auth/src/idp/stores.ts
@@ -363,7 +363,15 @@ export interface SshKeyStore {
   findByUser: (email: string) => Promise<SshKey[]>
   findByPublicKey: (publicKey: string) => Promise<SshKey | null>
   delete: (keyId: string) => Promise<void>
-  deleteAllForUser: (email: string) => Promise<void>
+  /**
+   * Delete every key for the user except (optionally) `exceptKeyId`.
+   * The exception is the safety hatch for "rotate one key into the
+   * place of another" flows: save the new one first, then call this
+   * with `exceptKeyId` set to the new id so the agent is never
+   * without an authenticator (see #295). Backwards-compatible — the
+   * options arg is optional.
+   */
+  deleteAllForUser: (email: string, opts?: { exceptKeyId?: string }) => Promise<void>
 }
 
 // --- Grant Challenge Store (ed25519 challenge-response) ---
@@ -459,9 +467,10 @@ export class InMemorySshKeyStore implements SshKeyStore {
     this.keys.delete(keyId)
   }
 
-  async deleteAllForUser(email: string): Promise<void> {
+  async deleteAllForUser(email: string, opts?: { exceptKeyId?: string }): Promise<void> {
+    const except = opts?.exceptKeyId
     for (const [id, key] of this.keys) {
-      if (key.userEmail === email) this.keys.delete(id)
+      if (key.userEmail === email && id !== except) this.keys.delete(id)
     }
   }
 }


### PR DESCRIPTION
Closes #292 #293 #294 #295 #296 from the 2026-05-04 audit.

| # | Fix |
|---|---|
| #292 | rate-limit regex covers /api/{enroll,register,my-agents,push,users} — were uncapped for brute-force |
| #293 | test/session.post.ts: NODE_ENV!=='production' guard + crypto.timingSafeEqual |
| #294 | agent-email derivation suffixes 8-hex owner-hash → no more dot-collapse collisions |
| #295 | my-agents PATCH validates new SSH key BEFORE deleting old; agent never without authenticator on failure |
| #296 | push/subscribe rejects 409 if endpoint already bound to a different user |

122 nuxt-auth-idp tests, 73 free-idp tests, 100 auth tests — all green.