### PR TITLE
fix(nuxt-auth-sp): OpenApeAuth form uses friendly OAuth-error copy

### DIFF
--- a/.changeset/openape-auth-friendly-error.md
+++ b/.changeset/openape-auth-friendly-error.md
@@ -1,0 +1,5 @@
+---
+'@openape/nuxt-auth-sp': patch
+---
+
+`<OpenApeAuth />` form now maps OAuth-error redirect codes to friendly copy via the same default map as `<OpenApeOAuthErrorAlert />` / `useOpenApeOAuthError()`. SPs that mount the form on their landing page (chat, sp-starter) automatically get the friendly message instead of the raw error code. SPs that want a richer banner (UAlert with dismiss-X, product-specific guidance) should drop `<OpenApeOAuthErrorAlert />` directly on the page.

--- a/modules/nuxt-auth-sp/src/runtime/components/OpenApeAuth.vue
+++ b/modules/nuxt-auth-sp/src/runtime/components/OpenApeAuth.vue
@@ -1,4 +1,6 @@
 <script setup>
+import { DEFAULT_OAUTH_ERROR_MESSAGES } from '../composables/useOpenApeOAuthError'
+
 defineProps({
   title: { type: String, required: false, default: 'Sign in' },
   subtitle: { type: String, required: false, default: 'Enter your email to continue' },
@@ -16,8 +18,14 @@ onMounted(async () => {
   if (user.value) {
     navigateTo('/dashboard')
   }
-  if (route.query.error) {
-    error.value = String(route.query.error)
+  // Surface IdP authorize-deny redirects (RFC 6749 §4.1.2.1) with
+  // friendly per-code copy. SPs that want richer UX (UAlert with
+  // dismiss-X, product-specific guidance) should drop
+  // <OpenApeOAuthErrorAlert /> on the page and skip this form's
+  // built-in error display.
+  if (typeof route.query.error === 'string' && route.query.error) {
+    const code = route.query.error
+    error.value = DEFAULT_OAUTH_ERROR_MESSAGES[code] ?? `Login failed: ${code}.`
   }
 })
 async function handleSubmit() {


### PR DESCRIPTION
Drive-by fix on top of #316: \`<OpenApeAuth />\` was setting \`error.value\` to the raw RFC code (\`access_denied\` etc). Use the same \`DEFAULT_OAUTH_ERROR_MESSAGES\` map we just added so the form mirrors the friendly copy from \`<OpenApeOAuthErrorAlert />\`. Drop-in for any SP using \`<OpenApeAuth />\` (chat, sp-starter today).