### PR TITLE
fix(nuxt-auth-sp): explicit imports so npm consumers work

### DIFF
--- a/.changeset/openape-auth-explicit-imports.md
+++ b/.changeset/openape-auth-explicit-imports.md
@@ -1,0 +1,7 @@
+---
+'@openape/nuxt-auth-sp': patch
+---
+
+Fix: `<OpenApeAuth />` blew up with `useOpenApeAuth is not defined` for SPs that consume the module from npm. The component relied on Nuxt's unimport to inject auto-imports into its `<script setup>`, but unimport doesn't reliably transform `.vue` files inside `node_modules` — same class of bug we fixed on the IdP side for the `/consent` page. Explicit imports from `#imports` make the component work for both workspace and npm consumers.
+
+Discovered via the sp-starter dry-run at test.deltamind.at: a fresh `pnpm install` + `pnpm dev` + visit `/login` returned 500 instead of rendering the form.

--- a/modules/nuxt-auth-sp/src/runtime/components/OpenApeAuth.vue
+++ b/modules/nuxt-auth-sp/src/runtime/components/OpenApeAuth.vue
@@ -1,4 +1,12 @@
 <script setup>
+// Module-shipped components live in `node_modules/.../dist/...`
+// after the consumer installs from npm. Nuxt's unimport plugin
+// doesn't reliably transform `.vue` files inside `node_modules`,
+// so component-internal calls like `useOpenApeAuth()` blow up at
+// SSR time with "useOpenApeAuth is not defined". Explicit imports
+// from `#imports` fix that — same shape as the IdP-side pages do.
+import { onMounted, ref } from 'vue'
+import { navigateTo, useOpenApeAuth, useRoute } from '#imports'
 import { DEFAULT_OAUTH_ERROR_MESSAGES } from '../composables/useOpenApeOAuthError'
 
 defineProps({

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
       "path-to-regexp": ">=8.4.0",
       "picomatch": ">=4.0.4",
       "serialize-javascript": ">=7.0.3",
+      "simple-git": ">=3.36.0",
       "socket.io-parser": ">=4.2.6"
     },
     "auditConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,7 @@ overrides:
   path-to-regexp: '>=8.4.0'
   picomatch: '>=4.0.4'
   serialize-javascript: '>=7.0.3'
+  simple-git: '>=3.36.0'
   socket.io-parser: '>=4.2.6'
 
 importers:
@@ -4208,6 +4209,12 @@ packages:
     resolution: {integrity: sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA==}
     engines: {node: '>= 8.0.0'}
     hasBin: true
+
+  '@simple-git/args-pathspec@1.0.3':
+    resolution: {integrity: sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==}
+
+  '@simple-git/argv-parser@1.1.1':
+    resolution: {integrity: sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==}
 
   '@simplewebauthn/browser@11.0.0':
     resolution: {integrity: sha512-KEGCStrl08QC2I561BzxqGiwoknblP6O1YW7jApdXLPtIqZ+vgJYAv8ssLCdm1wD8HGAHd49CJLkUF8X70x/pg==}
@@ -9505,8 +9512,8 @@ packages:
   simple-get@4.0.1:
     resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
 
-  simple-git@3.33.0:
-    resolution: {integrity: sha512-D4V/tGC2sjsoNhoMybKyGoE+v8A60hRawKQ1iFRA1zwuDgGZCBJ4ByOzZ5J8joBbi4Oam0qiPH+GhzmSBwbJng==}
+  simple-git@3.36.0:
+    resolution: {integrity: sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==}
 
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
@@ -12986,7 +12993,7 @@ snapshots:
       perfect-debounce: 2.1.0
       pkg-types: 2.3.0
       semver: 7.7.4
-      simple-git: 3.33.0
+      simple-git: 3.36.0
       sirv: 3.0.2
       structured-clone-es: 1.0.0
       tinyglobby: 0.2.15
@@ -13027,7 +13034,7 @@ snapshots:
       perfect-debounce: 2.1.0
       pkg-types: 2.3.0
       semver: 7.7.4
-      simple-git: 3.33.0
+      simple-git: 3.36.0
       sirv: 3.0.2
       structured-clone-es: 1.0.0
       tinyglobby: 0.2.15
@@ -15881,6 +15888,12 @@ snapshots:
     dependencies:
       fflate: 0.7.4
       string.prototype.codepointat: 0.2.1
+
+  '@simple-git/args-pathspec@1.0.3': {}
+
+  '@simple-git/argv-parser@1.1.1':
+    dependencies:
+      '@simple-git/args-pathspec': 1.0.3
 
   '@simplewebauthn/browser@11.0.0':
     dependencies:
@@ -23019,10 +23032,12 @@ snapshots:
       once: 1.4.0
       simple-concat: 1.0.1
 
-  simple-git@3.33.0:
+  simple-git@3.36.0:
     dependencies:
       '@kwsites/file-exists': 1.1.1
       '@kwsites/promise-deferred': 1.1.1
+      '@simple-git/args-pathspec': 1.0.3
+      '@simple-git/argv-parser': 1.1.1
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
Discovered while dry-running sp-starter to publish a real instance at test.deltamind.at: `pnpm install` + `pnpm dev` + visit `/login` returned 500 with `useOpenApeAuth is not defined`.

Cause: `<OpenApeAuth />` relies on Nuxt unimport to inject auto-imports into its `<script setup>`. Unimport doesn't reliably transform `.vue` files inside `node_modules`, so workspace consumers (chat) silently worked but npm consumers (any starter fork, plans/tasks/preview if they used the component) blew up.

Same class of bug as #304 fixed on the IdP side for `/consent`.

## Fix

Explicit imports from `#imports` and `vue`. Two-line diff effectively, plus a comment explaining why we deviate from the usual auto-import idiom.

## Test plan

- [x] Module lint+typecheck+test+build green (6 tasks)
- [ ] After merge + release: re-run the test.deltamind.at dry-run; `/login` should now render
