### PR TITLE
fix(apes): troop sync plist in system domain

### DIFF
--- a/.changeset/fix-troop-sync-system-domain.md
+++ b/.changeset/fix-troop-sync-system-domain.md
@@ -1,0 +1,7 @@
+---
+'@openape/apes': patch
+---
+
+Move troop sync plist from `~/Library/LaunchAgents/` (gui/<uid> domain) to `/Library/LaunchDaemons/` (system domain) with a `UserName` key — same pattern the bridge has always used. Hidden service accounts (IsHidden=1) never log in graphically, so their per-user launchd domain doesn't exist; `launchctl bootstrap gui/<uid>` was failing with "Domain does not support specified action" for every spawned agent. System-domain bootstrap doesn't need a user session — launchd runs the daemon as the agent uid via `UserName`.
+
+Side benefit: removes the `su -c '...'` wrapper, so no more shell-quoting issues with `set -u` inside the inner shell.

--- a/packages/apes/src/commands/agents/spawn.ts
+++ b/packages/apes/src/commands/agents/spawn.ts
@@ -180,11 +180,11 @@ export const spawnAgentCommand = defineCommand({
       // RunAtLoad fires it once eagerly so the agent registers at
       // troop.openape.ai within seconds of spawn finishing.
       const troopPlistLabel = `openape.troop.sync.${name}`
-      const troopPlistPath = `${homeDir}/Library/LaunchAgents/${troopPlistLabel}.plist`
+      const troopPlistPath = `/Library/LaunchDaemons/${troopPlistLabel}.plist`
       const troop = {
         plistLabel: troopPlistLabel,
         plistPath: troopPlistPath,
-        plistContent: buildSyncPlist({ agentName: name, apesBin: apes, homeDir }),
+        plistContent: buildSyncPlist({ agentName: name, apesBin: apes, homeDir, userName: name }),
       }
 
       const script = buildSpawnSetupScript({

--- a/packages/apes/src/lib/agent-bootstrap.ts
+++ b/packages/apes/src/lib/agent-bootstrap.ts
@@ -297,32 +297,35 @@ export interface SpawnTroopFiles {
  */
 function buildTroopBlock(troop: SpawnTroopFiles | null): string {
   if (!troop) return ''
+  // Plist lives in /Library/LaunchDaemons (system-wide), root-owned, mode 644
+  // — launchd refuses to load group/world-writable plists. The UserName key
+  // inside makes launchd run `apes agents sync` as the agent uid. Same
+  // pattern the bridge has always used; troop sync inherits it (M6 originally
+  // tried gui/<uid> but hidden agents have no user-launchd domain).
+  //
+  // Logs + task cache + LaunchAgents dir still live under the agent's home
+  // (sync writes there).
   return `
 mkdir -p "$HOME_DIR/Library/LaunchAgents" "$HOME_DIR/Library/Logs" "$HOME_DIR/.openape/agent/tasks"
 cat > ${shQuote(troop.plistPath)} ${shHeredoc(troop.plistContent)}
+chown root:wheel ${shQuote(troop.plistPath)}
 chmod 644 ${shQuote(troop.plistPath)}
 `
 }
 
 function buildTroopBootstrapBlock(troop: SpawnTroopFiles | null, name: string): string {
   if (!troop) return ''
-  // Hidden service-accounts (IsHidden=1) never log in, so their `gui/<uid>`
-  // launchd domain doesn't exist on a freshly-spawned user — `launchctl
-  // bootstrap gui/<uid>` would fail with "Domain does not support specified
-  // action". `launchctl asuser <uid>` (run as root) bootstraps launchd for
-  // that uid first, then the inner bootstrap runs in the now-existing
-  // domain. Agent name is interpolated at TS template time so the warn
-  // message survives `set -u` in the inner shell.
+  // System-domain bootstrap (root-only, doesn't need a user session).
+  // RunAtLoad fires the first sync immediately so the agent appears in
+  // the troop SP UI within seconds of spawn finishing.
   return `
-# Bootstrap the troop sync launchd into the agent's user domain so it
-# starts firing every 5 minutes. RunAtLoad in the plist also kicks off
-# an immediate first sync so the agent registers + appears in the troop
-# SP within seconds of spawn finishing.
+# Bootstrap the troop sync launchd in the system domain. setup.sh runs
+# as root via \`apes run --as root\`, so we have permission. Stale label
+# is bootouted first to make re-spawn idempotent.
 echo "==> Installing troop sync launchd as ${name}…"
-NAME_UID="$(id -u ${shQuote(name)})"
-launchctl asuser "$NAME_UID" launchctl bootout "gui/$NAME_UID/${troop.plistLabel}" 2>/dev/null || true
-launchctl asuser "$NAME_UID" launchctl bootstrap "gui/$NAME_UID" ${shQuote(troop.plistPath)} || \\
-  echo "warn: troop sync bootstrap failed; run \\\`apes agents sync\\\` manually as ${name} to register at troop.openape.ai"
+launchctl bootout "system/${troop.plistLabel}" 2>/dev/null || true
+launchctl bootstrap system ${shQuote(troop.plistPath)} || \\
+  echo "warn: troop sync bootstrap failed; check ${troop.plistPath}"
 `
 }
 

--- a/packages/apes/src/lib/troop-bootstrap.ts
+++ b/packages/apes/src/lib/troop-bootstrap.ts
@@ -1,6 +1,14 @@
 // Troop-side spawn integration. Installs the periodic sync launchd
-// plist for a freshly spawned agent and bootstraps it into the
-// agent's user-domain so it kicks off immediately.
+// plist for a freshly spawned agent and bootstraps it into the system
+// domain (run-as the agent via UserName) so it kicks off immediately.
+//
+// Why /Library/LaunchDaemons + system domain (not ~/Library/LaunchAgents
+// + gui/<uid>): spawned agents are hidden service accounts (IsHidden=1)
+// that never log in graphically, so their per-user launchd domain
+// doesn't exist. `launchctl bootstrap gui/<uid>` fails with "Domain does
+// not support specified action". The bridge had the same constraint and
+// solved it the same way — system-level plist with UserName key. Keeps
+// the daemon running 24/7 regardless of login state.
 //
 // The sync plist runs `apes agents sync` every 5 minutes (StartInterval).
 // It also fires once on bootstrap (the implicit launchctl bootstrap
@@ -14,14 +22,16 @@ export function syncPlistLabel(agentName: string): string {
   return `${SYNC_LABEL_PREFIX}.${agentName}`
 }
 
-export function syncPlistPath(homeDir: string, agentName: string): string {
-  return `${homeDir}/Library/LaunchAgents/${syncPlistLabel(agentName)}.plist`
+export function syncPlistPath(_homeDir: string, agentName: string): string {
+  return `/Library/LaunchDaemons/${syncPlistLabel(agentName)}.plist`
 }
 
 interface SyncPlistInput {
   agentName: string
   apesBin: string
   homeDir: string
+  /** macOS short username — passed to UserName so launchd runs the daemon as the agent. */
+  userName: string
   // Optional override for OPENAPE_TROOP_URL — exposed in the plist
   // EnvironmentVariables so the launchd-spawned `apes agents sync`
   // talks to the right SP. Default: https://troop.openape.ai (via
@@ -54,6 +64,8 @@ export function buildSyncPlist(input: SyncPlistInput): string {
 <dict>
   <key>Label</key>
   <string>${escape(syncPlistLabel(input.agentName))}</string>
+  <key>UserName</key>
+  <string>${escape(input.userName)}</string>
   <key>ProgramArguments</key>
   <array>
     <string>${escape(input.apesBin)}</string>

--- a/packages/apes/test/troop-bootstrap.test.ts
+++ b/packages/apes/test/troop-bootstrap.test.ts
@@ -4,15 +4,18 @@ import { buildSyncPlist, syncPlistLabel, syncPlistPath } from '../src/lib/troop-
 describe('troop-bootstrap', () => {
   it('label + path follow the openape.troop.sync.<agent> convention', () => {
     expect(syncPlistLabel('alice')).toBe('openape.troop.sync.alice')
+    // Plist lives in /Library/LaunchDaemons (system domain) — hidden
+    // service accounts have no per-user launchd domain to bootstrap into.
     expect(syncPlistPath('/Users/alice', 'alice'))
-      .toBe('/Users/alice/Library/LaunchAgents/openape.troop.sync.alice.plist')
+      .toBe('/Library/LaunchDaemons/openape.troop.sync.alice.plist')
   })
 
-  it('plist body includes the agents-sync invocation, RunAtLoad, 5min interval', () => {
+  it('plist body includes the agents-sync invocation, RunAtLoad, 5min interval, UserName', () => {
     const body = buildSyncPlist({
       agentName: 'alice',
       apesBin: '/usr/local/bin/apes',
       homeDir: '/Users/alice',
+      userName: 'alice',
     })
     expect(body).toContain('<string>openape.troop.sync.alice</string>')
     expect(body).toContain('<string>/usr/local/bin/apes</string>')
@@ -23,6 +26,9 @@ describe('troop-bootstrap', () => {
     expect(body).toContain('<key>RunAtLoad</key>')
     expect(body).toContain('<true/>')
     expect(body).toContain('<key>HOME</key><string>/Users/alice</string>')
+    // UserName makes launchd run the daemon as the agent uid.
+    expect(body).toContain('<key>UserName</key>')
+    expect(body).toContain('<string>alice</string>')
   })
 
   it('passes through OPENAPE_TROOP_URL when supplied (staging)', () => {
@@ -30,6 +36,7 @@ describe('troop-bootstrap', () => {
       agentName: 'alice',
       apesBin: '/usr/local/bin/apes',
       homeDir: '/Users/alice',
+      userName: 'alice',
       troopUrl: 'https://staging.troop.openape.ai',
     })
     expect(body).toContain('<key>OPENAPE_TROOP_URL</key>')
@@ -41,6 +48,7 @@ describe('troop-bootstrap', () => {
       agentName: 'a&b',
       apesBin: '/usr/local/bin/apes',
       homeDir: '/Users/alice',
+      userName: 'a&b',
     })
     expect(body).toContain('a&amp;b')
     expect(body).not.toContain('a&b<')


### PR DESCRIPTION
Hidden service accounts have no per-user launchd domain. Move troop sync plist from ~/Library/LaunchAgents/ + gui/<uid> to /Library/LaunchDaemons/ + system + UserName key — same pattern the bridge has always used. Found by attempting first end-to-end agent spawn after troop go-live.