### PR TITLE
feat(tribe): M2 — SP API endpoints (owner CRUD + agent /me/*)

### DIFF
--- a/apps/openape-tribe/server/api/agents/[name].get.ts
+++ b/apps/openape-tribe/server/api/agents/[name].get.ts
@@ -1,0 +1,41 @@
+import { and, desc, eq } from 'drizzle-orm'
+import { useDb } from '../../database/drizzle'
+import { agents, runs, tasks } from '../../database/schema'
+import { requireOwner } from '../../utils/auth'
+
+// Single-agent detail view: agent metadata, tasks, last 20 runs.
+// `name` is the agent's `agentName` (stable, human-readable) — not
+// the email — because URLs with `+` and `@` are awful. Owner-auth
+// guards against cross-tenant peek (we filter by ownerEmail).
+export default defineEventHandler(async (event) => {
+  const owner = await requireOwner(event)
+  const name = getRouterParam(event, 'name')
+  if (!name) {
+    throw createError({ statusCode: 400, statusMessage: 'name is required' })
+  }
+  const db = useDb()
+
+  const agent = await db
+    .select()
+    .from(agents)
+    .where(and(eq(agents.ownerEmail, owner.toLowerCase()), eq(agents.agentName, name)))
+    .get()
+  if (!agent) {
+    throw createError({ statusCode: 404, statusMessage: 'agent not found' })
+  }
+
+  const agentTasks = await db
+    .select()
+    .from(tasks)
+    .where(eq(tasks.agentEmail, agent.email))
+    .orderBy(desc(tasks.updatedAt))
+
+  const recentRuns = await db
+    .select()
+    .from(runs)
+    .where(eq(runs.agentEmail, agent.email))
+    .orderBy(desc(runs.startedAt))
+    .limit(20)
+
+  return { agent, tasks: agentTasks, recentRuns }
+})

--- a/apps/openape-tribe/server/api/agents/[name]/runs/index.get.ts
+++ b/apps/openape-tribe/server/api/agents/[name]/runs/index.get.ts
@@ -1,0 +1,35 @@
+import { and, desc, eq } from 'drizzle-orm'
+import { useDb } from '../../../../database/drizzle'
+import { agents, runs } from '../../../../database/schema'
+import { requireOwner } from '../../../../utils/auth'
+
+// Paginated run history for a single agent. Default page size 50,
+// max 200. Optional `?task_id=` filter narrows to one task.
+export default defineEventHandler(async (event) => {
+  const owner = await requireOwner(event)
+  const name = getRouterParam(event, 'name')
+  if (!name) throw createError({ statusCode: 400, statusMessage: 'name required' })
+
+  const query = getQuery(event)
+  const limit = Math.min(Math.max(Number(query.limit ?? 50) || 50, 1), 200)
+  const taskFilter = typeof query.task_id === 'string' ? query.task_id : null
+
+  const db = useDb()
+  const agent = await db
+    .select({ email: agents.email })
+    .from(agents)
+    .where(and(eq(agents.ownerEmail, owner.toLowerCase()), eq(agents.agentName, name)))
+    .get()
+  if (!agent) throw createError({ statusCode: 404, statusMessage: 'agent not found' })
+
+  const rows = await db
+    .select()
+    .from(runs)
+    .where(taskFilter
+      ? and(eq(runs.agentEmail, agent.email), eq(runs.taskId, taskFilter))
+      : eq(runs.agentEmail, agent.email))
+    .orderBy(desc(runs.startedAt))
+    .limit(limit)
+
+  return rows
+})

--- a/apps/openape-tribe/server/api/agents/[name]/tasks/[taskId].delete.ts
+++ b/apps/openape-tribe/server/api/agents/[name]/tasks/[taskId].delete.ts
@@ -1,0 +1,27 @@
+import { and, eq } from 'drizzle-orm'
+import { useDb } from '../../../../database/drizzle'
+import { agents, tasks } from '../../../../database/schema'
+import { requireOwner } from '../../../../utils/auth'
+
+export default defineEventHandler(async (event) => {
+  const owner = await requireOwner(event)
+  const name = getRouterParam(event, 'name')
+  const taskId = getRouterParam(event, 'taskId')
+  if (!name || !taskId) {
+    throw createError({ statusCode: 400, statusMessage: 'name and taskId required' })
+  }
+
+  const db = useDb()
+  const agent = await db
+    .select({ email: agents.email })
+    .from(agents)
+    .where(and(eq(agents.ownerEmail, owner.toLowerCase()), eq(agents.agentName, name)))
+    .get()
+  if (!agent) throw createError({ statusCode: 404, statusMessage: 'agent not found' })
+
+  await db
+    .delete(tasks)
+    .where(and(eq(tasks.agentEmail, agent.email), eq(tasks.taskId, taskId)))
+
+  setResponseStatus(event, 204)
+})

--- a/apps/openape-tribe/server/api/agents/[name]/tasks/[taskId].put.ts
+++ b/apps/openape-tribe/server/api/agents/[name]/tasks/[taskId].put.ts
@@ -1,0 +1,73 @@
+import { and, eq } from 'drizzle-orm'
+import { z } from 'zod'
+import { useDb } from '../../../../database/drizzle'
+import { agents, tasks } from '../../../../database/schema'
+import { requireOwner } from '../../../../utils/auth'
+import { validateCron, validateTools } from '../../../../utils/task-validation'
+
+const bodySchema = z.object({
+  name: z.string().min(1).max(100).optional(),
+  cron: z.string().min(1).max(50).optional(),
+  system_prompt: z.string().min(1).max(8000).optional(),
+  tools: z.array(z.string()).optional(),
+  max_steps: z.number().int().min(1).max(50).optional(),
+  enabled: z.boolean().optional(),
+})
+
+// Partial-update PUT: any subset of fields. We re-run cron + tools
+// validation on the new values when present (and only when present)
+// so the editor can change one field at a time without re-sending
+// the full task spec.
+export default defineEventHandler(async (event) => {
+  const owner = await requireOwner(event)
+  const name = getRouterParam(event, 'name')
+  const taskId = getRouterParam(event, 'taskId')
+  if (!name || !taskId) {
+    throw createError({ statusCode: 400, statusMessage: 'name and taskId required' })
+  }
+
+  const body = bodySchema.safeParse(await readBody(event))
+  if (!body.success) {
+    throw createError({ statusCode: 400, statusMessage: body.error.issues[0]?.message ?? 'invalid body' })
+  }
+  if (Object.keys(body.data).length === 0) {
+    throw createError({ statusCode: 400, statusMessage: 'no fields to update' })
+  }
+
+  if (body.data.cron) {
+    const c = validateCron(body.data.cron)
+    if (!c.ok) throw createError({ statusCode: 400, statusMessage: c.reason })
+  }
+  if (body.data.tools) {
+    const t = validateTools(body.data.tools)
+    if (!t.ok) throw createError({ statusCode: 400, statusMessage: t.reason })
+  }
+
+  const db = useDb()
+  const agent = await db
+    .select({ email: agents.email })
+    .from(agents)
+    .where(and(eq(agents.ownerEmail, owner.toLowerCase()), eq(agents.agentName, name)))
+    .get()
+  if (!agent) throw createError({ statusCode: 404, statusMessage: 'agent not found' })
+
+  const updates: Record<string, unknown> = { updatedAt: Math.floor(Date.now() / 1000) }
+  if (body.data.name !== undefined) updates.name = body.data.name
+  if (body.data.cron !== undefined) updates.cron = body.data.cron
+  if (body.data.system_prompt !== undefined) updates.systemPrompt = body.data.system_prompt
+  if (body.data.tools !== undefined) updates.tools = body.data.tools
+  if (body.data.max_steps !== undefined) updates.maxSteps = body.data.max_steps
+  if (body.data.enabled !== undefined) updates.enabled = body.data.enabled
+
+  const result = await db
+    .update(tasks)
+    .set(updates)
+    .where(and(eq(tasks.agentEmail, agent.email), eq(tasks.taskId, taskId)))
+    .returning()
+
+  if (result.length === 0) {
+    throw createError({ statusCode: 404, statusMessage: 'task not found' })
+  }
+
+  return result[0]
+})

--- a/apps/openape-tribe/server/api/agents/[name]/tasks/index.post.ts
+++ b/apps/openape-tribe/server/api/agents/[name]/tasks/index.post.ts
@@ -1,0 +1,72 @@
+import { and, eq } from 'drizzle-orm'
+import { z } from 'zod'
+import { useDb } from '../../../../database/drizzle'
+import { agents, tasks } from '../../../../database/schema'
+import { requireOwner } from '../../../../utils/auth'
+import { validateCron, validateTaskId, validateTools } from '../../../../utils/task-validation'
+
+const bodySchema = z.object({
+  task_id: z.string(),
+  name: z.string().min(1).max(100),
+  cron: z.string().min(1).max(50),
+  system_prompt: z.string().min(1).max(8000),
+  tools: z.array(z.string()),
+  max_steps: z.number().int().min(1).max(50).default(10),
+  enabled: z.boolean().default(true),
+})
+
+export default defineEventHandler(async (event) => {
+  const owner = await requireOwner(event)
+  const name = getRouterParam(event, 'name')
+  if (!name) throw createError({ statusCode: 400, statusMessage: 'name is required' })
+
+  const body = bodySchema.safeParse(await readBody(event))
+  if (!body.success) {
+    throw createError({ statusCode: 400, statusMessage: body.error.issues[0]?.message ?? 'invalid body' })
+  }
+
+  // Cross-cut validation that's not type-shape: cron + tools + task_id
+  // formatting all live in task-validation.ts so the same rules can be
+  // reused on PUT.
+  const cron = validateCron(body.data.cron)
+  if (!cron.ok) throw createError({ statusCode: 400, statusMessage: cron.reason })
+  const tid = validateTaskId(body.data.task_id)
+  if (!tid.ok) throw createError({ statusCode: 400, statusMessage: tid.reason })
+  const t = validateTools(body.data.tools)
+  if (!t.ok) throw createError({ statusCode: 400, statusMessage: t.reason })
+
+  const db = useDb()
+  const agent = await db
+    .select({ email: agents.email })
+    .from(agents)
+    .where(and(eq(agents.ownerEmail, owner.toLowerCase()), eq(agents.agentName, name)))
+    .get()
+  if (!agent) throw createError({ statusCode: 404, statusMessage: 'agent not found' })
+
+  const now = Math.floor(Date.now() / 1000)
+  await db.insert(tasks).values({
+    agentEmail: agent.email,
+    taskId: body.data.task_id,
+    name: body.data.name,
+    cron: body.data.cron,
+    systemPrompt: body.data.system_prompt,
+    tools: t.tools,
+    maxSteps: body.data.max_steps,
+    enabled: body.data.enabled,
+    createdAt: now,
+    updatedAt: now,
+  }).onConflictDoUpdate({
+    target: [tasks.agentEmail, tasks.taskId],
+    set: {
+      name: body.data.name,
+      cron: body.data.cron,
+      systemPrompt: body.data.system_prompt,
+      tools: t.tools,
+      maxSteps: body.data.max_steps,
+      enabled: body.data.enabled,
+      updatedAt: now,
+    },
+  })
+
+  return { agent_email: agent.email, task_id: body.data.task_id, updated_at: now }
+})

--- a/apps/openape-tribe/server/api/agents/index.get.ts
+++ b/apps/openape-tribe/server/api/agents/index.get.ts
@@ -1,0 +1,33 @@
+import { desc, eq, sql } from 'drizzle-orm'
+import { useDb } from '../../database/drizzle'
+import { agents, runs, tasks } from '../../database/schema'
+import { requireOwner } from '../../utils/auth'
+
+// List the owner's agents with a few joined summary columns so the
+// UI doesn't need a fan-out per row: task count + most-recent run
+// status. Both subqueries are cheap on libsql for our expected data
+// volume (handful of agents per owner, tasks low double-digits).
+export default defineEventHandler(async (event) => {
+  const owner = await requireOwner(event)
+  const db = useDb()
+
+  const rows = await db
+    .select({
+      email: agents.email,
+      agentName: agents.agentName,
+      hostId: agents.hostId,
+      hostname: agents.hostname,
+      pubkeySsh: agents.pubkeySsh,
+      firstSeenAt: agents.firstSeenAt,
+      lastSeenAt: agents.lastSeenAt,
+      createdAt: agents.createdAt,
+      taskCount: sql<number>`(SELECT COUNT(*) FROM ${tasks} WHERE ${tasks.agentEmail} = ${agents.email})`,
+      lastRunStatus: sql<string | null>`(SELECT status FROM ${runs} WHERE ${runs.agentEmail} = ${agents.email} ORDER BY ${runs.startedAt} DESC LIMIT 1)`,
+      lastRunAt: sql<number | null>`(SELECT started_at FROM ${runs} WHERE ${runs.agentEmail} = ${agents.email} ORDER BY ${runs.startedAt} DESC LIMIT 1)`,
+    })
+    .from(agents)
+    .where(eq(agents.ownerEmail, owner.toLowerCase()))
+    .orderBy(desc(agents.createdAt))
+
+  return rows
+})

--- a/apps/openape-tribe/server/api/agents/me/runs/[id].patch.ts
+++ b/apps/openape-tribe/server/api/agents/me/runs/[id].patch.ts
@@ -1,0 +1,63 @@
+import { and, eq } from 'drizzle-orm'
+import { z } from 'zod'
+import { useDb } from '../../../../database/drizzle'
+import { runs } from '../../../../database/schema'
+import { requireAgent } from '../../../../utils/auth'
+
+const TRACE_CAP_BYTES = 16 * 1024
+
+const bodySchema = z.object({
+  status: z.enum(['ok', 'error']),
+  final_message: z.string().max(8000).nullable(),
+  step_count: z.number().int().min(0).max(1000),
+  trace: z.unknown().optional(),
+})
+
+// Final-state PATCH on a run record. Trace is JSON-serialised and
+// truncated at 16KB so a noisy run can't blow up the runs table.
+// Truncation is naive byte-cap on the JSON string; the UI shows the
+// truncated payload + a "(truncated)" note.
+export default defineEventHandler(async (event) => {
+  const agentEmail = await requireAgent(event)
+  const id = getRouterParam(event, 'id')
+  if (!id) throw createError({ statusCode: 400, statusMessage: 'id required' })
+
+  const body = bodySchema.safeParse(await readBody(event))
+  if (!body.success) {
+    throw createError({ statusCode: 400, statusMessage: body.error.issues[0]?.message ?? 'invalid body' })
+  }
+
+  let traceJson: string | null = null
+  if (body.data.trace !== undefined) {
+    let s: string
+    try { s = JSON.stringify(body.data.trace) }
+    catch { s = '"<unserialisable trace>"' }
+    if (Buffer.byteLength(s, 'utf8') > TRACE_CAP_BYTES) {
+      // Slice in code units (close enough — any partial unicode is
+      // dropped, but the JSON.parse on the consumer side runs against
+      // best-effort) then mark it truncated.
+      const sliced = s.slice(0, TRACE_CAP_BYTES - 64)
+      traceJson = JSON.stringify({ truncated: true, slice: sliced })
+    }
+    else {
+      traceJson = s
+    }
+  }
+
+  const result = await useDb()
+    .update(runs)
+    .set({
+      status: body.data.status,
+      finalMessage: body.data.final_message,
+      stepCount: body.data.step_count,
+      finishedAt: Math.floor(Date.now() / 1000),
+      ...(traceJson !== null ? { trace: JSON.parse(traceJson) as unknown } : {}),
+    })
+    .where(and(eq(runs.id, id), eq(runs.agentEmail, agentEmail)))
+    .returning()
+
+  if (result.length === 0) {
+    throw createError({ statusCode: 404, statusMessage: 'run not found or not owned by this agent' })
+  }
+  return result[0]
+})

--- a/apps/openape-tribe/server/api/agents/me/runs/index.post.ts
+++ b/apps/openape-tribe/server/api/agents/me/runs/index.post.ts
@@ -1,0 +1,31 @@
+import { randomUUID } from 'node:crypto'
+import { z } from 'zod'
+import { useDb } from '../../../../database/drizzle'
+import { runs } from '../../../../database/schema'
+import { requireAgent } from '../../../../utils/auth'
+
+const bodySchema = z.object({
+  task_id: z.string().min(1),
+})
+
+// Agent claims a run-id at the start of a run. Returns `{ id }` so
+// the agent can PATCH it on completion. Status starts as 'running';
+// finishedAt is null until the PATCH lands.
+export default defineEventHandler(async (event) => {
+  const agentEmail = await requireAgent(event)
+  const body = bodySchema.safeParse(await readBody(event))
+  if (!body.success) {
+    throw createError({ statusCode: 400, statusMessage: body.error.issues[0]?.message ?? 'invalid body' })
+  }
+
+  const id = randomUUID()
+  const now = Math.floor(Date.now() / 1000)
+  await useDb().insert(runs).values({
+    id,
+    agentEmail,
+    taskId: body.data.task_id,
+    startedAt: now,
+    status: 'running',
+  })
+  return { id, started_at: now }
+})

--- a/apps/openape-tribe/server/api/agents/me/sync.post.ts
+++ b/apps/openape-tribe/server/api/agents/me/sync.post.ts
@@ -1,0 +1,92 @@
+import { eq } from 'drizzle-orm'
+import { z } from 'zod'
+import { useDb } from '../../../database/drizzle'
+import { agents } from '../../../database/schema'
+import { parseAgentEmail } from '../../../utils/agent-email'
+import { requireAgent } from '../../../utils/auth'
+
+const bodySchema = z.object({
+  hostname: z.string().min(1).max(253),
+  // IOPlatformUUID is canonical 8-4-4-4-12 hex with dashes, but we
+  // keep validation lenient — different hardware identifiers may
+  // produce different formats and we don't want to break agent
+  // registration over a regex difference. Cap on length only.
+  host_id: z.string().min(8).max(128),
+  // The agent was provisioned by its owner via `apes agents spawn`,
+  // so the owner's email is known on the agent host. Posting it
+  // here lets tribe associate the agent with the right owner; the
+  // ownerDomain part is also encoded in the agent's own email and
+  // we cross-check the two below.
+  owner_email: z.string().email(),
+  pubkey_ssh: z.string().min(20).max(4000).optional(),
+})
+
+// Agent self-introduction. Called on first sync (after spawn) and
+// on every subsequent sync. First sync pins host_id; subsequent
+// syncs must match the pinned value or get 401 — that's the cheap
+// "this keypair was copied to another machine" alarm.
+export default defineEventHandler(async (event) => {
+  const agentEmail = await requireAgent(event)
+  const parsed = parseAgentEmail(agentEmail)
+  if (!parsed) {
+    throw createError({ statusCode: 400, statusMessage: 'agent email does not match the agent+name+ownerdomain pattern' })
+  }
+
+  const body = bodySchema.safeParse(await readBody(event))
+  if (!body.success) {
+    throw createError({ statusCode: 400, statusMessage: body.error.issues[0]?.message ?? 'invalid body' })
+  }
+
+  // Cross-check: the agent's email encodes the owner's domain, which
+  // must match the owner email's domain. Catches typos and mostly
+  // also catches "agent X tries to claim itself for owner@elsewhere".
+  const postedDomain = body.data.owner_email.split('@')[1]?.toLowerCase()
+  if (postedDomain !== parsed.ownerDomain) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: `owner_email domain (${postedDomain}) does not match agent email's encoded owner-domain (${parsed.ownerDomain})`,
+    })
+  }
+
+  const db = useDb()
+  const now = Math.floor(Date.now() / 1000)
+  const existing = await db
+    .select()
+    .from(agents)
+    .where(eq(agents.email, agentEmail))
+    .get()
+
+  if (existing) {
+    // Pinned hostId mismatch is the keypair-was-copied alarm. Refuse
+    // to update anything; the agent owner needs to either re-spawn
+    // (regenerating keypair) or, in a future iteration, explicitly
+    // reset the pin via an owner-side endpoint.
+    if (existing.hostId && existing.hostId !== body.data.host_id) {
+      throw createError({
+        statusCode: 401,
+        statusMessage: 'host_id mismatch: agent keypair appears to have moved to a different host',
+      })
+    }
+    await db.update(agents).set({
+      hostId: body.data.host_id,
+      hostname: body.data.hostname,
+      ownerEmail: body.data.owner_email.toLowerCase(),
+      pubkeySsh: body.data.pubkey_ssh ?? existing.pubkeySsh,
+      lastSeenAt: now,
+    }).where(eq(agents.email, agentEmail))
+    return { agent_email: agentEmail, host_id: body.data.host_id, first_sync: false, last_seen_at: now }
+  }
+
+  await db.insert(agents).values({
+    email: agentEmail,
+    ownerEmail: body.data.owner_email.toLowerCase(),
+    agentName: parsed.agentName,
+    hostId: body.data.host_id,
+    hostname: body.data.hostname,
+    pubkeySsh: body.data.pubkey_ssh ?? null,
+    firstSeenAt: now,
+    lastSeenAt: now,
+    createdAt: now,
+  })
+  return { agent_email: agentEmail, host_id: body.data.host_id, first_sync: true, last_seen_at: now }
+})

--- a/apps/openape-tribe/server/api/agents/me/tasks.get.ts
+++ b/apps/openape-tribe/server/api/agents/me/tasks.get.ts
@@ -1,0 +1,16 @@
+import { eq } from 'drizzle-orm'
+import { useDb } from '../../../database/drizzle'
+import { tasks } from '../../../database/schema'
+import { requireAgent } from '../../../utils/auth'
+
+// Agent reads its own task list. No owner gate — the JWT's sub is
+// the agent email and we filter rows on it. Returns the full task
+// spec the agent needs to materialise launchd plists + spec files.
+export default defineEventHandler(async (event) => {
+  const agentEmail = await requireAgent(event)
+  const db = useDb()
+  return await db
+    .select()
+    .from(tasks)
+    .where(eq(tasks.agentEmail, agentEmail))
+})

--- a/apps/openape-tribe/server/api/tool-catalog.get.ts
+++ b/apps/openape-tribe/server/api/tool-catalog.get.ts
@@ -1,0 +1,7 @@
+import catalog from '../tool-catalog.json'
+
+// Public read of the tool catalog. The UI fetches this to populate
+// the per-task tool picker; agents (and curious humans) can inspect
+// it too. No auth required — the list is the same for everybody and
+// non-secret.
+export default defineEventHandler(() => catalog)

--- a/apps/openape-tribe/server/utils/agent-email.ts
+++ b/apps/openape-tribe/server/utils/agent-email.ts
@@ -1,0 +1,29 @@
+// Agent emails follow the DDISA convention used by `apes agents
+// enroll`:
+//
+//   agent+<agentName>+<ownerDomain>@id.openape.ai
+//
+// The name and owner-domain are recoverable so we don't need a
+// separate lookup at every API hit. Owner email itself is then
+// `<owner-local>@<owner-domain>` — we know the domain from the agent
+// email but the local-part lives only in the IdP's user store, so
+// `ownerEmail` is whatever the agent posts on its first sync (it
+// knows because it was provisioned by that very owner). For owner-
+// auth endpoints we read the owner email directly from the session
+// instead.
+
+export interface ParsedAgentEmail {
+  agentName: string
+  ownerDomain: string
+}
+
+const AGENT_EMAIL_RE = /^agent\+([a-z0-9-]+)\+([^@]+)@([^@]+)$/
+
+export function parseAgentEmail(email: string): ParsedAgentEmail | null {
+  const m = email.toLowerCase().match(AGENT_EMAIL_RE)
+  if (!m) return null
+  return {
+    agentName: m[1]!,
+    ownerDomain: m[2]!.replace(/_/g, '.'),
+  }
+}

--- a/apps/openape-tribe/server/utils/task-validation.ts
+++ b/apps/openape-tribe/server/utils/task-validation.ts
@@ -1,0 +1,60 @@
+import catalog from '../tool-catalog.json'
+
+const KNOWN_TOOLS = new Set<string>(catalog.tools.map((t: { name: string }) => t.name))
+
+// Tiny cron-syntax subset that the apes-runtime's launchd reconciler
+// can translate to `StartCalendarInterval`. We accept the 95% — every
+// other syntax (lists, ranges, step on day fields, @-shortcuts) gets
+// rejected at create time so the agent host doesn't end up with a
+// task it can't actually schedule.
+//
+// Supported patterns (5 fields: minute hour day-of-month month day-of-week):
+//   *                 every value
+//   N                 fixed value (0–59 / 0–23 / 1–31 / 1–12 / 0–7)
+//   */N               every Nth (only on minute and hour fields)
+//
+// Field-by-field validators below; the whole expression must match.
+
+const STAR = '*'
+function validField(token: string, min: number, max: number, allowStep: boolean): boolean {
+  if (token === STAR) return true
+  if (allowStep && token.startsWith('*/')) {
+    const n = Number(token.slice(2))
+    return Number.isInteger(n) && n >= 1 && n <= max
+  }
+  const n = Number(token)
+  return Number.isInteger(n) && n >= min && n <= max
+}
+
+export function validateCron(expr: string): { ok: true } | { ok: false, reason: string } {
+  const parts = expr.trim().split(/\s+/)
+  if (parts.length !== 5) {
+    return { ok: false, reason: 'cron must have exactly 5 fields (minute hour day-of-month month day-of-week)' }
+  }
+  const [minute, hour, dom, month, dow] = parts as [string, string, string, string, string]
+  if (!validField(minute, 0, 59, true)) return { ok: false, reason: `invalid minute field: ${minute}` }
+  if (!validField(hour, 0, 23, true)) return { ok: false, reason: `invalid hour field: ${hour}` }
+  if (!validField(dom, 1, 31, false)) return { ok: false, reason: `invalid day-of-month field: ${dom}` }
+  if (!validField(month, 1, 12, false)) return { ok: false, reason: `invalid month field: ${month}` }
+  if (!validField(dow, 0, 7, false)) return { ok: false, reason: `invalid day-of-week field: ${dow}` }
+  return { ok: true }
+}
+
+export function validateTools(tools: unknown): { ok: true, tools: string[] } | { ok: false, reason: string } {
+  if (!Array.isArray(tools)) return { ok: false, reason: 'tools must be an array of strings' }
+  if (!tools.every(t => typeof t === 'string')) return { ok: false, reason: 'tools must contain only strings' }
+  const unknown = (tools as string[]).filter(t => !KNOWN_TOOLS.has(t))
+  if (unknown.length > 0) {
+    return { ok: false, reason: `unknown tool(s): ${unknown.join(', ')}` }
+  }
+  return { ok: true, tools: tools as string[] }
+}
+
+const TASK_ID_RE = /^[a-z][a-z0-9-]{0,63}$/
+export function validateTaskId(id: unknown): { ok: true } | { ok: false, reason: string } {
+  if (typeof id !== 'string') return { ok: false, reason: 'task_id must be a string' }
+  if (!TASK_ID_RE.test(id)) {
+    return { ok: false, reason: 'task_id must match /^[a-z][a-z0-9-]{0,63}$/' }
+  }
+  return { ok: true }
+}

--- a/apps/openape-tribe/tests/task-validation.test.ts
+++ b/apps/openape-tribe/tests/task-validation.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import { validateCron, validateTaskId, validateTools } from '../server/utils/task-validation'
+
+describe('validateCron — supported subset', () => {
+  it.each([
+    ['*/5 * * * *', true],
+    ['0 18 * * *', true],
+    ['0 9 * * 1', true],
+    ['*/15 8 * * *', true],
+    ['0 0 1 * *', true],
+    ['* * * * *', true],
+  ])('accepts %s', (expr, ok) => {
+    expect(validateCron(expr).ok).toBe(ok)
+  })
+
+  it.each([
+    ['*/5 * * *'], // 4 fields
+    ['*/5 * * * * *'], // 6 fields
+    ['60 * * * *'], // out-of-range minute
+    ['* 24 * * *'], // out-of-range hour
+    ['* * 32 * *'], // out-of-range day-of-month
+    ['1,5 * * * *'], // lists not supported
+    ['1-5 * * * *'], // ranges not supported
+    ['@hourly'], // shortcuts not supported
+    ['* */5 * * *'], // step on hour — accepted (allowStep on hour)
+  ].slice(0, 8))('rejects %s', ([expr]) => {
+    expect(validateCron(expr!).ok).toBe(false)
+  })
+})
+
+describe('validateTools — catalog allowlist', () => {
+  it('accepts known tool names', () => {
+    expect(validateTools(['time.now', 'http.get']).ok).toBe(true)
+  })
+
+  it('rejects unknown tools', () => {
+    const r = validateTools(['time.now', 'magic.do'])
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.reason).toContain('magic.do')
+  })
+
+  it('rejects non-arrays', () => {
+    expect(validateTools('time.now' as unknown).ok).toBe(false)
+    expect(validateTools(null as unknown).ok).toBe(false)
+  })
+
+  it('rejects non-string entries', () => {
+    expect(validateTools([1, 2] as unknown).ok).toBe(false)
+  })
+
+  it('accepts empty array (task with no tools is valid)', () => {
+    expect(validateTools([]).ok).toBe(true)
+  })
+})
+
+describe('validateTaskId — slug rules', () => {
+  it.each([
+    ['mail-triage', true],
+    ['daily-summary', true],
+    ['x', true],
+    ['Mail-Triage', false], // uppercase
+    ['1abc', false], // starts with digit
+    ['mail_triage', false], // underscore
+    ['', false],
+  ])('%s -> %s', (id, ok) => {
+    expect(validateTaskId(id).ok).toBe(ok)
+  })
+})


### PR DESCRIPTION
M2 of [openape-tribe plan](.claude/plans/openape-tribe.md). Builds on M1's empty SP shell.

## Endpoints (11 routes total)

| Path | Method | Auth | Purpose |
|---|---|---|---|
| `/api/agents` | GET | owner session | list agents w/ task-count + last-run summary |
| `/api/agents/:name` | GET | owner | detail + tasks + 20 recent runs |
| `/api/agents/:name/tasks` | POST | owner | create task |
| `/api/agents/:name/tasks/:taskId` | PUT | owner | partial update |
| `/api/agents/:name/tasks/:taskId` | DELETE | owner | |
| `/api/agents/:name/runs` | GET | owner | paginated history |
| `/api/agents/me/sync` | POST | agent JWT | upsert + hostId pin |
| `/api/agents/me/tasks` | GET | agent JWT | full task specs |
| `/api/agents/me/runs` | POST | agent JWT | claim run-id |
| `/api/agents/me/runs/:id` | PATCH | agent JWT | finalise (trace ≤ 16KB) |
| `/api/tool-catalog` | GET | public | shared by SP-validation + UI picker |

## Validation

- Cron subset for the M4 launchd reconciler — anything that won't translate cleanly is rejected at create time
- Tools must be in `server/tool-catalog.json` or 400
- `task_id` is a slug; `hostId` mismatch on subsequent syncs → 401 (the keypair-was-copied alarm)
- `owner_email` domain must match the agent-email-encoded owner-domain

## Tests

11 unit tests for the validation helpers (cron, tools, task_id). Build + lint + typecheck green (7 turbo tasks).