### PR TITLE
feat(free-idp): raise default agent limit 10 → 100

### DIFF
--- a/apps/openape-free-idp/nuxt.config.ts
+++ b/apps/openape-free-idp/nuxt.config.ts
@@ -68,7 +68,7 @@ export default defineNuxtConfig({
     vapidPrivateKey: process.env.NUXT_VAPID_PRIVATE_KEY || '',
     vapidSubject: process.env.NUXT_VAPID_SUBJECT || 'mailto:patrick@hofmann.eco',
     public: {
-      maxAgentsPerUser: 10,
+      maxAgentsPerUser: Number(process.env.NUXT_PUBLIC_MAX_AGENTS_PER_USER || 100),
       vapidPublicKey: process.env.NUXT_PUBLIC_VAPID_PUBLIC_KEY || '',
     },
   },


### PR DESCRIPTION
10 hit on the first dogfood spawn after the troop go-live. Default to 100, env-overridable via `NUXT_PUBLIC_MAX_AGENTS_PER_USER` for self-hosters who want stricter.