### PR TITLE
fix(chat): web-push subs silently expire — pushsubscriptionchange + heartbeat

### DIFF
--- a/apps/openape-chat/app/composables/usePushSubscription.ts
+++ b/apps/openape-chat/app/composables/usePushSubscription.ts
@@ -55,6 +55,28 @@ export function usePushSubscription(): PushHandle {
     const reg = await getRegistration()
     const sub = await reg?.pushManager.getSubscription()
     subscribed.value = !!sub
+
+    // Heartbeat: re-POST the current subscription on every load. The
+    // server-side push.ts deletes a subscription row on 404/410 from the
+    // push service — but the browser-side PushSubscription is still
+    // "valid" from its own perspective, so without re-POSTing we'd quietly
+    // stay out of the DB and miss every subsequent notification. The POST
+    // is an idempotent upsert keyed on `endpoint`, so this is cheap and
+    // safe to call on every app open.
+    if (sub) {
+      const json = sub.toJSON() as { endpoint?: string, keys?: { p256dh: string, auth: string } }
+      if (json.endpoint && json.keys?.p256dh && json.keys?.auth) {
+        try {
+          await $fetch('/api/push/subscribe', {
+            method: 'POST',
+            body: { endpoint: json.endpoint, keys: json.keys },
+          })
+        }
+        catch {
+          // Best-effort heartbeat — never block UI on it.
+        }
+      }
+    }
   }
 
   function urlBase64ToUint8Array(base64: string): Uint8Array {

--- a/apps/openape-chat/sw.ts
+++ b/apps/openape-chat/sw.ts
@@ -113,6 +113,63 @@ self.addEventListener('notificationclick', (event) => {
   })())
 })
 
+// ---------------------------------------------------------------------------
+// pushsubscriptionchange — fires when the push service (FCM, APNs, Mozilla)
+// invalidates or rotates the subscription. Without this handler the
+// subscription silently dies: the server's 404/410 cleanup prunes the row,
+// the page-side `subscribed` ref still says `true` because the browser
+// PushSubscription object is "valid" from its perspective, and `enable()`
+// short-circuits without re-subscribing. End result: notifications stop
+// arriving and the user can only fix it by uninstalling+reinstalling the
+// PWA. With this handler the browser tells us when its old endpoint died,
+// we re-subscribe with the same VAPID key, and POST the new endpoint to
+// the server so the next push lands.
+// ---------------------------------------------------------------------------
+
+function urlBase64ToUint8Array(base64: string): Uint8Array {
+  const padding = '='.repeat((4 - base64.length % 4) % 4)
+  const b64 = (base64 + padding).replace(/-/g, '+').replace(/_/g, '/')
+  const raw = atob(b64)
+  const out = new Uint8Array(raw.length)
+  for (let i = 0; i < raw.length; i++) out[i] = raw.charCodeAt(i)
+  return out
+}
+
+self.addEventListener('pushsubscriptionchange', (event: Event) => {
+  // Cast: 'pushsubscriptionchange' isn't in lib.webworker.d.ts's strict
+  // event map yet for all TS targets. The shape is well-defined in the
+  // Push API spec and stable across browsers.
+  const e = event as ExtendableEvent
+  e.waitUntil((async () => {
+    try {
+      const res = await fetch('/api/push/vapid', { credentials: 'include' })
+      if (!res.ok) return
+      const { vapidPublicKey } = await res.json() as { vapidPublicKey?: string }
+      if (!vapidPublicKey) return
+
+      const keyBytes = urlBase64ToUint8Array(vapidPublicKey)
+      const keyBuffer = new ArrayBuffer(keyBytes.byteLength)
+      new Uint8Array(keyBuffer).set(keyBytes)
+      const sub = await self.registration.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: keyBuffer,
+      })
+      const json = sub.toJSON() as { endpoint: string, keys: { p256dh: string, auth: string } }
+      await fetch('/api/push/subscribe', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ endpoint: json.endpoint, keys: json.keys }),
+      })
+    }
+    catch {
+      // Best-effort. The browser will fire pushsubscriptionchange again
+      // if our re-subscribe also fails, and the page-side heartbeat will
+      // catch any drift the next time the user opens the app.
+    }
+  })())
+})
+
 self.addEventListener('install', () => {
   // Activate the new SW immediately on install so users see fresh behaviour
   // on their next reload (not the one after that).


### PR DESCRIPTION
## Symptom

Patrick reported that web-push notifications on chat.openape.ai stop arriving without the page surfacing anything, and the only fix is uninstalling + reinstalling the PWA.

## Two missing pieces

**1. SW `pushsubscriptionchange` handler.** When the push service rotates or invalidates the subscription the browser fires this event expecting the SW to re-subscribe. We didn't have a handler at all — the old PushSubscription stayed registered in the browser as a phantom (getSubscription() still returned it) but no push service would deliver to it. New handler fetches the VAPID key, re-subscribes, POSTs the new endpoint.

**2. Server-side cleanup is one-sided.** `server/utils/push.ts` deletes the DB row on 404/410 from the push service. The browser doesn't know. Next page open: `refresh()` saw the browser sub, set `subscribed = true`, `enable()` short-circuited without re-POSTing. So even after a successful SW re-subscribe there could be a stale-server-row window. Heartbeat: `refresh()` (called on mount) now always re-POSTs the current browser sub — idempotent upsert keyed on the endpoint URL.

Together these close both 'silent death' paths.

## Test plan

- [x] Lint + typecheck + build green (6 turbo tasks)
- [ ] After deploy via deploy-chat.yml: open chat.openape.ai PWA, check service worker registers without errors; `/api/push/subscribe` shows fresh `createdAt` after every reload (heartbeat working)
- [ ] Hard-test: manually delete a row from `push_subscriptions` server-side, reload PWA → row reappears within a beat (heartbeat re-creates it)
- [ ] Synthetic: rotate VAPID keys → next page open should re-subscribe transparently via the SW handler