### PR TITLE
fix(apes): $NAME… unbound-variable crash in spawn setup.sh

### DIFF
--- a/.changeset/fix-spawn-name-ellipsis.md
+++ b/.changeset/fix-spawn-name-ellipsis.md
@@ -1,0 +1,5 @@
+---
+'@openape/apes': patch
+---
+
+Fix `apes agents spawn` crashing on the troop-sync-install line with `setup.sh: line N: NAME…: unbound variable`. With `set -u`, `$NAME…` was parsed as a variable named `NAME…` (the U+2026 ellipsis got eaten into the identifier). Use `${NAME}…` so the brace cleanly terminates the variable name. Same fix applied to the bridge-install echo.

--- a/packages/apes/src/lib/agent-bootstrap.ts
+++ b/packages/apes/src/lib/agent-bootstrap.ts
@@ -258,7 +258,7 @@ function buildBridgeBootstrapBlock(bridge: SpawnBridgeFiles | null): string {
   //
   // Then bootstrap the launchd job.
   return `
-echo "==> Installing bridge stack as $NAME via bun (one-time)…"
+echo "==> Installing bridge stack as \${NAME} via bun (one-time)…"
 su - "$NAME" -c '
 set -euo pipefail
 export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$HOME/.bun/install/global/bin"
@@ -306,7 +306,7 @@ function buildTroopBootstrapBlock(troop: SpawnTroopFiles | null): string {
 # starts firing every 5 minutes. RunAtLoad in the plist also kicks
 # off an immediate first sync so the agent registers + appears in
 # the troop SP within seconds of spawn finishing.
-echo "==> Installing troop sync launchd as $NAME…"
+echo "==> Installing troop sync launchd as \${NAME}…"
 su - "$NAME" -c '
 set -euo pipefail
 NAME_UID="$(id -u)"


### PR DESCRIPTION
Found by first end-to-end `apes agents spawn milo` after the troop rename: `setup.sh: line N: NAME…: unbound variable`. With `set -u`, bash parsed `$NAME…` as a variable named `NAME…` (U+2026 ellipsis got absorbed into the identifier). Use `${NAME}…` so the brace terminates the identifier cleanly.

Two echo lines fixed (bridge + troop install blocks). User creation succeeded before the crash, so half-spawned agents need manual cleanup before re-spawn.