### PR TITLE
feat(idp): connected-services list + revoke for allowlist-user (#301)

### DIFF
--- a/.changeset/idp-consent-revoke.md
+++ b/.changeset/idp-consent-revoke.md
@@ -1,0 +1,17 @@
+---
+'@openape/auth': minor
+'@openape/nuxt-auth-idp': minor
+---
+
+Connected services UI — list & revoke approved SPs (#301 follow-up).
+
+Users running in DDISA `mode=allowlist-user` need to be able to walk back a previous consent. Without that, the consent screen was a one-way door.
+
+- **`@openape/auth.ConsentStore`**: extended with `list(userId)` and `revoke(userId, clientId)`. `InMemoryConsentStore` gets the implementations + 4 unit tests pinning sort-order, scoping, and idempotent revoke.
+- **`@openape/nuxt-auth-idp`**:
+  - `defineConsentStore` factory + auto-imported `createConsentStore` (unstorage default for module/playground/tests).
+  - `GET /api/account/consents` returns the approved SPs enriched with metadata (name + logo + verified flag); `DELETE /api/account/consents/:clientId` revokes.
+  - Account page (`/account`) gains a "Connected Services" card with the list + Widerrufen button per row. Verified SPs render their name/logo; unverified ones show the bare `client_id` plus an `unverifiziert` badge.
+- **`apps/openape-free-idp`**: `consents` table in the schema (composite PK on `(user_email, client_id)`, `granted_at` integer), Drizzle store (`createDrizzleConsentStore`) wired through `defineConsentStore` in the idp-stores plugin. The `02.database.ts` boot plugin's `CREATE TABLE IF NOT EXISTS` is the migration path for live DBs.
+
+Revoking sends the user back through the consent screen on the next /authorize against that SP, including unverified-warning UI if the SP didn't publish metadata.

--- a/apps/openape-free-idp/server/database/schema.ts
+++ b/apps/openape-free-idp/server/database/schema.ts
@@ -223,3 +223,17 @@ export const pushSubscriptions = sqliteTable('push_subscriptions', {
 }, table => [
   index('idx_push_subs_user_email').on(table.userEmail),
 ])
+
+// --- DDISA allowlist-user consents (#301) ---
+// One row per (user, SP) pair the user has approved via the consent
+// screen. PK is composite — re-approving the same SP just refreshes
+// `granted_at`. Revocation is a DELETE; the user sees the consent
+// screen again on next /authorize.
+export const consents = sqliteTable('consents', {
+  userEmail: text('user_email').notNull(),
+  clientId: text('client_id').notNull(),
+  grantedAt: integer('granted_at').notNull(),
+}, table => [
+  primaryKey({ columns: [table.userEmail, table.clientId] }),
+  index('idx_consents_user_email').on(table.userEmail),
+])

--- a/apps/openape-free-idp/server/plugins/02.database.ts
+++ b/apps/openape-free-idp/server/plugins/02.database.ts
@@ -150,6 +150,18 @@ export default defineNitroPlugin(async () => {
       created_at INTEGER NOT NULL
     )`)
     await db.run(sql`CREATE INDEX IF NOT EXISTS idx_push_subs_user_email ON push_subscriptions(user_email)`)
+
+    // DDISA allowlist-user consents (#301). One row per (user, SP)
+    // pair the user has approved on the consent screen. PK is
+    // composite — re-approval is an upsert on grantedAt; revocation
+    // is a DELETE.
+    await db.run(sql`CREATE TABLE IF NOT EXISTS consents (
+      user_email TEXT NOT NULL,
+      client_id TEXT NOT NULL,
+      granted_at INTEGER NOT NULL,
+      PRIMARY KEY (user_email, client_id)
+    )`)
+    await db.run(sql`CREATE INDEX IF NOT EXISTS idx_consents_user_email ON consents(user_email)`)
   }
   catch (err) {
     console.error('[database] Table creation failed (tables may already exist):', err)

--- a/apps/openape-free-idp/server/plugins/04.idp-stores.ts
+++ b/apps/openape-free-idp/server/plugins/04.idp-stores.ts
@@ -7,6 +7,7 @@ import { createDrizzleChallengeStore } from '../utils/drizzle-challenge-store'
 import { createDrizzleRegistrationUrlStore } from '../utils/drizzle-registration-url-store'
 import { createDrizzleKeyStore } from '../utils/drizzle-key-store'
 import { createDrizzleSshKeyStore } from '../utils/drizzle-ssh-key-store'
+import { createDrizzleConsentStore } from '../utils/drizzle-consent-store'
 
 export default defineNitroPlugin(() => {
   if (process.env.OPENAPE_E2E === '1') return
@@ -29,4 +30,7 @@ export default defineNitroPlugin(() => {
 
   // Milestone 5: SSH Keys
   defineSshKeyStore(() => createDrizzleSshKeyStore())
+
+  // DDISA allowlist-user consents (#301)
+  defineConsentStore(() => createDrizzleConsentStore())
 })

--- a/apps/openape-free-idp/server/utils/drizzle-consent-store.ts
+++ b/apps/openape-free-idp/server/utils/drizzle-consent-store.ts
@@ -1,0 +1,59 @@
+import type { ConsentStore } from '@openape/auth'
+import { and, desc, eq } from 'drizzle-orm'
+import { useDb } from '../database/drizzle'
+import { consents } from '../database/schema'
+
+/**
+ * Drizzle-backed ConsentStore for the DDISA `allowlist-user` policy
+ * mode (#301). One row per (user, SP) pair; re-approval is an upsert,
+ * revocation is a DELETE.
+ */
+export function createDrizzleConsentStore(): ConsentStore {
+  const db = useDb()
+
+  function lower(s: string): string {
+    return s.toLowerCase()
+  }
+
+  return {
+    async hasConsent(userId, clientId) {
+      const row = await db
+        .select({ userEmail: consents.userEmail })
+        .from(consents)
+        .where(and(eq(consents.userEmail, lower(userId)), eq(consents.clientId, lower(clientId))))
+        .get()
+      return !!row
+    },
+
+    async save(entry) {
+      const userEmail = lower(entry.userId)
+      const clientId = lower(entry.clientId)
+      await db
+        .insert(consents)
+        .values({ userEmail, clientId, grantedAt: entry.grantedAt })
+        .onConflictDoUpdate({
+          target: [consents.userEmail, consents.clientId],
+          set: { grantedAt: entry.grantedAt },
+        })
+    },
+
+    async list(userId) {
+      const rows = await db
+        .select()
+        .from(consents)
+        .where(eq(consents.userEmail, lower(userId)))
+        .orderBy(desc(consents.grantedAt))
+      return rows.map(r => ({
+        userId: r.userEmail,
+        clientId: r.clientId,
+        grantedAt: r.grantedAt,
+      }))
+    },
+
+    async revoke(userId, clientId) {
+      await db
+        .delete(consents)
+        .where(and(eq(consents.userEmail, lower(userId)), eq(consents.clientId, lower(clientId))))
+    },
+  }
+}

--- a/modules/nuxt-auth-idp/src/runtime/pages/account.vue
+++ b/modules/nuxt-auth-idp/src/runtime/pages/account.vue
@@ -19,13 +19,17 @@ const newSshKey = ref('')
 const newSshKeyName = ref('')
 const sshKeyAdding = ref(false)
 
+// Connected services (DDISA allowlist-user consents, #301)
+const consents = ref([])
+const consentsLoading = ref(false)
+
 onMounted(async () => {
   await fetchUser()
   if (!user.value) {
     await navigateTo('/login')
     return
   }
-  await Promise.all([loadCredentials(), loadSshKeys()])
+  await Promise.all([loadCredentials(), loadSshKeys(), loadConsents()])
 })
 async function loadCredentials() {
   credentialsLoading.value = true
@@ -123,6 +127,35 @@ async function handleDeleteSshKey(keyId) {
 }
 function fingerprint(keyId) {
   return `SHA256:${keyId.substring(0, 16)}...`
+}
+
+async function loadConsents() {
+  consentsLoading.value = true
+  try {
+    consents.value = await $fetch('/api/account/consents')
+  }
+  catch {
+    consents.value = []
+  }
+  finally {
+    consentsLoading.value = false
+  }
+}
+async function handleRevokeConsent(clientId, clientName) {
+  // Use the human-readable name in the prompt when we have one — falls
+  // back to the bare client_id (hostname) for unverified SPs.
+  const label = clientName || clientId
+  if (!confirm(`Zugriff für ${label} entfernen? Du wirst beim nächsten Login wieder gefragt.`))
+    return
+  error.value = ''
+  try {
+    await $fetch(`/api/account/consents/${encodeURIComponent(clientId)}`, { method: 'DELETE' })
+    success.value = `Zugriff für ${label} widerrufen`
+    await loadConsents()
+  }
+  catch (err) {
+    error.value = err?.data?.title ?? 'Failed to revoke access'
+  }
 }
 </script>
 
@@ -265,6 +298,74 @@ function fingerprint(keyId) {
               Add SSH Key
             </UButton>
           </div>
+        </UCard>
+
+        <UCard class="mt-6 mb-6" :ui="{ body: 'p-0' }">
+          <template #header>
+            <h2 class="text-lg font-semibold">
+              Connected Services
+            </h2>
+            <p class="text-sm text-muted mt-1">
+              Anwendungen, die du bei der Anmeldung an id.openape.ai genehmigt hast.
+              Widerrufen heißt: nächste Anmeldung an diesem Dienst zeigt wieder den Consent-Screen.
+            </p>
+          </template>
+
+          <div v-if="consentsLoading" class="p-6 text-center text-muted">
+            Loading...
+          </div>
+          <div v-else-if="consents.length === 0" class="p-6 text-center text-muted">
+            Keine Dienste genehmigt. (Setze <code>mode=allowlist-user</code> in deiner DDISA-DNS, um Consent-Screens zu aktivieren.)
+          </div>
+          <table v-else class="w-full">
+            <thead class="border-b border-(--ui-border)">
+              <tr>
+                <th class="text-left px-4 py-3 text-xs font-medium text-muted uppercase">
+                  Service
+                </th>
+                <th class="text-left px-4 py-3 text-xs font-medium text-muted uppercase">
+                  Genehmigt
+                </th>
+                <th class="text-right px-4 py-3 text-xs font-medium text-muted uppercase">
+                  Aktion
+                </th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-(--ui-border)">
+              <tr v-for="c in consents" :key="c.clientId" class="odd:bg-(--ui-bg-elevated)/40 even:bg-(--ui-bg) hover:bg-(--ui-bg-elevated)">
+                <td class="px-4 py-3 text-sm">
+                  <div class="flex items-center gap-2">
+                    <img v-if="c.logoUri" :src="c.logoUri" :alt="`${c.clientName} logo`" class="w-6 h-6 rounded bg-white p-0.5 object-contain shrink-0">
+                    <div class="min-w-0">
+                      <div class="font-medium truncate flex items-center gap-1.5">
+                        <a v-if="c.clientUri" :href="c.clientUri" target="_blank" rel="noopener" class="hover:underline">{{ c.clientName || c.clientId }}</a>
+                        <span v-else>{{ c.clientName || c.clientId }}</span>
+                        <UBadge v-if="!c.verified" color="warning" variant="subtle" size="xs">
+                          unverifiziert
+                        </UBadge>
+                      </div>
+                      <div v-if="c.clientName" class="text-xs text-muted truncate">
+                        {{ c.clientId }}
+                      </div>
+                    </div>
+                  </div>
+                </td>
+                <td class="px-4 py-3 text-xs text-muted whitespace-nowrap">
+                  {{ formatDate(c.grantedAt * 1000) }}
+                </td>
+                <td class="px-4 py-3 text-right">
+                  <UButton
+                    variant="ghost"
+                    size="xs"
+                    color="error"
+                    @click="handleRevokeConsent(c.clientId, c.clientName)"
+                  >
+                    Widerrufen
+                  </UButton>
+                </td>
+              </tr>
+            </tbody>
+          </table>
         </UCard>
 
         <UCard :ui="{ body: 'p-0' }">

--- a/modules/nuxt-auth-idp/src/runtime/server/api/account/consents/[clientId].delete.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/api/account/consents/[clientId].delete.ts
@@ -1,0 +1,30 @@
+import { defineEventHandler, getRouterParam, setResponseStatus } from 'h3'
+import { getAppSession } from '../../../utils/session'
+import { useIdpStores } from '../../../utils/stores'
+import { createProblemError } from '../../../utils/problem'
+
+/**
+ * Revoke a previously-granted consent for one SP. The user will see
+ * the consent screen again on their next /authorize against this
+ * client_id (DDISA core.md §2.3, #301 follow-up).
+ *
+ * Idempotent: revoking a non-existent consent returns 204 too. Avoids
+ * leaking which SPs the user has actually approved.
+ */
+export default defineEventHandler(async (event) => {
+  const session = await getAppSession(event)
+  if (!session.data.userId) {
+    throw createProblemError({ status: 401, title: 'Not authenticated' })
+  }
+
+  const clientId = getRouterParam(event, 'clientId')
+  if (!clientId) {
+    throw createProblemError({ status: 400, title: 'Missing clientId' })
+  }
+
+  const { consentStore } = useIdpStores()
+  await consentStore.revoke(session.data.userId, decodeURIComponent(clientId))
+
+  setResponseStatus(event, 204)
+  return null
+})

--- a/modules/nuxt-auth-idp/src/runtime/server/api/account/consents/index.get.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/api/account/consents/index.get.ts
@@ -1,0 +1,37 @@
+import { defineEventHandler } from 'h3'
+import { getAppSession } from '../../../utils/session'
+import { useIdpStores } from '../../../utils/stores'
+import { createProblemError } from '../../../utils/problem'
+
+/**
+ * List the SPs the authenticated user has approved via the
+ * `allowlist-user` consent flow (DDISA core.md §2.3, #301).
+ *
+ * Each entry is enriched with the SP's published metadata when
+ * available — name + logo for the connections UI. SPs that don't
+ * publish metadata fall back to displaying the bare client_id.
+ */
+export default defineEventHandler(async (event) => {
+  const session = await getAppSession(event)
+  if (!session.data.userId) {
+    throw createProblemError({ status: 401, title: 'Not authenticated' })
+  }
+
+  const { consentStore, clientMetadataStore } = useIdpStores()
+  const entries = await consentStore.list(session.data.userId)
+
+  // Resolve metadata in parallel — caller only sees aggregated rows.
+  const enriched = await Promise.all(entries.map(async (entry) => {
+    const metadata = await clientMetadataStore.resolve(entry.clientId).catch(() => null)
+    return {
+      clientId: entry.clientId,
+      grantedAt: entry.grantedAt,
+      verified: !!metadata,
+      clientName: metadata?.client_name ?? null,
+      clientUri: metadata?.client_uri ?? null,
+      logoUri: metadata?.logo_uri ?? null,
+    }
+  }))
+
+  return enriched
+})

--- a/modules/nuxt-auth-idp/src/runtime/server/utils/consent-store.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/utils/consent-store.ts
@@ -23,6 +23,10 @@ export function createConsentStore(): ConsentStore {
     return `consents:${userId.toLowerCase()}:${clientId.toLowerCase()}`
   }
 
+  function userPrefix(userId: string): string {
+    return `consents:${userId.toLowerCase()}:`
+  }
+
   return {
     async hasConsent(userId: string, clientId: string): Promise<boolean> {
       return await storage.hasItem(key(userId, clientId))
@@ -33,6 +37,25 @@ export function createConsentStore(): ConsentStore {
         key(entry.userId, entry.clientId),
         entry,
       )
+    },
+
+    async list(userId: string): Promise<ConsentEntry[]> {
+      // Linear scan over the user's namespace. Fine for any realistic
+      // user — even a power-user with hundreds of approved SPs is well
+      // under the limit unstorage is comfortable with. Sorting happens
+      // client-side because the storage isn't ordered.
+      const keys = await storage.getKeys(userPrefix(userId))
+      const entries: ConsentEntry[] = []
+      for (const k of keys) {
+        const v = await storage.getItem<ConsentEntry>(k)
+        if (v) entries.push(v)
+      }
+      entries.sort((a, b) => b.grantedAt - a.grantedAt)
+      return entries
+    },
+
+    async revoke(userId: string, clientId: string): Promise<void> {
+      await storage.removeItem(key(userId, clientId))
     },
   }
 }

--- a/modules/nuxt-auth-idp/src/runtime/server/utils/define-stores.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/utils/define-stores.ts
@@ -1,5 +1,5 @@
 import type { H3Event } from 'h3'
-import type { ChallengeStore as WebAuthnChallengeStore, CodeStore, CredentialStore, JtiStore, KeyStore, RefreshTokenStore, RegistrationUrlStore, UserStore } from '@openape/auth'
+import type { ChallengeStore as WebAuthnChallengeStore, CodeStore, ConsentStore, CredentialStore, JtiStore, KeyStore, RefreshTokenStore, RegistrationUrlStore, UserStore } from '@openape/auth'
 import type { ShapeStore } from '@openape/grants'
 import type { ExtendedGrantStore } from './grant-store'
 import type { ChallengeStore as GrantChallengeStore } from './grant-challenge-store'
@@ -54,6 +54,12 @@ export function defineRefreshTokenStore(factory: (event: H3Event) => RefreshToke
 
 export function defineSshKeyStore(factory: (event: H3Event) => SshKeyStore) {
   registerStoreFactory('sshKeyStore', factory)
+}
+
+// Consent Store (DDISA allowlist-user mode, #301)
+
+export function defineConsentStore(factory: (event: H3Event) => ConsentStore) {
+  registerStoreFactory('consentStore', factory)
 }
 
 // Shape Store (Phase 1 — server-side shape registry)

--- a/packages/auth/src/__tests__/authorize.test.ts
+++ b/packages/auth/src/__tests__/authorize.test.ts
@@ -65,3 +65,35 @@ describe('evaluatePolicy', () => {
     expect(await evaluatePolicy(undefined, 'sp', 'user', store)).toBe('consent')
   })
 })
+
+describe('InMemoryConsentStore — list / revoke (#301)', () => {
+  it('list returns approved SPs sorted by grantedAt desc', async () => {
+    const store = new InMemoryConsentStore()
+    await store.save({ userId: 'patrick@hofmann.eco', clientId: 'chat.openape.ai', grantedAt: 100 })
+    await store.save({ userId: 'patrick@hofmann.eco', clientId: 'plans.openape.ai', grantedAt: 200 })
+    // Other-user entry is excluded.
+    await store.save({ userId: 'other@example.com', clientId: 'tasks.openape.ai', grantedAt: 300 })
+
+    const out = await store.list('patrick@hofmann.eco')
+    expect(out.map(e => e.clientId)).toEqual(['plans.openape.ai', 'chat.openape.ai'])
+  })
+
+  it('list returns empty for user with no consents', async () => {
+    const store = new InMemoryConsentStore()
+    expect(await store.list('nobody@example.com')).toEqual([])
+  })
+
+  it('revoke removes consent — hasConsent returns false afterward', async () => {
+    const store = new InMemoryConsentStore()
+    await store.save({ userId: 'patrick@hofmann.eco', clientId: 'chat.openape.ai', grantedAt: 1 })
+    expect(await store.hasConsent('patrick@hofmann.eco', 'chat.openape.ai')).toBe(true)
+
+    await store.revoke('patrick@hofmann.eco', 'chat.openape.ai')
+    expect(await store.hasConsent('patrick@hofmann.eco', 'chat.openape.ai')).toBe(false)
+  })
+
+  it('revoke is a no-op when no consent exists', async () => {
+    const store = new InMemoryConsentStore()
+    await expect(store.revoke('a@x', 'b.example')).resolves.toBeUndefined()
+  })
+})

--- a/packages/auth/src/idp/stores.ts
+++ b/packages/auth/src/idp/stores.ts
@@ -35,6 +35,10 @@ export interface CodeStore {
 export interface ConsentStore {
   hasConsent: (userId: string, clientId: string) => Promise<boolean>
   save: (entry: ConsentEntry) => Promise<void>
+  /** All SPs the user has approved, sorted by `grantedAt` desc. */
+  list: (userId: string) => Promise<ConsentEntry[]>
+  /** Revoke consent for a specific SP. No-op if no consent existed. */
+  revoke: (userId: string, clientId: string) => Promise<void>
 }
 
 export interface KeyEntry {
@@ -136,6 +140,19 @@ export class InMemoryConsentStore implements ConsentStore {
 
   async save(entry: ConsentEntry): Promise<void> {
     this.consents.set(this.key(entry.userId, entry.clientId), entry)
+  }
+
+  async list(userId: string): Promise<ConsentEntry[]> {
+    const out: ConsentEntry[] = []
+    for (const entry of this.consents.values()) {
+      if (entry.userId === userId) out.push(entry)
+    }
+    out.sort((a, b) => b.grantedAt - a.grantedAt)
+    return out
+  }
+
+  async revoke(userId: string, clientId: string): Promise<void> {
+    this.consents.delete(this.key(userId, clientId))
   }
 }
 


### PR DESCRIPTION
Users running `mode=allowlist-user` can now walk back consents via the account page. List endpoint enriches with SP metadata (name/logo/verified flag); DELETE endpoint is idempotent. Drizzle-backed in free-idp. 118+131+73 tests pass.