### PR TITLE
fix(troop): unwrap verifyJWT payload

### DIFF
--- a/apps/openape-troop/server/utils/auth.ts
+++ b/apps/openape-troop/server/utils/auth.ts
@@ -75,9 +75,13 @@ export async function requireAgent(event: H3Event): Promise<string> {
     // because the agent JWT is a sealed token bound to the keypair
     // we registered at IdP-enroll, not a bearer trivially copyable
     // across SPs.
-    claims = await verifyJWT(token, getJwks(), {
-      issuer: idpUrl,
-    }) as DDISAClaims
+    //
+    // verifyJWT returns { payload, protectedHeader } — extract the
+    // payload before reading claims (treating the wrapper object as
+    // the claims silently produces `act: undefined` and rejects every
+    // valid agent token with a 403).
+    const result = await verifyJWT(token, getJwks(), { issuer: idpUrl })
+    claims = result.payload as DDISAClaims
   }
   catch {
     problem(401, 'Invalid or expired agent JWT')


### PR DESCRIPTION
Found by first end-to-end agent sync: every JWT was rejected with `act != agent` because troop's requireAgent treated verifyJWT's `{payload, protectedHeader}` wrapper as the claims directly. Pull payload out before reading.