### PR TITLE
fix(idp): default policy mode to consent, not open (#305)

### DIFF
--- a/.changeset/default-mode-consent.md
+++ b/.changeset/default-mode-consent.md
@@ -1,0 +1,9 @@
+---
+'@openape/nuxt-auth-idp': patch
+---
+
+Default policy mode for missing DDISA `mode` field is now `consent` (= prompt the user), not `open`. Closes #305.
+
+Per DDISA core.md §5.6: when the user's `_ddisa.{domain}` TXT record omits the `mode` field — or when no DDISA record exists at all — the IdP picks the default. The spec recommends prompting for consent; defaulting to `open` would silently issue assertions for any SP that asks, which is the inverse of what a missing record should mean.
+
+**Behavior change:** users without a DDISA record now see a consent screen on first login to a new SP. SPs they've already approved (stored in the consent store) still skip the prompt. Users who explicitly want permissive behavior can publish `mode=open` in their `_ddisa.{domain}` TXT record.

--- a/modules/nuxt-auth-idp/src/runtime/server/routes/authorize.get.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/routes/authorize.get.ts
@@ -166,7 +166,15 @@ export default defineEventHandler(async (event) => {
 
   const userDomain = extractDomain(userId)
   const ddisaRecord = await resolveDDISA(userDomain)
-  const policyMode = ddisaRecord?.mode ?? 'open'
+  // DDISA core.md §5.6: when the user's `_ddisa.{domain}` TXT record
+  // omits `mode` (or no record exists at all), the IdP picks the
+  // default. The spec recommends prompting for consent. Defaulting to
+  // `open` would silently issue assertions for any SP that asks —
+  // safe only for users who deliberately opted into permissive mode
+  // via DNS, which is exactly the inverse of what a missing record
+  // means. We pass `undefined` through to evaluatePolicy whose
+  // `default:` branch returns `'consent'`.
+  const policyMode = ddisaRecord?.mode
   const { consentStore } = useIdpStores()
   const decision = await evaluatePolicy(policyMode, params.client_id, userId, consentStore)
 

--- a/modules/nuxt-auth-idp/test/authorize-consent.test.ts
+++ b/modules/nuxt-auth-idp/test/authorize-consent.test.ts
@@ -144,6 +144,34 @@ describe('authorize.get — DDISA allowlist-user flow (#301)', () => {
     const target = mockSendRedirect.mock.calls[0][1]
     expect(target).toMatch(/^https:\/\/app\.example\.com\/auth\/callback\?code=/)
   })
+
+  it('passes undefined mode to evaluatePolicy when DDISA record is missing — not \'open\' (#305)', async () => {
+    // DDISA core.md §5.6 recommends prompting for consent when the
+    // DNS record is silent. Defaulting to 'open' would silently issue
+    // assertions for any user without a `_ddisa` TXT record, which is
+    // the inverse of what a missing record should mean.
+    const { resolveDDISA } = await import('@openape/core')
+    ;(resolveDDISA as any).mockResolvedValue(null)
+    const { evaluatePolicy } = await import('@openape/auth')
+    await callAuthorize()
+    expect(evaluatePolicy).toHaveBeenCalledWith(undefined, 'app.example.com', 'patrick@hofmann.eco', expect.anything())
+  })
+
+  it('passes undefined mode when DDISA record exists but `mode` field is omitted (#305)', async () => {
+    const { resolveDDISA } = await import('@openape/core')
+    ;(resolveDDISA as any).mockResolvedValue({ version: 'ddisa1', idp: 'https://id.openape.at', raw: 'v=ddisa1 idp=...' })
+    const { evaluatePolicy } = await import('@openape/auth')
+    await callAuthorize()
+    expect(evaluatePolicy).toHaveBeenCalledWith(undefined, 'app.example.com', 'patrick@hofmann.eco', expect.anything())
+  })
+
+  it('passes through explicit mode=open when DNS sets it — opt-in is honoured (#305)', async () => {
+    const { resolveDDISA } = await import('@openape/core')
+    ;(resolveDDISA as any).mockResolvedValue({ version: 'ddisa1', idp: 'https://id.openape.at', mode: 'open', raw: 'v=ddisa1 mode=open ...' })
+    const { evaluatePolicy } = await import('@openape/auth')
+    await callAuthorize()
+    expect(evaluatePolicy).toHaveBeenCalledWith('open', 'app.example.com', 'patrick@hofmann.eco', expect.anything())
+  })
 })
 
 describe('consent.post — approve/cancel/csrf', () => {

--- a/modules/nuxt-auth-idp/test/authorize-errors.test.ts
+++ b/modules/nuxt-auth-idp/test/authorize-errors.test.ts
@@ -138,6 +138,17 @@ describe('authorize endpoint — error redirects (RFC 6749 §4.1.2.1)', () => {
       update: vi.fn(),
     })
 
+    // DDISA record with explicit mode=open — without this the new
+    // safe-by-default policy resolution (#305) would short-circuit
+    // into the /consent redirect and we'd never reach the gate.
+    const { resolveDDISA } = await import('@openape/core')
+    ;(resolveDDISA as any).mockResolvedValueOnce({
+      version: 'ddisa1',
+      idp: 'https://id.openape.at',
+      mode: 'open',
+      raw: 'v=ddisa1 idp=https://id.openape.at; mode=open',
+    })
+
     const { default: handler } = await import('../src/runtime/server/routes/authorize.get')
 
     await expect(handler({} as any)).rejects.toMatchObject({ statusCode: 400 })


### PR DESCRIPTION
## Closes #305

## Problem

`modules/nuxt-auth-idp/src/runtime/server/routes/authorize.get.ts:169` had:

```ts
const policyMode = ddisaRecord?.mode ?? 'open'
```

Users without a `_ddisa` TXT record (or with a record that omits `mode`) get `'open'` — silent assertion to any SP that asks. DDISA core.md §5.6 says the opposite:

> `(not set)` | IdP-specific default behavior (RECOMMENDED: prompt for consent)

`evaluatePolicy`'s `default:` branch already returns `'consent'` correctly — but the routing layer overrode `undefined` to `'open'` before calling it, so the safe default was unreachable.

## Fix

One line: pass `undefined` through. The function-level default takes effect.

## Behavior change

Users without a DDISA record now see a consent screen on first login to a new SP. SPs already approved (consent store) still skip the prompt. Users who explicitly want permissive behavior publish `mode=open` in their `_ddisa.{domain}` TXT record.

## Tests

3 new tests in `authorize-consent.test.ts`:
- Missing DDISA record → `evaluatePolicy(undefined, ...)`
- Record present, `mode` field omitted → `evaluatePolicy(undefined, ...)`
- Explicit `mode=open` in DNS → `evaluatePolicy('open', ...)`

Plus updated the pre-existing `authorize-errors.test.ts` `authorization_details` gate test, which now mocks `mode=open` explicitly — under the safe default the request would short-circuit to `/consent` before reaching that gate.

134/134 module tests passing.