### PR TITLE
feat: DDISA DNS-cache bust + error_description on deny redirects

### DIFF
--- a/.changeset/dns-cache-bust-and-error-description.md
+++ b/.changeset/dns-cache-bust-and-error-description.md
@@ -1,0 +1,9 @@
+---
+'@openape/core': minor
+'@openape/nuxt-auth-idp': patch
+---
+
+Two small admin/DX additions:
+
+- **`@openape/core`**: new `clearDNSCacheFor(domain)` helper alongside the existing `clearDNSCache()`. Lets a domain owner drop the IdP's in-memory cache for their domain right after they update their `_ddisa.{domain}` TXT record, without waiting for the 300s positive TTL.
+- **`@openape/nuxt-auth-idp`**: the `decision === 'deny'` redirect for the bearer flow + the "back to SP" button on the `/denied` page now include an OAuth-spec `error_description` parameter alongside the bare `error=access_denied`. SPs can use this to render product-specific guidance instead of just the bare error code (`mode=deny` → "Domain owner forbids this IdP", `allowlist-admin` deny → "SP not on the admin-curated allowlist").

--- a/apps/openape-free-idp/app/pages/admin.vue
+++ b/apps/openape-free-idp/app/pages/admin.vue
@@ -93,6 +93,30 @@ async function recheck() {
   }
 }
 
+const bustingCache = ref(false)
+const cacheBustResult = ref('')
+async function bustDdisaCache() {
+  // Drops the IdP's in-memory DDISA cache for the caller's email
+  // domain — useful right after editing `_ddisa.{domain}` so the
+  // server picks up the new mode/idp without waiting on the 300s
+  // positive cache TTL. Gated to root admin server-side.
+  bustingCache.value = true
+  error.value = ''
+  cacheBustResult.value = ''
+  try {
+    const res = await ($fetch as any)('/api/free-idp/admin/dns-cache/bust', { method: 'POST' })
+    cacheBustResult.value = res.wasCached
+      ? `DNS-Cache für ${res.domain} verworfen — nächster /authorize resolved frisch.`
+      : `DNS-Cache für ${res.domain} war bereits leer — nichts zu tun.`
+  }
+  catch (err: any) {
+    error.value = err?.data?.title || err?.message || 'Cache-Bust fehlgeschlagen'
+  }
+  finally {
+    bustingCache.value = false
+  }
+}
+
 async function addToAllowlist() {
   const clientId = newClientId.value.trim().toLowerCase()
   if (!clientId) return
@@ -216,6 +240,25 @@ watch(user, async (u) => {
             </UBadge>
           </dd>
         </dl>
+
+        <div v-if="status.isRoot" class="mt-4 pt-4 border-t border-(--ui-border)">
+          <p class="text-sm text-muted mb-2">
+            DDISA-Resolver-Cache: nach DNS-Edits zurücksetzen, sonst greift der
+            300s-Cache. Nur Root-Admins.
+          </p>
+          <UButton
+            variant="soft"
+            size="xs"
+            icon="i-lucide-eraser"
+            :loading="bustingCache"
+            @click="bustDdisaCache"
+          >
+            DDISA-Cache busten
+          </UButton>
+          <p v-if="cacheBustResult" class="text-xs text-muted mt-2">
+            {{ cacheBustResult }}
+          </p>
+        </div>
       </UCard>
 
       <UCard v-if="!status.isRoot && status.adminTxtName" class="mb-6">

--- a/apps/openape-free-idp/server/api/free-idp/admin/dns-cache/bust.post.ts
+++ b/apps/openape-free-idp/server/api/free-idp/admin/dns-cache/bust.post.ts
@@ -1,0 +1,31 @@
+import { defineEventHandler, getQuery } from 'h3'
+import { clearDNSCacheFor } from '@openape/core'
+import { extractEmailDomain } from '../../../../utils/admin-claim'
+
+/**
+ * Bust the in-memory DDISA TXT-record cache for a specific bare
+ * domain. Useful right after the user updates `_ddisa.{domain}`
+ * via DNS and wants the IdP to pick it up immediately rather than
+ * waiting for the 300s positive (or 60s negative) cache TTL.
+ *
+ * Gated by `requireRootAdmin` because cache busting is only useful
+ * for someone who controls the DNS for that domain — and the DNS
+ * controller is exactly who establishes root-admin via the
+ * `_openape-admin-{idp}.{domain}` claim. Operators (DB-promoted)
+ * shouldn't need this; they don't manage DNS.
+ *
+ * Caller can omit `?domain=` to default to their own email domain,
+ * which is the common case. Cross-domain bust is allowed for root
+ * admins but requires explicit `?domain=` to avoid accidents.
+ */
+export default defineEventHandler(async (event) => {
+  const callerEmail = await requireRootAdmin(event)
+  const query = getQuery(event)
+  const target = String(query.domain ?? '').trim().toLowerCase()
+    || extractEmailDomain(callerEmail)
+  if (!target) {
+    throw createProblemError({ status: 400, title: 'No domain to bust' })
+  }
+  const wasCached = clearDNSCacheFor(target)
+  return { domain: target, wasCached }
+})

--- a/modules/nuxt-auth-idp/src/runtime/server/api/authorize/denied.post.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/api/authorize/denied.post.ts
@@ -41,6 +41,12 @@ export default defineEventHandler(async (event) => {
 
   const url = new URL(pending.params.redirect_uri)
   url.searchParams.set('error', 'access_denied')
+  url.searchParams.set(
+    'error_description',
+    pending.reason === 'mode-deny'
+      ? 'Domain owner forbids this IdP for the user\'s email domain.'
+      : 'SP is not on the admin-curated allowlist for the user\'s email domain.',
+  )
   if (pending.params.state) url.searchParams.set('state', pending.params.state)
   return { location: url.toString() }
 })

--- a/modules/nuxt-auth-idp/src/runtime/server/routes/authorize.get.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/routes/authorize.get.ts
@@ -205,8 +205,19 @@ export default defineEventHandler(async (event) => {
       deniedUrl.searchParams.set('client_id', params.client_id)
       return sendRedirect(event, deniedUrl.pathname + deniedUrl.search)
     }
+    // Bearer (agent) deny: redirect back to SP with the spec-defined
+    // error params. Include error_description so SP-side surface UI
+    // can render product-specific guidance instead of just the bare
+    // error code (RFC 6749 §4.1.2.1 "this parameter is OPTIONAL...
+    // intended for the developer").
     const redirectUrl = new URL(params.redirect_uri)
     redirectUrl.searchParams.set('error', 'access_denied')
+    redirectUrl.searchParams.set(
+      'error_description',
+      policyMode === 'deny'
+        ? 'Domain owner forbids this IdP for the user\'s email domain.'
+        : 'SP is not on the admin-curated allowlist for the user\'s email domain.',
+    )
     redirectUrl.searchParams.set('state', params.state)
     return sendRedirect(event, redirectUrl.toString())
   }

--- a/packages/core/src/__tests__/resolver-dns.test.ts
+++ b/packages/core/src/__tests__/resolver-dns.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { resolveTXT } from '../dns/node.js'
-import { clearDNSCache, resolveDDISA } from '../dns/resolver.js'
+import { clearDNSCache, clearDNSCacheFor, resolveDDISA } from '../dns/resolver.js'
 
 // Mock the node DNS resolver (resolver.ts tries node first, falls back to DoH)
 vi.mock('../dns/node.js', () => ({
@@ -87,4 +87,22 @@ describe('resolveDDISA with DNS resolution', () => {
     expect(mockResolveTXT).toHaveBeenCalledTimes(2)
   })
 
+  it('clearDNSCacheFor drops a single domain entry without touching others', async () => {
+    mockResolveTXT.mockResolvedValue(['v=ddisa1 idp=https://idp.example.com'])
+
+    // Warm two distinct entries.
+    await resolveDDISA('foo.com')
+    await resolveDDISA('bar.com')
+    expect(mockResolveTXT).toHaveBeenCalledTimes(2)
+
+    // Bust foo.com only — bar.com stays cached.
+    expect(clearDNSCacheFor('foo.com')).toBe(true)
+    await resolveDDISA('foo.com')
+    await resolveDDISA('bar.com')
+    expect(mockResolveTXT).toHaveBeenCalledTimes(3)
+  })
+
+  it('clearDNSCacheFor returns false when the entry was not cached', () => {
+    expect(clearDNSCacheFor('never-resolved.com')).toBe(false)
+  })
 })

--- a/packages/core/src/dns/index.ts
+++ b/packages/core/src/dns/index.ts
@@ -1,3 +1,3 @@
 export { resolveTXT as resolveTXTviaDoh } from './doh.js'
 export { extractDomain, parseDDISARecord } from './parser.js'
-export { clearDNSCache, resolveDDISA, resolveIdP } from './resolver.js'
+export { clearDNSCache, clearDNSCacheFor, resolveDDISA, resolveIdP } from './resolver.js'

--- a/packages/core/src/dns/resolver.ts
+++ b/packages/core/src/dns/resolver.ts
@@ -138,3 +138,19 @@ export async function resolveIdP(
 export function clearDNSCache(): void {
   cache.clear()
 }
+
+/**
+ * Drop the cache entry for a specific bare domain. Useful when the
+ * DNS owner just changed their `_ddisa` TXT record and wants the IdP
+ * to pick up the new value without waiting for the (positive) 300s
+ * TTL or the (negative) 60s TTL to expire.
+ *
+ * Caller passes the domain in the same form used by resolveDDISA
+ * (canonical case, no `_ddisa.` prefix). No-op if the entry doesn't
+ * exist. Returns whether something was deleted, so admin UIs can
+ * tell the user "cache was warm, now busted" vs "nothing was cached
+ * anyway".
+ */
+export function clearDNSCacheFor(domain: string): boolean {
+  return cache.delete(domain)
+}


### PR DESCRIPTION
Two small DX additions that came out of the deltamind.at admin-claim test cycle.

## DNS-cache bust

\`@openape/core\` gets a new \`clearDNSCacheFor(domain)\` next to the existing all-clear. \`apps/openape-free-idp\` exposes it via \`POST /api/free-idp/admin/dns-cache/bust\` (root-admin gated). The \`/admin\` page gets a "DDISA-Cache busten" button visible only to root admins. Use case: I just updated \`_ddisa.deltamind.at\` and don't want to wait 5 min for the IdP to notice.

## error_description on deny

The bearer-flow deny redirect and the \`/denied\` page's "back to SP" button now include a spec-compliant \`error_description\` alongside the bare \`error=access_denied\`. SPs surfacing OAuth errors (the \`<OpenApeOAuthErrorAlert />\` we just shipped) can use it to disambiguate \`mode=deny\` from \`allowlist-admin\` denies.

## Test plan

- [x] Core: 3 new resolver tests for cache-bust (warm-and-clear, no-op-when-cold, returns boolean for UX hint)
- [x] Module + free-idp: lint + typecheck + build green (15 turbo tasks)
- [ ] After deploy: \`POST /api/free-idp/admin/dns-cache/bust\` returns \`{ domain, wasCached }\`; UI button shows feedback message