### PR TITLE
fix(apes): cron tasks in system-domain (so they actually fire)

### DIFF
--- a/.changeset/fix-cron-tasks-system-domain.md
+++ b/.changeset/fix-cron-tasks-system-domain.md
@@ -1,0 +1,5 @@
+---
+'@openape/apes': patch
+---
+
+Fix cron tasks never firing on hidden service-account agents. Tasks plists were going to `~/Library/LaunchAgents/` and `launchctl bootstrap gui/<uid>` — same dead-end as the troop sync plist had before #338. Move task plists to `/Library/LaunchDaemons/` with `UserName=<agent>`, bootstrap into `system` domain. Sync daemon now runs as ROOT (so it can write into `/Library/LaunchDaemons/` and bootstrap system-domain jobs); chowns its writes in the agent's `$HOME` back to the agent uid via stat(`$HOME`).

--- a/packages/apes/src/commands/agents/sync.ts
+++ b/packages/apes/src/commands/agents/sync.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { chownSync, existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { defineCommand } from 'citty'
@@ -114,6 +114,31 @@ export const syncAgentCommand = defineCommand({
     const { system_prompt: systemPrompt, tasks } = await client.listTasks()
     consola.info(`Pulled ${tasks.length} task${tasks.length === 1 ? '' : 's'}`)
 
+    // Sync runs as ROOT in production (the launchd plist sets
+    // UserName=root so it can write /Library/LaunchDaemons/ and
+    // bootstrap into the system domain — a hidden service-account
+    // agent has no permission for either). Files we write into the
+    // agent's home need to be owned by the agent so the bridge daemon
+    // and `apes agents run` (both running AS the agent) can read
+    // them. Resolve agent's uid/gid by stat-ing $HOME — that's
+    // already chown'd to the agent at spawn time.
+    let agentUid: number | null = null
+    let agentGid: number | null = null
+    if (process.geteuid?.() === 0) {
+      try {
+        const homeStat = statSync(homedir())
+        agentUid = homeStat.uid
+        agentGid = homeStat.gid
+      }
+      catch { /* fall through, no chowning */ }
+    }
+    function chownToAgent(path: string): void {
+      if (agentUid !== null && agentGid !== null) {
+        try { chownSync(path, agentUid, agentGid) }
+        catch { /* best-effort */ }
+      }
+    }
+
     // Cache full task specs + agent-level config locally so the bridge
     // daemon and `apes agents run <task_id>` can execute without going
     // to network. Cache layout:
@@ -121,15 +146,21 @@ export const syncAgentCommand = defineCommand({
     //   ~/.openape/agent/tasks/<task_id>.json
     const agentDir = join(homedir(), '.openape', 'agent')
     mkdirSync(agentDir, { recursive: true })
+    chownToAgent(join(homedir(), '.openape'))
+    chownToAgent(agentDir)
+    const agentJsonPath = join(agentDir, 'agent.json')
     writeFileSync(
-      join(agentDir, 'agent.json'),
+      agentJsonPath,
       `${JSON.stringify({ systemPrompt }, null, 2)}\n`,
       { mode: 0o600 },
     )
+    chownToAgent(agentJsonPath)
     mkdirSync(TASK_CACHE_DIR, { recursive: true })
+    chownToAgent(TASK_CACHE_DIR)
     for (const task of tasks) {
       const path = join(TASK_CACHE_DIR, `${task.taskId}.json`)
       writeFileSync(path, `${JSON.stringify(task, null, 2)}\n`, { mode: 0o600 })
+      chownToAgent(path)
     }
 
     const apesBin = findApesBin()
@@ -138,6 +169,10 @@ export const syncAgentCommand = defineCommand({
       apesBin,
       homeDir: homedir(),
       desired: tasks,
+      // Sync runs as root in production — pass the agent username
+      // explicitly for the UserName plist key (launchd will then run
+      // each task daemon AS the agent, not as root).
+      userName: process.env.AGENT_USER || undefined,
     })
 
     if (result.added.length) consola.success(`launchd: added ${result.added.join(', ')}`)

--- a/packages/apes/src/lib/launchd-reconcile.ts
+++ b/packages/apes/src/lib/launchd-reconcile.ts
@@ -1,18 +1,26 @@
 import { execFileSync } from 'node:child_process'
 import { mkdirSync, readdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
-import { homedir, userInfo } from 'node:os'
+import { userInfo } from 'node:os'
 import { join } from 'node:path'
 import type { TaskSpec } from './troop-client'
 
-// Reconciles ~/Library/LaunchAgents/openape.troop.<agent>.<task>.plist
+// Reconciles /Library/LaunchDaemons/openape.troop.<agent>.<task>.plist
 // against the desired set from the troop SP.
 //
 // One plist per task. Filename encodes the agent name + task slug so
 // we can scope the diff with a glob — multiple agents on the same
 // macOS user (uncommon but possible) don't step on each other's
 // scheduled jobs. `enabled: false` tasks still get a plist written
-// (so the user can see them in the Library/LaunchAgents listing) but
-// the job is `bootout`-ed so launchd doesn't fire it.
+// (so the user can see them in the LaunchDaemons listing) but the
+// job is `bootout`-ed so launchd doesn't fire it.
+//
+// Plists live in /Library/LaunchDaemons (system domain) with a
+// UserName key so launchd runs the daemon as the agent uid. Same
+// reason as the troop-sync plist: hidden service-account agents
+// (IsHidden=1, UID < 500, never log in) have no per-user launchd
+// domain, so `launchctl bootstrap gui/<uid>` fails with "Domain does
+// not support specified action". System-domain bootstrap doesn't
+// need a user session.
 //
 // We avoid `launchctl` calls when nothing changed — content-equality
 // on the existing file vs the desired plist body. macOS's launchctl
@@ -28,7 +36,7 @@ export interface ReconcileResult {
 const PLIST_PREFIX = 'openape.troop.'
 
 function plistDir(): string {
-  return join(homedir(), 'Library', 'LaunchAgents')
+  return '/Library/LaunchDaemons'
 }
 
 function plistPath(agentName: string, taskId: string): string {
@@ -112,7 +120,7 @@ function escape(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
 }
 
-function plistBody(input: { label: string, apesBin: string, taskId: string, schedule: ScheduleSlot[], homeDir: string }): string {
+function plistBody(input: { label: string, apesBin: string, taskId: string, schedule: ScheduleSlot[], homeDir: string, userName: string }): string {
   const calendarBlocks = input.schedule.map((slot) => {
     const lines: string[] = []
     if (slot.Minute !== undefined) lines.push(`      <key>Minute</key><integer>${slot.Minute}</integer>`)
@@ -133,6 +141,8 @@ function plistBody(input: { label: string, apesBin: string, taskId: string, sche
 <dict>
   <key>Label</key>
   <string>${escape(input.label)}</string>
+  <key>UserName</key>
+  <string>${escape(input.userName)}</string>
   <key>ProgramArguments</key>
   <array>
     <string>${escape(input.apesBin)}</string>
@@ -146,6 +156,8 @@ function plistBody(input: { label: string, apesBin: string, taskId: string, sche
   <dict>
     <key>HOME</key>
     <string>${escape(input.homeDir)}</string>
+    <key>PATH</key>
+    <string>${escape(input.homeDir)}/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
   </dict>
 ${calendarKey}
   <key>StandardOutPath</key>
@@ -162,6 +174,12 @@ interface BuildArgs {
   apesBin: string
   homeDir: string
   task: TaskSpec
+  /**
+   * macOS short username for the UserName plist key (the agent that
+   * launchd should run the task as). Defaults to the current user when
+   * not supplied — handy in tests.
+   */
+  userName?: string
 }
 
 function buildPlistContent(args: BuildArgs): string {
@@ -171,22 +189,20 @@ function buildPlistContent(args: BuildArgs): string {
     taskId: args.task.taskId,
     schedule: cronToSchedule(args.task.cron),
     homeDir: args.homeDir,
+    userName: args.userName ?? userInfo().username,
   })
 }
 
-function uid(): number {
-  return userInfo().uid
-}
-
 function bootstrap(label: string, path: string): void {
-  // Idempotent: bootout first (silent if not loaded), then bootstrap.
-  try { execFileSync('/bin/launchctl', ['bootout', `gui/${uid()}/${label}`], { stdio: 'ignore' }) }
+  // System-domain bootstrap (no user session needed). Idempotent —
+  // bootout first (silent if not loaded), then bootstrap.
+  try { execFileSync('/bin/launchctl', ['bootout', `system/${label}`], { stdio: 'ignore' }) }
   catch { /* not loaded */ }
-  execFileSync('/bin/launchctl', ['bootstrap', `gui/${uid()}`, path], { stdio: 'ignore' })
+  execFileSync('/bin/launchctl', ['bootstrap', 'system', path], { stdio: 'ignore' })
 }
 
 function bootout(label: string): void {
-  try { execFileSync('/bin/launchctl', ['bootout', `gui/${uid()}/${label}`], { stdio: 'ignore' }) }
+  try { execFileSync('/bin/launchctl', ['bootout', `system/${label}`], { stdio: 'ignore' }) }
   catch { /* not loaded */ }
 }
 
@@ -195,6 +211,12 @@ export interface ReconcileInput {
   apesBin: string
   homeDir: string
   desired: TaskSpec[]
+  /**
+   * macOS short username for the UserName plist key. Defaults to the
+   * current user — that's only correct in tests; production sync runs
+   * as ROOT so the caller MUST pass the agent's username explicitly.
+   */
+  userName?: string
 }
 
 export function reconcile(input: ReconcileInput): ReconcileResult {
@@ -228,6 +250,7 @@ export function reconcile(input: ReconcileInput): ReconcileResult {
       apesBin: input.apesBin,
       homeDir: input.homeDir,
       task,
+      userName: input.userName,
     })
 
     let existingContent = ''

--- a/packages/apes/src/lib/troop-bootstrap.ts
+++ b/packages/apes/src/lib/troop-bootstrap.ts
@@ -30,7 +30,14 @@ interface SyncPlistInput {
   agentName: string
   apesBin: string
   homeDir: string
-  /** macOS short username — passed to UserName so launchd runs the daemon as the agent. */
+  /**
+   * macOS short username for the agent. The sync daemon itself runs
+   * as ROOT (so it can write into /Library/LaunchDaemons/ and
+   * `launchctl bootstrap system` task plists — system-domain
+   * operations a hidden service-account agent has no permission for).
+   * Sync resolves the agent's numeric uid/gid by stat-ing $HOME at
+   * runtime, then chowns its writes back to those ids.
+   */
   userName: string
   // Optional override for OPENAPE_TROOP_URL — exposed in the plist
   // EnvironmentVariables so the launchd-spawned `apes agents sync`
@@ -50,18 +57,24 @@ export function buildSyncPlist(input: SyncPlistInput): string {
   // Include the agent's bun bin (where apes itself is installed),
   // homebrew, and the standard system paths so the daemon can resolve
   // both `node` and `bun` regardless of how the agent host is set up.
+  //
+  // HOME is set to the agent's home dir even though the daemon runs as
+  // root — Node's `os.homedir()` reads $HOME first, so all of sync's
+  // file operations stay scoped under /Users/<agent>/. AGENT_UID/GID
+  // tell sync who to chown those files to after writing.
   const pathLine = `    <key>PATH</key><string>${escape(input.homeDir)}/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>\n`
+  const agentUserLine = `    <key>AGENT_USER</key><string>${escape(input.userName)}</string>\n`
   const envBlock = input.troopUrl
     ? `  <key>EnvironmentVariables</key>
   <dict>
     <key>HOME</key><string>${escape(input.homeDir)}</string>
-${pathLine}    <key>OPENAPE_TROOP_URL</key><string>${escape(input.troopUrl)}</string>
+${pathLine}${agentUserLine}    <key>OPENAPE_TROOP_URL</key><string>${escape(input.troopUrl)}</string>
   </dict>
 `
     : `  <key>EnvironmentVariables</key>
   <dict>
     <key>HOME</key><string>${escape(input.homeDir)}</string>
-${pathLine}  </dict>
+${pathLine}${agentUserLine}  </dict>
 `
 
   return `<?xml version="1.0" encoding="UTF-8"?>
@@ -70,8 +83,6 @@ ${pathLine}  </dict>
 <dict>
   <key>Label</key>
   <string>${escape(syncPlistLabel(input.agentName))}</string>
-  <key>UserName</key>
-  <string>${escape(input.userName)}</string>
   <key>ProgramArguments</key>
   <array>
     <string>${escape(input.apesBin)}</string>

--- a/packages/apes/src/lib/troop-client.ts
+++ b/packages/apes/src/lib/troop-client.ts
@@ -30,9 +30,11 @@ export interface TaskSpec {
 
 /** Response from /api/agents/me/tasks — agent config + task list. */
 export interface AgentTasksResponse {
-  /** Agent-level persona/behaviour rules — used as `system` for both
+  /**
+   * Agent-level persona/behaviour rules — used as `system` for both
    * cron task runs and live chat-bridge messages. Empty string when the
-   * owner hasn't set one. */
+   * owner hasn't set one.
+   */
   system_prompt: string
   tasks: TaskSpec[]
 }

--- a/packages/apes/test/troop-bootstrap.test.ts
+++ b/packages/apes/test/troop-bootstrap.test.ts
@@ -10,7 +10,7 @@ describe('troop-bootstrap', () => {
       .toBe('/Library/LaunchDaemons/openape.troop.sync.alice.plist')
   })
 
-  it('plist body includes the agents-sync invocation, RunAtLoad, 5min interval, UserName', () => {
+  it('plist body includes the agents-sync invocation, RunAtLoad, 5min interval, no UserName (runs as root)', () => {
     const body = buildSyncPlist({
       agentName: 'alice',
       apesBin: '/usr/local/bin/apes',
@@ -26,14 +26,19 @@ describe('troop-bootstrap', () => {
     expect(body).toContain('<key>RunAtLoad</key>')
     expect(body).toContain('<true/>')
     expect(body).toContain('<key>HOME</key><string>/Users/alice</string>')
-    // UserName makes launchd run the daemon as the agent uid.
-    expect(body).toContain('<key>UserName</key>')
-    expect(body).toContain('<string>alice</string>')
+    // No UserName — sync runs as ROOT so it can write
+    // /Library/LaunchDaemons/ and `launchctl bootstrap system` task
+    // plists. It chowns its writes back to the agent uid via stat($HOME).
+    expect(body).not.toContain('<key>UserName</key>')
     // PATH must include common node/bun locations so the apes binary's
     // `#!/usr/bin/env node` shebang resolves.
     expect(body).toContain('<key>PATH</key>')
     expect(body).toContain('/Users/alice/.bun/bin')
     expect(body).toContain('/opt/homebrew/bin')
+    // Sync (as root) reads AGENT_USER to plumb into the per-task plist
+    // UserName key so each task daemon runs as the agent.
+    expect(body).toContain('<key>AGENT_USER</key>')
+    expect(body).toContain('<string>alice</string>')
   })
 
   it('passes through OPENAPE_TROOP_URL when supplied (staging)', () => {


### PR DESCRIPTION
Patrick set up a `*/5 * * * *` task on igor6, saw nothing in chat. Diagnosis: same dead-end as #338 — task plists in `~/Library/LaunchAgents/` + `gui/<uid>` bootstrap fails on hidden agents. Move to `/Library/LaunchDaemons/` + system domain; sync daemon now runs as root and chowns its home-dir writes back to the agent.