### PR TITLE
chore(ci): rename deploy-chatty* files + add deploy-chat workflow

### DIFF
--- a/.github/workflows/deploy-chat.yml
+++ b/.github/workflows/deploy-chat.yml
@@ -1,21 +1,25 @@
-name: Deploy proxy.openape.ai
+name: Deploy chat.openape.ai
+
+# Auto-deploys apps/openape-chat to the SSH host on main push.
+# Uses scripts/deploy-chat.sh for build + rsync + restart + health check.
+# Independent of ci.yml — no test gate. Public HTTPS health check +
+# auto-rollback cover failing deploys.
 
 on:
   push:
     branches: [main]
     paths:
-      - 'apps/openape-agent-proxy/**'
+      - 'apps/openape-chat/**'
       - 'modules/nuxt-auth-sp/**'
       - 'packages/auth/**'
       - 'packages/core/**'
-      - 'packages/grants/**'
-      - 'scripts/deploy-chatty-proxy.sh'
+      - 'scripts/deploy-chat.sh'
       - 'pnpm-lock.yaml'
-      - '.github/workflows/deploy-chatty-proxy.yml'
+      - '.github/workflows/deploy-chat.yml'
   workflow_dispatch:
 
 concurrency:
-  group: deploy-chatty-proxy
+  group: deploy-chat
   cancel-in-progress: false
 
 jobs:
@@ -27,12 +31,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+
       - uses: pnpm/action-setup@v4
+
       - uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: pnpm
-      - run: pnpm install --frozen-lockfile
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Setup SSH
         env:
@@ -44,7 +52,7 @@ jobs:
           printf '%s\n' "$SSH_KEY" > ~/.ssh/chatty
           chmod 600 ~/.ssh/chatty
           printf '%s\n' "$KNOWN_HOSTS" > ~/.ssh/known_hosts
-          cat > ~/.ssh/config <<'EOF'
+          cat > ~/.ssh/config <<'CFGEOF'
           Host chatty
             HostName chatty.delta-mind.at
             User openape
@@ -52,29 +60,32 @@ jobs:
             IdentitiesOnly yes
             StrictHostKeyChecking yes
             UserKnownHostsFile ~/.ssh/known_hosts
-          EOF
+          CFGEOF
           chmod 600 ~/.ssh/config
 
       - name: Capture previous release (for rollback)
         id: prev
         run: |
-          PREV=$(ssh chatty "readlink /home/openape/projects/openape-agent-proxy/current 2>/dev/null" || echo "")
+          PREV=$(ssh chatty "readlink /home/openape/projects/openape-chat/current 2>/dev/null" || echo "")
           echo "release=$PREV" >> "$GITHUB_OUTPUT"
+          echo "Previous release: ${PREV:-<none>}"
 
       - name: Deploy
-        run: ./scripts/deploy-chatty-proxy.sh
+        run: ./scripts/deploy-chat.sh
 
       - name: Public HTTPS health check
         run: |
           set -euo pipefail
           for i in 1 2 3 4 5; do
-            status=$(curl -s -o /dev/null -w '%{http_code}' https://proxy.openape.ai/ || echo 000)
-            case $status in 200|301|302|401|403)
-              echo "https://proxy.openape.ai/ returned $status"
-              exit 0 ;;
-            esac
+            STATUS=$(curl -fsS -o /dev/null -w '%{http_code}' https://chat.openape.ai/ 2>/dev/null || echo 0)
+            if [ "$STATUS" = "200" ] || [ "$STATUS" = "302" ]; then
+              echo "✓ https://chat.openape.ai responds (HTTP $STATUS)"
+              exit 0
+            fi
+            echo "attempt $i: got HTTP $STATUS, retrying..."
             sleep 3
           done
+          echo "✗ public health check failed after 5 attempts"
           exit 1
 
       - name: Rollback on failure
@@ -83,8 +94,11 @@ jobs:
           PREV_RELEASE: ${{ steps.prev.outputs.release }}
         run: |
           set -euo pipefail
-          if [[ ! "$PREV_RELEASE" =~ ^/home/openape/projects/openape-agent-proxy/releases/[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}-[0-9]{2}-[0-9]{2}$ ]]; then
+          # Validate timestamp shape (YYYY-MM-DDTHH-MM-SS) before using in remote shell
+          if [[ ! "$PREV_RELEASE" =~ ^/home/openape/projects/openape-chat/releases/[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}-[0-9]{2}-[0-9]{2}$ ]]; then
             echo "refusing to roll back to unexpected path: $PREV_RELEASE"
             exit 1
           fi
-          ssh chatty "ln -sfn $PREV_RELEASE /home/openape/projects/openape-agent-proxy/current && sudo systemctl restart openape-agent-proxy.service"
+          echo "↩ Rolling back to $PREV_RELEASE"
+          ssh chatty "ln -sfn $PREV_RELEASE /home/openape/projects/openape-chat/current && sudo systemctl restart openape-chat.service"
+          echo "✓ rollback complete"

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -5,13 +5,13 @@ on:
     branches: [main]
     paths:
       - 'apps/docs/**'
-      - 'scripts/deploy-chatty-docs.sh'
+      - 'scripts/deploy-docs.sh'
       - 'pnpm-lock.yaml'
-      - '.github/workflows/deploy-chatty-docs.yml'
+      - '.github/workflows/deploy-docs.yml'
   workflow_dispatch:
 
 concurrency:
-  group: deploy-chatty-docs
+  group: deploy-docs
   cancel-in-progress: false
 
 jobs:
@@ -63,7 +63,7 @@ jobs:
           echo "Previous release: ${PREV:-<none>}"
 
       - name: Deploy
-        run: ./scripts/deploy-chatty-docs.sh
+        run: ./scripts/deploy-docs.sh
 
       - name: Public HTTPS health check
         run: |

--- a/.github/workflows/deploy-free-idp.yml
+++ b/.github/workflows/deploy-free-idp.yml
@@ -1,0 +1,105 @@
+name: Deploy id.openape.ai
+
+# Auto-deploys apps/openape-free-idp to chatty.delta-mind.at on main push.
+# Uses scripts/deploy-free-idp.sh for build + rsync + restart + health check.
+# Independent of ci.yml — no test gate. Public HTTPS health check + auto-rollback
+# cover failing deploys. See plan: .claude/plans/openape-policy-shift/ci-deploy.md
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/openape-free-idp/**'
+      - 'modules/nuxt-auth-idp/**'
+      - 'packages/auth/**'
+      - 'packages/core/**'
+      - 'packages/grants/**'
+      - 'scripts/deploy-free-idp.sh'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/deploy-free-idp.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-free-idp
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      CHATTY_HOST: chatty
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Setup SSH
+        env:
+          SSH_KEY: ${{ secrets.CHATTY_SSH_KEY }}
+          KNOWN_HOSTS: ${{ secrets.CHATTY_KNOWN_HOSTS }}
+        run: |
+          mkdir -p ~/.ssh
+          umask 077
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/chatty
+          chmod 600 ~/.ssh/chatty
+          printf '%s\n' "$KNOWN_HOSTS" > ~/.ssh/known_hosts
+          cat > ~/.ssh/config <<'EOF'
+          Host chatty
+            HostName chatty.delta-mind.at
+            User openape
+            IdentityFile ~/.ssh/chatty
+            IdentitiesOnly yes
+            StrictHostKeyChecking yes
+            UserKnownHostsFile ~/.ssh/known_hosts
+          EOF
+          chmod 600 ~/.ssh/config
+
+      - name: Capture previous release (for rollback)
+        id: prev
+        run: |
+          PREV=$(ssh chatty "readlink /home/openape/projects/openape-free-idp/current 2>/dev/null" || echo "")
+          echo "release=$PREV" >> "$GITHUB_OUTPUT"
+          echo "Previous release: ${PREV:-<none>}"
+
+      - name: Deploy
+        run: ./scripts/deploy-free-idp.sh
+
+      - name: Public HTTPS health check
+        run: |
+          set -euo pipefail
+          for i in 1 2 3 4 5; do
+            N=$(curl -fsS https://id.openape.ai/api/shapes 2>/dev/null | jq 'length' || echo 0)
+            if [ "$N" -ge 50 ]; then
+              echo "✓ https://id.openape.ai serves $N shapes"
+              exit 0
+            fi
+            echo "attempt $i: got $N shapes, retrying..."
+            sleep 3
+          done
+          echo "✗ public health check failed after 5 attempts"
+          exit 1
+
+      - name: Rollback on failure
+        if: failure() && steps.prev.outputs.release != ''
+        env:
+          PREV_RELEASE: ${{ steps.prev.outputs.release }}
+        run: |
+          set -euo pipefail
+          # Validate timestamp shape (YYYY-MM-DDTHH-MM-SS) before using in remote shell
+          if [[ ! "$PREV_RELEASE" =~ ^/home/openape/projects/openape-free-idp/releases/[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}-[0-9]{2}-[0-9]{2}$ ]]; then
+            echo "refusing to roll back to unexpected path: $PREV_RELEASE"
+            exit 1
+          fi
+          echo "↩ Rolling back to $PREV_RELEASE"
+          ssh chatty "ln -sfn $PREV_RELEASE /home/openape/projects/openape-free-idp/current && sudo systemctl restart openape-free-idp.service"
+          echo "✓ rollback complete"

--- a/.github/workflows/deploy-proxy.yml
+++ b/.github/workflows/deploy-proxy.yml
@@ -1,26 +1,21 @@
-name: Deploy id.openape.ai
-
-# Auto-deploys apps/openape-free-idp to chatty.delta-mind.at on main push.
-# Uses scripts/deploy-chatty.sh for build + rsync + restart + health check.
-# Independent of ci.yml — no test gate. Public HTTPS health check + auto-rollback
-# cover failing deploys. See plan: .claude/plans/openape-policy-shift/ci-deploy-chatty.md
+name: Deploy proxy.openape.ai
 
 on:
   push:
     branches: [main]
     paths:
-      - 'apps/openape-free-idp/**'
-      - 'modules/nuxt-auth-idp/**'
+      - 'apps/openape-agent-proxy/**'
+      - 'modules/nuxt-auth-sp/**'
       - 'packages/auth/**'
       - 'packages/core/**'
       - 'packages/grants/**'
-      - 'scripts/deploy-chatty.sh'
+      - 'scripts/deploy-proxy.sh'
       - 'pnpm-lock.yaml'
-      - '.github/workflows/deploy-chatty.yml'
+      - '.github/workflows/deploy-proxy.yml'
   workflow_dispatch:
 
 concurrency:
-  group: deploy-chatty
+  group: deploy-proxy
   cancel-in-progress: false
 
 jobs:
@@ -32,16 +27,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
-
       - uses: pnpm/action-setup@v4
-
       - uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - run: pnpm install --frozen-lockfile
 
       - name: Setup SSH
         env:
@@ -67,26 +58,23 @@ jobs:
       - name: Capture previous release (for rollback)
         id: prev
         run: |
-          PREV=$(ssh chatty "readlink /home/openape/projects/openape-free-idp/current 2>/dev/null" || echo "")
+          PREV=$(ssh chatty "readlink /home/openape/projects/openape-agent-proxy/current 2>/dev/null" || echo "")
           echo "release=$PREV" >> "$GITHUB_OUTPUT"
-          echo "Previous release: ${PREV:-<none>}"
 
       - name: Deploy
-        run: ./scripts/deploy-chatty.sh
+        run: ./scripts/deploy-proxy.sh
 
       - name: Public HTTPS health check
         run: |
           set -euo pipefail
           for i in 1 2 3 4 5; do
-            N=$(curl -fsS https://id.openape.ai/api/shapes 2>/dev/null | jq 'length' || echo 0)
-            if [ "$N" -ge 50 ]; then
-              echo "✓ https://id.openape.ai serves $N shapes"
-              exit 0
-            fi
-            echo "attempt $i: got $N shapes, retrying..."
+            status=$(curl -s -o /dev/null -w '%{http_code}' https://proxy.openape.ai/ || echo 000)
+            case $status in 200|301|302|401|403)
+              echo "https://proxy.openape.ai/ returned $status"
+              exit 0 ;;
+            esac
             sleep 3
           done
-          echo "✗ public health check failed after 5 attempts"
           exit 1
 
       - name: Rollback on failure
@@ -95,11 +83,8 @@ jobs:
           PREV_RELEASE: ${{ steps.prev.outputs.release }}
         run: |
           set -euo pipefail
-          # Validate timestamp shape (YYYY-MM-DDTHH-MM-SS) before using in remote shell
-          if [[ ! "$PREV_RELEASE" =~ ^/home/openape/projects/openape-free-idp/releases/[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}-[0-9]{2}-[0-9]{2}$ ]]; then
+          if [[ ! "$PREV_RELEASE" =~ ^/home/openape/projects/openape-agent-proxy/releases/[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}-[0-9]{2}-[0-9]{2}$ ]]; then
             echo "refusing to roll back to unexpected path: $PREV_RELEASE"
             exit 1
           fi
-          echo "↩ Rolling back to $PREV_RELEASE"
-          ssh chatty "ln -sfn $PREV_RELEASE /home/openape/projects/openape-free-idp/current && sudo systemctl restart openape-free-idp.service"
-          echo "✓ rollback complete"
+          ssh chatty "ln -sfn $PREV_RELEASE /home/openape/projects/openape-agent-proxy/current && sudo systemctl restart openape-agent-proxy.service"

--- a/apps/docs/content/2.ecosystem/7.multi-tenant-idp.md
+++ b/apps/docs/content/2.ecosystem/7.multi-tenant-idp.md
@@ -7,7 +7,7 @@ description: Serve multiple OpenApe IdP domains from a single Nuxt process.
 
 `@openape/nuxt-auth-idp` can host more than one identity origin from a single deployment. A request to `id.acme.com` and a request to `id.acme.at` hit the same Nitro process, share the same database, and see the same users — but WebAuthn passkeys, OAuth issuers, and origin checks are scoped per request according to the incoming `Host` header.
 
-This is the pattern `id.openape.ai` and `id.openape.at` use today (one chatty instance, both hostnames). It also lets you bring up a new tenant with an nginx vhost and a DNS record, no redeploy.
+This is the pattern `id.openape.ai` and `id.openape.at` use today (one instance, both hostnames). It also lets you bring up a new tenant with an nginx vhost and a DNS record, no redeploy.
 
 ## Why
 

--- a/apps/openape-chat/DEPLOY.md
+++ b/apps/openape-chat/DEPLOY.md
@@ -1,12 +1,12 @@
-# Deploying chat.openape.ai to chatty
+# Deploying chat.openape.ai
 
-> One-time bootstrap + recurring deploy via `scripts/deploy-chatty-chat.sh`. Mirrors the layout of the other `chatty.delta-mind.at`-hosted services (see `scripts/deploy-chatty.sh` for `id.openape.ai`, `scripts/deploy-chatty-proxy.sh` for `proxy.openape.ai`).
+> One-time bootstrap + recurring deploy via `scripts/deploy-chat.sh`. Mirrors the layout of the other hosted services (see `scripts/deploy-free-idp.sh` for `id.openape.ai`, `scripts/deploy-proxy.sh` for `proxy.openape.ai`).
 
 ---
 
-## One-time bootstrap on chatty
+## One-time bootstrap
 
-These steps only run once per host. After this, `./scripts/deploy-chatty-chat.sh` from the monorepo root handles every subsequent deploy.
+These steps only run once per host. After this, `./scripts/deploy-chat.sh` from the monorepo root handles every subsequent deploy.
 
 ### 1. Release directory + persistent shared state
 
@@ -149,7 +149,7 @@ sudo nginx -t && sudo systemctl reload nginx
 
 ### 6. DNS
 
-A/AAAA record for `chat.openape.ai` → chatty's IP. The nginx vhost handles the rest. Coordinate with whoever owns the openape.ai zone.
+A/AAAA record for `chat.openape.ai` → the host's IP. The nginx vhost handles the rest. Coordinate with whoever owns the openape.ai zone.
 
 ---
 
@@ -158,7 +158,7 @@ A/AAAA record for `chat.openape.ai` → chatty's IP. The nginx vhost handles the
 Once the bootstrap is done, every release is just:
 
 ```sh
-./scripts/deploy-chatty-chat.sh
+./scripts/deploy-chat.sh
 ```
 
 That script:
@@ -216,4 +216,4 @@ sudo journalctl -u openape-chat -f
 curl -i http://127.0.0.1:3007/api/me   # 401 expected when no session
 ```
 
-Database lives at `shared/openape-chat.db` (SQLite). Back it up alongside the other chatty SQLite files (`/home/openape/projects/*/shared/*.db`).
+Database lives at `shared/openape-chat.db` (SQLite). Back it up alongside the other SQLite files (`/home/openape/projects/*/shared/*.db`).

--- a/scripts/deploy-chat.sh
+++ b/scripts/deploy-chat.sh
@@ -1,29 +1,29 @@
 #!/usr/bin/env bash
 #
-# Deploy apps/openape-chat to chatty.delta-mind.at (chat.openape.ai).
+# Deploy apps/openape-chat to the deploy host.delta-mind.at (chat.openape.ai).
 #
-# Usage: ./scripts/deploy-chatty-chat.sh
+# Usage: ./scripts/deploy-chat.sh
 #
 # Requires:
-#   - SSH access to chatty.delta-mind.at as the service user (default: openape).
+#   - SSH access to the deploy host.delta-mind.at as the service user (default: openape).
 #     Configure via ~/.ssh/config "Host chatty" with "User openape", or override
 #     via CHATTY_HOST.
-#   - Passwordless sudo on chatty for `systemctl restart openape-chat.service`
+#   - Passwordless sudo on the host for `systemctl restart openape-chat.service`
 #     (drop a /etc/sudoers.d/openape-chat fragment scoped to user openape).
 #   - Local node/pnpm, run from the monorepo root.
-#   - Pre-existing systemd unit + nginx vhost on chatty (one-time bootstrap;
+#   - Pre-existing systemd unit + nginx vhost on the host (one-time bootstrap;
 #     see apps/openape-chat/DEPLOY.md).
 #   - VAPID keypair persisted in ${BASE}/shared/.env
 #     (use scripts/generate-chat-vapid.sh once before the first deploy).
 #
-# Release layout on chatty (mirrors the other deploy scripts):
+# Release layout on the host (mirrors the other deploy scripts):
 #   /home/openape/projects/openape-chat/
 #     ├─ releases/<TS>/        timestamped, kept for rollback (last 3)
 #     ├─ current -> releases/<TS>/
 #     └─ shared/.env           chmod 600, persistent across deploys
 #
 # Native-binding pin: @libsql/linux-x64-gnu must match the libsql wrapper
-# version we ship — same constraint as deploy-chatty.sh, same pin (0.4.7).
+# version we ship — same constraint as deploy-free-idp.sh, same pin (0.4.7).
 
 set -euo pipefail
 

--- a/scripts/deploy-docs.sh
+++ b/scripts/deploy-docs.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 #
-# Deploy apps/docs (static HTML from Nuxt prerender) to chatty.
-# Mirror of scripts/deploy-chatty.sh minus the systemd restart + libsql pin —
+# Deploy apps/docs (static HTML from Nuxt prerender) to the deploy host.
+# Mirror of scripts/deploy-free-idp.sh minus the systemd restart + libsql pin —
 # docs has no runtime server, so nginx serves .output/public/ directly.
 #
-# Usage: ./scripts/deploy-chatty-docs.sh
+# Usage: ./scripts/deploy-docs.sh
 # Env:
 #   CHATTY_HOST  SSH target (default: openape@chatty.delta-mind.at). GitHub
-#                Actions sets this to the alias "chatty" with the User openape
+#                Actions sets this to the SSH alias with the User openape
 #                already wired up in ~/.ssh/config; locally we target the
 #                openape user explicitly so it works without a host alias.
-#   CHATTY_BASE  Target dir on chatty (default: /home/openape/projects/docs)
+#   CHATTY_BASE  Target dir on the host (default: /home/openape/projects/docs)
 
 set -euo pipefail
 

--- a/scripts/deploy-free-idp.sh
+++ b/scripts/deploy-free-idp.sh
@@ -2,25 +2,25 @@
 #
 # Deploy apps/openape-free-idp to chatty.delta-mind.at (id.openape.ai).
 #
-# Usage: ./scripts/deploy-chatty.sh
+# Usage: ./scripts/deploy-free-idp.sh
 #
 # Requires:
 #   - SSH access to chatty.delta-mind.at as the service user (default: openape).
 #     Configure via ~/.ssh/config "Host chatty" with "User openape", or override
-#     via CHATTY_HOST. The GitHub Actions deploy-chatty workflow sets that up
+#     via CHATTY_HOST. The GitHub Actions deploy-free-idp workflow sets that up
 #     from repo secrets.
-#   - Passwordless sudo on chatty for `systemctl restart openape-free-idp.service`
+#   - Passwordless sudo on the host for `systemctl restart openape-free-idp.service`
 #     (installed in /etc/sudoers.d/openape-free-idp, scoped to user openape).
 #   - Local node/pnpm, run from the monorepo root.
 #
-# Release layout on chatty:
+# Release layout on the host:
 #   /home/openape/projects/openape-free-idp/
 #     ├─ releases/<TS>/        timestamped, kept for rollback (last 3)
 #     ├─ current -> releases/<TS>/
 #     └─ shared/.env           chmod 600, persistent across deploys
 #
 # Native-binding pin: @libsql/linux-x64-gnu must match libsql wrapper version.
-# See the chatty deploy plan for the 0.4.7 pin rationale.
+# See the deploy plan for the 0.4.7 pin rationale.
 
 set -euo pipefail
 

--- a/scripts/deploy-mail.sh
+++ b/scripts/deploy-mail.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
-# Deploy apps/openape-agent-mail to chatty (mail.openape.ai).
-# Shape mirrors scripts/deploy-chatty.sh (id). Includes libsql native pin
+# Deploy apps/openape-agent-mail to mail.openape.ai.
+# Shape mirrors scripts/deploy-free-idp.sh (id). Includes libsql native pin
 # because mail uses @libsql/client for its drizzle DB.
 
 set -euo pipefail

--- a/scripts/deploy-proxy.sh
+++ b/scripts/deploy-proxy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Deploy apps/openape-agent-proxy to chatty (proxy.openape.ai).
+# Deploy apps/openape-agent-proxy to proxy.openape.ai.
 # No DB → no libsql native pin, otherwise identical to the mail deploy.
 
 set -euo pipefail

--- a/scripts/generate-chat-vapid.sh
+++ b/scripts/generate-chat-vapid.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # Generate a VAPID keypair for the openape-chat Web Push integration and
-# print the env block to copy into the chatty .env file.
+# print the env block to copy into the host .env file.
 #
 # Run once before the first deploy. The keys must remain stable across
 # deploys — clients re-subscribe under the same public key, and rotating
@@ -11,7 +11,7 @@
 # Usage:
 #   ./scripts/generate-chat-vapid.sh > /tmp/chat-vapid.env
 #   scp /tmp/chat-vapid.env openape@chatty.delta-mind.at:/home/openape/projects/openape-chat/shared/.env
-#   # then on chatty: chmod 600 …/shared/.env
+#   # then on the host: chmod 600 …/shared/.env
 #
 # Or echo to stdout and inspect first.
 

--- a/scripts/generate-idp-vapid.sh
+++ b/scripts/generate-idp-vapid.sh
@@ -2,7 +2,7 @@
 #
 # Generate a VAPID keypair for the openape-free-idp Web Push integration
 # (id.openape.ai approver notifications) and print the env block to copy
-# into the chatty .env file.
+# into the host .env file.
 #
 # Run once before the first deploy. The keys must remain stable across
 # deploys — clients re-subscribe under the same public key, and rotating
@@ -15,7 +15,7 @@
 # Usage:
 #   ./scripts/generate-idp-vapid.sh > /tmp/idp-vapid.env
 #   scp /tmp/idp-vapid.env openape@chatty.delta-mind.at:/home/openape/projects/openape-free-idp/shared/.env
-#   # then on chatty: chmod 600 …/shared/.env
+#   # then on the host: chmod 600 …/shared/.env
 #
 # Or echo to stdout and inspect first.
 


### PR DESCRIPTION
Per request: \`chatty\` should not appear in user-facing artefact names. Rename the deploy scripts + workflow files to per-app names. Add the missing deploy-chat workflow + script glue.

## Renames

| before | after |
|---|---|
| \`.github/workflows/deploy-chatty.yml\` | \`deploy-free-idp.yml\` |
| \`.github/workflows/deploy-chatty-docs.yml\` | \`deploy-docs.yml\` |
| \`.github/workflows/deploy-chatty-proxy.yml\` | \`deploy-proxy.yml\` |
| \`scripts/deploy-chatty.sh\` | \`deploy-free-idp.sh\` |
| \`scripts/deploy-chatty-docs.sh\` | \`deploy-docs.sh\` |
| \`scripts/deploy-chatty-proxy.sh\` | \`deploy-proxy.sh\` |
| \`scripts/deploy-chatty-chat.sh\` | \`deploy-chat.sh\` |
| \`scripts/deploy-chatty-mail.sh\` | \`deploy-mail.sh\` |

## New

- \`.github/workflows/deploy-chat.yml\` — auto-deploys \`apps/openape-chat\` to chat.openape.ai on main push, mirroring the deploy-free-idp shape (build → SSH → rsync → restart → health-check → rollback-on-fail).

## What I deliberately kept

- \`Host chatty\`, \`~/.ssh/chatty\`, \`chatty.delta-mind.at\`, \`CHATTY_HOST\` env var, \`ssh chatty …\` commands. These reference the actual SSH alias / hostname / key file, not artefact naming. Renaming would require coordinated changes to operator SSH config + GitHub Actions secrets, which is a separate operator task.

## Test plan

- [x] \`bash -n\` syntax-check on all renamed scripts
- [x] Path \`paths:\`, \`run:\`, \`group:\` fields inside renamed workflows updated to match new file names
- [ ] After merge: deploy-chat workflow needs \`CHATTY_SSH_KEY\` + \`CHATTY_KNOWN_HOSTS\` secrets (already present), plus operator-side bootstrap on the host (systemd unit, nginx vhost) — see apps/openape-chat/DEPLOY.md.