### PR TITLE
fix(idp): consent approve no longer fails with 'no redirect target'

### DIFF
--- a/.changeset/consent-redirect-via-json.md
+++ b/.changeset/consent-redirect-via-json.md
@@ -1,0 +1,7 @@
+---
+'@openape/nuxt-auth-idp': patch
+---
+
+Fix: clicking "Anmelden" on the consent screen showed "Server did not return a redirect target." instead of completing the SP-login.
+
+`consent.post` previously returned a `302 sendRedirect` and the page tried to read the `Location` header from a `fetch({ redirect: 'manual' })` response. Browsers turn 3xx responses under `redirect: 'manual'` into opaque-redirect responses whose headers are unreadable per the Fetch spec — so the consent page could never get the location. Now the handler returns `{ location: '...' }` JSON and the page does a top-level `window.location.assign`. Same trust boundary; same hop sequence; just survives the Fetch spec.

--- a/modules/nuxt-auth-idp/src/runtime/pages/consent.vue
+++ b/modules/nuxt-auth-idp/src/runtime/pages/consent.vue
@@ -41,18 +41,19 @@ async function submit(action) {
   submitting.value = true
   error.value = ''
   try {
-    const res = await $fetch.raw('/api/authorize/consent', {
+    // The server returns `{ location }` in a JSON body rather than
+    // a 302 redirect. With `fetch({ redirect: 'manual' })` browsers
+    // turn 3xx responses into opaque-redirect types whose Location
+    // header is unreadable — that's the Fetch spec, not a server
+    // quirk. JSON sidesteps it; we do the top-level navigation
+    // ourselves, which is what we want anyway (the next hop is the
+    // SP's redirect_uri, cross-origin).
+    const { location } = await $fetch('/api/authorize/consent', {
       method: 'POST',
       body: { csrfToken: data.value.csrfToken, action },
-      redirect: 'manual',
     })
-    // The handler responds with 302 — fetch.raw exposes the Location
-    // header so we can do the navigation client-side. (Browser-fetch
-    // would follow it transparently but blocks cross-origin reads of
-    // the resulting body, which is fine — we navigate anyway.)
-    const target = res.headers.get('location')
-    if (target) {
-      window.location.assign(target)
+    if (typeof location === 'string' && location) {
+      window.location.assign(location)
     }
     else {
       error.value = 'Server did not return a redirect target.'

--- a/modules/nuxt-auth-idp/src/runtime/server/api/authorize/consent.post.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/api/authorize/consent.post.ts
@@ -1,4 +1,4 @@
-import { defineEventHandler, readBody, sendRedirect } from 'h3'
+import { defineEventHandler, readBody } from 'h3'
 import { getAppSession } from '../../utils/session'
 import { useIdpStores } from '../../utils/stores'
 import { createProblemError } from '../../utils/problem'
@@ -52,11 +52,20 @@ export default defineEventHandler(async (event) => {
   const captured = { params: pending.params, query: pending.query }
   await session.update({ pendingConsent: undefined })
 
+  // We deliberately return the navigation target as JSON instead of
+  // a 302 sendRedirect: the consent page calls this endpoint with
+  // `fetch({ redirect: 'manual' })` so the user-visible page can do
+  // a top-level `window.location.assign`. With `redirect: 'manual'`
+  // browsers turn the response into an opaque-redirect type whose
+  // headers aren't readable, so `headers.get('Location')` always
+  // returns null — that's the Fetch spec, not a server bug. JSON
+  // body sidesteps that entirely. Cancel and approve both flow
+  // through this same shape for symmetry.
   if (action === 'cancel') {
     const url = new URL(captured.params.redirect_uri)
     url.searchParams.set('error', 'access_denied')
     if (captured.params.state) url.searchParams.set('state', captured.params.state)
-    return sendRedirect(event, url.toString())
+    return { location: url.toString() }
   }
 
   // Persist the approval so subsequent /authorize calls skip the
@@ -77,5 +86,5 @@ export default defineEventHandler(async (event) => {
   for (const [k, v] of Object.entries(captured.query)) {
     if (typeof v === 'string') resumeUrl.searchParams.set(k, v)
   }
-  return sendRedirect(event, resumeUrl.pathname + resumeUrl.search)
+  return { location: resumeUrl.pathname + resumeUrl.search }
 })

--- a/modules/nuxt-auth-idp/test/authorize-consent.test.ts
+++ b/modules/nuxt-auth-idp/test/authorize-consent.test.ts
@@ -192,24 +192,23 @@ describe('consent.post — approve/cancel/csrf', () => {
     }
   })
 
-  async function postConsent(body) {
+  async function postConsent(body): Promise<{ location?: string } | undefined> {
     const { readBody } = await import('h3')
     ;(readBody).mockResolvedValue(body)
     const { default: handler } = await import('../src/runtime/server/api/authorize/consent.post')
     return await handler({ node: { req: { url: '/api/authorize/consent' } } } as any)
   }
 
-  it('saves consent and resumes /authorize on approve with valid CSRF', async () => {
-    await postConsent({ csrfToken: 'tok-good', action: 'approve' })
+  it('saves consent and returns the resume URL in JSON on approve with valid CSRF', async () => {
+    const res = await postConsent({ csrfToken: 'tok-good', action: 'approve' })
 
     expect(consentSave).toHaveBeenCalledWith(expect.objectContaining({
       userId: 'patrick@hofmann.eco',
       clientId: 'app.example.com',
     }))
     expect(sessionUpdate).toHaveBeenCalledWith({ pendingConsent: undefined })
-    const target = mockSendRedirect.mock.calls[0][1]
-    expect(target).toMatch(/\/authorize\?/)
-    expect(target).toContain('client_id=app.example.com')
+    expect(res?.location).toMatch(/\/authorize\?/)
+    expect(res?.location).toContain('client_id=app.example.com')
   })
 
   it('rejects on missing/wrong CSRF', async () => {
@@ -219,13 +218,12 @@ describe('consent.post — approve/cancel/csrf', () => {
     expect(consentSave).not.toHaveBeenCalled()
   })
 
-  it('redirects to redirect_uri with error=access_denied on cancel', async () => {
-    await postConsent({ csrfToken: 'tok-good', action: 'cancel' })
+  it('returns access_denied redirect to redirect_uri on cancel', async () => {
+    const res = await postConsent({ csrfToken: 'tok-good', action: 'cancel' })
 
     expect(consentSave).not.toHaveBeenCalled()
-    const target = mockSendRedirect.mock.calls[0][1]
-    expect(target).toMatch(/^https:\/\/app\.example\.com\/auth\/callback\?error=access_denied/)
-    expect(target).toContain('state=xyz')
+    expect(res?.location).toMatch(/^https:\/\/app\.example\.com\/auth\/callback\?error=access_denied/)
+    expect(res?.location).toContain('state=xyz')
   })
 
   it('rejects expired consent state (older than 5 min)', async () => {


### PR DESCRIPTION
## Symptom

After registering at id.openape.ai and being routed to the consent screen via \`mode=allowlist-user\`, clicking "Anmelden" showed:

> Server did not return a redirect target.

…and the SP login never completed.

## Cause

\`consent.post.ts\` returned a \`302 sendRedirect\`. The consent page calls it with \`fetch({ redirect: 'manual' })\` so it can do a top-level \`window.location.assign\` to the next hop (which may be cross-origin to the SP). But under \`redirect: 'manual'\`, browsers materialise 3xx responses as opaque-redirect responses — \`response.headers.get('Location')\` is unreadable per the Fetch spec, not just by convention. So the page never had a target.

## Fix

Return \`{ location: '...' }\` JSON instead of a 302. Same trust boundary, same hop sequence, just survives the Fetch spec. Updated tests pin the new shape (was: \`mockSendRedirect.mock.calls\`, now: \`res.location\`).

## Test plan

- [x] Module tests pass (134/134)
- [ ] After deploy: consent approve completes the SP login round-trip end-to-end