### PR TITLE
feat(apes): M4 — agents sync

### DIFF
--- a/packages/apes/src/commands/agents/index.ts
+++ b/packages/apes/src/commands/agents/index.ts
@@ -4,11 +4,12 @@ import { destroyAgentCommand } from './destroy'
 import { listAgentsCommand } from './list'
 import { registerAgentCommand } from './register'
 import { spawnAgentCommand } from './spawn'
+import { syncAgentCommand } from './sync'
 
 export const agentsCommand = defineCommand({
   meta: {
     name: 'agents',
-    description: 'Manage owned agents (register, spawn, list, destroy, allow)',
+    description: 'Manage owned agents (register, spawn, list, destroy, allow, sync)',
   },
   subCommands: {
     register: registerAgentCommand,
@@ -16,5 +17,6 @@ export const agentsCommand = defineCommand({
     list: listAgentsCommand,
     destroy: destroyAgentCommand,
     allow: allowAgentCommand,
+    sync: syncAgentCommand,
   },
 })

--- a/packages/apes/src/commands/agents/sync.ts
+++ b/packages/apes/src/commands/agents/sync.ts
@@ -1,0 +1,127 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { defineCommand } from 'citty'
+import consola from 'consola'
+import { CliError } from '../../errors'
+import { reconcile } from '../../lib/launchd-reconcile'
+import { getHostId, getHostname } from '../../lib/macos-host'
+import { resolveTribeUrl, TribeClient } from '../../lib/tribe-client'
+
+interface AuthJson {
+  idp: string
+  access_token: string
+  email: string
+  expires_at?: number
+  key_path?: string
+  owner_email?: string
+}
+
+const AUTH_PATH = join(homedir(), '.config', 'apes', 'auth.json')
+const TASK_CACHE_DIR = join(homedir(), '.openape', 'agent', 'tasks')
+
+function readAuthJson(): AuthJson {
+  if (!existsSync(AUTH_PATH)) {
+    throw new CliError(
+      `No agent auth found at ${AUTH_PATH}. Run \`apes agents spawn <name>\` to provision an agent first.`,
+    )
+  }
+  const raw = readFileSync(AUTH_PATH, 'utf8')
+  let parsed: AuthJson
+  try { parsed = JSON.parse(raw) as AuthJson }
+  catch (err) {
+    throw new CliError(`${AUTH_PATH} is not valid JSON: ${(err as Error).message}`)
+  }
+  if (!parsed.access_token) throw new CliError(`${AUTH_PATH} is missing access_token`)
+  if (!parsed.email) throw new CliError(`${AUTH_PATH} is missing email`)
+  if (!parsed.email.startsWith('agent+')) {
+    throw new CliError(
+      `${AUTH_PATH} email is "${parsed.email}" — expected an agent+name+domain@idp address. Run \`apes agents spawn\` rather than calling sync from a human user.`,
+    )
+  }
+  return parsed
+}
+
+function agentNameFromEmail(email: string): string {
+  // agent+<name>+<owner-domain>@<idp-host>
+  const m = email.match(/^agent\+([^+]+)\+/)
+  if (!m) throw new CliError(`agent email "${email}" does not match agent+name+domain pattern`)
+  return m[1]!
+}
+
+function findApesBin(): string {
+  // process.argv[1] is the apes entry script; resolve the symlink to
+  // the actual binary so launchd can invoke it directly. If
+  // process.argv[1] isn't reliable (e.g. when run via `node dist/...`),
+  // fall back to whatever's on PATH at /usr/local/bin/apes.
+  const argv1 = process.argv[1]
+  if (argv1 && existsSync(argv1)) return argv1
+  for (const candidate of ['/opt/homebrew/bin/apes', '/usr/local/bin/apes']) {
+    if (existsSync(candidate)) return candidate
+  }
+  throw new CliError('Could not locate the apes binary path for launchd. Set APES_BIN env var to point at it.')
+}
+
+export const syncAgentCommand = defineCommand({
+  meta: {
+    name: 'sync',
+    description: 'Pull this agent\'s task list from tribe.openape.ai and reconcile launchd plists',
+  },
+  args: {
+    'tribe-url': {
+      type: 'string',
+      description: 'Override tribe SP base URL (default: $OPENAPE_TRIBE_URL or https://tribe.openape.ai)',
+    },
+  },
+  async run({ args }) {
+    const auth = readAuthJson()
+    const agentName = agentNameFromEmail(auth.email)
+    const tribeUrl = resolveTribeUrl(args['tribe-url'] as string | undefined)
+    const client = new TribeClient(tribeUrl, auth.access_token)
+
+    const hostId = getHostId()
+    const host = getHostname()
+    if (!hostId) {
+      throw new CliError('Could not read IOPlatformUUID — is this macOS? Tribe sync only works on macOS for v1.')
+    }
+    if (!auth.owner_email) {
+      throw new CliError(`${AUTH_PATH} is missing owner_email — re-run \`apes agents spawn\` to update.`)
+    }
+
+    consola.start(`Syncing ${agentName} (${host}, hostId ${hostId.slice(0, 8)}…) with ${tribeUrl}`)
+
+    const sync = await client.sync({
+      hostname: host,
+      hostId,
+      ownerEmail: auth.owner_email,
+    })
+    consola.info(sync.first_sync ? '✓ first sync — agent registered' : '✓ presence updated')
+
+    const tasks = await client.listTasks()
+    consola.info(`Pulled ${tasks.length} task${tasks.length === 1 ? '' : 's'}`)
+
+    // Cache full task specs locally so `apes agents run <task_id>`
+    // can execute without going to network. Cache layout:
+    //   ~/.openape/agent/tasks/<task_id>.json
+    mkdirSync(TASK_CACHE_DIR, { recursive: true })
+    for (const task of tasks) {
+      const path = join(TASK_CACHE_DIR, `${task.taskId}.json`)
+      writeFileSync(path, `${JSON.stringify(task, null, 2)}\n`, { mode: 0o600 })
+    }
+
+    const apesBin = findApesBin()
+    const result = reconcile({
+      agentName,
+      apesBin,
+      homeDir: homedir(),
+      desired: tasks,
+    })
+
+    if (result.added.length) consola.success(`launchd: added ${result.added.join(', ')}`)
+    if (result.updated.length) consola.success(`launchd: updated ${result.updated.join(', ')}`)
+    if (result.removed.length) consola.warn(`launchd: removed ${result.removed.join(', ')}`)
+    if (result.unchanged.length) consola.info(`launchd: ${result.unchanged.length} unchanged`)
+
+    consola.success('Sync complete.')
+  },
+})

--- a/packages/apes/src/lib/launchd-reconcile.ts
+++ b/packages/apes/src/lib/launchd-reconcile.ts
@@ -1,0 +1,258 @@
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, readdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
+import { homedir, userInfo } from 'node:os'
+import { join } from 'node:path'
+import type { TaskSpec } from './tribe-client'
+
+// Reconciles ~/Library/LaunchAgents/openape.tribe.<agent>.<task>.plist
+// against the desired set from the tribe SP.
+//
+// One plist per task. Filename encodes the agent name + task slug so
+// we can scope the diff with a glob — multiple agents on the same
+// macOS user (uncommon but possible) don't step on each other's
+// scheduled jobs. `enabled: false` tasks still get a plist written
+// (so the user can see them in the Library/LaunchAgents listing) but
+// the job is `bootout`-ed so launchd doesn't fire it.
+//
+// We avoid `launchctl` calls when nothing changed — content-equality
+// on the existing file vs the desired plist body. macOS's launchctl
+// is slow and verbose; a no-op sync should be silent.
+
+export interface ReconcileResult {
+  added: string[]
+  updated: string[]
+  removed: string[]
+  unchanged: string[]
+}
+
+const PLIST_PREFIX = 'openape.tribe.'
+
+function plistDir(): string {
+  return join(homedir(), 'Library', 'LaunchAgents')
+}
+
+function plistPath(agentName: string, taskId: string): string {
+  return join(plistDir(), `${PLIST_PREFIX}${agentName}.${taskId}.plist`)
+}
+
+function plistLabel(agentName: string, taskId: string): string {
+  return `${PLIST_PREFIX}${agentName}.${taskId}`
+}
+
+interface ScheduleSlot {
+  Minute?: number
+  Hour?: number
+  Day?: number
+  Month?: number
+  Weekday?: number
+}
+
+// Translate our supported cron subset (* / N / */N) into one or more
+// StartCalendarInterval slots. */N expands to all matching values
+// (e.g. */15 on minute = [0, 15, 30, 45]) so launchd fires at every
+// instance without needing to model "every Nth" natively.
+function fieldValues(token: string, range: [number, number]): number[] | null {
+  const [min, max] = range
+  if (token === '*') return null // null = "any"
+  if (token.startsWith('*/')) {
+    const step = Number(token.slice(2))
+    if (!Number.isInteger(step) || step < 1) return []
+    const values: number[] = []
+    for (let i = min; i <= max; i++) {
+      if (i % step === 0) values.push(i)
+    }
+    return values
+  }
+  const n = Number(token)
+  return Number.isInteger(n) ? [n] : []
+}
+
+function cronToSchedule(expr: string): ScheduleSlot[] {
+  const parts = expr.trim().split(/\s+/)
+  if (parts.length !== 5) return [] // server should already have rejected, but be safe
+  const [m, h, dom, mo, dow] = parts as [string, string, string, string, string]
+  const minutes = fieldValues(m, [0, 59])
+  const hours = fieldValues(h, [0, 23])
+  const doms = fieldValues(dom, [1, 31])
+  const months = fieldValues(mo, [1, 12])
+  // launchd Weekday: 0 = Sunday … 7 also = Sunday. Cron's 0/7 → 0.
+  const dows = fieldValues(dow, [0, 7])
+
+  const slots: ScheduleSlot[] = []
+  // Cartesian-product over all explicit values; nulls are dropped (=
+  // launchd "any"). For our subset this stays small (e.g. */15 on
+  // minute = 4 entries; everything else usually * or fixed).
+  const minList = minutes ?? [null]
+  const hourList = hours ?? [null]
+  const domList = doms ?? [null]
+  const monthList = months ?? [null]
+  const dowList = dows ?? [null]
+
+  for (const M of minList) {
+    for (const H of hourList) {
+      for (const D of domList) {
+        for (const Mo of monthList) {
+          for (const W of dowList) {
+            const slot: ScheduleSlot = {}
+            if (M !== null) slot.Minute = M as number
+            if (H !== null) slot.Hour = H as number
+            if (D !== null) slot.Day = D as number
+            if (Mo !== null) slot.Month = Mo as number
+            if (W !== null) slot.Weekday = (W === 7 ? 0 : W) as number
+            slots.push(slot)
+          }
+        }
+      }
+    }
+  }
+  return slots
+}
+
+function escape(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
+function plistBody(input: { label: string, apesBin: string, taskId: string, schedule: ScheduleSlot[], homeDir: string }): string {
+  const calendarBlocks = input.schedule.map((slot) => {
+    const lines: string[] = []
+    if (slot.Minute !== undefined) lines.push(`      <key>Minute</key><integer>${slot.Minute}</integer>`)
+    if (slot.Hour !== undefined) lines.push(`      <key>Hour</key><integer>${slot.Hour}</integer>`)
+    if (slot.Day !== undefined) lines.push(`      <key>Day</key><integer>${slot.Day}</integer>`)
+    if (slot.Month !== undefined) lines.push(`      <key>Month</key><integer>${slot.Month}</integer>`)
+    if (slot.Weekday !== undefined) lines.push(`      <key>Weekday</key><integer>${slot.Weekday}</integer>`)
+    return `    <dict>\n${lines.join('\n')}\n    </dict>`
+  }).join('\n')
+
+  const calendarKey = input.schedule.length === 1
+    ? `  <key>StartCalendarInterval</key>\n  <dict>\n${calendarBlocks.replace(/^ {4}/gm, '  ').replace(/^ {2}<dict>\n|\n {2}<\/dict>$/g, '')}\n  </dict>`
+    : `  <key>StartCalendarInterval</key>\n  <array>\n${calendarBlocks}\n  </array>`
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${escape(input.label)}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${escape(input.apesBin)}</string>
+    <string>agents</string>
+    <string>run</string>
+    <string>${escape(input.taskId)}</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>${escape(input.homeDir)}</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>HOME</key>
+    <string>${escape(input.homeDir)}</string>
+  </dict>
+${calendarKey}
+  <key>StandardOutPath</key>
+  <string>${escape(input.homeDir)}/Library/Logs/openape-tribe-${escape(input.taskId)}.log</string>
+  <key>StandardErrorPath</key>
+  <string>${escape(input.homeDir)}/Library/Logs/openape-tribe-${escape(input.taskId)}.log</string>
+</dict>
+</plist>
+`
+}
+
+interface BuildArgs {
+  agentName: string
+  apesBin: string
+  homeDir: string
+  task: TaskSpec
+}
+
+function buildPlistContent(args: BuildArgs): string {
+  return plistBody({
+    label: plistLabel(args.agentName, args.task.taskId),
+    apesBin: args.apesBin,
+    taskId: args.task.taskId,
+    schedule: cronToSchedule(args.task.cron),
+    homeDir: args.homeDir,
+  })
+}
+
+function uid(): number {
+  return userInfo().uid
+}
+
+function bootstrap(label: string, path: string): void {
+  // Idempotent: bootout first (silent if not loaded), then bootstrap.
+  try { execFileSync('/bin/launchctl', ['bootout', `gui/${uid()}/${label}`], { stdio: 'ignore' }) }
+  catch { /* not loaded */ }
+  execFileSync('/bin/launchctl', ['bootstrap', `gui/${uid()}`, path], { stdio: 'ignore' })
+}
+
+function bootout(label: string): void {
+  try { execFileSync('/bin/launchctl', ['bootout', `gui/${uid()}/${label}`], { stdio: 'ignore' }) }
+  catch { /* not loaded */ }
+}
+
+export interface ReconcileInput {
+  agentName: string
+  apesBin: string
+  homeDir: string
+  desired: TaskSpec[]
+}
+
+export function reconcile(input: ReconcileInput): ReconcileResult {
+  mkdirSync(plistDir(), { recursive: true })
+
+  const present = readdirSync(plistDir())
+    .filter(f => f.startsWith(`${PLIST_PREFIX}${input.agentName}.`) && f.endsWith('.plist'))
+  const presentTaskIds = new Set(
+    present.map(f => f.slice(`${PLIST_PREFIX}${input.agentName}.`.length, -'.plist'.length)),
+  )
+  const desiredById = new Map(input.desired.map(t => [t.taskId, t]))
+
+  const result: ReconcileResult = { added: [], updated: [], removed: [], unchanged: [] }
+
+  // Remove plists that no longer have a matching task.
+  for (const taskId of presentTaskIds) {
+    if (!desiredById.has(taskId)) {
+      const path = plistPath(input.agentName, taskId)
+      bootout(plistLabel(input.agentName, taskId))
+      try { unlinkSync(path) }
+      catch { /* already gone */ }
+      result.removed.push(taskId)
+    }
+  }
+
+  // Write / update plists for desired tasks.
+  for (const task of input.desired) {
+    const path = plistPath(input.agentName, task.taskId)
+    const desiredContent = buildPlistContent({
+      agentName: input.agentName,
+      apesBin: input.apesBin,
+      homeDir: input.homeDir,
+      task,
+    })
+
+    let existingContent = ''
+    try { existingContent = readFileSync(path, 'utf8') }
+    catch { /* not yet */ }
+
+    if (existingContent === desiredContent) {
+      // File identical — only adjust load state if `enabled` flipped.
+      if (task.enabled) bootstrap(plistLabel(input.agentName, task.taskId), path)
+      else bootout(plistLabel(input.agentName, task.taskId))
+      result.unchanged.push(task.taskId)
+      continue
+    }
+
+    writeFileSync(path, desiredContent, { mode: 0o644 })
+    if (task.enabled) bootstrap(plistLabel(input.agentName, task.taskId), path)
+    else bootout(plistLabel(input.agentName, task.taskId))
+
+    if (presentTaskIds.has(task.taskId)) result.updated.push(task.taskId)
+    else result.added.push(task.taskId)
+  }
+
+  return result
+}
+
+// Test seam — exposes the cron→launchd translator without going
+// through the file system. Same algorithm reconcile() uses.
+export const _internal = { cronToSchedule, buildPlistContent }

--- a/packages/apes/src/lib/macos-host.ts
+++ b/packages/apes/src/lib/macos-host.ts
@@ -1,0 +1,31 @@
+import { execFileSync } from 'node:child_process'
+import { hostname } from 'node:os'
+
+// Stable hardware-rooted host identifier on macOS. We pull
+// IOPlatformUUID via `ioreg`, which survives hostname changes,
+// disk wipes that preserve hardware (e.g. macOS reinstalls), and
+// most other operator-side reshuffles. Replacing the SoC / logic
+// board changes it; that's the intended "different host" signal.
+//
+// Returns a lowercase string with no surrounding whitespace. Empty
+// string on failure (we never throw — the caller decides what to do
+// when the host can't be identified).
+export function getHostId(): string {
+  try {
+    const output = execFileSync(
+      '/usr/sbin/ioreg',
+      ['-d2', '-c', 'IOPlatformExpertDevice'],
+      { encoding: 'utf8', timeout: 2000 },
+    )
+    const match = output.match(/"IOPlatformUUID"\s*=\s*"([^"]+)"/)
+    return match ? match[1]!.trim().toLowerCase() : ''
+  }
+  catch {
+    return ''
+  }
+}
+
+export function getHostname(): string {
+  try { return hostname() }
+  catch { return '' }
+}

--- a/packages/apes/src/lib/tribe-client.ts
+++ b/packages/apes/src/lib/tribe-client.ts
@@ -1,0 +1,104 @@
+// Typed thin client for tribe.openape.ai's agent-side API. The CLI
+// never talks to the owner-side endpoints (those are for the web UI);
+// the tribe-client only knows about the three /me/* endpoints needed
+// by `apes agents sync` and `apes agents run`.
+//
+// Default endpoint is https://tribe.openape.ai. Override with the
+// OPENAPE_TRIBE_URL env var (handy for staging or local dev). The
+// agent JWT comes from `~/.config/apes/auth.json` — the file
+// `apes agents spawn` writes when it provisions the macOS user.
+
+export const DEFAULT_TRIBE_URL = 'https://tribe.openape.ai'
+
+export interface TaskSpec {
+  agentEmail: string
+  taskId: string
+  name: string
+  cron: string
+  systemPrompt: string
+  tools: string[]
+  maxSteps: number
+  enabled: boolean
+  createdAt: number
+  updatedAt: number
+}
+
+export interface SyncResponse {
+  agent_email: string
+  host_id: string
+  first_sync: boolean
+  last_seen_at: number
+}
+
+export interface RunStartResponse {
+  id: string
+  started_at: number
+}
+
+export interface RunFinalisePayload {
+  status: 'ok' | 'error'
+  final_message: string | null
+  step_count: number
+  trace?: unknown
+}
+
+export class TribeClient {
+  constructor(
+    public readonly tribeUrl: string,
+    public readonly agentJwt: string,
+  ) {}
+
+  private async request<T>(path: string, init?: RequestInit): Promise<T> {
+    const res = await fetch(`${this.tribeUrl}${path}`, {
+      ...init,
+      headers: {
+        ...(init?.headers ?? {}),
+        'Authorization': `Bearer ${this.agentJwt}`,
+        'Content-Type': 'application/json',
+      },
+    })
+    if (!res.ok) {
+      const text = await res.text().catch(() => '')
+      throw new Error(`tribe ${init?.method ?? 'GET'} ${path} failed: ${res.status} ${text}`)
+    }
+    if (res.status === 204) return undefined as T
+    return await res.json() as T
+  }
+
+  sync(input: { hostname: string, hostId: string, ownerEmail: string, pubkeySsh?: string }): Promise<SyncResponse> {
+    return this.request('/api/agents/me/sync', {
+      method: 'POST',
+      body: JSON.stringify({
+        hostname: input.hostname,
+        host_id: input.hostId,
+        owner_email: input.ownerEmail,
+        ...(input.pubkeySsh ? { pubkey_ssh: input.pubkeySsh } : {}),
+      }),
+    })
+  }
+
+  listTasks(): Promise<TaskSpec[]> {
+    return this.request('/api/agents/me/tasks')
+  }
+
+  startRun(taskId: string): Promise<RunStartResponse> {
+    return this.request('/api/agents/me/runs', {
+      method: 'POST',
+      body: JSON.stringify({ task_id: taskId }),
+    })
+  }
+
+  finaliseRun(id: string, payload: RunFinalisePayload): Promise<unknown> {
+    return this.request(`/api/agents/me/runs/${id}`, {
+      method: 'PATCH',
+      body: JSON.stringify(payload),
+    })
+  }
+}
+
+export function resolveTribeUrl(override?: string): string {
+  if (override) return override.replace(/\/$/, '')
+  const fromEnv = process.env.OPENAPE_TRIBE_URL
+  if (fromEnv) return fromEnv.replace(/\/$/, '')
+  return DEFAULT_TRIBE_URL
+}

--- a/packages/apes/test/launchd-reconcile.test.ts
+++ b/packages/apes/test/launchd-reconcile.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+import { _internal } from '../src/lib/launchd-reconcile'
+
+const { cronToSchedule, buildPlistContent } = _internal
+
+describe('cronToSchedule', () => {
+  it('* * * * * → one slot with no fields (launchd "every minute")', () => {
+    expect(cronToSchedule('* * * * *')).toEqual([{}])
+  })
+
+  it('0 18 * * * → fires every day at 18:00', () => {
+    expect(cronToSchedule('0 18 * * *')).toEqual([{ Minute: 0, Hour: 18 }])
+  })
+
+  it('*/15 * * * * → expands to 4 slots (0/15/30/45)', () => {
+    const slots = cronToSchedule('*/15 * * * *')
+    expect(slots).toHaveLength(4)
+    expect(slots.map(s => s.Minute)).toEqual([0, 15, 30, 45])
+  })
+
+  it('0 */6 * * * → 4 slots at 0/6/12/18 with Minute=0', () => {
+    const slots = cronToSchedule('0 */6 * * *')
+    expect(slots).toHaveLength(4)
+    expect(slots.every(s => s.Minute === 0)).toBe(true)
+    expect(slots.map(s => s.Hour)).toEqual([0, 6, 12, 18])
+  })
+
+  it('Sunday=7 in cron is normalized to launchd Weekday=0', () => {
+    const slots = cronToSchedule('0 9 * * 7')
+    expect(slots).toEqual([{ Minute: 0, Hour: 9, Weekday: 0 }])
+  })
+})
+
+describe('buildPlistContent', () => {
+  it('renders a valid plist body for a simple task', () => {
+    const body = buildPlistContent({
+      agentName: 'alice',
+      apesBin: '/usr/local/bin/apes',
+      homeDir: '/Users/alice',
+      task: {
+        agentEmail: 'agent+alice+example.com@id.openape.ai',
+        taskId: 'mail-triage',
+        name: 'Mail Triage',
+        cron: '*/15 * * * *',
+        systemPrompt: '...',
+        tools: ['mail.list'],
+        maxSteps: 10,
+        enabled: true,
+        createdAt: 0,
+        updatedAt: 0,
+      },
+    })
+    expect(body).toContain('<key>Label</key>')
+    expect(body).toContain('<string>openape.tribe.alice.mail-triage</string>')
+    expect(body).toContain('<string>/usr/local/bin/apes</string>')
+    expect(body).toContain('<string>agents</string>')
+    expect(body).toContain('<string>run</string>')
+    expect(body).toContain('<string>mail-triage</string>')
+    expect(body).toContain('<string>/Users/alice</string>')
+    // Multi-slot cron → array (not single dict)
+    expect(body).toContain('<array>')
+  })
+
+  it('escapes < and & in identifiers', () => {
+    const body = buildPlistContent({
+      agentName: 'alice',
+      apesBin: '/usr/local/bin/apes',
+      homeDir: '/Users/alice',
+      task: {
+        agentEmail: 'agent+alice+example.com@id.openape.ai',
+        taskId: 'foo&bar',
+        name: 'x',
+        cron: '* * * * *',
+        systemPrompt: '...',
+        tools: [],
+        maxSteps: 5,
+        enabled: true,
+        createdAt: 0,
+        updatedAt: 0,
+      },
+    })
+    expect(body).toContain('foo&amp;bar')
+    expect(body).not.toContain('foo&bar')
+  })
+})

--- a/packages/apes/test/tribe-client.test.ts
+++ b/packages/apes/test/tribe-client.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { DEFAULT_TRIBE_URL, resolveTribeUrl, TribeClient } from '../src/lib/tribe-client'
+
+describe('resolveTribeUrl', () => {
+  const original = process.env.OPENAPE_TRIBE_URL
+  afterEach(() => {
+    if (original === undefined) delete process.env.OPENAPE_TRIBE_URL
+    else process.env.OPENAPE_TRIBE_URL = original
+  })
+
+  it('returns the default when nothing is set', () => {
+    delete process.env.OPENAPE_TRIBE_URL
+    expect(resolveTribeUrl()).toBe(DEFAULT_TRIBE_URL)
+  })
+
+  it('honours the env var', () => {
+    process.env.OPENAPE_TRIBE_URL = 'https://staging.tribe.openape.ai'
+    expect(resolveTribeUrl()).toBe('https://staging.tribe.openape.ai')
+  })
+
+  it('explicit override beats the env var', () => {
+    process.env.OPENAPE_TRIBE_URL = 'https://staging.tribe.openape.ai'
+    expect(resolveTribeUrl('http://localhost:3010')).toBe('http://localhost:3010')
+  })
+
+  it('strips trailing slash', () => {
+    expect(resolveTribeUrl('http://localhost:3010/')).toBe('http://localhost:3010')
+  })
+})
+
+describe('TribeClient', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+  beforeEach(() => {
+    fetchMock = vi.fn()
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+  })
+
+  it('attaches the agent JWT as a Bearer header', async () => {
+    fetchMock.mockResolvedValue(new Response(JSON.stringify([]), { status: 200 }))
+    const client = new TribeClient('http://localhost:3010', 'test.jwt.value')
+    await client.listTasks()
+    const [, init] = fetchMock.mock.calls[0]!
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer test.jwt.value')
+  })
+
+  it('throws with the response body on non-2xx', async () => {
+    fetchMock.mockResolvedValue(new Response('boom', { status: 500 }))
+    const client = new TribeClient('http://localhost:3010', 'jwt')
+    await expect(client.listTasks()).rejects.toThrow(/500.*boom/)
+  })
+
+  it('returns undefined for 204 responses', async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 204 }))
+    const client = new TribeClient('http://localhost:3010', 'jwt')
+    const out = await client.finaliseRun('id-1', { status: 'ok', final_message: 'done', step_count: 1 })
+    expect(out).toBeUndefined()
+  })
+
+  it('sync POSTs the expected body shape', async () => {
+    fetchMock.mockResolvedValue(new Response(JSON.stringify({
+      agent_email: 'a',
+      host_id: 'h',
+      first_sync: true,
+      last_seen_at: 0,
+    }), { status: 200 }))
+    const client = new TribeClient('http://localhost:3010', 'jwt')
+    await client.sync({
+      hostname: 'mac.local',
+      hostId: 'AAAA-BBBB',
+      ownerEmail: 'patrick@example.com',
+      pubkeySsh: 'ssh-ed25519 …',
+    })
+    const [url, init] = fetchMock.mock.calls[0]!
+    expect(url).toBe('http://localhost:3010/api/agents/me/sync')
+    expect(init.method).toBe('POST')
+    const body = JSON.parse(init.body as string)
+    expect(body).toMatchObject({
+      hostname: 'mac.local',
+      host_id: 'AAAA-BBBB',
+      owner_email: 'patrick@example.com',
+      pubkey_ssh: 'ssh-ed25519 …',
+    })
+  })
+
+  it('startRun maps task_id, finaliseRun PATCHes the run id', async () => {
+    fetchMock
+      .mockResolvedValueOnce(new Response(JSON.stringify({ id: 'r-1', started_at: 1 }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({}), { status: 200 }))
+    const client = new TribeClient('http://localhost:3010', 'jwt')
+    await client.startRun('mail-triage')
+    await client.finaliseRun('r-1', { status: 'ok', final_message: null, step_count: 3, trace: { foo: 'bar' } })
+
+    expect(fetchMock.mock.calls[0]![0]).toBe('http://localhost:3010/api/agents/me/runs')
+    expect(fetchMock.mock.calls[1]![0]).toBe('http://localhost:3010/api/agents/me/runs/r-1')
+    expect(fetchMock.mock.calls[1]![1].method).toBe('PATCH')
+  })
+})


### PR DESCRIPTION
M4 of openape-tribe. Pieces: macos-host (IOPlatformUUID), tribe-client (typed wrapper), launchd-reconcile (cron→plist translator + idempotent apply), agents sync subcommand. 7 unit tests for the translator + plist renderer. Will be wired into spawn in M6.