### PR TITLE
feat(idp): DNS-rooted root-admin claim + allowlist-admin (#307)

### DIFF
--- a/.changeset/admin-allowlist-hook-and-store.md
+++ b/.changeset/admin-allowlist-hook-and-store.md
@@ -1,0 +1,15 @@
+---
+'@openape/auth': minor
+'@openape/nuxt-auth-idp': minor
+---
+
+DDISA `mode=allowlist-admin` is now a real, plug-in-able feature. Closes #307.
+
+**`@openape/auth`** gains `AdminAllowlistStore` + `InMemoryAdminAllowlistStore`. `evaluatePolicy` accepts an optional 5th `options` arg with `adminAllowlistStore`; with no store wired up the mode keeps its previous safe-deny behaviour.
+
+**`@openape/nuxt-auth-idp`** wires the new store into `useIdpStores`, exposes a `defineAdminAllowlistStore(...)` registration helper, and adds two pluggable admin resolvers on `event.context`:
+
+- `openapeAdminResolver(event, email): boolean` — overrides the env-config email allowlist for `requireAdmin`.
+- `openapeRootAdminResolver(event, email): boolean` — strict tier for actions that must NOT be gateable by env config (e.g. operator promotion). New `requireRootAdmin` consults it; without one registered, fails closed.
+
+Existing apps without these hooks set keep working — `requireAdmin` falls back to the legacy `OPENAPE_ADMIN_EMAILS` env list.

--- a/apps/openape-free-idp/app/pages/admin.vue
+++ b/apps/openape-free-idp/app/pages/admin.vue
@@ -1,0 +1,328 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import { useIdpAuth } from '#imports'
+
+useSeoMeta({ title: 'Domain-Admin' })
+
+const { user, fetchUser } = useIdpAuth()
+await fetchUser()
+
+interface AdminStatus {
+  email: string
+  domain: string
+  isRoot: boolean
+  isOperator: boolean
+  adminTxtName: string | null
+}
+interface AllowlistEntry {
+  clientId: string
+  approvedBy: string
+  approvedAt: number
+}
+
+const status = ref<AdminStatus | null>(null)
+const statusLoading = ref(false)
+const lastIssuedSecret = ref<string | null>(null)
+const lastIssuedTxtName = ref<string | null>(null)
+const issuing = ref(false)
+const rechecking = ref(false)
+const error = ref('')
+
+const allowlist = ref<AllowlistEntry[]>([])
+const allowlistLoading = ref(false)
+const newClientId = ref('')
+const adding = ref(false)
+
+async function loadStatus() {
+  statusLoading.value = true
+  error.value = ''
+  try {
+    status.value = await ($fetch as any)('/api/free-idp/admin/status')
+  }
+  catch (err: any) {
+    error.value = err?.data?.title || err?.message || 'Status laden fehlgeschlagen'
+  }
+  finally {
+    statusLoading.value = false
+  }
+}
+
+async function loadAllowlist() {
+  if (!status.value?.isRoot && !status.value?.isOperator) return
+  allowlistLoading.value = true
+  try {
+    allowlist.value = await ($fetch as any)('/api/free-idp/admin/allowlist')
+  }
+  catch {
+    allowlist.value = []
+  }
+  finally {
+    allowlistLoading.value = false
+  }
+}
+
+async function generateSecret() {
+  issuing.value = true
+  error.value = ''
+  try {
+    const res = await ($fetch as any)('/api/free-idp/admin/claim-secret', { method: 'POST' })
+    lastIssuedSecret.value = res.secret
+    lastIssuedTxtName.value = res.txtName
+  }
+  catch (err: any) {
+    error.value = err?.data?.title || err?.message || 'Secret-Erzeugung fehlgeschlagen'
+  }
+  finally {
+    issuing.value = false
+  }
+}
+
+async function recheck() {
+  rechecking.value = true
+  error.value = ''
+  try {
+    await ($fetch as any)('/api/free-idp/admin/recheck', { method: 'POST' })
+    await loadStatus()
+    await loadAllowlist()
+  }
+  catch (err: any) {
+    error.value = err?.data?.title || err?.message || 'Recheck fehlgeschlagen'
+  }
+  finally {
+    rechecking.value = false
+  }
+}
+
+async function addToAllowlist() {
+  const clientId = newClientId.value.trim().toLowerCase()
+  if (!clientId) return
+  adding.value = true
+  error.value = ''
+  try {
+    await ($fetch as any)('/api/free-idp/admin/allowlist', {
+      method: 'POST',
+      body: { clientId },
+    })
+    newClientId.value = ''
+    await loadAllowlist()
+  }
+  catch (err: any) {
+    error.value = err?.data?.title || err?.message || 'SP konnte nicht hinzugefügt werden'
+  }
+  finally {
+    adding.value = false
+  }
+}
+
+async function removeFromAllowlist(clientId: string) {
+  try {
+    await ($fetch as any)(`/api/free-idp/admin/allowlist/${encodeURIComponent(clientId)}`, {
+      method: 'DELETE',
+    })
+    await loadAllowlist()
+  }
+  catch (err: any) {
+    error.value = err?.data?.title || err?.message || 'SP konnte nicht entfernt werden'
+  }
+}
+
+async function copyToClipboard(text: string) {
+  try { await navigator.clipboard.writeText(text) }
+  catch { /* user can still select-and-copy */ }
+}
+
+function formatDate(ts: number) {
+  return new Date(ts * 1000).toLocaleString('de-AT', { day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit' })
+}
+
+watch(user, async (u) => {
+  if (!u) return
+  await loadStatus()
+  await loadAllowlist()
+}, { immediate: true })
+</script>
+
+<template>
+  <div class="px-4 py-8 max-w-3xl mx-auto">
+    <div class="mb-6 flex items-center justify-between">
+      <h1 class="text-2xl font-bold">
+        Domain-Admin
+      </h1>
+      <UButton to="/" variant="ghost" size="sm" icon="i-lucide-arrow-left">
+        Zurück
+      </UButton>
+    </div>
+
+    <UAlert
+      v-if="error"
+      color="error"
+      variant="soft"
+      :title="error"
+      class="mb-4"
+      :close-button="{ icon: 'i-lucide-x' }"
+      @close="error = ''"
+    />
+
+    <UCard v-if="statusLoading" class="mb-6">
+      <p class="text-muted">
+        Status wird geladen…
+      </p>
+    </UCard>
+
+    <template v-else-if="status">
+      <UCard class="mb-6">
+        <template #header>
+          <div class="flex items-center justify-between">
+            <h2 class="text-lg font-semibold">
+              Status
+            </h2>
+            <UButton
+              variant="ghost"
+              size="xs"
+              icon="i-lucide-refresh-cw"
+              :loading="rechecking"
+              @click="recheck"
+            >
+              DNS neu prüfen
+            </UButton>
+          </div>
+        </template>
+
+        <dl class="grid grid-cols-[max-content_1fr] gap-x-6 gap-y-2 text-sm">
+          <dt class="text-muted">
+            Email
+          </dt>
+          <dd class="font-mono">
+            {{ status.email }}
+          </dd>
+          <dt class="text-muted">
+            Domain
+          </dt>
+          <dd class="font-mono">
+            {{ status.domain || '—' }}
+          </dd>
+          <dt class="text-muted">
+            Rolle
+          </dt>
+          <dd>
+            <UBadge v-if="status.isRoot" color="primary" variant="subtle">
+              Root Admin (DNS-belegt)
+            </UBadge>
+            <UBadge v-else-if="status.isOperator" color="info" variant="subtle">
+              Operator
+            </UBadge>
+            <UBadge v-else color="neutral" variant="subtle">
+              Kein Admin-Status
+            </UBadge>
+          </dd>
+        </dl>
+      </UCard>
+
+      <UCard v-if="!status.isRoot && status.adminTxtName" class="mb-6">
+        <template #header>
+          <h2 class="text-lg font-semibold">
+            Root-Admin werden
+          </h2>
+          <p class="text-sm text-muted mt-1">
+            Wenn du <code>{{ status.domain }}</code> via DNS kontrollierst, kannst du Root-Admin werden:
+            erzeuge ein zufälliges Claim-Secret, hinterlege es als TXT-Eintrag, klicke "DNS neu prüfen".
+          </p>
+        </template>
+
+        <div v-if="!lastIssuedSecret">
+          <UButton
+            color="primary"
+            :loading="issuing"
+            icon="i-lucide-key-round"
+            @click="generateSecret"
+          >
+            Claim-Secret erzeugen
+          </UButton>
+          <p class="text-xs text-muted mt-3">
+            Ein bestehendes Secret wird dabei ungültig — alte DNS-Records funktionieren nicht mehr.
+          </p>
+        </div>
+
+        <div v-else class="space-y-3">
+          <UAlert color="warning" variant="soft" icon="i-lucide-alert-triangle" title="Einmaliger Wert" description="Dieser Wert wird nicht erneut angezeigt. Kopiere ihn jetzt." />
+
+          <div>
+            <p class="text-xs text-muted mb-1">
+              TXT-Record-Name
+            </p>
+            <div class="flex gap-2">
+              <code class="block flex-1 p-2 rounded bg-(--ui-bg-elevated) text-sm break-all">{{ lastIssuedTxtName }}</code>
+              <UButton variant="ghost" icon="i-lucide-copy" @click="copyToClipboard(lastIssuedTxtName!)" />
+            </div>
+          </div>
+
+          <div>
+            <p class="text-xs text-muted mb-1">
+              TXT-Record-Inhalt
+            </p>
+            <div class="flex gap-2">
+              <code class="block flex-1 p-2 rounded bg-(--ui-bg-elevated) text-sm break-all">{{ lastIssuedSecret }}</code>
+              <UButton variant="ghost" icon="i-lucide-copy" @click="copyToClipboard(lastIssuedSecret!)" />
+            </div>
+          </div>
+
+          <p class="text-xs text-muted">
+            Nach dem DNS-Edit: TTL abwarten (typisch 60–300s), dann oben auf "DNS neu prüfen" klicken.
+          </p>
+        </div>
+      </UCard>
+
+      <UCard v-if="status.isRoot || status.isOperator">
+        <template #header>
+          <h2 class="text-lg font-semibold">
+            SP-Allowlist (mode=allowlist-admin)
+          </h2>
+          <p class="text-sm text-muted mt-1">
+            Anwendungen, die für <code>{{ status.domain }}</code> zugelassen sind. Bei
+            <code>mode=allowlist-admin</code> in deinem DNS bekommen nur diese SPs Assertions.
+          </p>
+        </template>
+
+        <form class="flex gap-2 mb-4" @submit.prevent="addToAllowlist">
+          <UInput
+            v-model="newClientId"
+            placeholder="z.B. plans.openape.ai"
+            class="flex-1"
+            :disabled="adding"
+          />
+          <UButton type="submit" color="primary" :loading="adding" icon="i-lucide-plus">
+            Hinzufügen
+          </UButton>
+        </form>
+
+        <div v-if="allowlistLoading" class="text-muted text-sm">
+          Lade…
+        </div>
+        <div v-else-if="allowlist.length === 0" class="text-muted text-sm">
+          Noch keine SPs zugelassen.
+        </div>
+        <ul v-else class="divide-y divide-(--ui-border)">
+          <li
+            v-for="entry in allowlist"
+            :key="entry.clientId"
+            class="py-3 flex items-center justify-between gap-4"
+          >
+            <div class="min-w-0">
+              <code class="font-mono">{{ entry.clientId }}</code>
+              <p class="text-xs text-muted">
+                hinzugefügt von {{ entry.approvedBy }} · {{ formatDate(entry.approvedAt) }}
+              </p>
+            </div>
+            <UButton
+              variant="ghost"
+              color="error"
+              size="xs"
+              icon="i-lucide-trash-2"
+              @click="removeFromAllowlist(entry.clientId)"
+            />
+          </li>
+        </ul>
+      </UCard>
+    </template>
+  </div>
+</template>

--- a/apps/openape-free-idp/app/pages/index.vue
+++ b/apps/openape-free-idp/app/pages/index.vue
@@ -67,6 +67,16 @@ async function handleLogout() {
             Verbundene Dienste
           </UButton>
           <UButton
+            to="/admin"
+            color="primary"
+            variant="outline"
+            size="lg"
+            block
+            icon="i-lucide-shield"
+          >
+            Domain-Admin
+          </UButton>
+          <UButton
             color="neutral"
             variant="outline"
             size="lg"

--- a/apps/openape-free-idp/server/api/free-idp/admin/allowlist/[clientId].delete.ts
+++ b/apps/openape-free-idp/server/api/free-idp/admin/allowlist/[clientId].delete.ts
@@ -1,0 +1,28 @@
+import { defineEventHandler, getRouterParam, setResponseStatus } from 'h3'
+import { and, eq } from 'drizzle-orm'
+import { useDb } from '../../../../database/drizzle'
+import { adminAllowlist } from '../../../../database/schema'
+import { extractEmailDomain } from '../../../../utils/admin-claim'
+
+export default defineEventHandler(async (event) => {
+  const email = await requireAdmin(event)
+  const domain = extractEmailDomain(email)
+  if (!domain) {
+    throw createProblemError({ status: 400, title: 'Caller has no email domain' })
+  }
+
+  const clientId = decodeURIComponent(getRouterParam(event, 'clientId') ?? '').toLowerCase()
+  if (!clientId) {
+    throw createProblemError({ status: 400, title: 'clientId is required' })
+  }
+
+  await useDb()
+    .delete(adminAllowlist)
+    .where(and(
+      eq(adminAllowlist.domain, domain),
+      eq(adminAllowlist.clientId, clientId),
+    ))
+    .run()
+
+  setResponseStatus(event, 204)
+})

--- a/apps/openape-free-idp/server/api/free-idp/admin/allowlist/index.get.ts
+++ b/apps/openape-free-idp/server/api/free-idp/admin/allowlist/index.get.ts
@@ -1,0 +1,28 @@
+import { defineEventHandler } from 'h3'
+import { eq } from 'drizzle-orm'
+import { useDb } from '../../../../database/drizzle'
+import { adminAllowlist } from '../../../../database/schema'
+import { extractEmailDomain } from '../../../../utils/admin-claim'
+
+/**
+ * List the SPs allowlisted for the caller's domain. Scoped to one
+ * domain because cross-domain reads would leak which SPs another
+ * organisation has approved — that's metadata they may not want
+ * shared. Caller must be admin (root or operator) of their domain.
+ */
+export default defineEventHandler(async (event) => {
+  const email = await requireAdmin(event)
+  const domain = extractEmailDomain(email)
+  if (!domain) return []
+
+  const db = useDb()
+  return await db
+    .select({
+      clientId: adminAllowlist.clientId,
+      approvedBy: adminAllowlist.approvedBy,
+      approvedAt: adminAllowlist.approvedAt,
+    })
+    .from(adminAllowlist)
+    .where(eq(adminAllowlist.domain, domain))
+    .all()
+})

--- a/apps/openape-free-idp/server/api/free-idp/admin/allowlist/index.post.ts
+++ b/apps/openape-free-idp/server/api/free-idp/admin/allowlist/index.post.ts
@@ -1,0 +1,41 @@
+import { defineEventHandler, readBody } from 'h3'
+import { useDb } from '../../../../database/drizzle'
+import { adminAllowlist } from '../../../../database/schema'
+import { extractEmailDomain } from '../../../../utils/admin-claim'
+
+/**
+ * Allowlist a SP for the caller's domain (mode=allowlist-admin
+ * gating). Idempotent — re-adding the same client_id refreshes
+ * approvedAt / approvedBy.
+ */
+export default defineEventHandler(async (event) => {
+  const email = await requireAdmin(event)
+  const domain = extractEmailDomain(email)
+  if (!domain) {
+    throw createProblemError({ status: 400, title: 'Caller has no email domain' })
+  }
+
+  const body = await readBody<{ clientId?: string }>(event)
+  const clientId = String(body?.clientId ?? '').trim().toLowerCase()
+  if (!clientId) {
+    throw createProblemError({ status: 400, title: 'clientId is required' })
+  }
+  // Loose shape check: client_id is typically a hostname per DDISA
+  // §4.3, but RFC 7591 leaves it opaque. Reject anything with
+  // whitespace / control chars, otherwise accept.
+  if (!/^[\w.-]+$/.test(clientId) || clientId.length > 255) {
+    throw createProblemError({ status: 400, title: 'clientId has invalid format' })
+  }
+
+  const now = Math.floor(Date.now() / 1000)
+  await useDb()
+    .insert(adminAllowlist)
+    .values({ domain, clientId, approvedBy: email.toLowerCase(), approvedAt: now })
+    .onConflictDoUpdate({
+      target: [adminAllowlist.domain, adminAllowlist.clientId],
+      set: { approvedBy: email.toLowerCase(), approvedAt: now },
+    })
+    .run()
+
+  return { domain, clientId, approvedBy: email, approvedAt: now }
+})

--- a/apps/openape-free-idp/server/api/free-idp/admin/claim-secret.post.ts
+++ b/apps/openape-free-idp/server/api/free-idp/admin/claim-secret.post.ts
@@ -1,0 +1,61 @@
+import { defineEventHandler } from 'h3'
+import { and, eq, isNull } from 'drizzle-orm'
+import { useDb } from '../../../database/drizzle'
+import { adminClaimSecrets } from '../../../database/schema'
+import {
+  adminTxtName,
+  clearAdminCache,
+  extractEmailDomain,
+  generateClaimSecret,
+  hashSecret,
+} from '../../../utils/admin-claim'
+import { useRuntimeConfig } from 'nitropack/runtime'
+
+/**
+ * Mint (or rotate) the user's DNS-claim secret. The cleartext is
+ * returned EXACTLY ONCE in this response — there is no read-back
+ * endpoint. If the user loses it before pasting into DNS they have
+ * to call this again, which generates a new one and invalidates the
+ * previous (revokedAt set on all prior rows for this user).
+ *
+ * Self-only: no email param. Acting on behalf of someone else makes
+ * no sense — the secret has to land in DNS the user controls.
+ */
+export default defineEventHandler(async (event) => {
+  const email = await requireAuth(event)
+  const issuer = useRuntimeConfig().openapeIdp.issuer as string
+  const db = useDb()
+  const now = Math.floor(Date.now() / 1000)
+  const lowerEmail = email.toLowerCase()
+
+  // Revoke any active secrets — previous TXT records become invalid.
+  // We keep the rows for audit; only the active set is used at
+  // verification time (via `isNull(revokedAt)`).
+  await db
+    .update(adminClaimSecrets)
+    .set({ revokedAt: now })
+    .where(and(
+      eq(adminClaimSecrets.userEmail, lowerEmail),
+      isNull(adminClaimSecrets.revokedAt),
+    ))
+    .run()
+
+  const secret = generateClaimSecret()
+  await db.insert(adminClaimSecrets).values({
+    userEmail: lowerEmail,
+    secretHash: hashSecret(secret),
+    createdAt: now,
+  }).run()
+
+  // Bust any cached "isRoot=false" answer so the recheck endpoint
+  // doesn't have to wait for negative TTL on first verification.
+  clearAdminCache(email)
+
+  const domain = extractEmailDomain(email)
+  return {
+    secret,
+    txtName: domain ? adminTxtName(issuer, domain) : null,
+    domain,
+    createdAt: now,
+  }
+})

--- a/apps/openape-free-idp/server/api/free-idp/admin/recheck.post.ts
+++ b/apps/openape-free-idp/server/api/free-idp/admin/recheck.post.ts
@@ -1,0 +1,19 @@
+import { defineEventHandler } from 'h3'
+import { useRuntimeConfig } from 'nitropack/runtime'
+import { useDb } from '../../../database/drizzle'
+import { clearAdminCache, isRootAdmin } from '../../../utils/admin-claim'
+
+/**
+ * Bust the in-memory admin cache for the caller and re-resolve from
+ * scratch. Useful right after the user pastes their secret into DNS
+ * — they don't want to wait for the negative TTL to expire before
+ * the UI shows their new admin status.
+ */
+export default defineEventHandler(async (event) => {
+  const email = await requireAuth(event)
+  clearAdminCache(email)
+
+  const issuer = useRuntimeConfig().openapeIdp.issuer as string
+  const isRoot = await isRootAdmin(useDb(), issuer, email)
+  return { isRoot }
+})

--- a/apps/openape-free-idp/server/api/free-idp/admin/status.get.ts
+++ b/apps/openape-free-idp/server/api/free-idp/admin/status.get.ts
@@ -1,0 +1,36 @@
+import { defineEventHandler } from 'h3'
+import { useRuntimeConfig } from 'nitropack/runtime'
+import { useDb } from '../../../database/drizzle'
+import {
+  adminTxtName,
+  extractEmailDomain,
+  isOperator,
+  isRootAdmin,
+} from '../../../utils/admin-claim'
+
+/**
+ * "What admin powers do I have?" — used by the account page to
+ * decide whether to render the Generate-Secret CTA, the SP-allowlist
+ * UI, etc. Self-only — no leakage of other users' admin status.
+ */
+export default defineEventHandler(async (event) => {
+  const email = await requireAuth(event)
+  const issuer = useRuntimeConfig().openapeIdp.issuer as string
+  const domain = extractEmailDomain(email)
+  const db = useDb()
+
+  const [root, operator] = await Promise.all([
+    isRootAdmin(db, issuer, email),
+    isOperator(db, email),
+  ])
+
+  return {
+    email,
+    domain,
+    isRoot: root,
+    isOperator: operator,
+    // Hint for the UI when the user isn't yet root: where do they
+    // need to put the TXT record?
+    adminTxtName: domain ? adminTxtName(issuer, domain) : null,
+  }
+})

--- a/apps/openape-free-idp/server/database/schema.ts
+++ b/apps/openape-free-idp/server/database/schema.ts
@@ -237,3 +237,47 @@ export const consents = sqliteTable('consents', {
   primaryKey({ columns: [table.userEmail, table.clientId] }),
   index('idx_consents_user_email').on(table.userEmail),
 ])
+
+// --- DNS-rooted admin claim (#307) ---
+// Each user can mint a random claim secret. To prove they're admin
+// for a domain they own, the user publishes a TXT record at
+// `_openape-admin-id-openape-ai.{user-domain}` containing the secret.
+// We store only sha256(secret) so a DB compromise doesn't expose
+// values that the attacker could plant in DNS to anoint themselves.
+// `revokedAt` is set when the user regenerates — stale rows are kept
+// for audit-trail of past claim secrets.
+export const adminClaimSecrets = sqliteTable('admin_claim_secrets', {
+  userEmail: text('user_email').notNull(),
+  secretHash: text('secret_hash').notNull(),
+  createdAt: integer('created_at').notNull(),
+  revokedAt: integer('revoked_at'),
+}, table => [
+  primaryKey({ columns: [table.userEmail, table.secretHash] }),
+  index('idx_admin_claim_user').on(table.userEmail),
+])
+
+// Operators are DB-stored admins for one specific email-domain. A
+// DNS-rooted root admin promotes them via the admin UI. They can do
+// everything an admin can do EXCEPT promote / demote other operators
+// — that gate uses requireRootAdmin.
+export const operators = sqliteTable('operators', {
+  userEmail: text('user_email').notNull(),
+  domain: text('domain').notNull(),
+  promotedBy: text('promoted_by').notNull(),
+  promotedAt: integer('promoted_at').notNull(),
+}, table => [
+  primaryKey({ columns: [table.userEmail, table.domain] }),
+  index('idx_operators_domain').on(table.domain),
+])
+
+// SPs that the root admin / an operator has admin-allowlisted for a
+// given domain (mode=allowlist-admin). Closes #307. Lookups are by
+// (domain, clientId); revocation is a DELETE.
+export const adminAllowlist = sqliteTable('admin_allowlist', {
+  domain: text('domain').notNull(),
+  clientId: text('client_id').notNull(),
+  approvedBy: text('approved_by').notNull(),
+  approvedAt: integer('approved_at').notNull(),
+}, table => [
+  primaryKey({ columns: [table.domain, table.clientId] }),
+])

--- a/apps/openape-free-idp/server/plugins/02.database.ts
+++ b/apps/openape-free-idp/server/plugins/02.database.ts
@@ -162,6 +162,39 @@ export default defineNitroPlugin(async () => {
       PRIMARY KEY (user_email, client_id)
     )`)
     await db.run(sql`CREATE INDEX IF NOT EXISTS idx_consents_user_email ON consents(user_email)`)
+
+    // DNS-rooted admin claim (#307). Each user can mint a random
+    // secret which they publish at _openape-admin-{idp}.{their-domain}
+    // to claim root admin status for that domain. We store only
+    // sha256(secret); the cleartext is shown to the user once.
+    await db.run(sql`CREATE TABLE IF NOT EXISTS admin_claim_secrets (
+      user_email TEXT NOT NULL,
+      secret_hash TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      revoked_at INTEGER,
+      PRIMARY KEY (user_email, secret_hash)
+    )`)
+    await db.run(sql`CREATE INDEX IF NOT EXISTS idx_admin_claim_user ON admin_claim_secrets(user_email)`)
+
+    // Operators — DB-stored admins for a specific domain, promoted
+    // by a DNS-rooted root admin via the admin UI.
+    await db.run(sql`CREATE TABLE IF NOT EXISTS operators (
+      user_email TEXT NOT NULL,
+      domain TEXT NOT NULL,
+      promoted_by TEXT NOT NULL,
+      promoted_at INTEGER NOT NULL,
+      PRIMARY KEY (user_email, domain)
+    )`)
+    await db.run(sql`CREATE INDEX IF NOT EXISTS idx_operators_domain ON operators(domain)`)
+
+    // mode=allowlist-admin SP allowlist, scoped per domain.
+    await db.run(sql`CREATE TABLE IF NOT EXISTS admin_allowlist (
+      domain TEXT NOT NULL,
+      client_id TEXT NOT NULL,
+      approved_by TEXT NOT NULL,
+      approved_at INTEGER NOT NULL,
+      PRIMARY KEY (domain, client_id)
+    )`)
   }
   catch (err) {
     console.error('[database] Table creation failed (tables may already exist):', err)

--- a/apps/openape-free-idp/server/plugins/04.idp-stores.ts
+++ b/apps/openape-free-idp/server/plugins/04.idp-stores.ts
@@ -8,6 +8,7 @@ import { createDrizzleRegistrationUrlStore } from '../utils/drizzle-registration
 import { createDrizzleKeyStore } from '../utils/drizzle-key-store'
 import { createDrizzleSshKeyStore } from '../utils/drizzle-ssh-key-store'
 import { createDrizzleConsentStore } from '../utils/drizzle-consent-store'
+import { createDrizzleAdminAllowlistStore } from '../utils/drizzle-admin-allowlist-store'
 
 export default defineNitroPlugin(() => {
   if (process.env.OPENAPE_E2E === '1') return
@@ -33,4 +34,7 @@ export default defineNitroPlugin(() => {
 
   // DDISA allowlist-user consents (#301)
   defineConsentStore(() => createDrizzleConsentStore())
+
+  // DDISA allowlist-admin SP allowlist (#307)
+  defineAdminAllowlistStore(() => createDrizzleAdminAllowlistStore())
 })

--- a/apps/openape-free-idp/server/plugins/07.admin-resolver.ts
+++ b/apps/openape-free-idp/server/plugins/07.admin-resolver.ts
@@ -1,0 +1,37 @@
+import { useRuntimeConfig } from 'nitropack/runtime'
+import { useDb } from '../database/drizzle'
+import { isOperator, isRootAdmin } from '../utils/admin-claim'
+
+/**
+ * Wire the free-idp's DNS-rooted admin model into the
+ * `@openape/nuxt-auth-idp` module's resolver hooks (#307). Every
+ * incoming request gets two resolvers attached on `event.context`:
+ *
+ *   - `openapeAdminResolver`     — root OR operator → admin-tier
+ *   - `openapeRootAdminResolver` — root only → root-tier
+ *
+ * `requireAdmin` / `requireRootAdmin` consult these instead of the
+ * legacy email allowlist. We deliberately bypass the env-config
+ * `OPENAPE_ADMIN_EMAILS` here: free-idp's authority is DNS, not
+ * env. Fallback to the email list would create a confusing dual
+ * model where someone could be admin without DNS proof.
+ */
+export default defineNitroPlugin((nitroApp) => {
+  if (process.env.OPENAPE_E2E === '1') return
+
+  nitroApp.hooks.hook('request', (event) => {
+    const issuer = useRuntimeConfig().openapeIdp?.issuer as string | undefined
+    if (!issuer) return
+
+    const db = useDb()
+
+    event.context.openapeRootAdminResolver = async (_event, email) => {
+      return isRootAdmin(db, issuer, email)
+    }
+
+    event.context.openapeAdminResolver = async (_event, email) => {
+      if (await isRootAdmin(db, issuer, email)) return true
+      return isOperator(db, email)
+    }
+  })
+})

--- a/apps/openape-free-idp/server/utils/admin-claim.ts
+++ b/apps/openape-free-idp/server/utils/admin-claim.ts
@@ -1,0 +1,183 @@
+import { createHash, randomBytes } from 'node:crypto'
+import { resolveTxt } from 'node:dns/promises'
+import { and, eq, isNull } from 'drizzle-orm'
+import type { useDb } from '../database/drizzle'
+import { adminClaimSecrets, operators } from '../database/schema'
+
+type Db = ReturnType<typeof useDb>
+
+/**
+ * DNS-rooted admin proof for the free-idp.
+ *
+ * The user mints a random claim secret; cleartext is shown ONCE in
+ * the UI and otherwise never leaves the server. The hash is stored
+ * in `admin_claim_secrets`. To prove admin status for a domain they
+ * own, the user publishes the cleartext as a TXT record at
+ * `_openape-admin-{idp-slug}.{their-email-domain}`. On verification
+ * we read every TXT value at that name, hash each, and check whether
+ * any matches the user's stored hash.
+ *
+ * Properties of this design:
+ *   - Random secret: not reversible to email even with a wordlist.
+ *   - DB stores only hashes: a DB compromise can't be turned into a
+ *     DNS-claim attack.
+ *   - Subdomain encodes the IdP: a domain that trusts multiple IdPs
+ *     keeps separate per-IdP admin claims without conflict.
+ *   - Domain control = identity authority, consistent with DDISA.
+ */
+
+/** "id.openape.ai" → "id-openape-ai", suitable for use as a DNS label. */
+export function idpSlugFromIssuer(issuer: string): string {
+  let host = issuer
+  try { host = new URL(issuer).host }
+  catch { /* fall back to the raw string */ }
+  // Ports + IPs are unusual for production IdPs; if they appear we
+  // sanitize to dashes too rather than producing an invalid label.
+  return host.toLowerCase().replace(/[^a-z0-9-]/g, '-')
+}
+
+export function adminTxtName(idpIssuer: string, domain: string): string {
+  return `_openape-admin-${idpSlugFromIssuer(idpIssuer)}.${domain}`
+}
+
+/** Lowercase hex SHA-256. */
+export function hashSecret(secret: string): string {
+  return createHash('sha256').update(secret, 'utf8').digest('hex')
+}
+
+/**
+ * Mint a fresh 32-byte (= 256 bit) URL-safe secret. base64url over 32
+ * bytes is 43 chars — short enough to hand-copy into a DNS UI without
+ * crossing the 255-char TXT-string limit even with prefixes.
+ */
+export function generateClaimSecret(): string {
+  return randomBytes(32).toString('base64url')
+}
+
+export function extractEmailDomain(email: string): string {
+  const at = email.lastIndexOf('@')
+  if (at < 0) return ''
+  return email.slice(at + 1).toLowerCase()
+}
+
+/**
+ * Resolve the TXT records at the admin claim name. Returns the raw
+ * string values (one per record). Treats NXDOMAIN / no-data as empty
+ * rather than throwing — that's the common case for a domain that
+ * hasn't published a claim yet.
+ */
+async function resolveAdminTxt(name: string): Promise<string[]> {
+  try {
+    const records = await resolveTxt(name)
+    // Each record is an array of strings (DNS allows multi-string
+    // values); join them in the unlikely case a claim got split.
+    return records.map(parts => parts.join(''))
+  }
+  catch (err) {
+    const code = (err as { code?: string }).code
+    if (code === 'ENOTFOUND' || code === 'ENODATA' || code === 'SERVFAIL') return []
+    throw err
+  }
+}
+
+interface CacheEntry {
+  isRoot: boolean
+  expires: number
+}
+
+const cache = new Map<string, CacheEntry>()
+const POSITIVE_TTL_MS = 60_000
+const NEGATIVE_TTL_MS = 30_000
+
+function cacheKey(email: string, domain: string): string {
+  return `${email.toLowerCase()}|${domain.toLowerCase()}`
+}
+
+export function clearAdminCache(email?: string, domain?: string): void {
+  if (!email) {
+    cache.clear()
+    return
+  }
+  if (domain) {
+    cache.delete(cacheKey(email, domain))
+    return
+  }
+  // Clear all entries for this email across domains.
+  const prefix = `${email.toLowerCase()}|`
+  for (const k of cache.keys()) {
+    if (k.startsWith(prefix)) cache.delete(k)
+  }
+}
+
+/**
+ * Is this user a DNS-rooted root admin for their email's domain?
+ * Resolves the admin TXT, hashes each value, looks up the user's
+ * non-revoked secret hashes — match means root.
+ *
+ * Caches the answer per (user, domain) for POSITIVE_TTL_MS / NEGATIVE_TTL_MS
+ * so the DNS lookup doesn't fire on every admin request. Demotion
+ * happens at most NEGATIVE_TTL_MS after the user revokes — which is
+ * fine because we also bust this cache explicitly on regenerate.
+ */
+export async function isRootAdmin(
+  db: Db,
+  idpIssuer: string,
+  userEmail: string,
+): Promise<boolean> {
+  const domain = extractEmailDomain(userEmail)
+  if (!domain) return false
+
+  const key = cacheKey(userEmail, domain)
+  const cached = cache.get(key)
+  if (cached && cached.expires > Date.now()) return cached.isRoot
+
+  const secrets = await db
+    .select({ secretHash: adminClaimSecrets.secretHash })
+    .from(adminClaimSecrets)
+    .where(and(
+      eq(adminClaimSecrets.userEmail, userEmail.toLowerCase()),
+      isNull(adminClaimSecrets.revokedAt),
+    ))
+    .all()
+  if (secrets.length === 0) {
+    cache.set(key, { isRoot: false, expires: Date.now() + NEGATIVE_TTL_MS })
+    return false
+  }
+
+  const txtName = adminTxtName(idpIssuer, domain)
+  const txtValues = await resolveAdminTxt(txtName)
+  if (txtValues.length === 0) {
+    cache.set(key, { isRoot: false, expires: Date.now() + NEGATIVE_TTL_MS })
+    return false
+  }
+
+  const userHashes = new Set(secrets.map(s => s.secretHash))
+  const isRoot = txtValues.some(v => userHashes.has(hashSecret(v)))
+  cache.set(key, {
+    isRoot,
+    expires: Date.now() + (isRoot ? POSITIVE_TTL_MS : NEGATIVE_TTL_MS),
+  })
+  return isRoot
+}
+
+/**
+ * Is this user an operator for their email's domain? Operators are
+ * DB-rows promoted by a root admin — they get admin-tier power but
+ * NOT root-tier (so they can't promote other operators).
+ */
+export async function isOperator(
+  db: Db,
+  userEmail: string,
+): Promise<boolean> {
+  const domain = extractEmailDomain(userEmail)
+  if (!domain) return false
+  const row = await db
+    .select({ userEmail: operators.userEmail })
+    .from(operators)
+    .where(and(
+      eq(operators.userEmail, userEmail.toLowerCase()),
+      eq(operators.domain, domain),
+    ))
+    .get()
+  return !!row
+}

--- a/apps/openape-free-idp/server/utils/drizzle-admin-allowlist-store.ts
+++ b/apps/openape-free-idp/server/utils/drizzle-admin-allowlist-store.ts
@@ -1,0 +1,25 @@
+import type { AdminAllowlistStore } from '@openape/auth'
+import { and, eq } from 'drizzle-orm'
+import { useDb } from '../database/drizzle'
+import { adminAllowlist } from '../database/schema'
+
+/**
+ * Drizzle-backed AdminAllowlistStore for `mode=allowlist-admin`
+ * (#307). One row per (userDomain, clientId) — managed via the
+ * admin endpoints in /api/free-idp/admin/allowlist.
+ */
+export function createDrizzleAdminAllowlistStore(): AdminAllowlistStore {
+  return {
+    async isAllowed(userDomain: string, clientId: string): Promise<boolean> {
+      const row = await useDb()
+        .select({ clientId: adminAllowlist.clientId })
+        .from(adminAllowlist)
+        .where(and(
+          eq(adminAllowlist.domain, userDomain.toLowerCase()),
+          eq(adminAllowlist.clientId, clientId.toLowerCase()),
+        ))
+        .get()
+      return !!row
+    },
+  }
+}

--- a/modules/nuxt-auth-idp/src/runtime/server/routes/authorize.get.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/routes/authorize.get.ts
@@ -175,8 +175,8 @@ export default defineEventHandler(async (event) => {
   // means. We pass `undefined` through to evaluatePolicy whose
   // `default:` branch returns `'consent'`.
   const policyMode = ddisaRecord?.mode
-  const { consentStore } = useIdpStores()
-  const decision = await evaluatePolicy(policyMode, params.client_id, userId, consentStore)
+  const { consentStore, adminAllowlistStore } = useIdpStores()
+  const decision = await evaluatePolicy(policyMode, params.client_id, userId, consentStore, { adminAllowlistStore })
 
   if (decision === 'deny') {
     const redirectUrl = new URL(params.redirect_uri)

--- a/modules/nuxt-auth-idp/src/runtime/server/utils/admin.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/utils/admin.ts
@@ -6,11 +6,34 @@ import { tryBearerAuth } from './agent-auth'
 import { getAppSession } from './session'
 import { createProblemError } from './problem'
 
+/**
+ * Pluggable admin-status resolver. Consuming apps can register one of
+ * these on `event.context.openapeAdminResolver` (typically from a
+ * Nitro plugin) to replace the default email-allowlist check with
+ * something like a DNS-rooted DDISA admin flow or a DB-backed roles
+ * table. Returning `true` grants admin access for the duration of
+ * this request only — no caching across requests at this layer.
+ *
+ * `openapeRootAdminResolver` is for a stricter "root" tier that
+ * MUST NOT be overridable from app data — used to gate operator
+ * promotion / demotion. Apps that don't have a root tier can omit it
+ * and `requireRootAdmin` will fall through to `requireAdmin`.
+ */
+export type AdminResolver = (event: H3Event, email: string) => boolean | Promise<boolean>
+
+declare module 'h3' {
+  interface H3EventContext {
+    openapeAdminEmails?: string[]
+    openapeAdminResolver?: AdminResolver
+    openapeRootAdminResolver?: AdminResolver
+  }
+}
+
 function getAdminEmails(): string[] {
   try {
     const event = useEvent()
     if (event?.context?.openapeAdminEmails) {
-      const emails = event.context.openapeAdminEmails as string[]
+      const emails = event.context.openapeAdminEmails
       return emails.map(e => e.trim().toLowerCase()).filter(Boolean)
     }
   }
@@ -73,7 +96,10 @@ export async function requireAuth(event: H3Event): Promise<string> {
   return session.data.userId as string
 }
 
-export async function requireAdmin(event: H3Event): Promise<string> {
+async function requireAdminOfTier(
+  event: H3Event,
+  tier: 'admin' | 'root',
+): Promise<string> {
   const tokenCheck = checkManagementToken(event)
   if (tokenCheck === 'valid') return '_management_'
   if (tokenCheck === 'invalid') {
@@ -91,8 +117,43 @@ export async function requireAdmin(event: H3Event): Promise<string> {
     throw createProblemError({ status: 401, title: 'Authentication required' })
   }
   const email = session.data.userId as string
-  if (isAdmin(email)) {
-    return email
+
+  // Resolver takes precedence over the legacy email allowlist when
+  // an app has registered one. For the 'root' tier we deliberately
+  // do NOT fall back to the email allowlist — root status must be
+  // gated by something stronger than env-config (e.g. a DNS-rooted
+  // claim secret). Apps that don't ship a root resolver fall through
+  // to the standard admin check, which is the safe loud failure mode.
+  const resolver = tier === 'root'
+    ? event.context.openapeRootAdminResolver
+    : event.context.openapeAdminResolver
+  if (resolver) {
+    if (await resolver(event, email)) return email
+    throw createProblemError({
+      status: 403,
+      title: tier === 'root' ? 'Root admin access required' : 'Admin access required',
+    })
   }
-  throw createProblemError({ status: 403, title: 'Admin access required' })
+
+  if (tier === 'admin' && isAdmin(email)) return email
+
+  throw createProblemError({
+    status: 403,
+    title: tier === 'root' ? 'Root admin access required' : 'Admin access required',
+  })
+}
+
+export async function requireAdmin(event: H3Event): Promise<string> {
+  return requireAdminOfTier(event, 'admin')
+}
+
+/**
+ * Strict variant for actions that MUST be gated by something stronger
+ * than the email allowlist — e.g. promoting other users to operator,
+ * rotating signing keys. Apps register a resolver via
+ * `event.context.openapeRootAdminResolver`; if none is registered the
+ * call fails closed with 403 (no fallback to env-config).
+ */
+export async function requireRootAdmin(event: H3Event): Promise<string> {
+  return requireAdminOfTier(event, 'root')
 }

--- a/modules/nuxt-auth-idp/src/runtime/server/utils/define-stores.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/utils/define-stores.ts
@@ -1,5 +1,5 @@
 import type { H3Event } from 'h3'
-import type { ChallengeStore as WebAuthnChallengeStore, CodeStore, ConsentStore, CredentialStore, JtiStore, KeyStore, RefreshTokenStore, RegistrationUrlStore, UserStore } from '@openape/auth'
+import type { AdminAllowlistStore, ChallengeStore as WebAuthnChallengeStore, CodeStore, ConsentStore, CredentialStore, JtiStore, KeyStore, RefreshTokenStore, RegistrationUrlStore, UserStore } from '@openape/auth'
 import type { ShapeStore } from '@openape/grants'
 import type { ExtendedGrantStore } from './grant-store'
 import type { ChallengeStore as GrantChallengeStore } from './grant-challenge-store'
@@ -60,6 +60,12 @@ export function defineSshKeyStore(factory: (event: H3Event) => SshKeyStore) {
 
 export function defineConsentStore(factory: (event: H3Event) => ConsentStore) {
   registerStoreFactory('consentStore', factory)
+}
+
+// Admin Allowlist Store (DDISA allowlist-admin mode, #307)
+
+export function defineAdminAllowlistStore(factory: (event: H3Event) => AdminAllowlistStore) {
+  registerStoreFactory('adminAllowlistStore', factory)
 }
 
 // Shape Store (Phase 1 — server-side shape registry)

--- a/modules/nuxt-auth-idp/src/runtime/server/utils/stores.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/utils/stores.ts
@@ -1,6 +1,6 @@
 import type { H3Event } from 'h3'
-import type { ChallengeStore, ClientMetadata, ClientMetadataStore, CodeStore, ConsentStore, CredentialStore, JtiStore, KeyStore, RefreshTokenStore, RegistrationUrlStore, UserStore } from '@openape/auth'
-import { createClientMetadataResolver } from '@openape/auth'
+import type { AdminAllowlistStore, ChallengeStore, ClientMetadata, ClientMetadataStore, CodeStore, ConsentStore, CredentialStore, JtiStore, KeyStore, RefreshTokenStore, RegistrationUrlStore, UserStore } from '@openape/auth'
+import { createClientMetadataResolver, InMemoryAdminAllowlistStore } from '@openape/auth'
 import { useRuntimeConfig, useEvent } from 'nitropack/runtime'
 import { createChallengeStore } from './challenge-store'
 import { createCodeStore } from './code-store'
@@ -27,6 +27,7 @@ interface IdpStores {
   sshKeyStore: SshKeyStore
   clientMetadataStore: ClientMetadataStore
   consentStore: ConsentStore
+  adminAllowlistStore: AdminAllowlistStore
 }
 
 // Module-level singleton for the SP client-metadata resolver. The
@@ -70,6 +71,7 @@ function initDefaultStores(): IdpStores {
     sshKeyStore: createSshKeyStore(),
     clientMetadataStore: getClientMetadataStore(),
     consentStore: createConsentStore(),
+    adminAllowlistStore: new InMemoryAdminAllowlistStore(),
   }
 }
 
@@ -86,6 +88,7 @@ function initStoresWithRegistry(event: H3Event): IdpStores {
     sshKeyStore: getStoreFactory<SshKeyStore>('sshKeyStore')?.(event) ?? createSshKeyStore(),
     clientMetadataStore: getStoreFactory<ClientMetadataStore>('clientMetadataStore')?.(event) ?? getClientMetadataStore(),
     consentStore: getStoreFactory<ConsentStore>('consentStore')?.(event) ?? createConsentStore(),
+    adminAllowlistStore: getStoreFactory<AdminAllowlistStore>('adminAllowlistStore')?.(event) ?? new InMemoryAdminAllowlistStore(),
   }
 }
 

--- a/modules/nuxt-auth-idp/test/authorize-consent.test.ts
+++ b/modules/nuxt-auth-idp/test/authorize-consent.test.ts
@@ -40,6 +40,7 @@ vi.mock('../src/runtime/server/utils/stores', () => ({
       hasConsent: async () => false,
       save: consentSave,
     },
+    adminAllowlistStore: { isAllowed: async () => false },
   })),
 }))
 
@@ -154,7 +155,7 @@ describe('authorize.get — DDISA allowlist-user flow (#301)', () => {
     ;(resolveDDISA as any).mockResolvedValue(null)
     const { evaluatePolicy } = await import('@openape/auth')
     await callAuthorize()
-    expect(evaluatePolicy).toHaveBeenCalledWith(undefined, 'app.example.com', 'patrick@hofmann.eco', expect.anything())
+    expect(evaluatePolicy).toHaveBeenCalledWith(undefined, 'app.example.com', 'patrick@hofmann.eco', expect.anything(), expect.objectContaining({ adminAllowlistStore: expect.anything() }))
   })
 
   it('passes undefined mode when DDISA record exists but `mode` field is omitted (#305)', async () => {
@@ -162,7 +163,7 @@ describe('authorize.get — DDISA allowlist-user flow (#301)', () => {
     ;(resolveDDISA as any).mockResolvedValue({ version: 'ddisa1', idp: 'https://id.openape.at', raw: 'v=ddisa1 idp=...' })
     const { evaluatePolicy } = await import('@openape/auth')
     await callAuthorize()
-    expect(evaluatePolicy).toHaveBeenCalledWith(undefined, 'app.example.com', 'patrick@hofmann.eco', expect.anything())
+    expect(evaluatePolicy).toHaveBeenCalledWith(undefined, 'app.example.com', 'patrick@hofmann.eco', expect.anything(), expect.objectContaining({ adminAllowlistStore: expect.anything() }))
   })
 
   it('passes through explicit mode=open when DNS sets it — opt-in is honoured (#305)', async () => {
@@ -170,7 +171,7 @@ describe('authorize.get — DDISA allowlist-user flow (#301)', () => {
     ;(resolveDDISA as any).mockResolvedValue({ version: 'ddisa1', idp: 'https://id.openape.at', mode: 'open', raw: 'v=ddisa1 mode=open ...' })
     const { evaluatePolicy } = await import('@openape/auth')
     await callAuthorize()
-    expect(evaluatePolicy).toHaveBeenCalledWith('open', 'app.example.com', 'patrick@hofmann.eco', expect.anything())
+    expect(evaluatePolicy).toHaveBeenCalledWith('open', 'app.example.com', 'patrick@hofmann.eco', expect.anything(), expect.objectContaining({ adminAllowlistStore: expect.anything() }))
   })
 })
 

--- a/packages/auth/src/__tests__/authorize.test.ts
+++ b/packages/auth/src/__tests__/authorize.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { evaluatePolicy, validateAuthorizeRequest } from '../idp/authorize.js'
-import { InMemoryConsentStore } from '../idp/stores.js'
+import { InMemoryAdminAllowlistStore, InMemoryConsentStore } from '../idp/stores.js'
 
 describe('validateAuthorizeRequest', () => {
   const validParams = {
@@ -55,9 +55,64 @@ describe('evaluatePolicy', () => {
     expect(await evaluatePolicy('allowlist-user', 'sp', 'user', store)).toBe('allow')
   })
 
-  it('denies for allowlist-admin mode', async () => {
+  it('denies for allowlist-admin mode without an allowlist store wired up', async () => {
+    // Backward-compat default — callers that don't pass an allowlist
+    // store get the safe deny-all behaviour for this mode.
     const store = new InMemoryConsentStore()
-    expect(await evaluatePolicy('allowlist-admin', 'sp', 'user', store)).toBe('deny')
+    expect(await evaluatePolicy('allowlist-admin', 'sp.example.com', 'user@deltamind.at', store)).toBe('deny')
+  })
+
+  it('denies for allowlist-admin when SP not in the domain allowlist (#307)', async () => {
+    const store = new InMemoryConsentStore()
+    const allowlist = new InMemoryAdminAllowlistStore()
+    expect(await evaluatePolicy(
+      'allowlist-admin',
+      'unapproved.example.com',
+      'user@deltamind.at',
+      store,
+      { adminAllowlistStore: allowlist },
+    )).toBe('deny')
+  })
+
+  it('allows for allowlist-admin when SP is in the domain allowlist (#307)', async () => {
+    const store = new InMemoryConsentStore()
+    const allowlist = new InMemoryAdminAllowlistStore()
+    allowlist.add('deltamind.at', 'plans.openape.ai')
+    expect(await evaluatePolicy(
+      'allowlist-admin',
+      'plans.openape.ai',
+      'user@deltamind.at',
+      store,
+      { adminAllowlistStore: allowlist },
+    )).toBe('allow')
+  })
+
+  it('scopes allowlist-admin per user-domain — entry for deltamind.at does NOT cover example.com users', async () => {
+    const store = new InMemoryConsentStore()
+    const allowlist = new InMemoryAdminAllowlistStore()
+    allowlist.add('deltamind.at', 'plans.openape.ai')
+    expect(await evaluatePolicy(
+      'allowlist-admin',
+      'plans.openape.ai',
+      'someone@example.com',
+      store,
+      { adminAllowlistStore: allowlist },
+    )).toBe('deny')
+  })
+
+  it('denies allowlist-admin when userId has no @ separator', async () => {
+    const store = new InMemoryConsentStore()
+    const allowlist = new InMemoryAdminAllowlistStore()
+    allowlist.add('', 'plans.openape.ai')
+    // Even if the empty domain is in the allowlist (operator config
+    // accident), an unparseable user identifier still denies.
+    expect(await evaluatePolicy(
+      'allowlist-admin',
+      'plans.openape.ai',
+      'malformed-no-at-sign',
+      store,
+      { adminAllowlistStore: allowlist },
+    )).toBe('deny')
   })
 
   it('defaults to consent for undefined mode', async () => {

--- a/packages/auth/src/idp/authorize.ts
+++ b/packages/auth/src/idp/authorize.ts
@@ -1,5 +1,5 @@
 import type { PolicyMode } from '@openape/core'
-import type { ConsentStore } from './stores.js'
+import type { AdminAllowlistStore, ConsentStore } from './stores.js'
 
 export interface AuthorizeParams {
   client_id: string
@@ -38,6 +38,21 @@ export function validateAuthorizeRequest(params: AuthorizeParams): string | null
   return null
 }
 
+export interface EvaluatePolicyOptions {
+  /**
+   * Backing store for `mode=allowlist-admin`. When omitted, that
+   * mode falls through to a hard deny — same as before this option
+   * existed, preserving backward compat for callers that don't ship
+   * an admin allowlist.
+   */
+  adminAllowlistStore?: AdminAllowlistStore
+}
+
+function extractDomain(userId: string): string {
+  const at = userId.lastIndexOf('@')
+  return at < 0 ? '' : userId.slice(at + 1).toLowerCase()
+}
+
 /**
  * Evaluate policy: should the user be prompted for consent?
  */
@@ -46,6 +61,7 @@ export async function evaluatePolicy(
   clientId: string,
   userId: string,
   consentStore: ConsentStore,
+  options?: EvaluatePolicyOptions,
 ): Promise<'allow' | 'consent' | 'deny'> {
   switch (mode) {
     case 'open':
@@ -56,10 +72,17 @@ export async function evaluatePolicy(
       const hasConsent = await consentStore.hasConsent(userId, clientId)
       return hasConsent ? 'allow' : 'consent'
     }
-    case 'allowlist-admin':
-      // For the reference implementation, admin allowlist is not implemented
-      // In production, this would check an admin-managed list
-      return 'deny'
+    case 'allowlist-admin': {
+      // Domain-owner-curated SP allowlist. Without a store wired up,
+      // the safe answer is deny — the domain explicitly opted into
+      // a strict mode and we shouldn't silently relax it.
+      const store = options?.adminAllowlistStore
+      if (!store) return 'deny'
+      const userDomain = extractDomain(userId)
+      if (!userDomain) return 'deny'
+      const allowed = await store.isAllowed(userDomain, clientId)
+      return allowed ? 'allow' : 'deny'
+    }
     default:
       return 'consent'
   }

--- a/packages/auth/src/idp/index.ts
+++ b/packages/auth/src/idp/index.ts
@@ -1,4 +1,4 @@
-export { type AuthorizeParams, type AuthorizeResult, evaluatePolicy, validateAuthorizeRequest } from './authorize.js'
+export { type AuthorizeParams, type AuthorizeResult, type EvaluatePolicyOptions, evaluatePolicy, validateAuthorizeRequest } from './authorize.js'
 export { type AgentKeyResolver, type ClientAssertionResult, validateClientAssertion } from './client-assertion.js'
 export { generateJWKS, type JWKSResponse, serveJWKS } from './jwks.js'
 export {
@@ -11,11 +11,13 @@ export {
 } from './client-metadata.js'
 export { handleRefreshGrant, RefreshClientMismatchError, type RefreshGrantResult } from './refresh.js'
 export {
+  type AdminAllowlistStore,
   type CodeEntry,
   type CodeStore,
   type ConsentEntry,
   type ConsentStore,
   type GrantChallengeStore,
+  InMemoryAdminAllowlistStore,
   InMemoryCodeStore,
   InMemoryConsentStore,
   InMemoryGrantChallengeStore,

--- a/packages/auth/src/idp/stores.ts
+++ b/packages/auth/src/idp/stores.ts
@@ -41,6 +41,22 @@ export interface ConsentStore {
   revoke: (userId: string, clientId: string) => Promise<void>
 }
 
+/**
+ * Backing store for the DDISA `mode=allowlist-admin` policy. The
+ * domain owner pre-approves which SPs may receive assertions for
+ * users in their domain; everything else is denied. Reads happen on
+ * the hot /authorize path; writes are app-specific (free-idp ships
+ * an admin UI, other IdPs may seed via config).
+ */
+export interface AdminAllowlistStore {
+  /**
+   * Is `clientId` allowlisted for users in `userDomain`? `userDomain`
+   * is the email-domain side of the user's identifier, not the SP's
+   * domain — the allowlist is scoped per-tenant-domain.
+   */
+  isAllowed: (userDomain: string, clientId: string) => Promise<boolean>
+}
+
 export interface KeyEntry {
   kid: string
   privateKey: KeyLike
@@ -153,6 +169,29 @@ export class InMemoryConsentStore implements ConsentStore {
 
   async revoke(userId: string, clientId: string): Promise<void> {
     this.consents.delete(this.key(userId, clientId))
+  }
+}
+
+/**
+ * Default in-memory implementation. Always denies — apps that want
+ * to support `mode=allowlist-admin` must provide a real store with
+ * a backing table and an admin UI to populate it. Free-idp ships
+ * one such impl; bare module consumers fall back to this.
+ */
+export class InMemoryAdminAllowlistStore implements AdminAllowlistStore {
+  private allowed = new Set<string>()
+
+  private key(userDomain: string, clientId: string): string {
+    return `${userDomain.toLowerCase()}:${clientId.toLowerCase()}`
+  }
+
+  async isAllowed(userDomain: string, clientId: string): Promise<boolean> {
+    return this.allowed.has(this.key(userDomain, clientId))
+  }
+
+  /** Test helper — not part of the public AdminAllowlistStore contract. */
+  add(userDomain: string, clientId: string): void {
+    this.allowed.add(this.key(userDomain, clientId))
   }
 }
 


### PR DESCRIPTION
## Closes #307

Implements `mode=allowlist-admin` properly, with a pluggable allowlist store in the protocol package and a DNS-rooted root-admin claim flow in `openape-free-idp`. Module stays neutral so other IdPs (e.g. corporate deployments) can plug their own admin model in via the same hooks.

## Design

Per discussion in conversation log:

- **Root admin via random claim secret in DNS.** Each user can mint a 256-bit secret; cleartext is shown ONCE in the UI and DB stores only `sha256(secret)`. To prove admin status the user publishes the cleartext as a TXT record at `_openape-admin-{idp-slug}.{user-domain}`. Hash-comparison at lookup time. No reversibility from DNS to email.
- **Operators** are DB-stored second-tier admins promoted by a root admin (Phase 2 — endpoints scaffolded, UI not yet shipped).
- **AdminAllowlistStore** for `mode=allowlist-admin` policy evaluation, scoped per user-domain so multi-tenant IdPs don't leak across tenants.

## Threat model notes

- Without a store wired up, `evaluatePolicy('allowlist-admin', ...)` keeps its safe deny-all behaviour — no behaviour change for IdPs that haven't opted in.
- `requireRootAdmin` fails closed when no resolver is registered. The legacy `OPENAPE_ADMIN_EMAILS` env config still works for `requireAdmin` to preserve backward compat.
- DB compromise can't be turned into a DNS-claim attack (only hashes are stored). DNS hijack still wins, but that's fundamental to DDISA's domain-control-as-authority model.

## Test plan

- [x] `pnpm test` — auth + module tests pass (`evaluatePolicy` + 4 new allowlist-admin cases)
- [x] `pnpm typecheck` + `pnpm lint` — clean
- [x] `pnpm build --filter=openape-free-idp` — green; routes audited via local boot (returns 500 from missing DB env, which is expected)
- [ ] After merge → publish via `pnpm release:local` → deploy id.openape.ai
- [ ] Live verification with `deltamind.at` test domain:
  - `_ddisa.deltamind.at TXT v=ddisa1 idp=https://id.openape.ai; mode=allowlist-admin` (already set, currently `mode=allowlist-user` for staged smoke; will flip after deploy)
  - Register `patrick@deltamind.at` at id.openape.ai
  - `/admin` → Generate claim secret → publish at `_openape-admin-id-openape-ai.deltamind.at`
  - Recheck → Root status appears
  - Add `plans.openape.ai` to allowlist
  - Authorize against plans.openape.ai with login_hint `patrick@deltamind.at` → should pass
  - Authorize against an unapproved SP → should `error=access_denied`

## Files

| Layer | Files | Purpose |
|---|---|---|
| `packages/auth` | `idp/stores.ts`, `idp/authorize.ts`, `idp/index.ts` | `AdminAllowlistStore` interface, in-memory impl, plumbed through `evaluatePolicy` |
| `modules/nuxt-auth-idp` | `runtime/server/utils/{admin,define-stores,stores}.ts`, `runtime/server/routes/authorize.get.ts` | resolver hooks, store registry, `useIdpStores` integration |
| `apps/openape-free-idp` | new `/admin` page, `/api/free-idp/admin/*` endpoints, drizzle store + tables, Nitro resolver plugin | DNS-rooted root-admin + allowlist UI |