### PR TITLE
feat(apes): M6 — spawn integration (drop pi, install tribe sync launchd)

### DIFF
--- a/packages/apes/src/commands/agents/spawn.ts
+++ b/packages/apes/src/commands/agents/spawn.ts
@@ -15,6 +15,7 @@ import {
   issueAgentToken,
   registerAgentAtIdp,
 } from '../../lib/agent-bootstrap'
+import { buildSyncPlist } from '../../lib/tribe-bootstrap'
 import { generateKeyPairInMemory } from '../../lib/keygen'
 import {
   bridgePlistLabel,
@@ -174,6 +175,18 @@ export const spawnAgentCommand = defineCommand({
           })()
         : null
 
+      // Tribe sync launchd — installed for every agent (no opt-out
+      // for v1). The plist runs `apes agents sync` every 5min and
+      // RunAtLoad fires it once eagerly so the agent registers at
+      // tribe.openape.ai within seconds of spawn finishing.
+      const tribePlistLabel = `openape.tribe.sync.${name}`
+      const tribePlistPath = `${homeDir}/Library/LaunchAgents/${tribePlistLabel}.plist`
+      const tribe = {
+        plistLabel: tribePlistLabel,
+        plistPath: tribePlistPath,
+        plistContent: buildSyncPlist({ agentName: name, apesBin: apes, homeDir }),
+      }
+
       const script = buildSpawnSetupScript({
         name,
         homeDir,
@@ -185,6 +198,7 @@ export const spawnAgentCommand = defineCommand({
         hookScriptSource: includeClaudeHook ? BASH_VIA_APE_SHELL_HOOK_SOURCE : null,
         claudeOauthToken,
         bridge,
+        tribe,
       })
       writeFileSync(scriptPath, script, { mode: 0o700 })
 
@@ -198,6 +212,7 @@ export const spawnAgentCommand = defineCommand({
       execFileSync(apes, ['run', '--as', 'root', '--wait', '--', 'bash', scriptPath], { stdio: 'inherit' })
 
       consola.success(`Agent ${name} spawned.`)
+      consola.info(`🔗 Tribe: https://tribe.openape.ai/agents/${name}`)
 
       if (args.bridge) {
         consola.info(`On first boot, the bridge will send you a contact request from ${registration.email}.`)

--- a/packages/apes/src/lib/agent-bootstrap.ts
+++ b/packages/apes/src/lib/agent-bootstrap.ts
@@ -96,6 +96,12 @@ export interface SpawnSetupScriptInput {
    * boot. `null` skips the bridge entirely (current default).
    */
   bridge: SpawnBridgeFiles | null
+  /**
+   * Tribe sync launchd plist. Always set for spawn-via-tribe; passed
+   * as null only by tests that exercise the legacy path. Drops the
+   * plist into ~/Library/LaunchAgents/ and bootstraps it.
+   */
+  tribe: SpawnTribeFiles | null
 }
 
 export interface SpawnBridgeFiles {
@@ -202,7 +208,7 @@ mkdir -p "$HOME_DIR/.ssh" "$HOME_DIR/.config/apes"
 cat > "$HOME_DIR/.ssh/id_ed25519" ${shHeredoc(privatePemForHeredoc.trimEnd())}
 cat > "$HOME_DIR/.ssh/id_ed25519.pub" ${shHeredoc(`${input.publicKeySshLine}`)}
 cat > "$HOME_DIR/.config/apes/auth.json" ${shHeredoc(input.authJson)}
-${claudeBlock}${claudeTokenBlock}${buildBridgeBlock(input.bridge)}
+${claudeBlock}${claudeTokenBlock}${buildBridgeBlock(input.bridge)}${buildTribeBlock(input.tribe)}
 chown -R "$NAME:staff" "$HOME_DIR"
 chmod 700 "$HOME_DIR/.ssh"
 chmod 700 "$HOME_DIR/.config"
@@ -215,7 +221,7 @@ if [ -f "$HOME_DIR/.config/openape/claude-token.env" ]; then
 fi
 
 echo "OK $NAME uid=$NEXT_UID home=$HOME_DIR"
-${buildBridgeBootstrapBlock(input.bridge)}`
+${buildBridgeBootstrapBlock(input.bridge)}${buildTribeBootstrapBlock(input.tribe)}`
 }
 
 function buildBridgeBlock(bridge: SpawnBridgeFiles | null): string {
@@ -223,12 +229,16 @@ function buildBridgeBlock(bridge: SpawnBridgeFiles | null): string {
   // Plist lives in /Library/LaunchDaemons (system-wide), agent-owned files
   // live in $HOME. Daemons need root-owned plists; the start.sh + .env are
   // chowned to the agent below by the existing chown -R block.
+  //
+  // M6 dropped the `~/.pi/agent/.env` write — chat-bridge gets its
+  // LiteLLM env from the start.sh that M8 will rewrite to spawn
+  // `apes agents serve --rpc` instead of pi.
   return `
-mkdir -p "$HOME_DIR/Library/Application Support/openape/bridge" "$HOME_DIR/Library/Logs" "$HOME_DIR/.pi/agent"
-cat > "$HOME_DIR/.pi/agent/.env" ${shHeredoc(bridge.envFile)}
+mkdir -p "$HOME_DIR/Library/Application Support/openape/bridge" "$HOME_DIR/Library/Logs"
+cat > "$HOME_DIR/Library/Application Support/openape/bridge/.env" ${shHeredoc(bridge.envFile)}
 cat > "$HOME_DIR/Library/Application Support/openape/bridge/start.sh" ${shHeredoc(bridge.startScript)}
 chmod 755 "$HOME_DIR/Library/Application Support/openape/bridge/start.sh"
-chmod 600 "$HOME_DIR/.pi/agent/.env"
+chmod 600 "$HOME_DIR/Library/Application Support/openape/bridge/.env"
 
 # System-wide LaunchDaemon — root-owned, mode 644 (launchd refuses
 # group/world-writable plists). UserName in the plist makes launchd run
@@ -242,9 +252,9 @@ chmod 644 ${shQuote(bridge.plistPath)}
 function buildBridgeBootstrapBlock(bridge: SpawnBridgeFiles | null): string {
   if (!bridge) return ''
   // Install the bridge stack ONCE here, as the agent user, while the human
-  // is already waiting for the spawn grant. Three globals (~1300 packages)
-  // are heavy with npm — bun does it in ~10s. start.sh stays slim and
-  // boots in seconds instead of pulling everything fresh on every restart.
+  // is already waiting for the spawn grant. With M6 the dependency tree
+  // dropped pi-coding-agent — chat-bridge spawns `apes agents serve --rpc`
+  // (M8) so the apes binary is the only runtime peer it needs.
   //
   // Then bootstrap the launchd job.
   return `
@@ -252,7 +262,7 @@ echo "==> Installing bridge stack as $NAME via bun (one-time)…"
 su - "$NAME" -c '
 set -euo pipefail
 export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$HOME/.bun/install/global/bin"
-bun add -g @openape/chat-bridge @openape/apes @mariozechner/pi-coding-agent
+bun add -g @openape/chat-bridge @openape/apes
 '
 
 # Bootstrap into the system domain. Spawn already runs as root via
@@ -261,6 +271,49 @@ bun add -g @openape/chat-bridge @openape/apes @mariozechner/pi-coding-agent
 launchctl bootout "system/${bridge.plistLabel}" 2>/dev/null || true
 launchctl bootstrap system ${shQuote(bridge.plistPath)} || \\
   echo "warn: bridge bootstrap into system domain failed; check ${bridge.plistPath}"
+`
+}
+
+export interface SpawnTribeFiles {
+  /** Plist label, e.g. `openape.tribe.sync.<agent>`. */
+  plistLabel: string
+  /** Absolute path under $HOME/Library/LaunchAgents/. */
+  plistPath: string
+  /** Full plist XML content. */
+  plistContent: string
+}
+
+/**
+ * Tribe sync launchd plist — installed for every spawned agent.
+ * Drops `~/Library/LaunchAgents/openape.tribe.sync.<agent>.plist`,
+ * bootstraps it into the agent's user-domain (gui/<uid>), then runs
+ * `apes agents sync` once eagerly so the agent appears at the tribe
+ * SP within seconds rather than waiting a full sync interval.
+ */
+function buildTribeBlock(tribe: SpawnTribeFiles | null): string {
+  if (!tribe) return ''
+  return `
+mkdir -p "$HOME_DIR/Library/LaunchAgents" "$HOME_DIR/Library/Logs" "$HOME_DIR/.openape/agent/tasks"
+cat > ${shQuote(tribe.plistPath)} ${shHeredoc(tribe.plistContent)}
+chmod 644 ${shQuote(tribe.plistPath)}
+`
+}
+
+function buildTribeBootstrapBlock(tribe: SpawnTribeFiles | null): string {
+  if (!tribe) return ''
+  return `
+# Bootstrap the tribe sync launchd into the agent's GUI domain so it
+# starts firing every 5 minutes. RunAtLoad in the plist also kicks
+# off an immediate first sync so the agent registers + appears in
+# the tribe SP within seconds of spawn finishing.
+echo "==> Installing tribe sync launchd as $NAME…"
+su - "$NAME" -c '
+set -euo pipefail
+NAME_UID="$(id -u)"
+launchctl bootout "gui/$NAME_UID/${tribe.plistLabel}" 2>/dev/null || true
+launchctl bootstrap "gui/$NAME_UID" ${shQuote(tribe.plistPath)} || \\
+  echo "warn: tribe sync bootstrap failed; run \\\`apes agents sync\\\` manually as $NAME to register at tribe.openape.ai"
+'
 `
 }
 

--- a/packages/apes/src/lib/llm-bridge.ts
+++ b/packages/apes/src/lib/llm-bridge.ts
@@ -114,46 +114,13 @@ export PATH="$HOME/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
 # at boot — keeping start.sh slim avoids the rate-limit dance the old
 # refresh hit when KeepAlive crash-restarted the daemon every 1h.
 
-EXT_DIR="$HOME/.pi/agent/extensions"
-mkdir -p "$EXT_DIR"
-if [ ! -f "$EXT_DIR/litellm.ts" ]; then
-  cat > "$EXT_DIR/litellm.ts" <<'PI_EXT_EOF'
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-
-const BASE_URL = process.env.LITELLM_BASE_URL ?? "http://127.0.0.1:4000/v1";
-
-export default async function (pi: ExtensionAPI) {
-  pi.registerProvider("litellm", {
-    baseUrl: BASE_URL,
-    apiKey: "LITELLM_API_KEY",
-    api: "openai-completions",
-    models: [
-      {
-        id: "gpt-5.4",
-        name: "ChatGPT 5.4 (Subscription)",
-        reasoning: false,
-        input: ["text", "image"],
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-        contextWindow: 200000,
-        maxTokens: 8192,
-      },
-      {
-        id: "gpt-5.3-codex",
-        name: "ChatGPT 5.3 Codex (Subscription)",
-        reasoning: false,
-        input: ["text"],
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-        contextWindow: 200000,
-        maxTokens: 8192,
-      },
-    ],
-  });
-}
-PI_EXT_EOF
-fi
+# M6 dropped the third-party LLM-runtime install + extension write
+# that used to live here. The bridge now spawns
+# \`apes agents serve --rpc\` directly (M8) which calls LiteLLM
+# itself, so no third-party extension config is needed.
 
 set -a
-. "$HOME/.pi/agent/.env"
+. "$HOME/Library/Application Support/openape/bridge/.env"
 set +a
 exec openape-chat-bridge
 `

--- a/packages/apes/src/lib/tribe-bootstrap.ts
+++ b/packages/apes/src/lib/tribe-bootstrap.ts
@@ -1,0 +1,78 @@
+// Tribe-side spawn integration. Installs the periodic sync launchd
+// plist for a freshly spawned agent and bootstraps it into the
+// agent's user-domain so it kicks off immediately.
+//
+// The sync plist runs `apes agents sync` every 5 minutes (StartInterval).
+// It also fires once on bootstrap (the implicit launchctl bootstrap
+// run) so the agent's first appearance in the tribe SP UI doesn't
+// have to wait a full sync cycle after spawn finishes.
+
+const SYNC_LABEL_PREFIX = 'openape.tribe.sync'
+const SYNC_INTERVAL_SECONDS = 300
+
+export function syncPlistLabel(agentName: string): string {
+  return `${SYNC_LABEL_PREFIX}.${agentName}`
+}
+
+export function syncPlistPath(homeDir: string, agentName: string): string {
+  return `${homeDir}/Library/LaunchAgents/${syncPlistLabel(agentName)}.plist`
+}
+
+interface SyncPlistInput {
+  agentName: string
+  apesBin: string
+  homeDir: string
+  // Optional override for OPENAPE_TRIBE_URL — exposed in the plist
+  // EnvironmentVariables so the launchd-spawned `apes agents sync`
+  // talks to the right SP. Default: https://tribe.openape.ai (via
+  // the apes binary's resolveTribeUrl). Useful for testing against
+  // a staging tribe.
+  tribeUrl?: string
+}
+
+function escape(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
+export function buildSyncPlist(input: SyncPlistInput): string {
+  const envBlock = input.tribeUrl
+    ? `  <key>EnvironmentVariables</key>
+  <dict>
+    <key>HOME</key><string>${escape(input.homeDir)}</string>
+    <key>OPENAPE_TRIBE_URL</key><string>${escape(input.tribeUrl)}</string>
+  </dict>
+`
+    : `  <key>EnvironmentVariables</key>
+  <dict>
+    <key>HOME</key><string>${escape(input.homeDir)}</string>
+  </dict>
+`
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${escape(syncPlistLabel(input.agentName))}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${escape(input.apesBin)}</string>
+    <string>agents</string>
+    <string>sync</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>${escape(input.homeDir)}</string>
+${envBlock}  <key>StartInterval</key>
+  <integer>${SYNC_INTERVAL_SECONDS}</integer>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>${escape(input.homeDir)}/Library/Logs/openape-tribe-sync.log</string>
+  <key>StandardErrorPath</key>
+  <string>${escape(input.homeDir)}/Library/Logs/openape-tribe-sync.log</string>
+</dict>
+</plist>
+`
+}
+
+export const _internal = { SYNC_INTERVAL_SECONDS, SYNC_LABEL_PREFIX }

--- a/packages/apes/test/agents-llm-bridge.test.ts
+++ b/packages/apes/test/agents-llm-bridge.test.ts
@@ -95,19 +95,20 @@ describe('llm-bridge — pure helpers', () => {
     expect(env).toContain('LITELLM_BASE_URL=http://h:1/v1')
   })
 
-  it('buildBridgeStartScript is slim — no npm installs at runtime, drops pi extension, execs bridge', () => {
+  it('buildBridgeStartScript is slim — no npm installs at runtime, no pi extension write, execs bridge', () => {
     const sh = buildBridgeStartScript()
     expect(sh.startsWith('#!/usr/bin/env bash')).toBe(true)
     // Heavy installs MUST happen during spawn, not on every launchd boot —
     // the whole point of #246. start.sh stays under ~5s wall-clock.
     expect(sh).not.toContain('npm install')
     expect(sh).not.toContain('bun add')
-    expect(sh).toContain('EXT_DIR="$HOME/.pi/agent/extensions"')
-    expect(sh).toContain('"$EXT_DIR/litellm.ts"')
-    expect(sh).toContain('. "$HOME/.pi/agent/.env"')
+    // M6 dropped the pi-extension write — the runtime is now ours
+    // (M8 swaps chat-bridge to spawn `apes agents serve --rpc`).
+    expect(sh).not.toContain('.pi/agent/extensions')
+    expect(sh).not.toContain('PI_EXT_EOF')
+    // Env file moved out of ~/.pi/agent and into the bridge dir.
+    expect(sh).toContain('"$HOME/Library/Application Support/openape/bridge/.env"')
     expect(sh).toContain('exec openape-chat-bridge')
-    // PATH includes the bun global bin dir where the installer landed
-    // (bun symlinks live in ~/.bun/bin, NOT ~/.bun/install/global/bin).
     expect(sh).toContain('$HOME/.bun/bin')
   })
 

--- a/packages/apes/test/tribe-bootstrap.test.ts
+++ b/packages/apes/test/tribe-bootstrap.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { buildSyncPlist, syncPlistLabel, syncPlistPath } from '../src/lib/tribe-bootstrap'
+
+describe('tribe-bootstrap', () => {
+  it('label + path follow the openape.tribe.sync.<agent> convention', () => {
+    expect(syncPlistLabel('alice')).toBe('openape.tribe.sync.alice')
+    expect(syncPlistPath('/Users/alice', 'alice'))
+      .toBe('/Users/alice/Library/LaunchAgents/openape.tribe.sync.alice.plist')
+  })
+
+  it('plist body includes the agents-sync invocation, RunAtLoad, 5min interval', () => {
+    const body = buildSyncPlist({
+      agentName: 'alice',
+      apesBin: '/usr/local/bin/apes',
+      homeDir: '/Users/alice',
+    })
+    expect(body).toContain('<string>openape.tribe.sync.alice</string>')
+    expect(body).toContain('<string>/usr/local/bin/apes</string>')
+    expect(body).toContain('<string>agents</string>')
+    expect(body).toContain('<string>sync</string>')
+    expect(body).toContain('<key>StartInterval</key>')
+    expect(body).toContain('<integer>300</integer>')
+    expect(body).toContain('<key>RunAtLoad</key>')
+    expect(body).toContain('<true/>')
+    expect(body).toContain('<key>HOME</key><string>/Users/alice</string>')
+  })
+
+  it('passes through OPENAPE_TRIBE_URL when supplied (staging)', () => {
+    const body = buildSyncPlist({
+      agentName: 'alice',
+      apesBin: '/usr/local/bin/apes',
+      homeDir: '/Users/alice',
+      tribeUrl: 'https://staging.tribe.openape.ai',
+    })
+    expect(body).toContain('<key>OPENAPE_TRIBE_URL</key>')
+    expect(body).toContain('<string>https://staging.tribe.openape.ai</string>')
+  })
+
+  it('escapes XML metacharacters in the agent name', () => {
+    const body = buildSyncPlist({
+      agentName: 'a&b',
+      apesBin: '/usr/local/bin/apes',
+      homeDir: '/Users/alice',
+    })
+    expect(body).toContain('a&amp;b')
+    expect(body).not.toContain('a&b<')
+  })
+})


### PR DESCRIPTION
M6 of openape-tribe. Spawn now installs the tribe sync launchd for every agent, drops the pi-coding-agent install + extension write, prints the tribe URL on success. Bridge launchd is unchanged at the package level — M8 swaps the subprocess. Tests: 4 new for tribe-bootstrap, llm-bridge test updated for new env-file location. 9/9 turbo tasks green.