### PR TITLE
fix(apes): troop sync plist PATH env

### DIFF
--- a/.changeset/fix-troop-sync-plist-path.md
+++ b/.changeset/fix-troop-sync-plist-path.md
@@ -1,0 +1,5 @@
+---
+'@openape/apes': patch
+---
+
+Add PATH to the troop sync plist's EnvironmentVariables so the daemon can find `node` (and `bun`). launchd defaults to `/usr/bin:/bin:/usr/sbin:/sbin` — too narrow for the apes binary's `#!/usr/bin/env node` shebang. Without this the sync log filled with `env: node: No such file or directory` and the agent never reached troop.openape.ai.

--- a/packages/apes/src/lib/troop-bootstrap.ts
+++ b/packages/apes/src/lib/troop-bootstrap.ts
@@ -45,17 +45,23 @@ function escape(s: string): string {
 }
 
 export function buildSyncPlist(input: SyncPlistInput): string {
+  // launchd defaults PATH to /usr/bin:/bin:/usr/sbin:/sbin — too narrow
+  // for the apes binary's `#!/usr/bin/env node` shebang to find node.
+  // Include the agent's bun bin (where apes itself is installed),
+  // homebrew, and the standard system paths so the daemon can resolve
+  // both `node` and `bun` regardless of how the agent host is set up.
+  const pathLine = `    <key>PATH</key><string>${escape(input.homeDir)}/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>\n`
   const envBlock = input.troopUrl
     ? `  <key>EnvironmentVariables</key>
   <dict>
     <key>HOME</key><string>${escape(input.homeDir)}</string>
-    <key>OPENAPE_TROOP_URL</key><string>${escape(input.troopUrl)}</string>
+${pathLine}    <key>OPENAPE_TROOP_URL</key><string>${escape(input.troopUrl)}</string>
   </dict>
 `
     : `  <key>EnvironmentVariables</key>
   <dict>
     <key>HOME</key><string>${escape(input.homeDir)}</string>
-  </dict>
+${pathLine}  </dict>
 `
 
   return `<?xml version="1.0" encoding="UTF-8"?>

--- a/packages/apes/test/troop-bootstrap.test.ts
+++ b/packages/apes/test/troop-bootstrap.test.ts
@@ -29,6 +29,11 @@ describe('troop-bootstrap', () => {
     // UserName makes launchd run the daemon as the agent uid.
     expect(body).toContain('<key>UserName</key>')
     expect(body).toContain('<string>alice</string>')
+    // PATH must include common node/bun locations so the apes binary's
+    // `#!/usr/bin/env node` shebang resolves.
+    expect(body).toContain('<key>PATH</key>')
+    expect(body).toContain('/Users/alice/.bun/bin')
+    expect(body).toContain('/opt/homebrew/bin')
   })
 
   it('passes through OPENAPE_TROOP_URL when supplied (staging)', () => {


### PR DESCRIPTION
Found by first end-to-end spawn: sync log was filling with `env: node: No such file or directory` because launchd's default PATH doesn't include node. Add ~/.bun/bin + homebrew to the plist EnvironmentVariables.