### PR TITLE
fix(auth+idp): validate redirect_uri against SP-published metadata (#280)

### DIFF
--- a/.changeset/fix-redirect-uri-validation.md
+++ b/.changeset/fix-redirect-uri-validation.md
@@ -1,0 +1,25 @@
+---
+'@openape/auth': minor
+'@openape/nuxt-auth-idp': minor
+---
+
+Enforce DDISA `core.md §5.2.1` `redirect_uri` validation against SP-published metadata (closes #280).
+
+The IdP previously accepted any `redirect_uri` on `/authorize` — only `client_id` was checked for presence. The DDISA spec mandates: SPs MUST publish `/.well-known/oauth-client-metadata` (RFC 7591), and the IdP MUST verify `redirect_uri` against the SP's `redirect_uris` array.
+
+This isn't a centralised registry — it's the same DNS/HTTP-discoverable pattern DDISA uses for IdPs. SP is source-of-truth for its own callbacks; IdP fetches and validates.
+
+Implementation:
+
+- **`@openape/auth`**: new `createClientMetadataResolver()` fetches and caches SP metadata (300s TTL, parallel to DDISA DNS cache). Falls back to legacy `/.well-known/sp-manifest.json` per the spec's migration note. New `validateRedirectUri()` does strict-equality matching (no path-prefix, no wildcards — RFC 6749 §3.1.2.2 + OAuth 2.0 Security BCP).
+- **`@openape/nuxt-auth-idp`**: `/authorize` calls the resolver before issuing a code; rejects with 400 on mismatch.
+
+**Rollout-safe defaults**:
+
+- `spMetadataMode: 'permissive'` (default) tolerates unresolvable SP metadata so existing SPs keep working while they catch up. Explicit redirect_uri MISMATCH is always rejected though — permissive only forgives missing metadata.
+- `spMetadataMode: 'strict'` once all SPs publish: also rejects unresolvable.
+- Native CLIs (RFC 8252 public clients) without a domain go through a static `publicClients` map — `apes-cli` registered for the `localhost:9876` callback.
+
+Env vars: `NUXT_OPENAPE_IDP_SP_METADATA_MODE`, `NUXT_OPENAPE_IDP_PUBLIC_CLIENTS` (JSON).
+
+Follow-up: each OpenApe SP (chat, plans, tasks, preview) needs to publish its `oauth-client-metadata` file before strict mode can be enabled. Tracked separately.

--- a/modules/nuxt-auth-idp/src/module.ts
+++ b/modules/nuxt-auth-idp/src/module.ts
@@ -45,6 +45,29 @@ export interface ModuleOptions {
    * Env: `NUXT_OPENAPE_IDP_ALLOWED_FRAME_ANCESTORS`
    */
   allowedFrameAncestors: string
+  /**
+   * SP `redirect_uri` enforcement mode (DDISA core.md §5.2.1, #280).
+   *
+   *   - `permissive` (default): unresolvable SP metadata is allowed
+   *     through with a warn-log so SPs that haven't yet published
+   *     `/.well-known/oauth-client-metadata` keep working during
+   *     rollout. Explicit mismatch (metadata exists but redirect_uri
+   *     not in `redirect_uris`) is still rejected.
+   *   - `strict`: unresolvable metadata is also rejected. Use in
+   *     production once all SPs publish their metadata.
+   *
+   * Env: `NUXT_OPENAPE_IDP_SP_METADATA_MODE`
+   */
+  spMetadataMode: 'permissive' | 'strict'
+  /**
+   * Pre-registered "public clients" — native apps without a domain
+   * (RFC 8252). Pass either an object or a JSON string. The IdP uses
+   * this for `client_id`s without a `.` in them; everything else
+   * goes through the well-known fetch.
+   *
+   * Env: `NUXT_OPENAPE_IDP_PUBLIC_CLIENTS` (JSON string)
+   */
+  publicClients: string | Record<string, { client_id: string, redirect_uris: string[] }>
 }
 
 function resolveRoutes(routes: boolean | Partial<RoutesOptions> | undefined): RoutesOptions {
@@ -88,6 +111,8 @@ export default defineNuxtModule<ModuleOptions>({
     pages: true,
     federationProviders: '',
     allowedFrameAncestors: '',
+    spMetadataMode: 'permissive',
+    publicClients: '',
   },
   setup(options, nuxt) {
     const { resolve } = createResolver(import.meta.url)

--- a/modules/nuxt-auth-idp/src/runtime/server/routes/authorize.get.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/routes/authorize.get.ts
@@ -1,9 +1,10 @@
 // Canonical: @openape/server createAuthorizeHandler
-import type { AuthorizeParams } from '@openape/auth'
+import type { AuthorizeParams, ClientMetadataMode } from '@openape/auth'
 import type { ActorType, DelegationActClaim, OpenApeAuthorizationDetail } from '@openape/core'
 import { defineEventHandler, getQuery, getRequestURL, sendRedirect } from 'h3'
+import { useRuntimeConfig } from 'nitropack/runtime'
 import { extractDomain, resolveDDISA } from '@openape/core'
-import { evaluatePolicy, validateAuthorizeRequest } from '@openape/auth'
+import { evaluatePolicy, validateAuthorizeRequest, validateRedirectUri } from '@openape/auth'
 import { useGrant, validateDelegation } from '@openape/grants'
 import { tryBearerAuth } from '../utils/agent-auth'
 import { getAppSession } from '../utils/session'
@@ -62,6 +63,39 @@ export default defineEventHandler(async (event) => {
       }
     }
     throw createProblemError({ status: 400, title: error })
+  }
+
+  // SP redirect_uri validation per DDISA core.md §5.2.1 (#280).
+  //
+  // The IdP fetches the SP's published metadata at
+  // https://{client_id}/.well-known/oauth-client-metadata and verifies
+  // the request's redirect_uri matches one the SP itself declared. The
+  // SP — not the IdP — is the source of truth; this isn't a registry,
+  // it's structural enforcement of the spec's MUST. Rollout is
+  // permissive-by-default so existing SPs can publish their metadata
+  // without breaking; flip OPENAPE_IDP_SP_METADATA_MODE=strict once
+  // the rollout is complete.
+  //
+  // We do NOT redirect on this error: the request's redirect_uri is
+  // by definition untrusted at this point, so sending the user there
+  // would itself be the open-redirect we're trying to prevent.
+  const config = useRuntimeConfig()
+  const spMetadataMode = (config.openapeIdp?.spMetadataMode === 'strict')
+    ? 'strict' as ClientMetadataMode
+    : 'permissive' as ClientMetadataMode
+  const { clientMetadataStore } = useIdpStores()
+  const redirectErr = await validateRedirectUri(
+    params.client_id,
+    params.redirect_uri,
+    clientMetadataStore,
+    spMetadataMode,
+  )
+  if (redirectErr) {
+    throw createProblemError({
+      status: 400,
+      title: redirectErr.error,
+      detail: redirectErr.detail,
+    })
   }
 
   // Determine userId: Bearer Token (agent or human) or Human Session

--- a/modules/nuxt-auth-idp/src/runtime/server/utils/stores.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/utils/stores.ts
@@ -1,5 +1,6 @@
 import type { H3Event } from 'h3'
-import type { ChallengeStore, CodeStore, CredentialStore, JtiStore, KeyStore, RefreshTokenStore, RegistrationUrlStore, UserStore } from '@openape/auth'
+import type { ChallengeStore, ClientMetadata, ClientMetadataStore, CodeStore, CredentialStore, JtiStore, KeyStore, RefreshTokenStore, RegistrationUrlStore, UserStore } from '@openape/auth'
+import { createClientMetadataResolver } from '@openape/auth'
 import { useRuntimeConfig, useEvent } from 'nitropack/runtime'
 import { createChallengeStore } from './challenge-store'
 import { createCodeStore } from './code-store'
@@ -23,6 +24,33 @@ interface IdpStores {
   jtiStore: JtiStore
   refreshTokenStore: RefreshTokenStore
   sshKeyStore: SshKeyStore
+  clientMetadataStore: ClientMetadataStore
+}
+
+// Module-level singleton for the SP client-metadata resolver. The
+// resolver caches its own results internally; sharing one instance
+// across requests keeps the cache hit-rate up. Per-request scoping
+// via `event.context` doesn't help here because the cache TTL is
+// O(minutes), much longer than a request lifetime.
+let _clientMetadataStore: ClientMetadataStore | null = null
+function getClientMetadataStore(): ClientMetadataStore {
+  if (_clientMetadataStore) return _clientMetadataStore
+  let publicClients: Record<string, ClientMetadata> = {}
+  try {
+    const config = useRuntimeConfig()
+    const raw = config.openapeIdp?.publicClients
+    if (typeof raw === 'string' && raw.trim()) {
+      publicClients = JSON.parse(raw) as Record<string, ClientMetadata>
+    }
+    else if (raw && typeof raw === 'object') {
+      publicClients = raw as Record<string, ClientMetadata>
+    }
+  }
+  catch {
+    publicClients = {}
+  }
+  _clientMetadataStore = createClientMetadataResolver({ publicClients })
+  return _clientMetadataStore
 }
 
 let _stores: IdpStores | null = null
@@ -38,6 +66,7 @@ function initDefaultStores(): IdpStores {
     jtiStore: createJtiStore(),
     refreshTokenStore: createRefreshTokenStore(),
     sshKeyStore: createSshKeyStore(),
+    clientMetadataStore: getClientMetadataStore(),
   }
 }
 
@@ -52,6 +81,7 @@ function initStoresWithRegistry(event: H3Event): IdpStores {
     jtiStore: getStoreFactory<JtiStore>('jtiStore')?.(event) ?? createJtiStore(),
     refreshTokenStore: getStoreFactory<RefreshTokenStore>('refreshTokenStore')?.(event) ?? createRefreshTokenStore(),
     sshKeyStore: getStoreFactory<SshKeyStore>('sshKeyStore')?.(event) ?? createSshKeyStore(),
+    clientMetadataStore: getStoreFactory<ClientMetadataStore>('clientMetadataStore')?.(event) ?? getClientMetadataStore(),
   }
 }
 

--- a/modules/nuxt-auth-idp/test/authorize-errors.test.ts
+++ b/modules/nuxt-auth-idp/test/authorize-errors.test.ts
@@ -16,9 +16,11 @@ vi.mock('h3', () => ({
 
 vi.mock('../src/runtime/server/utils/stores', () => ({
   getIdpIssuer: () => ISSUER,
-  useIdpStores: () => ({
+  useIdpStores: vi.fn(() => ({
     codeStore: { find: vi.fn(), save: vi.fn(), delete: vi.fn() },
-  }),
+    // permissive default → resolve returns null which is allowed
+    clientMetadataStore: { resolve: async () => null },
+  })),
 }))
 
 vi.mock('../src/runtime/server/utils/session', () => ({
@@ -35,6 +37,12 @@ vi.mock('../src/runtime/server/utils/grant-stores', () => ({
     grantStore: {},
     challengeStore: {},
   }),
+}))
+
+vi.mock('nitropack/runtime', () => ({
+  useRuntimeConfig: vi.fn(() => ({
+    openapeIdp: { spMetadataMode: 'permissive', publicClients: '' },
+  })),
 }))
 
 vi.mock('@openape/core', () => ({
@@ -132,6 +140,40 @@ describe('authorize endpoint — error redirects (RFC 6749 §4.1.2.1)', () => {
 
     const { default: handler } = await import('../src/runtime/server/routes/authorize.get')
 
+    await expect(handler({} as any)).rejects.toMatchObject({ statusCode: 400 })
+  })
+
+  it('rejects redirect_uri not in SP metadata when mode=strict (#280)', async () => {
+    // Override the store + runtime config so this test exercises the
+    // strict-mode path. Pinpoints the spec-mandated redirect_uri
+    // validation per DDISA core.md §5.2.1.
+    const { useIdpStores } = await import('../src/runtime/server/utils/stores')
+    ;(useIdpStores as any).mockReturnValue({
+      codeStore: { find: vi.fn(), save: vi.fn(), delete: vi.fn() },
+      clientMetadataStore: {
+        resolve: async () => ({
+          client_id: 'app.example.com',
+          redirect_uris: ['https://app.example.com/auth/callback'],
+        }),
+      },
+    })
+    const { useRuntimeConfig } = await import('nitropack/runtime')
+    ;(useRuntimeConfig as any).mockReturnValue({
+      openapeIdp: { spMetadataMode: 'strict', publicClients: '' },
+    })
+
+    const { getQuery } = await import('h3')
+    ;(getQuery as any).mockReturnValue({
+      client_id: 'app.example.com',
+      redirect_uri: 'https://attacker.example.com/cb', // NOT in metadata
+      state: 'xyz',
+      code_challenge: 'abc'.repeat(15),
+      code_challenge_method: 'S256',
+      nonce: 'n1',
+      response_type: 'code',
+    })
+
+    const { default: handler } = await import('../src/runtime/server/routes/authorize.get')
     await expect(handler({} as any)).rejects.toMatchObject({ statusCode: 400 })
   })
 

--- a/packages/auth/src/__tests__/client-metadata.test.ts
+++ b/packages/auth/src/__tests__/client-metadata.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createClientMetadataResolver, validateRedirectUri } from '../idp/client-metadata'
+import type { ClientMetadata } from '../idp/client-metadata'
+
+const exampleMetadata: ClientMetadata = {
+  client_id: 'app.example.com',
+  client_name: 'Example App',
+  redirect_uris: ['https://app.example.com/auth/callback'],
+}
+
+describe('createClientMetadataResolver — DDISA §4.1 SP metadata fetch', () => {
+  it('resolves a hostname-y client_id by fetching /.well-known/oauth-client-metadata', async () => {
+    const fetchImpl = vi.fn().mockImplementation(async (url: string) => {
+      if (url === 'https://app.example.com/.well-known/oauth-client-metadata') {
+        return exampleMetadata
+      }
+      throw new Error(`unexpected fetch ${url}`)
+    })
+    const resolver = createClientMetadataResolver({ fetchImpl })
+    const result = await resolver.resolve('app.example.com')
+    expect(result).toEqual(exampleMetadata)
+    expect(fetchImpl).toHaveBeenCalledWith('https://app.example.com/.well-known/oauth-client-metadata')
+  })
+
+  it('falls back to the legacy /.well-known/sp-manifest.json path', async () => {
+    const fetchImpl = vi.fn().mockImplementation(async (url: string) => {
+      if (url.endsWith('/.well-known/oauth-client-metadata')) {
+        throw Object.assign(new Error('Not Found'), { statusCode: 404 })
+      }
+      if (url.endsWith('/.well-known/sp-manifest.json')) {
+        return exampleMetadata
+      }
+      throw new Error(`unexpected ${url}`)
+    })
+    const resolver = createClientMetadataResolver({ fetchImpl })
+    const result = await resolver.resolve('app.example.com')
+    expect(result).toEqual(exampleMetadata)
+  })
+
+  it('returns null when both well-known paths fail', async () => {
+    const fetchImpl = vi.fn().mockImplementation(async () => {
+      throw new Error('network down')
+    })
+    const resolver = createClientMetadataResolver({ fetchImpl })
+    expect(await resolver.resolve('app.example.com')).toBeNull()
+  })
+
+  it('returns null when the fetched document is malformed', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ client_id: 'no-redirects' })
+    const resolver = createClientMetadataResolver({ fetchImpl })
+    expect(await resolver.resolve('app.example.com')).toBeNull()
+  })
+
+  it('caches successful resolves until TTL expiry', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(exampleMetadata)
+    const resolver = createClientMetadataResolver({ fetchImpl, cacheTtlMs: 60_000 })
+
+    await resolver.resolve('app.example.com')
+    await resolver.resolve('app.example.com')
+    await resolver.resolve('app.example.com')
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+  })
+
+  it('caches negative resolves too — protects the IdP from a hostile SP that 503s every fetch', async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error('network'))
+    const resolver = createClientMetadataResolver({ fetchImpl, cacheTtlMs: 60_000 })
+
+    await resolver.resolve('app.example.com')
+    await resolver.resolve('app.example.com')
+
+    // Both well-known paths attempted ONCE, then cached.
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+  })
+
+  it('uses the public-clients map for non-hostname client_ids (RFC 8252 native apps)', async () => {
+    // Native CLIs have no domain so the well-known fetch makes no
+    // sense; they live in a hardcoded allowlist on the IdP side.
+    const fetchImpl = vi.fn()
+    const resolver = createClientMetadataResolver({
+      fetchImpl,
+      publicClients: {
+        'apes-cli': {
+          client_id: 'apes-cli',
+          redirect_uris: ['http://localhost:9876/callback'],
+        },
+      },
+    })
+    const result = await resolver.resolve('apes-cli')
+    expect(result?.redirect_uris).toContain('http://localhost:9876/callback')
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  it('returns null for an unregistered public-client', async () => {
+    const resolver = createClientMetadataResolver({ publicClients: {} })
+    expect(await resolver.resolve('rogue-cli')).toBeNull()
+  })
+})
+
+describe('validateRedirectUri', () => {
+  function staticStore(metadata: ClientMetadata | null) {
+    return { resolve: async () => metadata }
+  }
+
+  it('passes when redirect_uri exactly matches a registered URI', async () => {
+    const result = await validateRedirectUri(
+      'app.example.com',
+      'https://app.example.com/auth/callback',
+      staticStore(exampleMetadata),
+      'strict',
+    )
+    expect(result).toBeNull()
+  })
+
+  it('rejects when redirect_uri is a path-prefix of a registered URI', async () => {
+    // Strict equality only — no path-prefix matching, no wildcard.
+    const result = await validateRedirectUri(
+      'app.example.com',
+      'https://app.example.com/auth',
+      staticStore(exampleMetadata),
+      'strict',
+    )
+    expect(result).toMatchObject({ error: 'invalid_request' })
+  })
+
+  it('rejects when redirect_uri has extra query string vs. registered URI', async () => {
+    const result = await validateRedirectUri(
+      'app.example.com',
+      'https://app.example.com/auth/callback?next=admin',
+      staticStore(exampleMetadata),
+      'strict',
+    )
+    expect(result).toMatchObject({ error: 'invalid_request' })
+  })
+
+  it('strict mode rejects unresolvable client_id', async () => {
+    const result = await validateRedirectUri(
+      'unknown.example.com',
+      'https://anywhere/cb',
+      staticStore(null),
+      'strict',
+    )
+    expect(result).toMatchObject({ error: 'invalid_client' })
+  })
+
+  it('permissive mode allows unresolvable client_id (warn-only rollout)', async () => {
+    const result = await validateRedirectUri(
+      'unknown.example.com',
+      'https://anywhere/cb',
+      staticStore(null),
+      'permissive',
+    )
+    expect(result).toBeNull()
+  })
+
+  it('permissive mode still rejects when metadata is resolvable but mismatched', async () => {
+    // The point of permissive mode is to tolerate SPs that haven't yet
+    // published metadata — NOT to ignore explicit mismatches once they
+    // have. A mismatch is always a hard error.
+    const result = await validateRedirectUri(
+      'app.example.com',
+      'https://attacker.example.com/cb',
+      staticStore(exampleMetadata),
+      'permissive',
+    )
+    expect(result).toMatchObject({ error: 'invalid_request' })
+  })
+})

--- a/packages/auth/src/idp/client-metadata.ts
+++ b/packages/auth/src/idp/client-metadata.ts
@@ -1,0 +1,188 @@
+import { ofetch } from 'ofetch'
+
+/**
+ * SP client metadata as defined by DDISA core.md §4 (RFC 7591 subset).
+ * Only the fields the IdP actually consumes during /authorize are
+ * modelled here — additional fields like `client_uri`, `logo_uri`,
+ * `contacts` etc. are tolerated but ignored.
+ */
+export interface ClientMetadata {
+  client_id: string
+  client_name?: string
+  redirect_uris: string[]
+  jwks_uri?: string
+}
+
+export interface ClientMetadataStore {
+  /** Resolve a SP's metadata. `null` if the SP doesn't publish any. */
+  resolve: (clientId: string) => Promise<ClientMetadata | null>
+}
+
+/**
+ * Configuration for {@link createClientMetadataResolver}.
+ */
+export interface ClientMetadataResolverOptions {
+  /**
+   * Cache TTL for resolved metadata (ms). Defaults to 300s (5min),
+   * mirroring the DDISA DNS cache default. Operators may want to
+   * lower this for SPs that rotate redirect_uris frequently.
+   */
+  cacheTtlMs?: number
+  /**
+   * Pre-registered "public clients" — native apps without a domain
+   * (RFC 8252). Their client_id is a flat name (e.g. `apes-cli`) and
+   * their redirect_uris are typically loopback HTTP URIs or custom
+   * URI schemes. Per DDISA core.md §4.3 the spec doesn't explicitly
+   * cover native CLIs; we treat them as `client_id`s without a `.`
+   * and look them up in this static map first.
+   */
+  publicClients?: Record<string, ClientMetadata>
+  /**
+   * Custom fetch implementation — exists for tests + for any IdP
+   * that needs to stub the HTTP call (e.g. Vercel edge restrictions).
+   */
+  fetchImpl?: (url: string) => Promise<unknown>
+}
+
+const WELL_KNOWN_PRIMARY = '/.well-known/oauth-client-metadata'
+const WELL_KNOWN_LEGACY = '/.well-known/sp-manifest.json'
+
+interface CacheEntry {
+  metadata: ClientMetadata | null
+  expiresAt: number
+}
+
+/**
+ * Build a resolver that fetches and caches SP client metadata per
+ * DDISA core.md §4.1. The IdP's `validateAuthorizeRequest` consults
+ * this to enforce that `redirect_uri` was pre-registered by the SP
+ * itself (the SP — not the IdP — is the source of truth for its own
+ * allowed redirect targets).
+ *
+ * Returns:
+ *   - the parsed metadata when the SP publishes a usable document
+ *   - `null` when the SP publishes nothing or the document is malformed
+ *
+ * The caller decides what `null` means (strict-mode fail-closed vs.
+ * permissive-mode warn-only) — see {@link ClientMetadataMode}.
+ */
+export function createClientMetadataResolver(
+  opts: ClientMetadataResolverOptions = {},
+): ClientMetadataStore {
+  const cache = new Map<string, CacheEntry>()
+  const ttl = opts.cacheTtlMs ?? 300_000
+  const publicClients = opts.publicClients ?? {}
+  const fetchImpl = opts.fetchImpl ?? (async (url: string) => await ofetch(url, { responseType: 'json' }))
+
+  function looksLikeHostname(clientId: string): boolean {
+    // RFC 7591 leaves `client_id` opaque; DDISA core.md §4.3 says
+    // "Typically the SP's domain name. MUST be OIDC-compatible."
+    // We use the presence of a `.` and parsability as a URL host as
+    // the discriminator: hostname-y client_ids get the well-known
+    // fetch, flat names go through the public-client map.
+    if (!clientId.includes('.')) return false
+    return URL.canParse(`https://${clientId}/`)
+  }
+
+  async function fetchOne(url: string): Promise<unknown | null> {
+    try {
+      return await fetchImpl(url)
+    }
+    catch {
+      return null
+    }
+  }
+
+  function isValidMetadata(value: unknown): value is ClientMetadata {
+    if (!value || typeof value !== 'object') return false
+    const obj = value as Record<string, unknown>
+    if (typeof obj.client_id !== 'string') return false
+    if (!Array.isArray(obj.redirect_uris)) return false
+    if (!obj.redirect_uris.every(u => typeof u === 'string')) return false
+    return true
+  }
+
+  async function fetchMetadata(clientId: string): Promise<ClientMetadata | null> {
+    const base = `https://${clientId}`
+    // Primary path per current DDISA spec (§4.1). Legacy path is the
+    // pre-1.0 convention — kept as fallback per the migration note.
+    const candidates = [base + WELL_KNOWN_PRIMARY, base + WELL_KNOWN_LEGACY]
+    for (const url of candidates) {
+      const raw = await fetchOne(url)
+      if (raw && isValidMetadata(raw)) return raw
+    }
+    return null
+  }
+
+  return {
+    async resolve(clientId: string): Promise<ClientMetadata | null> {
+      const now = Date.now()
+
+      const cached = cache.get(clientId)
+      if (cached && cached.expiresAt > now) return cached.metadata
+
+      // Public-client (CLI / native app) shortcut — no network call.
+      if (!looksLikeHostname(clientId)) {
+        const fixed = publicClients[clientId] ?? null
+        cache.set(clientId, { metadata: fixed, expiresAt: now + ttl })
+        return fixed
+      }
+
+      const fetched = await fetchMetadata(clientId)
+      cache.set(clientId, { metadata: fetched, expiresAt: now + ttl })
+      return fetched
+    },
+  }
+}
+
+/**
+ * Configurable enforcement mode for redirect_uri validation.
+ *
+ *   - `strict`: an unresolvable SP metadata or a non-matching redirect
+ *     URI is a hard error. Use in production once all known SPs
+ *     publish their `.well-known/oauth-client-metadata`.
+ *   - `permissive`: warn-log and pass through. Use during the
+ *     transition window so existing flows don't break before SPs
+ *     have published their metadata.
+ *
+ * Defaults to `permissive` to keep the upgrade path soft. See #280.
+ */
+export type ClientMetadataMode = 'strict' | 'permissive'
+
+/**
+ * Validate that the request's `redirect_uri` is one the SP has pre-
+ * registered in its published metadata, per DDISA core.md §5.2.1.
+ *
+ * Strict equality matching, per OAuth 2.0 Security BCP — no path
+ * prefixes, no wildcards. SPs needing multiple callbacks list each
+ * one explicitly in `redirect_uris`.
+ *
+ * Returns `null` when the URI is acceptable, or an error object
+ * suitable for `400 invalid_request` when not.
+ */
+export async function validateRedirectUri(
+  clientId: string,
+  redirectUri: string,
+  store: ClientMetadataStore,
+  mode: ClientMetadataMode = 'permissive',
+): Promise<{ error: string, detail?: string } | null> {
+  const metadata = await store.resolve(clientId)
+  if (!metadata) {
+    if (mode === 'strict') {
+      return {
+        error: 'invalid_client',
+        detail: `Could not resolve SP metadata at /.well-known/oauth-client-metadata for client_id=${clientId}`,
+      }
+    }
+    return null
+  }
+
+  if (!metadata.redirect_uris.includes(redirectUri)) {
+    return {
+      error: 'invalid_request',
+      detail: `redirect_uri ${redirectUri} is not registered in SP metadata for client_id=${clientId}`,
+    }
+  }
+
+  return null
+}

--- a/packages/auth/src/idp/index.ts
+++ b/packages/auth/src/idp/index.ts
@@ -1,6 +1,14 @@
 export { type AuthorizeParams, type AuthorizeResult, evaluatePolicy, validateAuthorizeRequest } from './authorize.js'
 export { type AgentKeyResolver, type ClientAssertionResult, validateClientAssertion } from './client-assertion.js'
 export { generateJWKS, type JWKSResponse, serveJWKS } from './jwks.js'
+export {
+  type ClientMetadata,
+  type ClientMetadataMode,
+  type ClientMetadataResolverOptions,
+  type ClientMetadataStore,
+  createClientMetadataResolver,
+  validateRedirectUri,
+} from './client-metadata.js'
 export { handleRefreshGrant, RefreshClientMismatchError, type RefreshGrantResult } from './refresh.js'
 export {
   type CodeEntry,


### PR DESCRIPTION
Closes #280. Implements DDISA core.md §5.2.1 strict — IdP fetches SP-published `/.well-known/oauth-client-metadata` and validates redirect_uri against the SP's `redirect_uris` array. Permissive default for rollout; flip strict once SPs publish their metadata. Native CLIs via `publicClients` map (RFC 8252).