### PR TITLE
feat(idp): DDISA allowlist-user policy mode + consent screen (#301)

### DIFF
--- a/.changeset/idp-allowlist-user-consent.md
+++ b/.changeset/idp-allowlist-user-consent.md
@@ -1,0 +1,23 @@
+---
+'@openape/nuxt-auth-idp': minor
+'@openape/auth': patch
+---
+
+Implement DDISA `allowlist-user` policy mode (consent screen) per core.md §2.3 (closes #301).
+
+Previously: `evaluatePolicy` had the right logic for `allowlist-user`, but `authorize.get.ts` treated `decision === 'consent'` as an error (`access_denied` redirect) and used a `noopConsentStore` that always returned `hasConsent: false`. Net effect: any user with `mode=allowlist-user` in their `_ddisa.{domain}` TXT record was permanently locked out.
+
+Now:
+
+- **Real `ConsentStore`** backed by unstorage (default) with the same shape as `@openape/auth`'s in-memory implementation. Free-idp can swap in a Drizzle-backed version via the existing store-registry.
+- **`authorize.get.ts` routing fixed**: `'deny'` still produces `access_denied`; `'consent'` stashes the original /authorize state in the user's session under `pendingConsent` (with a one-shot CSRF token) and redirects to `/consent`.
+- **`/consent` page** (Vue) renders metadata-aware UI:
+  - SP that publishes `/.well-known/oauth-client-metadata` → "verified" tone with name + logo + policy/tos links
+  - SP that publishes nothing → "unverified" tone with explicit warning + de-emphasised primary action
+- **`POST /api/authorize/consent`** validates CSRF token, persists consent (so subsequent /authorize calls skip the screen), drops the pending state from the session, and resumes the original /authorize flow.
+- **Cancel** redirects the user to the SP's `redirect_uri` with `error=access_denied`.
+- **TTL guard**: pending consent state expires after 5 min so a stale token can't be replayed across sessions.
+
+Mode is **per-user-DNS**, not a global IdP toggle. Users opt in by setting their `_ddisa.{domain}` TXT record to `mode=allowlist-user`. Users who keep `mode=open` (or no TXT) see no consent screen — current behaviour preserved.
+
+Adds optional RFC 7591 fields (`client_uri`, `logo_uri`, `policy_uri`, `tos_uri`, `contacts`) to `ClientMetadata` so the consent UI can render them.

--- a/modules/nuxt-auth-idp/src/runtime/pages/consent.vue
+++ b/modules/nuxt-auth-idp/src/runtime/pages/consent.vue
@@ -1,0 +1,238 @@
+<script setup>
+import { onMounted, ref } from 'vue'
+import { navigateTo, useIdpAuth } from '#imports'
+
+// DDISA core.md §2.3 `allowlist-user` consent screen. Rendered when
+// the user's DDISA TXT record sets `mode=allowlist-user` and they
+// haven't yet consented to the requesting SP. See issue #301.
+//
+// Two visual variants:
+//   - SP published metadata at /.well-known/oauth-client-metadata
+//     → "verified" tone, name + logo + links from the metadata
+//   - SP did NOT publish metadata
+//     → "unverified" tone with explicit warning. Primary action is
+//       still labelled but visually de-emphasised vs. cancel.
+
+definePageMeta({ layout: false })
+
+const { user, fetchUser } = useIdpAuth()
+const data = ref(null)
+const error = ref('')
+const submitting = ref(false)
+
+onMounted(async () => {
+  await fetchUser()
+  if (!user.value) {
+    // Shouldn't happen — /authorize redirects to /login first — but
+    // be defensive: drop them at /login if their session vanished.
+    await navigateTo('/login')
+    return
+  }
+  try {
+    data.value = await $fetch('/api/authorize/consent')
+  }
+  catch (err) {
+    error.value = err?.data?.title || err?.message || 'Failed to load consent details.'
+  }
+})
+
+async function submit(action) {
+  if (!data.value || submitting.value) return
+  submitting.value = true
+  error.value = ''
+  try {
+    const res = await $fetch.raw('/api/authorize/consent', {
+      method: 'POST',
+      body: { csrfToken: data.value.csrfToken, action },
+      redirect: 'manual',
+    })
+    // The handler responds with 302 — fetch.raw exposes the Location
+    // header so we can do the navigation client-side. (Browser-fetch
+    // would follow it transparently but blocks cross-origin reads of
+    // the resulting body, which is fine — we navigate anyway.)
+    const target = res.headers.get('location')
+    if (target) {
+      window.location.assign(target)
+    }
+    else {
+      error.value = 'Server did not return a redirect target.'
+      submitting.value = false
+    }
+  }
+  catch (err) {
+    error.value = err?.data?.title || err?.message || 'Consent submission failed.'
+    submitting.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="consent-root">
+    <div v-if="error && !data" class="card error-card">
+      <h1>Konnte Consent-Anfrage nicht laden</h1>
+      <p class="muted">
+        {{ error }}
+      </p>
+      <a href="/" class="btn btn-secondary">Zur Startseite</a>
+    </div>
+
+    <div v-else-if="data" class="card" :class="data.verified ? 'verified' : 'unverified'">
+      <header>
+        <span class="badge" :class="data.verified ? 'badge-verified' : 'badge-warn'">
+          {{ data.verified ? 'Verifizierter Dienst' : 'Unverifizierter Dienst' }}
+        </span>
+      </header>
+
+      <template v-if="data.verified">
+        <div class="sp-row">
+          <img v-if="data.metadata?.logo_uri" :src="data.metadata.logo_uri" :alt="`${data.metadata.client_name} logo`" class="logo">
+          <div>
+            <h1>{{ data.metadata?.client_name || data.clientId }}</h1>
+            <p class="muted">
+              {{ data.clientId }}
+            </p>
+          </div>
+        </div>
+        <p>Diese Anwendung möchte deine OpenApe-Identität nutzen.</p>
+        <p class="muted small">
+          Nach der Anmeldung wirst du zu <code>{{ data.redirectUri }}</code> weitergeleitet.
+        </p>
+        <p v-if="data.metadata?.policy_uri || data.metadata?.tos_uri" class="muted small">
+          <a v-if="data.metadata.policy_uri" :href="data.metadata.policy_uri" target="_blank" rel="noopener">Datenschutz</a>
+          <span v-if="data.metadata.policy_uri && data.metadata.tos_uri"> · </span>
+          <a v-if="data.metadata.tos_uri" :href="data.metadata.tos_uri" target="_blank" rel="noopener">AGB</a>
+        </p>
+      </template>
+
+      <template v-else>
+        <h1>Anmeldung an einen unverifizierten Dienst</h1>
+        <p>
+          Diese Anwendung hat keine Authentifizierungs-Metadaten unter
+          <code>/.well-known/oauth-client-metadata</code> veröffentlicht.
+          Wir können nicht bestätigen, wer sie betreibt.
+        </p>
+        <dl class="kv">
+          <dt>Domain</dt>
+          <dd><code>{{ data.clientId }}</code></dd>
+          <dt>Weiterleitung</dt>
+          <dd><code>{{ data.redirectUri }}</code></dd>
+        </dl>
+        <p>
+          Wenn du diesen Dienst nicht erkennst oder ihm nicht vertraust,
+          brich hier ab. Nach dem Anmelden bekommt diese Anwendung
+          deine Identität.
+        </p>
+      </template>
+
+      <p v-if="error" class="error">
+        {{ error }}
+      </p>
+
+      <div class="actions">
+        <button
+          v-if="data.verified"
+          class="btn btn-primary"
+          :disabled="submitting"
+          @click="submit('approve')"
+        >
+          Anmelden
+        </button>
+        <button
+          v-else
+          class="btn btn-warning"
+          :disabled="submitting"
+          @click="submit('approve')"
+        >
+          Trotzdem anmelden
+        </button>
+        <button
+          class="btn btn-secondary"
+          :disabled="submitting"
+          @click="submit('cancel')"
+        >
+          Abbrechen
+        </button>
+      </div>
+    </div>
+
+    <div v-else class="card">
+      <p class="muted">
+        Lade …
+      </p>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.consent-root {
+  min-height: 100dvh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  background: #0b0b10;
+  color: #e4e4ea;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+.card {
+  width: 100%;
+  max-width: 480px;
+  background: #15151b;
+  border: 1px solid #2a2a35;
+  border-radius: 12px;
+  padding: 1.75rem;
+}
+.card.unverified {
+  border-color: #c97a18;
+  background: linear-gradient(180deg, rgba(201,122,24,0.08), #15151b);
+}
+.card.verified {
+  border-color: #2a2a35;
+}
+.error-card { border-color: #c83030; }
+.badge {
+  display: inline-block;
+  padding: 0.25rem 0.625rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  letter-spacing: 0.02em;
+  margin-bottom: 1rem;
+}
+.badge-verified {
+  background: rgba(60,180,60,0.15);
+  color: #6ec96e;
+  border: 1px solid rgba(60,180,60,0.3);
+}
+.badge-warn {
+  background: rgba(201,122,24,0.18);
+  color: #f0a83d;
+  border: 1px solid rgba(201,122,24,0.4);
+}
+.sp-row { display: flex; gap: 0.875rem; align-items: center; margin-bottom: 0.5rem; }
+.logo { width: 48px; height: 48px; border-radius: 8px; background: #fff; object-fit: contain; padding: 4px; }
+h1 { font-size: 1.25rem; margin: 0 0 0.25rem; }
+p { line-height: 1.5; margin: 0.5rem 0; }
+.muted { color: #9b9ba8; }
+.small { font-size: 0.875rem; }
+.kv { display: grid; grid-template-columns: max-content 1fr; gap: 0.25rem 1rem; margin: 0.875rem 0; }
+.kv dt { color: #9b9ba8; font-size: 0.875rem; }
+.kv dd { margin: 0; }
+code { background: #25252e; padding: 0.125rem 0.375rem; border-radius: 4px; font-size: 0.875em; }
+.error { color: #ff7070; font-size: 0.875rem; margin-top: 0.5rem; }
+.actions { display: flex; flex-direction: column-reverse; gap: 0.5rem; margin-top: 1.25rem; }
+@media (min-width: 480px) { .actions { flex-direction: row; justify-content: flex-end; } }
+.btn {
+  appearance: none;
+  border: 0;
+  border-radius: 8px;
+  padding: 0.625rem 1rem;
+  font-size: 0.9375rem;
+  cursor: pointer;
+  font-weight: 500;
+}
+.btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.btn-primary { background: #4a86ff; color: white; }
+.btn-warning { background: #c97a18; color: white; }
+.btn-secondary { background: transparent; color: #c0c0cc; border: 1px solid #3a3a48; }
+.btn-secondary:hover:not(:disabled) { background: #25252e; }
+</style>

--- a/modules/nuxt-auth-idp/src/runtime/server/api/authorize/consent.get.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/api/authorize/consent.get.ts
@@ -1,0 +1,59 @@
+import { defineEventHandler } from 'h3'
+import { getAppSession } from '../../utils/session'
+import { useIdpStores } from '../../utils/stores'
+import { createProblemError } from '../../utils/problem'
+
+interface PendingConsent {
+  params: {
+    client_id: string
+    redirect_uri: string
+    state: string
+    [k: string]: unknown
+  }
+  query: Record<string, string>
+  csrfToken: string
+  createdAt: number
+}
+
+/**
+ * Render-data feed for the `/consent` page. Returns:
+ *   - the SP info (client_id, redirect_uri) for display
+ *   - the resolved client metadata (name, logo, …) when published —
+ *     decides verified-vs-unverified branch in the UI
+ *   - the CSRF token the page must echo back in its POST
+ *
+ * Reads exclusively from the session — never trusts query params for
+ * the redirect_uri or client_id (those would let a phishing link
+ * forge a "logging in to chat.openape.ai" UI when in fact the session
+ * holds a different SP).
+ */
+export default defineEventHandler(async (event) => {
+  const session = await getAppSession(event)
+  if (!session.data.userId) {
+    throw createProblemError({ status: 401, title: 'Not authenticated' })
+  }
+
+  const pending = (session.data as { pendingConsent?: PendingConsent }).pendingConsent
+  if (!pending) {
+    throw createProblemError({ status: 404, title: 'No pending consent in session' })
+  }
+
+  const { clientMetadataStore } = useIdpStores()
+  const metadata = await clientMetadataStore.resolve(pending.params.client_id).catch(() => null)
+
+  return {
+    csrfToken: pending.csrfToken,
+    clientId: pending.params.client_id,
+    redirectUri: pending.params.redirect_uri,
+    verified: !!metadata,
+    metadata: metadata
+      ? {
+          client_name: metadata.client_name,
+          client_uri: metadata.client_uri ?? null,
+          logo_uri: metadata.logo_uri ?? null,
+          policy_uri: metadata.policy_uri ?? null,
+          tos_uri: metadata.tos_uri ?? null,
+        }
+      : null,
+  }
+})

--- a/modules/nuxt-auth-idp/src/runtime/server/api/authorize/consent.post.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/api/authorize/consent.post.ts
@@ -1,0 +1,81 @@
+import { defineEventHandler, readBody, sendRedirect } from 'h3'
+import { getAppSession } from '../../utils/session'
+import { useIdpStores } from '../../utils/stores'
+import { createProblemError } from '../../utils/problem'
+
+interface PendingConsent {
+  params: {
+    client_id: string
+    redirect_uri: string
+    state: string
+    [k: string]: unknown
+  }
+  query: Record<string, string>
+  csrfToken: string
+  createdAt: number
+}
+
+const CONSENT_TTL_MS = 5 * 60_000 // 5 minutes — long enough to read, short enough to keep the trust window tight
+
+export default defineEventHandler(async (event) => {
+  const session = await getAppSession(event)
+  const userId = session.data.userId
+  if (!userId) {
+    throw createProblemError({ status: 401, title: 'Not authenticated' })
+  }
+
+  const pending = (session.data as { pendingConsent?: PendingConsent }).pendingConsent
+  if (!pending) {
+    throw createProblemError({ status: 400, title: 'No pending consent in session — start the /authorize flow again' })
+  }
+
+  // TTL: a stale consent state is dropped — the user has to re-initiate.
+  // Defends against an attacker keeping a token alive across an old
+  // /authorize they had no business approving.
+  if (Date.now() - pending.createdAt > CONSENT_TTL_MS) {
+    await session.update({ pendingConsent: undefined })
+    throw createProblemError({ status: 400, title: 'Consent request expired — start the /authorize flow again' })
+  }
+
+  const body = await readBody<{ csrfToken?: string, action?: 'approve' | 'cancel' }>(event)
+  if (!body.csrfToken || body.csrfToken !== pending.csrfToken) {
+    // Constant CSRF mismatch error so a probing attacker can't
+    // distinguish "no session" from "wrong token".
+    throw createProblemError({ status: 403, title: 'Invalid CSRF token' })
+  }
+
+  const action = body.action === 'cancel' ? 'cancel' : 'approve'
+
+  // Whatever the outcome, drop the pending state so the token can't
+  // be replayed. We still need params/query for the redirect, so we
+  // capture them on a const before clearing.
+  const captured = { params: pending.params, query: pending.query }
+  await session.update({ pendingConsent: undefined })
+
+  if (action === 'cancel') {
+    const url = new URL(captured.params.redirect_uri)
+    url.searchParams.set('error', 'access_denied')
+    if (captured.params.state) url.searchParams.set('state', captured.params.state)
+    return sendRedirect(event, url.toString())
+  }
+
+  // Persist the approval so subsequent /authorize calls skip the
+  // consent screen — matches standard OAuth "approve once, remembered"
+  // UX. Future work: account-page UI to view/revoke connected SPs.
+  const { consentStore } = useIdpStores()
+  await consentStore.save({
+    userId,
+    clientId: captured.params.client_id,
+    grantedAt: Math.floor(Date.now() / 1000),
+  })
+
+  // Re-enter the /authorize flow with the original query string. The
+  // consent gate now passes (`hasConsent` is true if remembered, or
+  // re-evaluation hits the same path with one-shot allow if not — see
+  // note below). The handler issues the code as usual.
+  const resumeUrl = new URL('/authorize', new URL(event.node.req.url ?? '', 'http://x').origin)
+  for (const [k, v] of Object.entries(captured.query)) {
+    if (typeof v === 'string') resumeUrl.searchParams.set(k, v)
+  }
+  return sendRedirect(event, resumeUrl.pathname + resumeUrl.search)
+})

--- a/modules/nuxt-auth-idp/src/runtime/server/routes/authorize.get.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/routes/authorize.get.ts
@@ -167,12 +167,47 @@ export default defineEventHandler(async (event) => {
   const userDomain = extractDomain(userId)
   const ddisaRecord = await resolveDDISA(userDomain)
   const policyMode = ddisaRecord?.mode ?? 'open'
-  const noopConsentStore = { hasConsent: async () => false, save: async () => {} }
-  const decision = await evaluatePolicy(policyMode, params.client_id, userId, noopConsentStore)
+  const { consentStore } = useIdpStores()
+  const decision = await evaluatePolicy(policyMode, params.client_id, userId, consentStore)
 
-  if (decision !== 'allow') {
+  if (decision === 'deny') {
     const redirectUrl = new URL(params.redirect_uri)
     redirectUrl.searchParams.set('error', 'access_denied')
+    redirectUrl.searchParams.set('state', params.state)
+    return sendRedirect(event, redirectUrl.toString())
+  }
+
+  if (decision === 'consent') {
+    // DDISA core.md §2.3 `allowlist-user` mode: stash the original
+    // /authorize query in the session and redirect the user to the
+    // consent page. The page reads the stashed state, renders the SP
+    // info (using clientMetadataStore for verified-vs-unverified UI),
+    // and POSTs a CSRF-token-protected confirmation back. On approve
+    // the consent is persisted (so the user isn't asked again) and we
+    // bounce the user back to /authorize, which re-evaluates and now
+    // sees `decision === 'allow'`. See issue #301.
+    if (!bearerPayload) {
+      const session = await getAppSession(event)
+      const csrfToken = crypto.randomUUID()
+      await session.update({
+        pendingConsent: {
+          params,
+          query: query as Record<string, string>,
+          csrfToken,
+          createdAt: Date.now(),
+        },
+      })
+      const consentUrl = new URL('/consent', getRequestURL(event).origin)
+      // The csrf token is *not* in the URL — only in the session, so
+      // it's never logged. The consent page POSTs the token from the
+      // form back, server compares against the session.
+      consentUrl.searchParams.set('client_id', params.client_id)
+      return sendRedirect(event, consentUrl.pathname + consentUrl.search)
+    }
+    // Bearer flow can't show a consent UI — agents must use explicit
+    // grant API instead. Falls through to access_denied.
+    const redirectUrl = new URL(params.redirect_uri)
+    redirectUrl.searchParams.set('error', 'consent_required')
     redirectUrl.searchParams.set('state', params.state)
     return sendRedirect(event, redirectUrl.toString())
   }

--- a/modules/nuxt-auth-idp/src/runtime/server/utils/consent-store.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/utils/consent-store.ts
@@ -1,0 +1,38 @@
+import type { ConsentEntry, ConsentStore } from '@openape/auth'
+import { useIdpStorage } from './storage'
+
+/**
+ * Persistent ConsentStore backed by `unstorage`.
+ *
+ * Records that a given user has approved a given SP for the
+ * `allowlist-user` policy mode (DDISA core.md §2.3). Once consent
+ * is on file the user no longer sees the consent screen for that SP.
+ *
+ * The free-idp deployment can swap this for a Drizzle-backed store
+ * via the store-registry (see `define-stores.ts`); the in-memory
+ * fallback in `@openape/auth` covers tests + dev playground.
+ */
+export function createConsentStore(): ConsentStore {
+  const storage = useIdpStorage()
+
+  function key(userId: string, clientId: string): string {
+    // Lower-case both halves so casing inconsistencies between IdP-emitted
+    // emails and SP-supplied client_ids don't end up creating duplicate
+    // rows. clientId is conventionally a hostname so case-insensitive
+    // matches the public DNS reality.
+    return `consents:${userId.toLowerCase()}:${clientId.toLowerCase()}`
+  }
+
+  return {
+    async hasConsent(userId: string, clientId: string): Promise<boolean> {
+      return await storage.hasItem(key(userId, clientId))
+    },
+
+    async save(entry: ConsentEntry): Promise<void> {
+      await storage.setItem<ConsentEntry>(
+        key(entry.userId, entry.clientId),
+        entry,
+      )
+    },
+  }
+}

--- a/modules/nuxt-auth-idp/src/runtime/server/utils/stores.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/utils/stores.ts
@@ -1,9 +1,10 @@
 import type { H3Event } from 'h3'
-import type { ChallengeStore, ClientMetadata, ClientMetadataStore, CodeStore, CredentialStore, JtiStore, KeyStore, RefreshTokenStore, RegistrationUrlStore, UserStore } from '@openape/auth'
+import type { ChallengeStore, ClientMetadata, ClientMetadataStore, CodeStore, ConsentStore, CredentialStore, JtiStore, KeyStore, RefreshTokenStore, RegistrationUrlStore, UserStore } from '@openape/auth'
 import { createClientMetadataResolver } from '@openape/auth'
 import { useRuntimeConfig, useEvent } from 'nitropack/runtime'
 import { createChallengeStore } from './challenge-store'
 import { createCodeStore } from './code-store'
+import { createConsentStore } from './consent-store'
 import { createCredentialStore } from './credential-store'
 import { createJtiStore } from './jti-store'
 import { createKeyStore } from './key-store'
@@ -25,6 +26,7 @@ interface IdpStores {
   refreshTokenStore: RefreshTokenStore
   sshKeyStore: SshKeyStore
   clientMetadataStore: ClientMetadataStore
+  consentStore: ConsentStore
 }
 
 // Module-level singleton for the SP client-metadata resolver. The
@@ -67,6 +69,7 @@ function initDefaultStores(): IdpStores {
     refreshTokenStore: createRefreshTokenStore(),
     sshKeyStore: createSshKeyStore(),
     clientMetadataStore: getClientMetadataStore(),
+    consentStore: createConsentStore(),
   }
 }
 
@@ -82,6 +85,7 @@ function initStoresWithRegistry(event: H3Event): IdpStores {
     refreshTokenStore: getStoreFactory<RefreshTokenStore>('refreshTokenStore')?.(event) ?? createRefreshTokenStore(),
     sshKeyStore: getStoreFactory<SshKeyStore>('sshKeyStore')?.(event) ?? createSshKeyStore(),
     clientMetadataStore: getStoreFactory<ClientMetadataStore>('clientMetadataStore')?.(event) ?? getClientMetadataStore(),
+    consentStore: getStoreFactory<ConsentStore>('consentStore')?.(event) ?? createConsentStore(),
   }
 }
 

--- a/modules/nuxt-auth-idp/test/authorize-consent.test.ts
+++ b/modules/nuxt-auth-idp/test/authorize-consent.test.ts
@@ -1,0 +1,217 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Pin the DDISA `allowlist-user` policy mode flow (#301):
+//   - decision === 'consent' redirects to /consent (not access_denied)
+//   - consent.post.ts requires CSRF + writes to ConsentStore + resumes /authorize
+//   - cancel returns access_denied to the SP
+//   - existing 'allow' / 'deny' branches still work
+
+const ISSUER = 'https://id.openape.at'
+const REDIRECT_URI = 'https://app.example.com/auth/callback'
+
+const mockSendRedirect = vi.fn()
+const consentSave = vi.fn(async () => {})
+const sessionUpdate = vi.fn(async () => {})
+let sessionData = {}
+let pendingConsent
+let evaluatePolicyResult = 'allow'
+
+vi.mock('h3', () => ({
+  defineEventHandler: fn => fn,
+  getQuery: vi.fn(),
+  getRequestURL: () => new URL('https://id.openape.at/authorize'),
+  sendRedirect: (...args) => mockSendRedirect(...args),
+  readBody: vi.fn(),
+  createError: opts => Object.assign(new Error(opts.statusMessage), { statusCode: opts.statusCode }),
+}))
+
+vi.mock('nitropack/runtime', () => ({
+  useRuntimeConfig: vi.fn(() => ({
+    openapeIdp: { spMetadataMode: 'permissive', publicClients: '' },
+  })),
+}))
+
+vi.mock('../src/runtime/server/utils/stores', () => ({
+  getIdpIssuer: () => ISSUER,
+  useIdpStores: vi.fn(() => ({
+    codeStore: { find: vi.fn(), save: vi.fn(), delete: vi.fn() },
+    clientMetadataStore: { resolve: async () => null },
+    consentStore: {
+      hasConsent: async () => false,
+      save: consentSave,
+    },
+  })),
+}))
+
+vi.mock('../src/runtime/server/utils/session', () => ({
+  getAppSession: vi.fn(async () => ({
+    data: { ...sessionData, pendingConsent },
+    update: sessionUpdate,
+  })),
+}))
+
+vi.mock('../src/runtime/server/utils/agent-auth', () => ({
+  tryBearerAuth: vi.fn().mockResolvedValue(null),
+  tryAgentAuth: vi.fn().mockResolvedValue(null),
+}))
+
+vi.mock('../src/runtime/server/utils/grant-stores', () => ({
+  useGrantStores: () => ({ grantStore: {}, challengeStore: {} }),
+}))
+
+vi.mock('../src/runtime/server/utils/problem', () => ({
+  createProblemError: opts =>
+    Object.assign(new Error(opts.title), { statusCode: opts.status, data: opts }),
+}))
+
+vi.mock('@openape/core', () => ({
+  extractDomain: () => 'hofmann.eco',
+  resolveDDISA: vi.fn(),
+  createProblemDetails: opts => ({ ...opts, type: opts.type ?? 'about:blank' }),
+}))
+
+vi.mock('@openape/auth', () => ({
+  validateAuthorizeRequest: () => null,
+  validateRedirectUri: async () => null,
+  evaluatePolicy: vi.fn(async () => evaluatePolicyResult),
+}))
+
+vi.mock('@openape/grants', () => ({
+  approveGrant: vi.fn(),
+  createGrant: vi.fn(),
+  useGrant: vi.fn(),
+  validateDelegation: vi.fn(),
+}))
+
+beforeEach(() => {
+  mockSendRedirect.mockClear()
+  consentSave.mockClear()
+  sessionUpdate.mockClear()
+  sessionData = { userId: 'patrick@hofmann.eco', userName: 'Patrick' }
+  pendingConsent = undefined
+  evaluatePolicyResult = 'allow'
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+async function callAuthorize(query = {}) {
+  const { getQuery } = await import('h3')
+  ;(getQuery).mockReturnValue({
+    client_id: 'app.example.com',
+    redirect_uri: REDIRECT_URI,
+    state: 'xyz',
+    code_challenge: 'abc'.repeat(15),
+    code_challenge_method: 'S256',
+    nonce: 'n1',
+    response_type: 'code',
+    ...query,
+  })
+  const { default: handler } = await import('../src/runtime/server/routes/authorize.get')
+  return await handler({} as any)
+}
+
+describe('authorize.get — DDISA allowlist-user flow (#301)', () => {
+  it('redirects to /consent when policy decision === \'consent\' (not access_denied)', async () => {
+    evaluatePolicyResult = 'consent'
+
+    await callAuthorize()
+
+    expect(sessionUpdate).toHaveBeenCalledWith(expect.objectContaining({
+      pendingConsent: expect.objectContaining({
+        params: expect.objectContaining({ client_id: 'app.example.com' }),
+        csrfToken: expect.any(String),
+      }),
+    }))
+    expect(mockSendRedirect).toHaveBeenCalled()
+    const target = mockSendRedirect.mock.calls[0][1]
+    // Either absolute URL or pathname-only — we accept both forms.
+    expect(target).toMatch(/\/consent\?/)
+    expect(target).toContain('client_id=app.example.com')
+  })
+
+  it('returns access_denied when policy decision === \'deny\' (unchanged behaviour)', async () => {
+    evaluatePolicyResult = 'deny'
+    await callAuthorize()
+    const target = mockSendRedirect.mock.calls[0][1]
+    expect(target).toMatch(/^https:\/\/app\.example\.com\/auth\/callback\?error=access_denied/)
+  })
+
+  it('proceeds to code issuance when decision === \'allow\'', async () => {
+    evaluatePolicyResult = 'allow'
+    await callAuthorize()
+    const target = mockSendRedirect.mock.calls[0][1]
+    expect(target).toMatch(/^https:\/\/app\.example\.com\/auth\/callback\?code=/)
+  })
+})
+
+describe('consent.post — approve/cancel/csrf', () => {
+  beforeEach(() => {
+    pendingConsent = {
+      params: { client_id: 'app.example.com', redirect_uri: REDIRECT_URI, state: 'xyz' },
+      query: {
+        client_id: 'app.example.com',
+        redirect_uri: REDIRECT_URI,
+        state: 'xyz',
+        code_challenge: 'abc'.repeat(15),
+        code_challenge_method: 'S256',
+        response_type: 'code',
+      },
+      csrfToken: 'tok-good',
+      createdAt: Date.now(),
+    }
+  })
+
+  async function postConsent(body) {
+    const { readBody } = await import('h3')
+    ;(readBody).mockResolvedValue(body)
+    const { default: handler } = await import('../src/runtime/server/api/authorize/consent.post')
+    return await handler({ node: { req: { url: '/api/authorize/consent' } } } as any)
+  }
+
+  it('saves consent and resumes /authorize on approve with valid CSRF', async () => {
+    await postConsent({ csrfToken: 'tok-good', action: 'approve' })
+
+    expect(consentSave).toHaveBeenCalledWith(expect.objectContaining({
+      userId: 'patrick@hofmann.eco',
+      clientId: 'app.example.com',
+    }))
+    expect(sessionUpdate).toHaveBeenCalledWith({ pendingConsent: undefined })
+    const target = mockSendRedirect.mock.calls[0][1]
+    expect(target).toMatch(/\/authorize\?/)
+    expect(target).toContain('client_id=app.example.com')
+  })
+
+  it('rejects on missing/wrong CSRF', async () => {
+    await expect(postConsent({ csrfToken: 'wrong', action: 'approve' }))
+      .rejects
+      .toMatchObject({ statusCode: 403 })
+    expect(consentSave).not.toHaveBeenCalled()
+  })
+
+  it('redirects to redirect_uri with error=access_denied on cancel', async () => {
+    await postConsent({ csrfToken: 'tok-good', action: 'cancel' })
+
+    expect(consentSave).not.toHaveBeenCalled()
+    const target = mockSendRedirect.mock.calls[0][1]
+    expect(target).toMatch(/^https:\/\/app\.example\.com\/auth\/callback\?error=access_denied/)
+    expect(target).toContain('state=xyz')
+  })
+
+  it('rejects expired consent state (older than 5 min)', async () => {
+    pendingConsent.createdAt = Date.now() - 10 * 60_000 // 10 min ago
+    await expect(postConsent({ csrfToken: 'tok-good', action: 'approve' }))
+      .rejects
+      .toMatchObject({ statusCode: 400 })
+    // Pending should be cleared
+    expect(sessionUpdate).toHaveBeenCalledWith({ pendingConsent: undefined })
+  })
+
+  it('rejects when no pending consent exists in session', async () => {
+    pendingConsent = undefined
+    await expect(postConsent({ csrfToken: 'tok-good', action: 'approve' }))
+      .rejects
+      .toMatchObject({ statusCode: 400 })
+  })
+})

--- a/packages/auth/src/idp/client-metadata.ts
+++ b/packages/auth/src/idp/client-metadata.ts
@@ -11,6 +11,16 @@ export interface ClientMetadata {
   client_name?: string
   redirect_uris: string[]
   jwks_uri?: string
+  /** RFC 7591 §2 — homepage / description URL. Used by consent UIs. */
+  client_uri?: string
+  /** RFC 7591 §2 — logo for the consent UI. */
+  logo_uri?: string
+  /** RFC 7591 §2 — privacy policy link. */
+  policy_uri?: string
+  /** RFC 7591 §2 — terms-of-service link. */
+  tos_uri?: string
+  /** RFC 7591 §2 — admin contact emails. */
+  contacts?: string[]
 }
 
 export interface ClientMetadataStore {


### PR DESCRIPTION
Closes #301. Implements DDISA core.md §2.3 `allowlist-user` mode — when a user sets their `_ddisa.{domain}` TXT to `mode=allowlist-user`, they get a consent screen on first SP encounter with metadata-aware verified/unverified UI. Mode is per-user-DNS, not a global toggle. Closes the previous "locked out" bug (decision=='consent' was returning access_denied with a noop ConsentStore). 131 tests pass.