### PR TITLE
fix(troop): parseAgentEmail handles canonical agent format

### DIFF
--- a/apps/openape-troop/server/utils/agent-email.ts
+++ b/apps/openape-troop/server/utils/agent-email.ts
@@ -1,29 +1,47 @@
-// Agent emails follow the DDISA convention used by `apes agents
-// enroll`:
+// Agent emails follow the DDISA convention written by the IdP's
+// `deriveAgentEmail`:
 //
-//   agent+<agentName>+<ownerDomain>@id.openape.ai
+//   <agentName>-<ownerHash>+<owner-local>+<owner-domain-encoded>@<idp>
 //
-// The name and owner-domain are recoverable so we don't need a
-// separate lookup at every API hit. Owner email itself is then
-// `<owner-local>@<owner-domain>` — we know the domain from the agent
-// email but the local-part lives only in the IdP's user store, so
-// `ownerEmail` is whatever the agent posts on its first sync (it
-// knows because it was provisioned by that very owner). For owner-
-// auth endpoints we read the owner email directly from the session
-// instead.
+// (e.g. `igor4-cb6bf26a+patrick+hofmann_eco@id.openape.ai`)
+//
+// The owner-domain has its dots replaced by underscores so the email
+// stays a single subaddressed mailbox. The 8-char ownerHash suffix on
+// the name disambiguates same-named agents across owners. We also
+// accept the older two-segment shape (`<name>+<owner-local>+<domain>`,
+// no hash) so pre-hash dogfood agents keep parsing.
+//
+// Owner email itself is `<owner-local>@<owner-domain>` — domain is
+// recoverable from the email, local-part lives in the IdP and is
+// posted by the agent on its first sync.
 
 export interface ParsedAgentEmail {
   agentName: string
   ownerDomain: string
 }
 
-const AGENT_EMAIL_RE = /^agent\+([a-z0-9-]+)\+([^@]+)@([^@]+)$/
+const OWNER_HASH_RE = /^(.+)-([a-f0-9]{8})$/
 
 export function parseAgentEmail(email: string): ParsedAgentEmail | null {
-  const m = email.toLowerCase().match(AGENT_EMAIL_RE)
-  if (!m) return null
-  return {
-    agentName: m[1]!,
-    ownerDomain: m[2]!.replace(/_/g, '.'),
-  }
+  const lower = email.toLowerCase()
+  const atIdx = lower.lastIndexOf('@')
+  if (atIdx < 0) return null
+  const local = lower.slice(0, atIdx)
+  const parts = local.split('+')
+  // Need at least <name>+<owner-local>+<owner-domain>.
+  if (parts.length < 3) return null
+
+  const namePart = parts[0]!
+  // Owner-domain is everything after the second `+`, joined back with
+  // `+` in case of weird edge cases (shouldn't happen for valid
+  // domains but we don't want to lose data).
+  const ownerDomain = parts.slice(2).join('+').replace(/_/g, '.')
+  if (!ownerDomain || !namePart) return null
+
+  // Strip the 8-char ownerHash suffix if present so the stored
+  // agentName matches what the user typed.
+  const m = namePart.match(OWNER_HASH_RE)
+  const agentName = m ? m[1]! : namePart
+
+  return { agentName, ownerDomain }
 }

--- a/apps/openape-troop/tests/agent-email.test.ts
+++ b/apps/openape-troop/tests/agent-email.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { parseAgentEmail } from '../server/utils/agent-email'
+
+describe('parseAgentEmail', () => {
+  it('parses the canonical hash-suffixed format from deriveAgentEmail', () => {
+    const got = parseAgentEmail('igor4-cb6bf26a+patrick+hofmann_eco@id.openape.ai')
+    expect(got).toEqual({ agentName: 'igor4', ownerDomain: 'hofmann.eco' })
+  })
+
+  it('preserves hyphens in the agent name (only the trailing 8-hex hash is stripped)', () => {
+    const got = parseAgentEmail('agent-bot1-aabbccdd+patrick+hofmann_eco@id.openape.ai')
+    expect(got).toEqual({ agentName: 'agent-bot1', ownerDomain: 'hofmann.eco' })
+  })
+
+  it('accepts the older format without owner-hash suffix', () => {
+    const got = parseAgentEmail('agenta+patrick+hofmann_eco@id.openape.ai')
+    expect(got).toEqual({ agentName: 'agenta', ownerDomain: 'hofmann.eco' })
+  })
+
+  it('handles dotted owner-domains (encoded as underscores)', () => {
+    const got = parseAgentEmail('alice-12345678+pete+example_co_uk@id.openape.ai')
+    expect(got).toEqual({ agentName: 'alice', ownerDomain: 'example.co.uk' })
+  })
+
+  it('lowercases the input', () => {
+    const got = parseAgentEmail('IGOR4-CB6BF26A+Patrick+Hofmann_Eco@id.openape.ai')
+    expect(got).toEqual({ agentName: 'igor4', ownerDomain: 'hofmann.eco' })
+  })
+
+  it('rejects non-agent addresses (no `+` subaddressing)', () => {
+    expect(parseAgentEmail('patrick@hofmann.eco')).toBeNull()
+  })
+
+  it('rejects too few `+` segments', () => {
+    expect(parseAgentEmail('alice+patrick@id.openape.ai')).toBeNull()
+  })
+
+  it('rejects strings without an @', () => {
+    expect(parseAgentEmail('alice-12345678+patrick+hofmann_eco')).toBeNull()
+  })
+})


### PR DESCRIPTION
Same stale regex bug as #340 but on the server side. Switch to split-based parsing that handles all 3 historical formats.