### PR TITLE
feat(free-idp): operator-management UI + endpoints (#307 phase 2)

### DIFF
--- a/apps/openape-free-idp/app/pages/admin.vue
+++ b/apps/openape-free-idp/app/pages/admin.vue
@@ -19,6 +19,11 @@ interface AllowlistEntry {
   approvedBy: string
   approvedAt: number
 }
+interface OperatorEntry {
+  userEmail: string
+  promotedBy: string
+  promotedAt: number
+}
 
 const status = ref<AdminStatus | null>(null)
 const statusLoading = ref(false)
@@ -32,6 +37,11 @@ const allowlist = ref<AllowlistEntry[]>([])
 const allowlistLoading = ref(false)
 const newClientId = ref('')
 const adding = ref(false)
+
+const operators = ref<OperatorEntry[]>([])
+const operatorsLoading = ref(false)
+const newOperatorEmail = ref('')
+const promoting = ref(false)
 
 async function loadStatus() {
   statusLoading.value = true
@@ -61,6 +71,53 @@ async function loadAllowlist() {
   }
 }
 
+async function loadOperators() {
+  if (!status.value?.isRoot && !status.value?.isOperator) return
+  operatorsLoading.value = true
+  try {
+    operators.value = await ($fetch as any)('/api/free-idp/admin/operators')
+  }
+  catch {
+    operators.value = []
+  }
+  finally {
+    operatorsLoading.value = false
+  }
+}
+
+async function promoteOperator() {
+  const email = newOperatorEmail.value.trim().toLowerCase()
+  if (!email) return
+  promoting.value = true
+  error.value = ''
+  try {
+    await ($fetch as any)('/api/free-idp/admin/operators', {
+      method: 'POST',
+      body: { email },
+    })
+    newOperatorEmail.value = ''
+    await loadOperators()
+  }
+  catch (err: any) {
+    error.value = err?.data?.title || err?.message || 'Operator-Promotion fehlgeschlagen'
+  }
+  finally {
+    promoting.value = false
+  }
+}
+
+async function demoteOperator(email: string) {
+  try {
+    await ($fetch as any)(`/api/free-idp/admin/operators/${encodeURIComponent(email)}`, {
+      method: 'DELETE',
+    })
+    await loadOperators()
+  }
+  catch (err: any) {
+    error.value = err?.data?.title || err?.message || 'Operator-Demote fehlgeschlagen'
+  }
+}
+
 async function generateSecret() {
   issuing.value = true
   error.value = ''
@@ -84,6 +141,7 @@ async function recheck() {
     await ($fetch as any)('/api/free-idp/admin/recheck', { method: 'POST' })
     await loadStatus()
     await loadAllowlist()
+    await loadOperators()
   }
   catch (err: any) {
     error.value = err?.data?.title || err?.message || 'Recheck fehlgeschlagen'
@@ -163,6 +221,7 @@ watch(user, async (u) => {
   if (!u) return
   await loadStatus()
   await loadAllowlist()
+  await loadOperators()
 }, { immediate: true })
 </script>
 
@@ -362,6 +421,69 @@ watch(user, async (u) => {
               size="xs"
               icon="i-lucide-trash-2"
               @click="removeFromAllowlist(entry.clientId)"
+            />
+          </li>
+        </ul>
+      </UCard>
+
+      <UCard v-if="status.isRoot || status.isOperator" class="mt-6">
+        <template #header>
+          <h2 class="text-lg font-semibold">
+            Operators
+          </h2>
+          <p class="text-sm text-muted mt-1">
+            Mit-Admins für <code>{{ status.domain }}</code>. Operators können dieselben
+            Admin-Aktionen wie der Root-Admin durchführen — außer andere Operators
+            promoten/demoten. Nur Root-Admins können diese Liste ändern.
+          </p>
+        </template>
+
+        <form
+          v-if="status.isRoot"
+          class="flex gap-2 mb-4"
+          @submit.prevent="promoteOperator"
+        >
+          <UInput
+            v-model="newOperatorEmail"
+            type="email"
+            :placeholder="`alice@${status.domain || 'beispiel.com'}`"
+            class="flex-1"
+            :disabled="promoting"
+          />
+          <UButton type="submit" color="primary" :loading="promoting" icon="i-lucide-user-plus">
+            Promoten
+          </UButton>
+        </form>
+
+        <p v-else class="text-xs text-muted mb-4">
+          Nur ein Root-Admin kann Operators hinzufügen.
+        </p>
+
+        <div v-if="operatorsLoading" class="text-muted text-sm">
+          Lade…
+        </div>
+        <div v-else-if="operators.length === 0" class="text-muted text-sm">
+          Keine Operators ernannt.
+        </div>
+        <ul v-else class="divide-y divide-(--ui-border)">
+          <li
+            v-for="op in operators"
+            :key="op.userEmail"
+            class="py-3 flex items-center justify-between gap-4"
+          >
+            <div class="min-w-0">
+              <code class="font-mono">{{ op.userEmail }}</code>
+              <p class="text-xs text-muted">
+                promoted von {{ op.promotedBy }} · {{ formatDate(op.promotedAt) }}
+              </p>
+            </div>
+            <UButton
+              v-if="status.isRoot"
+              variant="ghost"
+              color="error"
+              size="xs"
+              icon="i-lucide-trash-2"
+              @click="demoteOperator(op.userEmail)"
             />
           </li>
         </ul>

--- a/apps/openape-free-idp/server/api/free-idp/admin/operators/[email].delete.ts
+++ b/apps/openape-free-idp/server/api/free-idp/admin/operators/[email].delete.ts
@@ -1,0 +1,34 @@
+import { defineEventHandler, getRouterParam, setResponseStatus } from 'h3'
+import { and, eq } from 'drizzle-orm'
+import { useDb } from '../../../../database/drizzle'
+import { operators } from '../../../../database/schema'
+import { clearAdminCache, extractEmailDomain } from '../../../../utils/admin-claim'
+
+/**
+ * Demote an operator. Root-admin only — see operators.post.ts for
+ * the security rationale (operators promoting/demoting each other
+ * lets one compromise propagate).
+ */
+export default defineEventHandler(async (event) => {
+  const callerEmail = await requireRootAdmin(event)
+  const domain = extractEmailDomain(callerEmail)
+  if (!domain) {
+    throw createProblemError({ status: 400, title: 'Caller has no email domain' })
+  }
+
+  const target = decodeURIComponent(getRouterParam(event, 'email') ?? '').toLowerCase()
+  if (!target) {
+    throw createProblemError({ status: 400, title: 'email is required' })
+  }
+
+  await useDb()
+    .delete(operators)
+    .where(and(
+      eq(operators.userEmail, target),
+      eq(operators.domain, domain),
+    ))
+    .run()
+
+  clearAdminCache(target, domain)
+  setResponseStatus(event, 204)
+})

--- a/apps/openape-free-idp/server/api/free-idp/admin/operators/index.get.ts
+++ b/apps/openape-free-idp/server/api/free-idp/admin/operators/index.get.ts
@@ -1,0 +1,27 @@
+import { defineEventHandler } from 'h3'
+import { eq } from 'drizzle-orm'
+import { useDb } from '../../../../database/drizzle'
+import { operators } from '../../../../database/schema'
+import { extractEmailDomain } from '../../../../utils/admin-claim'
+
+/**
+ * List operators for the caller's domain. Visible to root admins
+ * (DNS-rooted) and to operators themselves (so they can see who
+ * else has the same scope they do). Operators are scoped per
+ * domain, so the list never leaks across tenants.
+ */
+export default defineEventHandler(async (event) => {
+  const email = await requireAdmin(event)
+  const domain = extractEmailDomain(email)
+  if (!domain) return []
+
+  return await useDb()
+    .select({
+      userEmail: operators.userEmail,
+      promotedBy: operators.promotedBy,
+      promotedAt: operators.promotedAt,
+    })
+    .from(operators)
+    .where(eq(operators.domain, domain))
+    .all()
+})

--- a/apps/openape-free-idp/server/api/free-idp/admin/operators/index.post.ts
+++ b/apps/openape-free-idp/server/api/free-idp/admin/operators/index.post.ts
@@ -1,0 +1,61 @@
+import { defineEventHandler, readBody } from 'h3'
+import { useDb } from '../../../../database/drizzle'
+import { operators } from '../../../../database/schema'
+import { clearAdminCache, extractEmailDomain } from '../../../../utils/admin-claim'
+
+/**
+ * Promote a user to operator for the caller's domain. Gated by
+ * `requireRootAdmin` — only DNS-rooted root admins can extend the
+ * admin tier; operators can't promote other operators (otherwise a
+ * compromise of one operator account would let the attacker
+ * persistently extend their access).
+ *
+ * The promoted user's email-domain is implicitly the caller's
+ * domain — promoting a user from a different domain doesn't make
+ * sense (operators only have power within their own tenant).
+ */
+export default defineEventHandler(async (event) => {
+  const callerEmail = await requireRootAdmin(event)
+  const domain = extractEmailDomain(callerEmail)
+  if (!domain) {
+    throw createProblemError({ status: 400, title: 'Caller has no email domain' })
+  }
+
+  const body = await readBody<{ email?: string }>(event)
+  const email = String(body?.email ?? '').trim().toLowerCase()
+  if (!email || !email.includes('@')) {
+    throw createProblemError({ status: 400, title: 'email is required' })
+  }
+  // Cross-domain promote would be confusing — an operator for
+  // example.com couldn't actually do anything for deltamind.at
+  // because all admin actions scope to the caller's domain. Reject.
+  const targetDomain = extractEmailDomain(email)
+  if (targetDomain !== domain) {
+    throw createProblemError({
+      status: 400,
+      title: 'Operators must share the root admin\'s email domain',
+    })
+  }
+
+  const now = Math.floor(Date.now() / 1000)
+  await useDb()
+    .insert(operators)
+    .values({
+      userEmail: email,
+      domain,
+      promotedBy: callerEmail.toLowerCase(),
+      promotedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: [operators.userEmail, operators.domain],
+      set: { promotedBy: callerEmail.toLowerCase(), promotedAt: now },
+    })
+    .run()
+
+  // Bust the in-memory admin-status cache so the new operator picks
+  // up their role on the next request without waiting for the 30s
+  // negative TTL.
+  clearAdminCache(email, domain)
+
+  return { userEmail: email, domain, promotedBy: callerEmail, promotedAt: now }
+})


### PR DESCRIPTION
Phase 2 of #307. The Drizzle \`operators\` table existed; now there's an actual API + UI to use it.

## Endpoints

| Route | Auth | Purpose |
|---|---|---|
| \`GET /api/free-idp/admin/operators\` | admin (root or op) | list operators for caller's domain |
| \`POST /api/free-idp/admin/operators\` | **root** | promote a user to operator |
| \`DELETE /api/free-idp/admin/operators/:email\` | **root** | demote |

## UI

New section on \`/admin\`, visible to root + operator. Root sees the promote-form + per-row demote button. Operator sees the list read-only — they can see who else has the same scope they do, but can't extend or revoke. Rationale: operator-on-operator promotion would let one compromised operator account persistently extend access; only the DNS-rooted root can extend the admin tier.

## Scoping

Cross-domain promote is server-rejected: an operator for \`example.com\` has no effective power for \`deltamind.at\` users (admin actions all scope to caller's domain), so the API rejects \`@example.com\` emails when the root is \`@deltamind.at\`. Saves footgun.

## Test plan

- [x] Lint + typecheck + build green (8 turbo tasks)
- [ ] After deploy: visit /admin as root, promote a user from same domain → list shows them; UI hides demote-trash from operators