### PR TITLE
fix: tool-name wire encoding + per-task chat thread

### DIFF
--- a/apps/openape-chat-bridge/src/chat-api.ts
+++ b/apps/openape-chat-bridge/src/chat-api.ts
@@ -68,6 +68,21 @@ export class ChatApi {
     })
   }
 
+  /**
+   * Create a named thread in a room. Used by the cron-runner to drop
+   * each task's runs into its own thread so the chat sidebar shows
+   * one thread per task instead of all task DMs piling into the
+   * main thread.
+   */
+  async createThread(roomId: string, name: string): Promise<{ id: string, name: string }> {
+    const url = `${this.endpoint}/api/rooms/${encodeURIComponent(roomId)}/threads`
+    return await ofetch<{ id: string, name: string }>(url, {
+      method: 'POST',
+      headers: { Authorization: await this.bearer() },
+      body: { name: name.slice(0, 100) },
+    })
+  }
+
   async patchMessage(messageId: string, body: string): Promise<void> {
     const trimmed = clamp(body, MAX_BODY)
     const url = `${this.endpoint}/api/messages/${encodeURIComponent(messageId)}`

--- a/apps/openape-chat-bridge/src/cron-runner.ts
+++ b/apps/openape-chat-bridge/src/cron-runner.ts
@@ -271,16 +271,25 @@ export class CronRunner {
     const prefix = turn.status === 'error' ? '❌' : '✅'
     const text = turn.accumulated.trim() || (turn.status === 'error' ? '(crashed)' : '(no output)')
     const body = `${prefix} *${turn.taskName}*\n\n${text}`.slice(0, 9000)
-    const threadId = this.taskThreads.get(turn.taskId)
+    let threadId = this.taskThreads.get(turn.taskId)
+    // First run of this task — explicitly create a new chat thread
+    // named after the task so the chat sidebar gets a dedicated entry
+    // (otherwise messages without thread_id land in the room's main
+    // thread, fanning out everything into one stream).
+    if (!threadId) {
+      try {
+        const created = await this.deps.chat.createThread(turn.roomId, turn.taskName || turn.taskId)
+        threadId = created.id
+        this.taskThreads.set(turn.taskId, threadId)
+        this.persistTaskThreads()
+        this.deps.log(`task ${turn.taskId} thread created: ${threadId}`)
+      }
+      catch (err) {
+        this.deps.log(`createThread failed for ${turn.taskId}, falling back to main thread: ${err instanceof Error ? err.message : String(err)}`)
+      }
+    }
     try {
       const posted = await this.deps.chat.postMessage(turn.roomId, body, threadId ? { threadId } : {})
-      // First run of this task — server allocated a fresh thread when
-      // we posted without threadId. Cache + persist it so every
-      // subsequent run lands in the same thread.
-      if (!threadId && posted.threadId) {
-        this.taskThreads.set(turn.taskId, posted.threadId)
-        this.persistTaskThreads()
-      }
       this.deps.log(`task DM posted (session=${sid}, ${turn.accumulated.length} chars, thread=${posted.threadId})`)
     }
     catch (err) {

--- a/packages/apes/src/lib/agent-runtime.ts
+++ b/packages/apes/src/lib/agent-runtime.ts
@@ -1,4 +1,4 @@
-import { asOpenAiTools  } from './agent-tools'
+import { asOpenAiTools, localToolName, wireToolName } from './agent-tools'
 import type { ToolDefinition } from './agent-tools'
 
 // Shared agent loop: send messages + tools to LiteLLM (OpenAI-
@@ -138,18 +138,23 @@ export async function runLoop(opts: RunOptions): Promise<RunResult> {
     }
 
     // Execute each tool call; the model sees the result on the next turn.
+    // Wire-format names (`time_now`) get decoded to local catalog names
+    // (`time.now`) for lookup + handler events; we send back the same
+    // wire name in the tool message so the next request validates.
     for (const call of assistant.tool_calls) {
-      const tool = opts.tools.find(t => t.name === call.function.name)
+      const wireName = call.function.name
+      const localName = localToolName(wireName)
+      const tool = opts.tools.find(t => t.name === localName)
       let parsedArgs: unknown
       try { parsedArgs = JSON.parse(call.function.arguments) }
       catch { parsedArgs = {} }
-      opts.handlers?.onToolCall?.({ name: call.function.name, args: parsedArgs })
-      trace.push({ step, type: 'tool_call', tool: call.function.name, preview: previewJson(parsedArgs) })
+      opts.handlers?.onToolCall?.({ name: localName, args: parsedArgs })
+      trace.push({ step, type: 'tool_call', tool: localName, preview: previewJson(parsedArgs) })
 
       let result: unknown
       let isError = false
       if (!tool) {
-        result = `unknown tool: ${call.function.name}`
+        result = `unknown tool: ${localName}`
         isError = true
       }
       else {
@@ -163,18 +168,18 @@ export async function runLoop(opts: RunOptions): Promise<RunResult> {
       }
 
       if (isError) {
-        opts.handlers?.onToolError?.({ name: call.function.name, error: String(result) })
-        trace.push({ step, type: 'tool_error', tool: call.function.name, preview: previewJson(result) })
+        opts.handlers?.onToolError?.({ name: localName, error: String(result) })
+        trace.push({ step, type: 'tool_error', tool: localName, preview: previewJson(result) })
       }
       else {
-        opts.handlers?.onToolResult?.({ name: call.function.name, result })
-        trace.push({ step, type: 'tool_result', tool: call.function.name, preview: previewJson(result) })
+        opts.handlers?.onToolResult?.({ name: localName, result })
+        trace.push({ step, type: 'tool_result', tool: localName, preview: previewJson(result) })
       }
 
       messages.push({
         role: 'tool',
         tool_call_id: call.id,
-        name: call.function.name,
+        name: wireToolName(localName),
         content: typeof result === 'string' ? result : JSON.stringify(result),
       })
     }

--- a/packages/apes/src/lib/agent-tools/index.ts
+++ b/packages/apes/src/lib/agent-tools/index.ts
@@ -61,10 +61,35 @@ export function taskTools(names: string[]): ToolDefinition[] {
 /**
  * Format the registry slice as the OpenAI `tools` param. Strips the
  * `execute` function — only the spec part goes to the LLM.
+ *
+ * Tool names get sent through `wireToolName()` because some upstreams
+ * — notably ChatGPT's Responses API behind LiteLLM — enforce
+ * `^[a-zA-Z0-9_-]+$` and reject our dotted catalog names like
+ * `time.now`. Use `localToolName()` to map back when the model emits
+ * a tool_call.
  */
 export function asOpenAiTools(tools: ToolDefinition[]): { type: 'function', function: Omit<ToolDefinition, 'execute'> }[] {
   return tools.map(t => ({
     type: 'function' as const,
-    function: { name: t.name, description: t.description, parameters: t.parameters },
+    function: { name: wireToolName(t.name), description: t.description, parameters: t.parameters },
   }))
+}
+
+/** Encode a local tool name (e.g. `time.now`) for the wire format. */
+export function wireToolName(local: string): string {
+  return local.replace(/\./g, '_')
+}
+
+/**
+ * Decode a tool name from the wire format back to its local form. The
+ * encoding is `.` → `_`; we recover the original by looking for an
+ * exact match in the catalog and only fall back to passing the name
+ * through if no match is found (so unknown tool names still surface
+ * as the obvious "unknown tool" error rather than silent rewrites).
+ */
+export function localToolName(wire: string): string {
+  for (const t of Object.values(TOOLS)) {
+    if (wireToolName(t.name) === wire) return t.name
+  }
+  return wire
 }

--- a/packages/apes/test/agent-tools.test.ts
+++ b/packages/apes/test/agent-tools.test.ts
@@ -20,11 +20,13 @@ describe('tool registry', () => {
     expect(() => taskTools(['time.now', 'magic.do'])).toThrow(/unknown tool/)
   })
 
-  it('asOpenAiTools strips execute', () => {
+  it('asOpenAiTools strips execute and wire-encodes the name (dots → underscores)', () => {
     const out = asOpenAiTools([TOOLS['time.now']!])
     expect(out[0]).toEqual({
       type: 'function',
-      function: expect.objectContaining({ name: 'time.now' }),
+      // ChatGPT's Responses API enforces ^[a-zA-Z0-9_-]+$ on tool names
+      // — dot-bearing catalog names get wire-encoded to underscores.
+      function: expect.objectContaining({ name: 'time_now' }),
     })
     expect((out[0]!.function as Record<string, unknown>).execute).toBeUndefined()
   })


### PR DESCRIPTION
First cron-task fire produced `❌ Uhrzeit (runtime error: ...Invalid tools[0].name...)`. Fix the tool-name pattern by wire-encoding dots to underscores in both directions. Plus: explicitly create a per-task chat thread on first DM so they don't all stack into the main thread.