### PR TITLE
feat(idp): friendly /denied page for human authorize-deny flow

### DIFF
--- a/.changeset/idp-deny-page.md
+++ b/.changeset/idp-deny-page.md
@@ -1,0 +1,7 @@
+---
+'@openape/nuxt-auth-idp': minor
+---
+
+Friendly deny page for the human authorize flow. Previously a `decision === 'deny'` (from `mode=deny` or an unapproved `mode=allowlist-admin` SP) silently bounced the user back to the SP with a URL-param error they wouldn't read. Now the IdP shows `/denied` with reason-specific copy ("Der Domain-Admin hat <SP> noch nicht freigegeben", "Bitte den Admin, …") and a "back to SP" button that completes the OAuth-spec redirect (RFC 6749 §4.1.2.1). Bearer flows skip the page — agents have no UI so they get the spec-direct redirect as before.
+
+New routes: `/denied` (page), `GET /api/authorize/denied`, `POST /api/authorize/denied`.

--- a/modules/nuxt-auth-idp/src/module.ts
+++ b/modules/nuxt-auth-idp/src/module.ts
@@ -209,6 +209,7 @@ export default defineNuxtModule<ModuleOptions>({
           { name: 'openape-account', path: '/account', file: resolve('./runtime/pages/account.vue') },
           { name: 'openape-admin', path: '/admin', file: resolve('./runtime/pages/admin.vue') },
           { name: 'openape-consent', path: '/consent', file: resolve('./runtime/pages/consent.vue') },
+          { name: 'openape-denied', path: '/denied', file: resolve('./runtime/pages/denied.vue') },
         ]
 
         if (grants.enablePages) {
@@ -288,6 +289,10 @@ export default defineNuxtModule<ModuleOptions>({
       // DDISA `allowlist-user` consent endpoints used by the /consent page (#301).
       addServerHandler({ route: '/api/authorize/consent', handler: resolve('./runtime/server/api/authorize/consent.get') })
       addServerHandler({ route: '/api/authorize/consent', method: 'post', handler: resolve('./runtime/server/api/authorize/consent.post') })
+
+      // Friendly deny page used by `mode=deny` and unapproved-allowlist-admin (#307).
+      addServerHandler({ route: '/api/authorize/denied', handler: resolve('./runtime/server/api/authorize/denied.get') })
+      addServerHandler({ route: '/api/authorize/denied', method: 'post', handler: resolve('./runtime/server/api/authorize/denied.post') })
     }
 
     // Server route handlers — Admin

--- a/modules/nuxt-auth-idp/src/runtime/pages/denied.vue
+++ b/modules/nuxt-auth-idp/src/runtime/pages/denied.vue
@@ -1,0 +1,180 @@
+<script setup>
+import { computed, onMounted, ref } from 'vue'
+import { useIdpAuth } from '#imports'
+
+// Friendly deny page for the human authorize flow. The OAuth spec
+// (RFC 6749 §4.1.2.1) requires the IdP to eventually redirect back
+// to the SP's redirect_uri with `error=access_denied`, but doing
+// that silently strands the user with a URL fragment they won't
+// read. We instead route them here with the reason in session,
+// show context-sensitive copy, and only complete the spec redirect
+// on the explicit "back to SP" button click. Bearer flows skip
+// this page entirely — they get the spec-direct redirect.
+
+definePageMeta({ layout: false })
+
+const { user, fetchUser } = useIdpAuth()
+const data = ref(null)
+const error = ref('')
+const submitting = ref(false)
+
+onMounted(async () => {
+  await fetchUser()
+  try {
+    data.value = await $fetch('/api/authorize/denied')
+  }
+  catch (err) {
+    error.value = err?.data?.title || err?.message || 'Konnte Deny-Status nicht laden'
+  }
+})
+
+const heading = computed(() => {
+  if (data.value?.reason === 'mode-deny') return 'Anmeldung über diesen IdP nicht möglich'
+  return 'Anmeldung nicht freigegeben'
+})
+
+const explanation = computed(() => {
+  if (!data.value) return ''
+  if (data.value.reason === 'mode-deny') {
+    return 'Der Domain-Owner hat diesen IdP für deine Email-Domain explizit gesperrt (mode=deny). Wende dich an deinen Domain-Admin.'
+  }
+  // allowlist-admin-not-approved
+  return `Der Domain-Admin hat ${data.value.clientId} noch nicht zur Liste der erlaubten Anwendungen hinzugefügt. Bitte den Admin, ${data.value.clientId} freizugeben.`
+})
+
+async function backToSp() {
+  if (!data.value || submitting.value) return
+  submitting.value = true
+  error.value = ''
+  try {
+    const { location } = await $fetch('/api/authorize/denied', { method: 'POST' })
+    if (typeof location === 'string' && location) {
+      window.location.assign(location)
+    }
+    else {
+      error.value = 'Konnte keinen Redirect-Pfad ermitteln.'
+      submitting.value = false
+    }
+  }
+  catch (err) {
+    error.value = err?.data?.title || err?.message || 'Redirect fehlgeschlagen'
+    submitting.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="denied-root">
+    <div v-if="error && !data" class="card error-card">
+      <h1>Konnte Anmeldestatus nicht laden</h1>
+      <p class="muted">
+        {{ error }}
+      </p>
+      <a href="/" class="btn btn-secondary">Zur Startseite</a>
+    </div>
+
+    <div v-else-if="data" class="card">
+      <header>
+        <span class="badge badge-warn">Zugriff verweigert</span>
+      </header>
+
+      <h1>{{ heading }}</h1>
+
+      <div class="sp-row">
+        <p class="muted">
+          Anwendung: <code>{{ data.clientId }}</code>
+        </p>
+      </div>
+
+      <p>{{ explanation }}</p>
+
+      <p v-if="user && data.reason === 'allowlist-admin-not-approved'" class="muted small">
+        Wenn du selbst Domain-Admin bist, kannst du <a href="/admin">die Allowlist hier verwalten</a>.
+      </p>
+
+      <p v-if="error" class="error">
+        {{ error }}
+      </p>
+
+      <div class="actions">
+        <button
+          class="btn btn-primary"
+          :disabled="submitting"
+          @click="backToSp"
+        >
+          Zurück zu {{ data.clientId }}
+        </button>
+        <a href="/" class="btn btn-secondary">Startseite</a>
+      </div>
+    </div>
+
+    <div v-else class="card">
+      <p class="muted">
+        Lade …
+      </p>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.denied-root {
+  min-height: 100dvh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  background: #0b0b10;
+  color: #e4e4ea;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+.card {
+  width: 100%;
+  max-width: 480px;
+  background: #15151b;
+  border: 1px solid #c97a18;
+  background: linear-gradient(180deg, rgba(201,122,24,0.08), #15151b);
+  border-radius: 12px;
+  padding: 1.75rem;
+}
+.error-card { border-color: #c83030; background: #15151b; }
+.badge {
+  display: inline-block;
+  padding: 0.25rem 0.625rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  letter-spacing: 0.02em;
+  margin-bottom: 1rem;
+}
+.badge-warn {
+  background: rgba(201,122,24,0.18);
+  color: #f0a83d;
+  border: 1px solid rgba(201,122,24,0.4);
+}
+.sp-row { display: flex; gap: 0.875rem; align-items: center; margin-bottom: 0.5rem; }
+h1 { font-size: 1.25rem; margin: 0 0 0.75rem; }
+p { line-height: 1.5; margin: 0.5rem 0; }
+.muted { color: #9b9ba8; }
+.muted a { color: #c0c0cc; }
+.small { font-size: 0.875rem; }
+code { background: #25252e; padding: 0.125rem 0.375rem; border-radius: 4px; font-size: 0.875em; }
+.error { color: #ff7070; font-size: 0.875rem; margin-top: 0.5rem; }
+.actions { display: flex; flex-direction: column-reverse; gap: 0.5rem; margin-top: 1.25rem; }
+@media (min-width: 480px) { .actions { flex-direction: row; justify-content: flex-end; } }
+.btn {
+  appearance: none;
+  border: 0;
+  border-radius: 8px;
+  padding: 0.625rem 1rem;
+  font-size: 0.9375rem;
+  cursor: pointer;
+  font-weight: 500;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.btn-primary { background: #4a86ff; color: white; }
+.btn-secondary { background: transparent; color: #c0c0cc; border: 1px solid #3a3a48; }
+.btn-secondary:hover:not(:disabled) { background: #25252e; }
+</style>

--- a/modules/nuxt-auth-idp/src/runtime/server/api/authorize/denied.get.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/api/authorize/denied.get.ts
@@ -1,0 +1,39 @@
+import { defineEventHandler } from 'h3'
+import { getAppSession } from '../../utils/session'
+import { createProblemError } from '../../utils/problem'
+
+interface PendingDeny {
+  params: {
+    client_id: string
+    redirect_uri: string
+    state: string
+    [k: string]: unknown
+  }
+  query: Record<string, string>
+  reason: string
+  createdAt: number
+}
+
+/**
+ * Render-data feed for the /denied page. Returns the SP context so
+ * the page can show the user where they tried to log in, the deny
+ * reason for copy variation, and (later) the trusted redirect URI
+ * to navigate to when the user clicks the OAuth-spec "back to SP"
+ * button. Reads exclusively from the session — never from query
+ * params — so a phishing link can't fake the SP context.
+ */
+export default defineEventHandler(async (event) => {
+  const session = await getAppSession(event)
+  const pending = (session.data as { pendingDeny?: PendingDeny }).pendingDeny
+  if (!pending) {
+    throw createProblemError({
+      status: 404,
+      title: 'No pending deny in session — start the /authorize flow again',
+    })
+  }
+
+  return {
+    clientId: pending.params.client_id,
+    reason: pending.reason,
+  }
+})

--- a/modules/nuxt-auth-idp/src/runtime/server/api/authorize/denied.post.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/api/authorize/denied.post.ts
@@ -1,0 +1,46 @@
+import { defineEventHandler } from 'h3'
+import { getAppSession } from '../../utils/session'
+import { createProblemError } from '../../utils/problem'
+
+interface PendingDeny {
+  params: {
+    client_id: string
+    redirect_uri: string
+    state: string
+    [k: string]: unknown
+  }
+  query: Record<string, string>
+  reason: string
+  createdAt: number
+}
+
+/**
+ * Complete the OAuth-spec deny redirect (RFC 6749 §4.1.2.1) — the
+ * /denied page calls this when the user clicks the "back to SP"
+ * button. Returns `{ location }` JSON so the page can do a top-
+ * level navigation (same pattern as consent.post for the same
+ * Fetch-spec-redirect-headers reason). The redirect_uri comes
+ * straight from the session (set by /authorize after we already
+ * validated it against the SP's published metadata) — never from
+ * client input.
+ */
+export default defineEventHandler(async (event) => {
+  const session = await getAppSession(event)
+  const pending = (session.data as { pendingDeny?: PendingDeny }).pendingDeny
+  if (!pending) {
+    throw createProblemError({
+      status: 400,
+      title: 'No pending deny in session',
+    })
+  }
+
+  // Single-shot — clear the state regardless. Replaying isn't a
+  // security issue here (the redirect just delivers an error to the
+  // SP) but stale state has no purpose either.
+  await session.update({ pendingDeny: undefined })
+
+  const url = new URL(pending.params.redirect_uri)
+  url.searchParams.set('error', 'access_denied')
+  if (pending.params.state) url.searchParams.set('state', pending.params.state)
+  return { location: url.toString() }
+})

--- a/modules/nuxt-auth-idp/src/runtime/server/routes/authorize.get.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/routes/authorize.get.ts
@@ -179,6 +179,32 @@ export default defineEventHandler(async (event) => {
   const decision = await evaluatePolicy(policyMode, params.client_id, userId, consentStore, { adminAllowlistStore })
 
   if (decision === 'deny') {
+    // OAuth 2.0 §4.1.2.1 says we MUST eventually redirect back with
+    // error=access_denied — we honour that on the "Back to SP"
+    // button. But silently dropping the user there with a URL param
+    // they likely won't read is bad UX, especially for the
+    // allowlist-admin case where the user has a clear next step
+    // (ask their domain admin). For human flows we stash the deny
+    // context and route to /denied where the user sees a reason-
+    // specific message + back button. Bearer flows have no UI so
+    // they fall through to the spec-direct redirect.
+    if (!bearerPayload) {
+      const session = await getAppSession(event)
+      await session.update({
+        pendingDeny: {
+          params,
+          query: query as Record<string, string>,
+          // `policyMode` distinguishes "domain owner forbids this
+          // IdP entirely" (mode=deny) from "SP not allowlisted"
+          // (mode=allowlist-admin). The page renders different copy.
+          reason: policyMode === 'deny' ? 'mode-deny' : 'allowlist-admin-not-approved',
+          createdAt: Date.now(),
+        },
+      })
+      const deniedUrl = new URL('/denied', getRequestURL(event).origin)
+      deniedUrl.searchParams.set('client_id', params.client_id)
+      return sendRedirect(event, deniedUrl.pathname + deniedUrl.search)
+    }
     const redirectUrl = new URL(params.redirect_uri)
     redirectUrl.searchParams.set('error', 'access_denied')
     redirectUrl.searchParams.set('state', params.state)

--- a/modules/nuxt-auth-idp/test/authorize-consent.test.ts
+++ b/modules/nuxt-auth-idp/test/authorize-consent.test.ts
@@ -132,11 +132,22 @@ describe('authorize.get — DDISA allowlist-user flow (#301)', () => {
     expect(target).toContain('client_id=app.example.com')
   })
 
-  it('returns access_denied when policy decision === \'deny\' (unchanged behaviour)', async () => {
+  it('routes the human flow to /denied on policy deny — friendly UX over silent SP-redirect', async () => {
+    // OAuth-spec compliance is preserved by the /denied page's
+    // "back to SP" button (covered by denied.post tests). Here we
+    // pin that we DON'T silently strand the user at the SP with a
+    // URL-param error — that's the bad UX we replaced.
     evaluatePolicyResult = 'deny'
     await callAuthorize()
+    expect(sessionUpdate).toHaveBeenCalledWith(expect.objectContaining({
+      pendingDeny: expect.objectContaining({
+        params: expect.objectContaining({ client_id: 'app.example.com' }),
+        reason: expect.any(String),
+      }),
+    }))
     const target = mockSendRedirect.mock.calls[0][1]
-    expect(target).toMatch(/^https:\/\/app\.example\.com\/auth\/callback\?error=access_denied/)
+    expect(target).toMatch(/\/denied\?/)
+    expect(target).toContain('client_id=app.example.com')
   })
 
   it('proceeds to code issuance when decision === \'allow\'', async () => {


### PR DESCRIPTION
## Why

The user reported that an unapproved \`mode=allowlist-admin\` login redirected them straight back to plans.openape.ai with \`?error=access_denied\` in the URL. Spec-correct (RFC 6749 §4.1.2.1) but the user has no clue what happened or how to proceed.

## What

Human flow on policy deny:
1. \`/authorize\` stashes \`pendingDeny\` in session, redirects to \`/denied\`
2. \`/denied\` page reads context via \`GET /api/authorize/denied\`, shows reason-specific copy:
   - \`mode-deny\` → "Anmeldung über diesen IdP nicht möglich. Domain-Owner hat den IdP gesperrt."
   - \`allowlist-admin-not-approved\` → "Der Domain-Admin hat <SP> noch nicht freigegeben. Bitte den Admin, <SP> freizugeben."
3. "Back to SP" button calls \`POST /api/authorize/denied\`, completes the OAuth-spec redirect
4. If the user IS the domain admin, page hints at \`/admin\` for self-service allowlist management

Bearer flow is unchanged — agents have no UI, they get the spec-direct redirect.

## Test plan

- [x] Unit test pinning new routing (\`pendingDeny\` stashed, \`/denied?\` redirect)
- [x] 134 module tests pass
- [x] free-idp build green
- [ ] After deploy: re-attempt the failing login from earlier — user should land on /denied with the reason copy and "Back to plans.openape.ai" button instead of being stranded at the SP

## Files

| Path | Purpose |
|---|---|
| \`runtime/server/routes/authorize.get.ts\` | stash + redirect to /denied for human deny |
| \`runtime/server/api/authorize/denied.{get,post}.ts\` | read state + complete OAuth redirect |
| \`runtime/pages/denied.vue\` | reason-specific UI |
| \`module.ts\` | register page + handlers |
| test updates | pin new routing |