### PR TITLE
fix(apes): spawn launchd bootstrap for hidden agents

### DIFF
--- a/.changeset/fix-spawn-launchd-asuser.md
+++ b/.changeset/fix-spawn-launchd-asuser.md
@@ -1,0 +1,11 @@
+---
+'@openape/apes': patch
+---
+
+Fix `apes agents spawn` exiting nonzero after macOS user creation. Two related bugs:
+
+1. **`$NAME` unbound inside `su - $NAME -c '...'`**: the inner shell starts fresh and doesn't inherit `NAME` from setup.sh. With `set -u`, the first `$NAME` reference inside the single-quoted block crashed the inner shell, propagated through `set -e` in setup.sh, and made the whole spawn fail despite the user being created. Fix: interpolate the literal name at TS-template time so the inner shell never sees a bash variable.
+
+2. **`launchctl bootstrap gui/<uid>` fails for hidden service accounts**: spawned agents have `IsHidden=1` and never log in graphically, so the user's `gui/<uid>` launchd domain doesn't exist. `bootstrap` fails with "Domain does not support specified action". Fix: prefix with `launchctl asuser <uid>` (run as root in setup.sh) which bootstraps launchd for that uid first, then the inner bootstrap runs in the now-existing domain.
+
+Repro: any fresh `apes agents spawn <name>` failed with `Command failed: bash setup.sh` while leaving the macOS user + plist files in place but no active launchd job. Manual `launchctl bootstrap` later would have hit the same domain error.

--- a/packages/apes/src/lib/agent-bootstrap.ts
+++ b/packages/apes/src/lib/agent-bootstrap.ts
@@ -221,7 +221,7 @@ if [ -f "$HOME_DIR/.config/openape/claude-token.env" ]; then
 fi
 
 echo "OK $NAME uid=$NEXT_UID home=$HOME_DIR"
-${buildBridgeBootstrapBlock(input.bridge)}${buildTroopBootstrapBlock(input.troop)}`
+${buildBridgeBootstrapBlock(input.bridge, name)}${buildTroopBootstrapBlock(input.troop, name)}`
 }
 
 function buildBridgeBlock(bridge: SpawnBridgeFiles | null): string {
@@ -249,7 +249,7 @@ chmod 644 ${shQuote(bridge.plistPath)}
 `
 }
 
-function buildBridgeBootstrapBlock(bridge: SpawnBridgeFiles | null): string {
+function buildBridgeBootstrapBlock(bridge: SpawnBridgeFiles | null, name: string): string {
   if (!bridge) return ''
   // Install the bridge stack ONCE here, as the agent user, while the human
   // is already waiting for the spawn grant. With M6 the dependency tree
@@ -257,9 +257,14 @@ function buildBridgeBootstrapBlock(bridge: SpawnBridgeFiles | null): string {
   // (M8) so the apes binary is the only runtime peer it needs.
   //
   // Then bootstrap the launchd job.
+  //
+  // The literal agent name is interpolated at TS-template time (not via
+  // the bash $NAME var) because the inner `su -c '...'` runs in a fresh
+  // shell that doesn't inherit setup.sh's NAME — `set -u` would crash on
+  // the first $NAME reference inside the single-quoted block.
   return `
-echo "==> Installing bridge stack as \${NAME} via bun (one-time)…"
-su - "$NAME" -c '
+echo "==> Installing bridge stack as ${name} via bun (one-time)…"
+su - ${shQuote(name)} -c '
 set -euo pipefail
 export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$HOME/.bun/install/global/bin"
 bun add -g @openape/chat-bridge @openape/apes
@@ -299,21 +304,25 @@ chmod 644 ${shQuote(troop.plistPath)}
 `
 }
 
-function buildTroopBootstrapBlock(troop: SpawnTroopFiles | null): string {
+function buildTroopBootstrapBlock(troop: SpawnTroopFiles | null, name: string): string {
   if (!troop) return ''
+  // Hidden service-accounts (IsHidden=1) never log in, so their `gui/<uid>`
+  // launchd domain doesn't exist on a freshly-spawned user — `launchctl
+  // bootstrap gui/<uid>` would fail with "Domain does not support specified
+  // action". `launchctl asuser <uid>` (run as root) bootstraps launchd for
+  // that uid first, then the inner bootstrap runs in the now-existing
+  // domain. Agent name is interpolated at TS template time so the warn
+  // message survives `set -u` in the inner shell.
   return `
-# Bootstrap the troop sync launchd into the agent's GUI domain so it
-# starts firing every 5 minutes. RunAtLoad in the plist also kicks
-# off an immediate first sync so the agent registers + appears in
-# the troop SP within seconds of spawn finishing.
-echo "==> Installing troop sync launchd as \${NAME}…"
-su - "$NAME" -c '
-set -euo pipefail
-NAME_UID="$(id -u)"
-launchctl bootout "gui/$NAME_UID/${troop.plistLabel}" 2>/dev/null || true
-launchctl bootstrap "gui/$NAME_UID" ${shQuote(troop.plistPath)} || \\
-  echo "warn: troop sync bootstrap failed; run \\\`apes agents sync\\\` manually as $NAME to register at troop.openape.ai"
-'
+# Bootstrap the troop sync launchd into the agent's user domain so it
+# starts firing every 5 minutes. RunAtLoad in the plist also kicks off
+# an immediate first sync so the agent registers + appears in the troop
+# SP within seconds of spawn finishing.
+echo "==> Installing troop sync launchd as ${name}…"
+NAME_UID="$(id -u ${shQuote(name)})"
+launchctl asuser "$NAME_UID" launchctl bootout "gui/$NAME_UID/${troop.plistLabel}" 2>/dev/null || true
+launchctl asuser "$NAME_UID" launchctl bootstrap "gui/$NAME_UID" ${shQuote(troop.plistPath)} || \\
+  echo "warn: troop sync bootstrap failed; run \\\`apes agents sync\\\` manually as ${name} to register at troop.openape.ai"
 `
 }
 


### PR DESCRIPTION
Two bugs that together made every `apes agents spawn` exit nonzero despite the user being created correctly. Found by attempting to spawn igor2 after the troop go-live.