### PR TITLE
fix(core): cache negative DDISA resolves (#306)

### DIFF
--- a/.changeset/negative-dns-cache.md
+++ b/.changeset/negative-dns-cache.md
@@ -1,0 +1,11 @@
+---
+'@openape/core': minor
+---
+
+`resolveDDISA` now caches negative results too. Closes #306.
+
+Previously, domains without a `_ddisa.{domain}` TXT record re-queried DNS (or DoH) on every call. That added latency on the happy path for users from non-DDISA domains and gave attackers a cheap DoS vector via crafted `/authorize?login_hint=foo@no-ddisa.com` requests.
+
+Negative entries get a shorter TTL than positive ones (60s vs 300s default) so that a domain which *just* added a DDISA record gets picked up promptly. Tunable per-call via the new `negativeCacheTTL` option on `ResolverOptions`. Constants: `DEFAULT_DNS_NEGATIVE_CACHE_TTL`.
+
+Transient errors (DNS server failures, network unreachable) propagate as throws and are NOT cached — only verified "no records exist" answers are.

--- a/packages/core/src/__tests__/resolver-dns.test.ts
+++ b/packages/core/src/__tests__/resolver-dns.test.ts
@@ -60,4 +60,31 @@ describe('resolveDDISA with DNS resolution', () => {
     const record = await resolveDDISA('doh-fallback.com', { noCache: true })
     expect(record).toBeNull()
   })
+
+  it('caches negative resolves so a non-DDISA domain does NOT re-query DNS each time (#306)', async () => {
+    // Without negative caching, every authorize for a user from a
+    // non-DDISA domain would re-hit the resolver — wasted latency
+    // plus a DoS vector. We cache `null` results just like positive
+    // ones, but with a shorter TTL.
+    mockResolveTXT.mockResolvedValue([])
+
+    expect(await resolveDDISA('no-record.com')).toBeNull()
+    expect(await resolveDDISA('no-record.com')).toBeNull()
+    expect(await resolveDDISA('no-record.com')).toBeNull()
+
+    expect(mockResolveTXT).toHaveBeenCalledTimes(1)
+  })
+
+  it('respects negativeCacheTTL override on the negative path', async () => {
+    mockResolveTXT.mockResolvedValue([])
+
+    // 0 means "expired immediately" → next call re-queries
+    expect(await resolveDDISA('zero-neg.com', { negativeCacheTTL: 0 })).toBeNull()
+    // Tiny sleep so the expiry check (`expires > Date.now()`) sees the entry as stale
+    await new Promise(r => setTimeout(r, 5))
+    expect(await resolveDDISA('zero-neg.com')).toBeNull()
+
+    expect(mockResolveTXT).toHaveBeenCalledTimes(2)
+  })
+
 })

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -9,8 +9,18 @@ export const WELL_KNOWN_JWKS = '/.well-known/jwks.json'
 export const WELL_KNOWN_OAUTH_CLIENT_METADATA = '/.well-known/oauth-client-metadata'
 export const WELL_KNOWN_OPENID_CONFIG = '/.well-known/openid-configuration'
 
-/** Default DNS cache TTL in seconds */
+/** Default DNS cache TTL in seconds (positive results) */
 export const DEFAULT_DNS_CACHE_TTL = 300
+
+/**
+ * Default DNS cache TTL in seconds for negative results — domains
+ * with no DDISA TXT record. Shorter than the positive TTL so that a
+ * domain that *just* added a record gets picked up reasonably fast.
+ * Long enough to absorb typical authorize-storm patterns and prevent
+ * an attacker from forcing repeated DNS queries by hammering
+ * `/authorize?login_hint=foo@no-ddisa.com`.
+ */
+export const DEFAULT_DNS_NEGATIVE_CACHE_TTL = 60
 
 /** DoH providers with CORS support */
 export const DOH_PROVIDERS = [

--- a/packages/core/src/dns/resolver.ts
+++ b/packages/core/src/dns/resolver.ts
@@ -1,10 +1,10 @@
 import type { DDISARecord, ResolverOptions } from '../types/index.js'
-import { DEFAULT_DNS_CACHE_TTL } from '../constants.js'
+import { DEFAULT_DNS_CACHE_TTL, DEFAULT_DNS_NEGATIVE_CACHE_TTL } from '../constants.js'
 import { resolveTXT as resolveDoh } from './doh.js'
 import { parseDDISARecord } from './parser.js'
 
 interface CacheEntry {
-  record: DDISARecord
+  record: DDISARecord | null
   expires: number
 }
 
@@ -94,8 +94,20 @@ export async function resolveDDISA(
     }
   }
 
-  if (parsed.length === 0)
+  // Cache negative results too (#306). Without this, every authorize
+  // for a user from a non-DDISA domain re-queries DNS — wasted
+  // latency on the happy path and a DoS vector via crafted
+  // login_hints. Note this only fires when `resolveTXTRecords`
+  // returned successfully (possibly empty); transient errors
+  // propagate up and are NOT cached so the next call retries.
+  if (parsed.length === 0) {
+    const negTtl = options?.negativeCacheTTL ?? DEFAULT_DNS_NEGATIVE_CACHE_TTL
+    cache.set(domain, {
+      record: null,
+      expires: Date.now() + negTtl * 1000,
+    })
     return null
+  }
 
   // Sort by priority (lowest = highest priority, like MX). Default priority = 10.
   parsed.sort((a, b) => (a.priority ?? 10) - (b.priority ?? 10))

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -352,8 +352,14 @@ export interface OpenApeManifest {
 
 /** DNS resolver options */
 export interface ResolverOptions {
-  /** Cache TTL in seconds (default: 300) */
+  /** Cache TTL in seconds for positive results (default: 300) */
   cacheTTL?: number
+  /**
+   * Cache TTL in seconds for negative results — domains with no
+   * DDISA record (default: 60). Shorter than positive TTL to let a
+   * domain that just added a record be picked up promptly.
+   */
+  negativeCacheTTL?: number
   /** DoH provider URL (for edge/browser) */
   dohProvider?: string
   /** Skip cache */


### PR DESCRIPTION
## Closes #306

## Problem

`packages/core/src/dns/resolver.ts:97-98` returned `null` without populating the cache:

```ts
if (parsed.length === 0)
  return null
```

Every authorize for a user from a non-DDISA domain re-queried DNS — wasted latency on the happy path, plus a cheap DoS vector via crafted `/authorize?login_hint=foo@no-ddisa.com` requests.

## Fix

Cache null results too, with a shorter TTL than positive results (60s vs 300s default). Tunable per-call via new `negativeCacheTTL` option on `ResolverOptions`.

Transient errors (DNS server failures, network unreachable) still propagate as throws and are NOT cached — only verified "no records exist" answers are. The throw paths never reach `cache.set` so this is a free property.

## Tests

2 new tests in `resolver-dns.test.ts`:
- 3 consecutive calls for a non-DDISA domain → only 1 underlying DNS query
- `negativeCacheTTL: 0` makes the next call re-query

Plus full monorepo typecheck (31/31) green — the `record: DDISARecord | null` type widening doesn't break any consumer.

## Note

Bumped `@openape/core` as `minor` because of the new public option `ResolverOptions.negativeCacheTTL` and the new exported constant `DEFAULT_DNS_NEGATIVE_CACHE_TTL`.