### PR TITLE
feat(nuxt-auth-sp): useOpenApeOAuthError + alert component

### DIFF
--- a/.changeset/sp-oauth-error-helpers.md
+++ b/.changeset/sp-oauth-error-helpers.md
@@ -1,0 +1,7 @@
+---
+'@openape/nuxt-auth-sp': minor
+---
+
+Add `useOpenApeOAuthError()` composable + `<OpenApeOAuthErrorAlert />` component for surfacing IdP-side authorize-deny errors (RFC 6749 §4.1.2.1) on the SP's landing page. Without this, an SP redirected back with `?error=access_denied` left the user on the regular login form with no clue what happened. Drop the component on a login page and the user sees a friendly title + reason copy instead.
+
+The composable exposes `{ error, dismiss }`; the component wraps it in a UAlert with sensible defaults. SPs can override the per-code copy via the `messages` prop / option for product-specific guidance.

--- a/modules/nuxt-auth-sp/src/runtime/components/OpenApeOAuthErrorAlert.vue
+++ b/modules/nuxt-auth-sp/src/runtime/components/OpenApeOAuthErrorAlert.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+// Default-styled UAlert that surfaces OAuth-error redirects from
+// the IdP per RFC 6749 §4.1.2.1. Drop this on your login landing
+// page and the user gets a friendly message instead of mysterious
+// URL params. Uses the `useOpenApeOAuthError` composable under the
+// hood — for custom styling pull that directly and skip this
+// component.
+
+import { useOpenApeOAuthError } from '../composables/useOpenApeOAuthError'
+
+const props = defineProps<{
+  /** Override the default friendly copy per error code. Merged on top of the module's defaults. */
+  messages?: Record<string, string>
+  /** Override the alert title. Default: "Login nicht möglich". */
+  title?: string
+  /** Tailwind/UAlert color, default 'warning'. */
+  color?: 'warning' | 'error' | 'info' | 'neutral'
+  /** UAlert variant, default 'subtle'. */
+  variant?: 'subtle' | 'soft' | 'solid' | 'outline'
+}>()
+
+const { error, dismiss } = useOpenApeOAuthError({ messages: props.messages })
+</script>
+
+<template>
+  <UAlert
+    v-if="error"
+    :color="color ?? 'warning'"
+    :variant="variant ?? 'subtle'"
+    icon="i-lucide-shield-alert"
+    :title="title ?? 'Login nicht möglich'"
+    :description="error.message"
+    :close-button="{ icon: 'i-lucide-x' }"
+    @close="dismiss"
+  />
+</template>

--- a/modules/nuxt-auth-sp/src/runtime/composables/useOpenApeOAuthError.ts
+++ b/modules/nuxt-auth-sp/src/runtime/composables/useOpenApeOAuthError.ts
@@ -1,0 +1,101 @@
+import { computed } from 'vue'
+import type { ComputedRef } from 'vue'
+import { useRoute, useRouter } from '#imports'
+
+/**
+ * Default user-facing copy for the RFC 6749 §4.1.2.1 OAuth error
+ * codes. SPs can override by passing `messages` to `useOpenApeOAuthError`,
+ * partial overrides are merged with these defaults.
+ */
+export const DEFAULT_OAUTH_ERROR_MESSAGES: Record<string, string> = {
+  access_denied:
+    'Die Anmeldung wurde vom Identity Provider abgelehnt. Wahrscheinlich hat dein Domain-Admin diese Anwendung noch nicht freigegeben — frag deinen Admin oder versuche eine andere Email-Adresse.',
+  consent_required:
+    'Diese Anmeldung benötigt eine explizite Zustimmung. Bitte versuche es erneut und stimme im Login-Fenster zu.',
+  login_required:
+    'Anmeldung erforderlich. Bitte erneut versuchen.',
+  invalid_request:
+    'Anmeldung fehlgeschlagen (invalid_request). Bitte erneut versuchen oder Support kontaktieren.',
+  invalid_scope:
+    'Anmeldung fehlgeschlagen (invalid_scope). Bitte erneut versuchen oder Support kontaktieren.',
+  unauthorized_client:
+    'Anmeldung fehlgeschlagen (unauthorized_client). Bitte erneut versuchen oder Support kontaktieren.',
+  unsupported_response_type:
+    'Anmeldung fehlgeschlagen (unsupported_response_type). Bitte erneut versuchen oder Support kontaktieren.',
+  server_error:
+    'Der Identity Provider hat gerade einen Fehler. Bitte in ein paar Minuten erneut versuchen.',
+  temporarily_unavailable:
+    'Der Identity Provider ist gerade nicht verfügbar. Bitte in ein paar Minuten erneut versuchen.',
+}
+
+const FALLBACK_MESSAGE = (code: string) => `Anmeldung fehlgeschlagen: ${code}.`
+
+export interface OAuthError {
+  /** RFC 6749 error code, e.g. 'access_denied'. */
+  code: string
+  /** RFC 6749 error_description if the IdP supplied one. */
+  description: string
+  /** Friendly copy mapped from `code`, or the SP's override. */
+  message: string
+}
+
+export interface UseOAuthErrorOptions {
+  /**
+   * Per-SP overrides for the friendly copy. Merged on top of
+   * `DEFAULT_OAUTH_ERROR_MESSAGES`. Useful when an SP wants to add
+   * its own product-specific guidance ("contact Plans-Support") or
+   * translate to a different locale.
+   */
+  messages?: Record<string, string>
+}
+
+/**
+ * Surface RFC 6749 §4.1.2.1 OAuth-error redirects on the SP's
+ * landing page. The IdP redirects here with `?error=<code>` (and
+ * optionally `error_description`, `state`) when an authorize
+ * request is rejected. Without dedicated handling the user just
+ * sees the regular login form with mysterious URL params.
+ *
+ * Returns:
+ *   - reactive `error` (null when no error in URL)
+ *   - `dismiss()` to strip the OAuth params from the URL so a
+ *     refresh doesn't re-render the alert
+ *
+ * Pair with `<OpenApeOAuthErrorAlert />` for a default-styled
+ * UAlert, or render the message yourself for custom UI.
+ */
+export function useOpenApeOAuthError(opts: UseOAuthErrorOptions = {}): {
+  error: ComputedRef<OAuthError | null>
+  dismiss: () => void
+} {
+  const route = useRoute()
+  const router = useRouter()
+
+  const messageMap = { ...DEFAULT_OAUTH_ERROR_MESSAGES, ...(opts.messages ?? {}) }
+
+  const error = computed<OAuthError | null>(() => {
+    const code = route.query.error
+    if (typeof code !== 'string' || !code) return null
+    const description = typeof route.query.error_description === 'string'
+      ? route.query.error_description
+      : ''
+    return {
+      code,
+      description,
+      message: messageMap[code] ?? FALLBACK_MESSAGE(code),
+    }
+  })
+
+  function dismiss() {
+    // Strip OAuth-callback params so a refresh doesn't re-show the
+    // alert. Keep the rest of the query intact so deep-links and
+    // unrelated params survive.
+    const next = { ...route.query }
+    delete next.error
+    delete next.error_description
+    delete next.state
+    router.replace({ path: route.path, query: next })
+  }
+
+  return { error, dismiss }
+}

--- a/modules/nuxt-auth-sp/test/oauth-error.test.ts
+++ b/modules/nuxt-auth-sp/test/oauth-error.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+// `useOpenApeOAuthError` consumes Nuxt's `useRoute` + `useRouter`
+// from `#imports`. We mock those so we can drive the route.query
+// directly and assert behaviour without booting Nuxt.
+
+const routeQuery = ref<Record<string, unknown>>({})
+const routePath = ref('/')
+const replaceCalls: Array<{ path: string, query: Record<string, unknown> }> = []
+
+vi.mock('#imports', () => ({
+  useRoute: () => ({ get query() { return routeQuery.value }, get path() { return routePath.value } }),
+  useRouter: () => ({
+    replace: (target: { path: string, query: Record<string, unknown> }) => {
+      replaceCalls.push(target)
+      routeQuery.value = target.query
+    },
+  }),
+}))
+
+const { useOpenApeOAuthError, DEFAULT_OAUTH_ERROR_MESSAGES } = await import('../src/runtime/composables/useOpenApeOAuthError')
+
+describe('useOpenApeOAuthError', () => {
+  it('returns null when there is no `error` in the query', () => {
+    routeQuery.value = {}
+    const { error } = useOpenApeOAuthError()
+    expect(error.value).toBeNull()
+  })
+
+  it('maps known error codes to default friendly copy', () => {
+    routeQuery.value = { error: 'access_denied', state: 'xyz' }
+    const { error } = useOpenApeOAuthError()
+    expect(error.value).toMatchObject({
+      code: 'access_denied',
+      message: DEFAULT_OAUTH_ERROR_MESSAGES.access_denied,
+    })
+  })
+
+  it('falls back to a generic message for unknown error codes', () => {
+    routeQuery.value = { error: 'something_weird' }
+    const { error } = useOpenApeOAuthError()
+    expect(error.value?.message).toContain('something_weird')
+  })
+
+  it('honours per-call message overrides on top of defaults', () => {
+    routeQuery.value = { error: 'access_denied' }
+    const { error } = useOpenApeOAuthError({
+      messages: { access_denied: 'Custom Plans copy.' },
+    })
+    expect(error.value?.message).toBe('Custom Plans copy.')
+  })
+
+  it('exposes RFC 6749 error_description when supplied', () => {
+    routeQuery.value = { error: 'access_denied', error_description: 'SP not on allowlist' }
+    const { error } = useOpenApeOAuthError()
+    expect(error.value?.description).toBe('SP not on allowlist')
+  })
+
+  it('dismiss() strips OAuth params from the URL but keeps unrelated ones', () => {
+    routeQuery.value = {
+      error: 'access_denied',
+      error_description: 'foo',
+      state: 'xyz',
+      // Unrelated query the SP put there for its own routing.
+      tab: 'features',
+    }
+    routePath.value = '/'
+    replaceCalls.length = 0
+
+    const { dismiss, error } = useOpenApeOAuthError()
+    expect(error.value).not.toBeNull()
+    dismiss()
+
+    expect(replaceCalls).toHaveLength(1)
+    expect(replaceCalls[0]).toEqual({ path: '/', query: { tab: 'features' } })
+    // After dismiss the computed re-evaluates and reports null.
+    expect(error.value).toBeNull()
+  })
+})


### PR DESCRIPTION
## Why

We just shipped a friendly OAuth-error banner on plans.openape.ai (#7 over there). The same pattern should live in the SP module so chat / tasks / preview / sp-starter and future SPs get it for free.

## What

- New composable \`useOpenApeOAuthError({ messages? })\` returning \`{ error, dismiss }\`. \`error\` is reactively derived from \`route.query.error\`; null when absent. \`dismiss()\` strips \`error\`, \`error_description\`, \`state\` from the URL while keeping unrelated query params.
- New component \`<OpenApeOAuthErrorAlert />\` that wraps the composable with a \`UAlert\` (warning, subtle, shield-alert icon) — drop-in replacement for the bespoke alert each SP would otherwise build.
- Default per-code copy lives in \`DEFAULT_OAUTH_ERROR_MESSAGES\`, exported so SPs can selectively override.

## Test plan

- [x] 6 vitest unit tests for the composable
- [x] Module lint + typecheck + build green
- [ ] After publish: migrate plans / chat / tasks / preview / sp-starter to use the helper

## Migration shape (for downstream SPs)

\`\`\`vue
<!-- before: 50+ lines of bespoke error mapping -->

<!-- after: -->
<OpenApeOAuthErrorAlert :messages="{ access_denied: '...optional product-specific copy...' }" />
\`\`\`