### PR TITLE
fix(nuxt-auth-idp): register missing consent + delegation API handlers

### DIFF
--- a/.changeset/register-consent-api-handlers.md
+++ b/.changeset/register-consent-api-handlers.md
@@ -1,0 +1,11 @@
+---
+'@openape/nuxt-auth-idp': patch
+---
+
+Register six previously-unregistered server route handlers so consuming apps actually expose them:
+
+- `GET /api/authorize/consent` and `POST /api/authorize/consent` (used by the `/consent` page from the `allowlist-user` flow, #301)
+- `GET /api/account/consents` and `DELETE /api/account/consents/:clientId` (self-service consent management)
+- `GET /api/admin/delegations` and `DELETE /api/admin/delegations/:id` (admin)
+
+The handler files existed under `runtime/server/api/` but were never wired up in the module's `addServerHandler` calls, so requests hit a 404 in production.

--- a/modules/nuxt-auth-idp/src/module.ts
+++ b/modules/nuxt-auth-idp/src/module.ts
@@ -256,6 +256,11 @@ export default defineNuxtModule<ModuleOptions>({
       addServerHandler({ route: '/api/me/sessions', handler: resolve('./runtime/server/api/me/sessions/index.get') })
       addServerHandler({ route: '/api/me/sessions/:familyId', method: 'delete', handler: resolve('./runtime/server/api/me/sessions/[familyId].delete') })
 
+      // Self-service Consents — caller manages their own DDISA
+      // `allowlist-user` SP approvals (#301).
+      addServerHandler({ route: '/api/account/consents', handler: resolve('./runtime/server/api/account/consents/index.get') })
+      addServerHandler({ route: '/api/account/consents/:clientId', method: 'delete', handler: resolve('./runtime/server/api/account/consents/[clientId].delete') })
+
       // WebAuthn Registration
       addServerHandler({ route: '/api/webauthn/register/options', method: 'post', handler: resolve('./runtime/server/api/webauthn/register/options.post') })
       addServerHandler({ route: '/api/webauthn/register/verify', method: 'post', handler: resolve('./runtime/server/api/webauthn/register/verify.post') })
@@ -279,6 +284,10 @@ export default defineNuxtModule<ModuleOptions>({
       addServerHandler({ route: '/.well-known/jwks.json', handler: resolve('./runtime/server/routes/well-known/jwks.json.get') })
       addServerHandler({ route: '/.well-known/openid-configuration', handler: resolve('./runtime/server/routes/well-known/openid-configuration.get') })
       addServerHandler({ route: '/userinfo', handler: resolve('./runtime/server/routes/userinfo.get') })
+
+      // DDISA `allowlist-user` consent endpoints used by the /consent page (#301).
+      addServerHandler({ route: '/api/authorize/consent', handler: resolve('./runtime/server/api/authorize/consent.get') })
+      addServerHandler({ route: '/api/authorize/consent', method: 'post', handler: resolve('./runtime/server/api/authorize/consent.post') })
     }
 
     // Server route handlers — Admin
@@ -310,6 +319,10 @@ export default defineNuxtModule<ModuleOptions>({
       addServerHandler({ route: '/api/admin/registration-urls', handler: resolve('./runtime/server/api/admin/registration-urls/index.get') })
       addServerHandler({ route: '/api/admin/registration-urls', method: 'post', handler: resolve('./runtime/server/api/admin/registration-urls/index.post') })
       addServerHandler({ route: '/api/admin/registration-urls/:token', method: 'delete', handler: resolve('./runtime/server/api/admin/registration-urls/[token].delete') })
+
+      // Admin Delegations
+      addServerHandler({ route: '/api/admin/delegations', handler: resolve('./runtime/server/api/admin/delegations/index.get') })
+      addServerHandler({ route: '/api/admin/delegations/:id', method: 'delete', handler: resolve('./runtime/server/api/admin/delegations/[id].delete') })
     }
 
     // Server route handlers — Grants


### PR DESCRIPTION
## Problem

After PR #304 the `/consent` page renders, but the page's first action — `$fetch('/api/authorize/consent')` — fails with 404. The handler file existed (`runtime/server/api/authorize/consent.get.ts`) but was never registered in `module.ts` via `addServerHandler`.

A full audit found **six** handler files in the same situation:

| File | Status before |
|---|---|
| `api/authorize/consent.get` | 404 — needed by `/consent` page |
| `api/authorize/consent.post` | 404 — needed by `/consent` form submit |
| `api/account/consents/index.get` | 404 — self-service consent list |
| `api/account/consents/[clientId].delete` | 404 — self-service consent revoke |
| `api/admin/delegations/index.get` | 404 (admin block) |
| `api/admin/delegations/[id].delete` | 404 (admin block) |

## Fix

Registered all six in the appropriate `routeConfig` block (`auth`, `oauth`, or `admin`).

## Test plan

- [x] Local build of `apps/openape-free-idp` started, routes verified non-404 (return 500 from missing DB env, which is expected in unconfigured local test)
- [x] Lint + typecheck green
- [ ] After merge → free-idp deploy → `https://id.openape.ai/consent?client_id=plans.openape.ai` should now load the consent UI without the "Konnte Consent-Anfrage nicht laden" error
- [ ] `/api/account/consents` returns 401 unauthenticated, 200 with valid session

## Notes

This is the second of two missing-registration fixes for the consent flow (after #304). I should have caught both in the first PR — apologies for the round-trip.