### PR TITLE
fix(nuxt-auth-idp): register /consent page route

### DIFF
--- a/.changeset/register-consent-page.md
+++ b/.changeset/register-consent-page.md
@@ -1,0 +1,5 @@
+---
+'@openape/nuxt-auth-idp': patch
+---
+
+Register the `/consent` page so the DDISA `allowlist-user` flow can render its consent screen. Without this the page-route wasn't extended and the SP redirect from `/authorize` hit a 404.

--- a/modules/nuxt-auth-idp/src/module.ts
+++ b/modules/nuxt-auth-idp/src/module.ts
@@ -208,6 +208,7 @@ export default defineNuxtModule<ModuleOptions>({
           { name: 'openape-register', path: '/register', file: resolve('./runtime/pages/register.vue') },
           { name: 'openape-account', path: '/account', file: resolve('./runtime/pages/account.vue') },
           { name: 'openape-admin', path: '/admin', file: resolve('./runtime/pages/admin.vue') },
+          { name: 'openape-consent', path: '/consent', file: resolve('./runtime/pages/consent.vue') },
         ]
 
         if (grants.enablePages) {


### PR DESCRIPTION
## Problem

`id.openape.ai/consent?client_id=plans.openape.ai` returns 404. The DDISA allowlist-user consent screen exists at `modules/nuxt-auth-idp/src/runtime/pages/consent.vue`, but the page was never added to `extendPages` in `module.ts`, so the route never gets registered in consuming apps (free-idp on `id.openape.ai`).

## Fix

Add `consent` to the always-on module page list (it's DDISA core, not grants-gated).

## Test plan

- [ ] Merge → release PR publishes `@openape/nuxt-auth-idp` patch
- [ ] Deploy `apps/openape-free-idp`
- [ ] Verify `https://id.openape.ai/consent?client_id=plans.openape.ai` renders the consent screen instead of 404