### PR TITLE
feat(idp): direct nav to Connected Services for SP revoke

### DIFF
--- a/.changeset/connected-services-anchor.md
+++ b/.changeset/connected-services-anchor.md
@@ -1,0 +1,5 @@
+---
+'@openape/nuxt-auth-idp': patch
+---
+
+Add `id="connected-services"` anchor to the Connected Services card on `/account` so consuming apps can deep-link to the SP-revoke section. Without it the section is the fourth of five on the page and easy to miss.

--- a/apps/openape-free-idp/app/pages/index.vue
+++ b/apps/openape-free-idp/app/pages/index.vue
@@ -57,6 +57,16 @@ async function handleLogout() {
             Berechtigungen
           </UButton>
           <UButton
+            to="/account#connected-services"
+            color="primary"
+            variant="outline"
+            size="lg"
+            block
+            icon="i-lucide-link"
+          >
+            Verbundene Dienste
+          </UButton>
+          <UButton
             color="neutral"
             variant="outline"
             size="lg"

--- a/modules/nuxt-auth-idp/src/runtime/pages/account.vue
+++ b/modules/nuxt-auth-idp/src/runtime/pages/account.vue
@@ -300,7 +300,7 @@ async function handleRevokeConsent(clientId, clientName) {
           </div>
         </UCard>
 
-        <UCard class="mt-6 mb-6" :ui="{ body: 'p-0' }">
+        <UCard id="connected-services" class="mt-6 mb-6" :ui="{ body: 'p-0' }">
           <template #header>
             <h2 class="text-lg font-semibold">
               Connected Services


### PR DESCRIPTION
## Problem

User reports there's no link on id.openape.ai that leads to the SP-revoke UI. The endpoint and the table exist (`/api/account/consents` GET/DELETE, rendered in `account.vue`'s "Connected Services" card), but discoverability is broken:

- Free-idp landing only links to `/account` via "Passkeys verwalten"
- `/account` has 5 sections; "Connected Services" is the 4th — easy to miss

## Fix

- `@openape/nuxt-auth-idp`: anchor `id="connected-services"` on the card so any IdP built on this module can deep-link.
- `apps/openape-free-idp`: dedicated "Verbundene Dienste" button on the logged-in landing → `/account#connected-services`.

## Test plan

- [x] Lint + typecheck + build green for both packages
- [ ] After deploy: visit https://id.openape.ai logged in → click "Verbundene Dienste" → page scrolls to the card → revoke flow reachable