### PR TITLE
feat(nest): Stage 1 — local control-plane daemon (apes nest install/status)

### DIFF
--- a/.changeset/feat-openape-nest-stage-1.md
+++ b/.changeset/feat-openape-nest-stage-1.md
@@ -1,0 +1,15 @@
+---
+'@openape/apes': minor
+'@openape/nest': minor
+---
+
+**Stage 1 of the Nest control-plane** (per [plan 01KR5TXQXWDC1YDESJJYTPFFMK](https://plans.openape.ai/plans/01KR5TXQXWDC1YDESJJYTPFFMK)). The Nest is a local daemon that hosts agents on a single computer — once installed, `apes agents spawn` becomes fast (no per-spawn DDISA approvals required after the one-time always-grant) and per-agent launchd plists get replaced by a single supervised process tree.
+
+**New package** `@openape/nest`: HTTP daemon on `127.0.0.1:9091` with `/agents` (POST/DELETE/GET) and `/status` endpoints; persistent registry at `~/.openape/nest/agents.json`; supervisor for chat-bridge children with bounded backoff restart.
+
+**New `@openape/apes` verbs**:
+- `apes nest install` — writes `~/Library/LaunchAgents/ai.openape.nest.plist`, bootstraps it, prints next-step instructions for the always-grant
+- `apes nest status` — talks to the daemon, lists supervised processes
+- `apes nest uninstall` — bootouts + removes the plist (registry preserved)
+
+Stage 1 MVP runs the nest as the human user (eventual migration to a dedicated `_openape_nest` service-account is Stage 1.5). Migration of existing agents from per-agent launchd plists into supervisor-managed children comes in a follow-up PR.

--- a/apps/openape-nest/package.json
+++ b/apps/openape-nest/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@openape/nest",
+  "version": "0.1.0",
+  "description": "OpenApe Nest — local control-plane daemon that supervises agent processes on this computer. Talks to troop SP for ownership state, spawns/destroys agents via DDISA always-grants, supervises chat-bridge children (replacing per-agent launchd plists).",
+  "type": "module",
+  "license": "MIT",
+  "private": false,
+  "bin": {
+    "openape-nest": "./dist/index.mjs"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@openape/cli-auth": "workspace:*",
+    "ofetch": "^1.4.1"
+  },
+  "devDependencies": {
+    "@antfu/eslint-config": "catalog:",
+    "@types/node": "catalog:",
+    "eslint": "catalog:",
+    "tsup": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "keywords": [
+    "openape",
+    "nest",
+    "agent",
+    "control-plane",
+    "supervisor"
+  ]
+}

--- a/apps/openape-nest/src/api/agents.ts
+++ b/apps/openape-nest/src/api/agents.ts
@@ -1,0 +1,109 @@
+// HTTP API handlers for /agents and /status. Each handler is small and
+// independent — the daemon's index.ts just routes to them. Spawn /
+// destroy delegate the privileged ops to `apes agents spawn|destroy`
+// via execFile (going through the existing always-grant flow); the
+// nest never directly creates macOS users itself.
+
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { listAgents, removeAgent, upsertAgent, findAgent  } from '../lib/registry'
+import type { AgentEntry } from '../lib/registry'
+import type { Supervisor } from '../lib/supervisor'
+
+const execFileAsync = promisify(execFile)
+
+const NAME_REGEX = /^[a-z][a-z0-9-]{0,23}$/
+
+interface RouteCtx {
+  url: URL
+  body: unknown
+  log: (line: string) => void
+  apesBin: string
+  supervisor: Supervisor
+}
+
+export function handleNestStatus(ctx: RouteCtx): { agents: number, processes: ReturnType<Supervisor['status']> } {
+  return {
+    agents: listAgents().length,
+    processes: ctx.supervisor.status(),
+  }
+}
+
+export function handleAgentsList(_ctx: RouteCtx): { agents: AgentEntry[] } {
+  return { agents: listAgents() }
+}
+
+export async function handleAgentSpawn(ctx: RouteCtx): Promise<{ name: string, email: string, uid: number, home: string }> {
+  const body = ctx.body as Record<string, unknown> | undefined
+  const name = typeof body?.name === 'string' ? body.name : ''
+  if (!NAME_REGEX.test(name)) {
+    throw new Error(`name must match ${NAME_REGEX} (got "${name}")`)
+  }
+  if (findAgent(name)) {
+    throw new Error(`agent "${name}" is already registered with this nest`)
+  }
+
+  // Delegate privileged setup to the existing apes spawn flow. The nest
+  // daemon runs as the human user and has the always-grant cached, so
+  // this `apes run --as root -- apes agents spawn <name>` reuses the
+  // grant silently — no human prompt.
+  const args = ['run', '--as', 'root', '--', 'apes', 'agents', 'spawn', name]
+  const includeBridge = body?.bridge === true
+  if (includeBridge) {
+    args.push('--bridge')
+    if (typeof body?.bridgeKey === 'string') args.push('--bridge-key', body.bridgeKey)
+    if (typeof body?.bridgeBaseUrl === 'string') args.push('--bridge-base-url', body.bridgeBaseUrl)
+    if (typeof body?.bridgeModel === 'string') args.push('--bridge-model', body.bridgeModel)
+  }
+  ctx.log(`nest: spawning agent "${name}" via apes...`)
+  const { stdout: _stdout } = await execFileAsync(ctx.apesBin, args, { maxBuffer: 4 * 1024 * 1024 })
+
+  // After spawn, look up uid + home for registry. Fall back to
+  // /Users/<name> + dscl-resolved uid.
+  const uid = await readUidFromDscl(name)
+  const entry: AgentEntry = {
+    name,
+    uid,
+    home: `/Users/${name}`,
+    email: '', // filled in on first sync — we don't know it locally
+    registeredAt: Math.floor(Date.now() / 1000),
+    bridge: includeBridge
+      ? {
+          baseUrl: typeof body?.bridgeBaseUrl === 'string' ? body.bridgeBaseUrl : undefined,
+          apiKey: typeof body?.bridgeKey === 'string' ? body.bridgeKey : undefined,
+          model: typeof body?.bridgeModel === 'string' ? body.bridgeModel : undefined,
+        }
+      : undefined,
+  }
+  upsertAgent(entry)
+  ctx.supervisor.reconcile(listAgents())
+  return { name, email: entry.email, uid, home: entry.home }
+}
+
+export async function handleAgentDestroy(ctx: RouteCtx, name: string): Promise<{ name: string, removed: boolean }> {
+  if (!NAME_REGEX.test(name)) throw new Error(`invalid agent name "${name}"`)
+  const entry = findAgent(name)
+  if (!entry) throw new Error(`agent "${name}" not registered with this nest`)
+
+  // Stop our supervised child first so destroy doesn't race a respawn.
+  ctx.supervisor.stop(name)
+
+  // Delegate privileged teardown.
+  ctx.log(`nest: destroying agent "${name}"...`)
+  const args = ['run', '--as', 'root', '--', 'apes', 'agents', 'destroy', name, '--force']
+  await execFileAsync(ctx.apesBin, args, { maxBuffer: 4 * 1024 * 1024 })
+
+  removeAgent(name)
+  ctx.supervisor.reconcile(listAgents())
+  return { name, removed: true }
+}
+
+async function readUidFromDscl(name: string): Promise<number> {
+  try {
+    const { stdout } = await execFileAsync('/usr/bin/dscl', ['.', '-read', `/Users/${name}`, 'UniqueID'])
+    const match = stdout.match(/UniqueID:\s*(\d+)/)
+    if (match) return Number(match[1])
+  }
+  catch { /* fall through */ }
+  return -1
+}

--- a/apps/openape-nest/src/index.ts
+++ b/apps/openape-nest/src/index.ts
@@ -1,0 +1,108 @@
+// OpenApe Nest daemon — local control-plane that hosts agents on this
+// computer. Listens on 127.0.0.1:9091 (localhost-only, no auth — only
+// processes running as the same human user can reach it). Talks to
+// troop SP for ownership state, supervises chat-bridge children, runs
+// the cron loop in the bridge process (since #348).
+//
+// Bootstrapped by `apes nest install` — see packages/apes/src/commands/
+// nest/install.ts. Started + KeepAlive'd by launchd via
+// /Library/LaunchAgents/ai.openape.nest.plist (user domain — daemon
+// runs as the human user, not root or _openape_nest yet; that
+// privilege-isolation step is Stage 1.5).
+
+import { createServer   } from 'node:http'
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import process from 'node:process'
+import { handleAgentsList, handleAgentSpawn, handleAgentDestroy, handleNestStatus } from './api/agents'
+import { Supervisor } from './lib/supervisor'
+import { listAgents } from './lib/registry'
+
+const HOST = '127.0.0.1'
+const PORT = Number(process.env.OPENAPE_NEST_PORT ?? 9091)
+const APES_BIN = process.env.OPENAPE_APES_BIN ?? 'apes'
+
+function log(line: string): void {
+  process.stderr.write(`${new Date().toISOString()}  ${line}\n`)
+}
+
+const supervisor = new Supervisor({ apesBin: APES_BIN, log })
+
+// Initial reconcile from the persisted registry — re-spawns the
+// chat-bridge child for every agent that was registered before the
+// last daemon shutdown (or boot).
+supervisor.reconcile(listAgents())
+log(`nest: supervisor reconciled, ${supervisor.size()} agent process(es) running`)
+
+interface RouteCtx {
+  url: URL
+  body: unknown
+  log: typeof log
+  apesBin: string
+  supervisor: Supervisor
+}
+
+async function readJsonBody(req: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = []
+  for await (const chunk of req) chunks.push(chunk as Buffer)
+  if (chunks.length === 0) return {}
+  const text = Buffer.concat(chunks).toString('utf8')
+  if (!text.trim()) return {}
+  try { return JSON.parse(text) }
+  catch { throw new Error('invalid JSON body') }
+}
+
+function send(res: ServerResponse, status: number, body: unknown): void {
+  res.writeHead(status, { 'content-type': 'application/json' })
+  res.end(JSON.stringify(body))
+}
+
+const server = createServer((req, res) => {
+  ;(async () => {
+    try {
+      const url = new URL(req.url ?? '/', `http://${HOST}:${PORT}`)
+      const body = req.method && ['POST', 'PUT', 'PATCH'].includes(req.method)
+        ? await readJsonBody(req)
+        : {}
+      const ctx: RouteCtx = { url, body, log, apesBin: APES_BIN, supervisor }
+
+      if (req.method === 'GET' && url.pathname === '/status') {
+        return send(res, 200, handleNestStatus(ctx))
+      }
+      if (req.method === 'GET' && url.pathname === '/agents') {
+        return send(res, 200, handleAgentsList(ctx))
+      }
+      if (req.method === 'POST' && url.pathname === '/agents') {
+        const result = await handleAgentSpawn(ctx)
+        return send(res, 201, result)
+      }
+      const destroyMatch = req.method === 'DELETE' && url.pathname.match(/^\/agents\/([^/]+)$/)
+      if (destroyMatch) {
+        const result = await handleAgentDestroy(ctx, destroyMatch[1]!)
+        return send(res, 200, result)
+      }
+
+      send(res, 404, { error: 'not found' })
+    }
+    catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      log(`nest: request failed: ${msg}`)
+      send(res, 500, { error: msg })
+    }
+  })()
+})
+
+server.listen(PORT, HOST, () => {
+  log(`nest: listening on http://${HOST}:${PORT}`)
+})
+
+process.on('SIGTERM', () => {
+  log('nest: SIGTERM — stopping supervisor')
+  supervisor.stopAll()
+  server.close(() => process.exit(0))
+})
+
+process.on('SIGINT', () => {
+  log('nest: SIGINT — stopping supervisor')
+  supervisor.stopAll()
+  server.close(() => process.exit(0))
+})

--- a/apps/openape-nest/src/lib/registry.ts
+++ b/apps/openape-nest/src/lib/registry.ts
@@ -1,0 +1,91 @@
+// Nest registry — the source of truth for "which agents live on this
+// computer". Persisted to ~/.openape/nest/agents.json so the supervisor
+// re-spawns the right children after a daemon restart.
+//
+// Each entry holds the bare minimum needed to (a) re-spawn the agent's
+// chat-bridge child and (b) destroy the agent later. Tasks, system
+// prompt, etc. live in the agent's own $HOME and aren't duplicated here.
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+export interface AgentEntry {
+  /** macOS short username — also the agent's display name. */
+  name: string
+  /** Numeric uid — read from dscl at registration time. */
+  uid: number
+  /** Absolute home directory. */
+  home: string
+  /** DDISA email at IdP. */
+  email: string
+  /** When the agent was first added to this nest. */
+  registeredAt: number
+  /**
+   * Bridge config the supervisor passes via env when spawning the
+   * child. Mirrors what `apes agents spawn --bridge*` would have written
+   * into the bridge's .env, but kept on the nest side so we can update
+   * it (model swap, key rotation) without re-running spawn.
+   */
+  bridge?: {
+    baseUrl?: string
+    apiKey?: string
+    model?: string
+  }
+}
+
+interface RegistryFile {
+  version: 1
+  agents: AgentEntry[]
+}
+
+const REGISTRY_DIR = join(homedir(), '.openape', 'nest')
+const REGISTRY_PATH = join(REGISTRY_DIR, 'agents.json')
+
+function emptyRegistry(): RegistryFile {
+  return { version: 1, agents: [] }
+}
+
+export function readRegistry(): RegistryFile {
+  if (!existsSync(REGISTRY_PATH)) return emptyRegistry()
+  try {
+    const parsed = JSON.parse(readFileSync(REGISTRY_PATH, 'utf8')) as RegistryFile
+    if (parsed?.version !== 1 || !Array.isArray(parsed.agents)) return emptyRegistry()
+    return parsed
+  }
+  catch {
+    return emptyRegistry()
+  }
+}
+
+export function writeRegistry(reg: RegistryFile): void {
+  mkdirSync(REGISTRY_DIR, { recursive: true })
+  writeFileSync(REGISTRY_PATH, `${JSON.stringify(reg, null, 2)}\n`, { mode: 0o600 })
+}
+
+export function listAgents(): AgentEntry[] {
+  return readRegistry().agents
+}
+
+export function findAgent(name: string): AgentEntry | undefined {
+  return readRegistry().agents.find(a => a.name === name)
+}
+
+export function upsertAgent(entry: AgentEntry): void {
+  const reg = readRegistry()
+  const existing = reg.agents.findIndex(a => a.name === entry.name)
+  if (existing >= 0) reg.agents[existing] = entry
+  else reg.agents.push(entry)
+  writeRegistry(reg)
+}
+
+export function removeAgent(name: string): boolean {
+  const reg = readRegistry()
+  const before = reg.agents.length
+  reg.agents = reg.agents.filter(a => a.name !== name)
+  if (reg.agents.length === before) return false
+  writeRegistry(reg)
+  return true
+}
+
+export const _internal = { REGISTRY_PATH }

--- a/apps/openape-nest/src/lib/supervisor.ts
+++ b/apps/openape-nest/src/lib/supervisor.ts
@@ -1,0 +1,148 @@
+// Process supervisor — spawns one chat-bridge child per registered
+// agent, restarts on crash with bounded backoff. Replaces per-agent
+// launchd plists.
+//
+// How the uid switch works: the nest itself runs as the human user,
+// each agent has its own macOS uid. We use `apes run --as <agent>`
+// which goes through the existing escapes-helper (already root-
+// trusted, validates the always-grant the human approved at
+// `apes nest install` time). Lazy-spawned: kicks in when the
+// supervisor sees the entry in the registry.
+
+import { spawn  } from 'node:child_process'
+import type { ChildProcess } from 'node:child_process'
+import type { AgentEntry } from './registry'
+
+interface Supervised {
+  child: ChildProcess
+  consecutiveCrashes: number
+  startedAt: number
+  /** Timer for the next restart attempt; cleared on stop or successful exit. */
+  restartTimer?: NodeJS.Timeout
+}
+
+const MIN_BACKOFF_MS = 1_000
+const MAX_BACKOFF_MS = 60_000
+
+export interface SupervisorDeps {
+  /** Path to the apes binary used for the `apes run --as` invocation. */
+  apesBin: string
+  log: (line: string) => void
+}
+
+export class Supervisor {
+  private children = new Map<string, Supervised>()
+
+  constructor(private deps: SupervisorDeps) {}
+
+  /**
+   * Bring the supervised set in line with the desired set. Spawns
+   * agents that aren't running, kills agents that are no longer in
+   * the registry. Idempotent — call after every registry mutation.
+   */
+  reconcile(desired: AgentEntry[]): void {
+    const desiredNames = new Set(desired.map(a => a.name))
+    // Stop children for agents no longer in the registry.
+    for (const [name] of this.children) {
+      if (!desiredNames.has(name)) this.stop(name)
+    }
+    // Start children for agents that should be running.
+    for (const agent of desired) {
+      if (!this.children.has(agent.name)) this.start(agent)
+    }
+  }
+
+  /** Number of currently-running supervised processes. */
+  size(): number {
+    return this.children.size
+  }
+
+  /** Snapshot of supervised state — useful for /agents GET. */
+  status(): Array<{ name: string, pid: number, uptimeSec: number, consecutiveCrashes: number }> {
+    const now = Date.now()
+    return Array.from(this.children.entries()).map(([name, s]) => ({
+      name,
+      pid: s.child.pid ?? -1,
+      uptimeSec: Math.floor((now - s.startedAt) / 1000),
+      consecutiveCrashes: s.consecutiveCrashes,
+    }))
+  }
+
+  start(agent: AgentEntry): void {
+    if (this.children.has(agent.name)) return
+    this.deps.log(`supervisor: starting ${agent.name}`)
+    this.spawnChild(agent, 0)
+  }
+
+  stop(name: string): void {
+    const s = this.children.get(name)
+    if (!s) return
+    this.deps.log(`supervisor: stopping ${name}`)
+    if (s.restartTimer) clearTimeout(s.restartTimer)
+    this.children.delete(name)
+    try { s.child.kill('SIGTERM') }
+    catch { /* already gone */ }
+  }
+
+  /** Kill all children — called on daemon shutdown. */
+  stopAll(): void {
+    for (const name of Array.from(this.children.keys())) this.stop(name)
+  }
+
+  private spawnChild(agent: AgentEntry, prevCrashes: number): void {
+    // The bridge picks up its config (LITELLM_*, system prompt, model
+    // overrides) from $HOME/Library/Application Support/openape/bridge/.env
+    // — same file `apes agents spawn --bridge` writes today. Nothing
+    // changes inside the bridge process itself.
+    // `apes run` automatically reuses an existing always/timed grant
+    // that matches the command pattern (see findExistingGrant). The
+    // human approves the always-grant once during `apes nest install`;
+    // every supervisor restart from then on is silent (no human prompt).
+    const args = ['run', '--as', agent.name, '--', 'openape-chat-bridge']
+    const child = spawn(this.deps.apesBin, args, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      detached: false,
+    })
+
+    child.stdout?.on('data', chunk => this.forwardLog(agent.name, 'stdout', chunk))
+    child.stderr?.on('data', chunk => this.forwardLog(agent.name, 'stderr', chunk))
+
+    const supervised: Supervised = {
+      child,
+      consecutiveCrashes: prevCrashes,
+      startedAt: Date.now(),
+    }
+    this.children.set(agent.name, supervised)
+
+    child.on('exit', (code, signal) => {
+      const stillManaged = this.children.get(agent.name) === supervised
+      if (!stillManaged) return // stopped intentionally; caller already removed
+
+      const ranLongEnough = Date.now() - supervised.startedAt > 30_000
+      const nextCrashes = ranLongEnough ? 1 : prevCrashes + 1
+      const backoff = Math.min(MAX_BACKOFF_MS, MIN_BACKOFF_MS * 2 ** Math.max(0, nextCrashes - 1))
+      this.deps.log(
+        `supervisor: ${agent.name} exited code=${code} signal=${signal ?? 'none'} `
+        + `consecutive=${nextCrashes} → respawn in ${backoff}ms`,
+      )
+      supervised.restartTimer = setTimeout(() => {
+        // Race: a stop() between now and the timer firing would have
+        // deleted us — guard one more time.
+        if (this.children.get(agent.name) !== supervised) return
+        this.children.delete(agent.name)
+        this.spawnChild(agent, nextCrashes)
+      }, backoff)
+    })
+  }
+
+  private forwardLog(name: string, stream: 'stdout' | 'stderr', chunk: Buffer): void {
+    // One line at a time — chat-bridge already prefixes with ISO ts,
+    // we add the agent name so a single nest log can serve all.
+    const text = chunk.toString('utf8')
+    for (const line of text.split('\n')) {
+      const trimmed = line.trimEnd()
+      if (!trimmed) continue
+      this.deps.log(`[${name}/${stream}] ${trimmed}`)
+    }
+  }
+}

--- a/apps/openape-nest/test/registry.test.ts
+++ b/apps/openape-nest/test/registry.test.ts
@@ -1,0 +1,66 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+let tmp: string
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'nest-registry-'))
+  vi.stubEnv('HOME', tmp)
+  vi.resetModules()
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  rmSync(tmp, { recursive: true, force: true })
+})
+
+describe('nest registry', () => {
+  it('readRegistry returns an empty stub when the file is missing', async () => {
+    const { readRegistry } = await import('../src/lib/registry')
+    expect(readRegistry()).toEqual({ version: 1, agents: [] })
+  })
+
+  it('upsert + list + find + remove round-trips through the JSON file', async () => {
+    const { upsertAgent, listAgents, findAgent, removeAgent, _internal } = await import('../src/lib/registry')
+
+    upsertAgent({
+      name: 'igor7',
+      uid: 449,
+      home: '/Users/igor7',
+      email: 'igor7-cb6bf26a+x+y@id.openape.ai',
+      registeredAt: 1,
+    })
+    expect(listAgents()).toHaveLength(1)
+    expect(findAgent('igor7')?.uid).toBe(449)
+
+    // upsert overwrites the same name
+    upsertAgent({
+      name: 'igor7',
+      uid: 449,
+      home: '/Users/igor7',
+      email: 'igor7-cb6bf26a+x+y@id.openape.ai',
+      registeredAt: 1,
+      bridge: { model: 'gpt-5.4' },
+    })
+    expect(findAgent('igor7')?.bridge?.model).toBe('gpt-5.4')
+
+    // file is on disk where we expect it (so `apes nest install` can
+    // pre-seed it during a migration step later)
+    expect(readFileSync(_internal.REGISTRY_PATH, 'utf8')).toContain('igor7')
+
+    expect(removeAgent('igor7')).toBe(true)
+    expect(removeAgent('igor7')).toBe(false)
+    expect(listAgents()).toHaveLength(0)
+  })
+
+  it('readRegistry shrugs off corrupt JSON', async () => {
+    const { _internal, readRegistry } = await import('../src/lib/registry')
+    // Write a half-broken file; reader must not throw.
+    const dir = join(tmp, '.openape', 'nest')
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(_internal.REGISTRY_PATH, '{not json', 'utf8')
+    expect(readRegistry()).toEqual({ version: 1, agents: [] })
+  })
+})

--- a/apps/openape-nest/tsconfig.json
+++ b/apps/openape-nest/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/apps/openape-nest/tsup.config.ts
+++ b/apps/openape-nest/tsup.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  target: 'node22',
+  platform: 'node',
+  clean: true,
+  shims: false,
+  dts: false,
+  sourcemap: false,
+  banner: { js: '#!/usr/bin/env node' },
+})

--- a/packages/apes/src/cli.ts
+++ b/packages/apes/src/cli.ts
@@ -19,6 +19,7 @@ import { delegationsCommand } from './commands/grants/delegations'
 import { delegationRevokeCommand } from './commands/grants/delegation-revoke'
 import { adminCommand } from './commands/admin/index'
 import { agentsCommand } from './commands/agents/index'
+import { nestCommand } from './commands/nest/index'
 import { adapterCommand } from './commands/adapter/index'
 import { runCommand } from './commands/run'
 import { proxyCommand } from './commands/proxy'
@@ -147,6 +148,7 @@ const main = defineCommand({
     health: healthCommand,
     grants: grantsCommand,
     agents: agentsCommand,
+    nest: nestCommand,
     admin: adminCommand,
     run: runCommand,
     proxy: proxyCommand,

--- a/packages/apes/src/commands/nest/index.ts
+++ b/packages/apes/src/commands/nest/index.ts
@@ -1,0 +1,16 @@
+import { defineCommand } from 'citty'
+import { installNestCommand } from './install'
+import { statusNestCommand } from './status'
+import { uninstallNestCommand } from './uninstall'
+
+export const nestCommand = defineCommand({
+  meta: {
+    name: 'nest',
+    description: 'Manage the local Nest control-plane daemon (install, status, uninstall). The Nest hosts agents on this computer — once installed, `apes agents spawn` is fast (no per-spawn DDISA approvals) and per-agent launchd plists are replaced by a single supervised process tree.',
+  },
+  subCommands: {
+    install: installNestCommand,
+    status: statusNestCommand,
+    uninstall: uninstallNestCommand,
+  },
+})

--- a/packages/apes/src/commands/nest/install.ts
+++ b/packages/apes/src/commands/nest/install.ts
@@ -1,0 +1,150 @@
+// `apes nest install` — bootstrap the local nest-daemon.
+//
+// Stage 1 MVP: the daemon runs as the human user (a future stage will
+// migrate to a dedicated `_openape_nest` service-account). Setup is
+// three things:
+//
+//   1. Write ~/Library/LaunchAgents/ai.openape.nest.plist (user domain
+//      — autostarts at login, KeepAlive=true)
+//   2. `launchctl bootstrap` the plist into the user-launchd domain
+//   3. Print instructions for the always-grant the user needs to
+//      approve once at id.openape.ai/grant-approval
+//
+// Idempotent — re-running on an already-installed nest just re-bootstraps
+// (effectively a restart).
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { homedir, userInfo } from 'node:os'
+import { join } from 'node:path'
+import { defineCommand } from 'citty'
+import consola from 'consola'
+
+const PLIST_LABEL = 'ai.openape.nest'
+
+function plistPath(): string {
+  return join(homedir(), 'Library', 'LaunchAgents', `${PLIST_LABEL}.plist`)
+}
+
+function escape(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
+interface PlistArgs {
+  nestBin: string
+  apesBin: string
+  homeDir: string
+  port: number
+}
+
+function buildPlist(args: PlistArgs): string {
+  const logsDir = join(args.homeDir, 'Library', 'Logs')
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${escape(PLIST_LABEL)}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${escape(args.nestBin)}</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>${escape(args.homeDir)}</string>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>ThrottleInterval</key>
+  <integer>10</integer>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>HOME</key><string>${escape(args.homeDir)}</string>
+    <key>PATH</key><string>${escape(args.homeDir)}/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    <key>OPENAPE_NEST_PORT</key><string>${args.port}</string>
+    <key>OPENAPE_APES_BIN</key><string>${escape(args.apesBin)}</string>
+  </dict>
+  <key>StandardOutPath</key>
+  <string>${escape(logsDir)}/openape-nest.log</string>
+  <key>StandardErrorPath</key>
+  <string>${escape(logsDir)}/openape-nest.log</string>
+</dict>
+</plist>
+`
+}
+
+function findBinary(name: string): string {
+  for (const dir of [
+    join(homedir(), '.bun', 'bin'),
+    '/opt/homebrew/bin',
+    '/usr/local/bin',
+    '/usr/bin',
+  ]) {
+    const p = join(dir, name)
+    if (existsSync(p)) return p
+  }
+  throw new Error(`could not locate ${name} on PATH; install it first`)
+}
+
+export const installNestCommand = defineCommand({
+  meta: {
+    name: 'install',
+    description: 'Install + start the local nest-daemon (idempotent — re-running just restarts)',
+  },
+  args: {
+    port: {
+      type: 'string',
+      description: 'Port for the nest HTTP API (default: 9091)',
+    },
+  },
+  async run({ args }) {
+    const homeDir = homedir()
+    const port = Number(args.port ?? 9091)
+    if (!Number.isInteger(port) || port < 1024 || port > 65535) {
+      throw new Error(`invalid port ${port}`)
+    }
+    const nestBin = findBinary('openape-nest')
+    const apesBin = findBinary('apes')
+
+    consola.info(`Installing nest at ${plistPath()}`)
+    consola.info(`  nest binary: ${nestBin}`)
+    consola.info(`  apes binary: ${apesBin}`)
+    consola.info(`  HTTP port:   ${port}`)
+
+    mkdirSync(join(homeDir, 'Library', 'LaunchAgents'), { recursive: true })
+
+    const desired = buildPlist({ nestBin, apesBin, homeDir, port })
+    let existing = ''
+    try { existing = readFileSync(plistPath(), 'utf8') }
+    catch { /* not yet installed */ }
+
+    if (existing !== desired) {
+      writeFileSync(plistPath(), desired, { mode: 0o644 })
+      consola.success('Wrote launchd plist')
+    }
+    else {
+      consola.info('plist already up to date')
+    }
+
+    // Idempotent (re)load. bootout silently no-ops if the job isn't
+    // loaded yet; bootstrap fails loud if the plist has a syntax error,
+    // which is what we want.
+    const uid = userInfo().uid
+    try {
+      execFileSync('/bin/launchctl', ['bootout', `gui/${uid}/${PLIST_LABEL}`], { stdio: 'ignore' })
+    }
+    catch { /* not loaded */ }
+    execFileSync('/bin/launchctl', ['bootstrap', `gui/${uid}`, plistPath()], { stdio: 'inherit' })
+    consola.success(`Nest daemon bootstrapped — http://127.0.0.1:${port}`)
+
+    consola.info('')
+    consola.info('Next: approve the always-grant for nest-managed spawn/destroy.')
+    consola.info('Run this once and choose "Always" when the IdP UI prompts:')
+    consola.info('')
+    consola.info('  apes run --as root --approval=always --reason "nest-managed agent spawn" \\')
+    consola.info('    -- apes agents spawn _grant_pattern_seed_')
+    consola.info('')
+    consola.info('(The seed-spawn will fail because "_grant_pattern_seed_" is not a valid')
+    consola.info('agent name — that\'s expected. The grant just needs to be approved-as-always.)')
+  },
+})

--- a/packages/apes/src/commands/nest/status.ts
+++ b/packages/apes/src/commands/nest/status.ts
@@ -1,0 +1,68 @@
+// `apes nest status` — show what the local nest is supervising.
+//
+// Talks to the nest-daemon's /status + /agents endpoints. If the daemon
+// isn't running (curl-style ECONNREFUSED on localhost), prints a hint
+// to run `apes nest install`.
+
+import process from 'node:process'
+import { defineCommand } from 'citty'
+import consola from 'consola'
+
+const DEFAULT_PORT = 9091
+
+interface NestStatus {
+  agents: number
+  processes: Array<{ name: string, pid: number, uptimeSec: number, consecutiveCrashes: number }>
+}
+
+export const statusNestCommand = defineCommand({
+  meta: {
+    name: 'status',
+    description: 'Print state of the local nest-daemon (agents registered, processes supervised)',
+  },
+  args: {
+    port: { type: 'string', description: 'Override nest port (default: 9091)' },
+    json: { type: 'boolean', description: 'JSON output for scripts' },
+  },
+  async run({ args }) {
+    const port = Number(args.port ?? process.env.OPENAPE_NEST_PORT ?? DEFAULT_PORT)
+    const url = `http://127.0.0.1:${port}/status`
+    let status: NestStatus
+    try {
+      const res = await fetch(url)
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      status = (await res.json()) as NestStatus
+    }
+    catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      if (msg.includes('ECONNREFUSED') || msg.includes('fetch failed')) {
+        consola.error(`Nest daemon is not running at http://127.0.0.1:${port}`)
+        consola.info('  Run:  apes nest install')
+        process.exit(2)
+      }
+      throw err
+    }
+
+    if (args.json) {
+      console.log(JSON.stringify(status, null, 2))
+      return
+    }
+    consola.info(`Nest at http://127.0.0.1:${port} — ${status.agents} agent(s) registered, ${status.processes.length} supervised`)
+    if (status.processes.length === 0) {
+      consola.info('  (no processes running)')
+      return
+    }
+    for (const p of status.processes) {
+      const uptime = humanDuration(p.uptimeSec)
+      const crashTag = p.consecutiveCrashes > 0 ? ` ⚠ ${p.consecutiveCrashes} crash(es)` : ''
+      consola.info(`  ${p.name.padEnd(16)} pid=${String(p.pid).padEnd(6)} up=${uptime}${crashTag}`)
+    }
+  },
+})
+
+function humanDuration(sec: number): string {
+  if (sec < 60) return `${sec}s`
+  if (sec < 3600) return `${Math.floor(sec / 60)}m`
+  if (sec < 86400) return `${Math.floor(sec / 3600)}h`
+  return `${Math.floor(sec / 86400)}d`
+}

--- a/packages/apes/src/commands/nest/uninstall.ts
+++ b/packages/apes/src/commands/nest/uninstall.ts
@@ -1,0 +1,37 @@
+// `apes nest uninstall` — bootout + remove the nest-daemon's launchd
+// plist. Doesn't touch the registered agents or their macOS users —
+// they stay; only the supervisor goes away. After uninstall, agents
+// can still be re-supervised by re-installing later (registry persists
+// at ~/.openape/nest/agents.json).
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, unlinkSync } from 'node:fs'
+import { homedir, userInfo } from 'node:os'
+import { join } from 'node:path'
+import { defineCommand } from 'citty'
+import consola from 'consola'
+
+const PLIST_LABEL = 'ai.openape.nest'
+
+export const uninstallNestCommand = defineCommand({
+  meta: {
+    name: 'uninstall',
+    description: 'Stop + remove the local nest-daemon (registry + agents preserved)',
+  },
+  async run() {
+    const uid = userInfo().uid
+    const path = join(homedir(), 'Library', 'LaunchAgents', `${PLIST_LABEL}.plist`)
+    try {
+      execFileSync('/bin/launchctl', ['bootout', `gui/${uid}/${PLIST_LABEL}`], { stdio: 'ignore' })
+      consola.success('Nest daemon stopped')
+    }
+    catch {
+      consola.info('Nest daemon was not loaded')
+    }
+    if (existsSync(path)) {
+      unlinkSync(path)
+      consola.success(`Removed ${path}`)
+    }
+    consola.info('Registry at ~/.openape/nest/agents.json kept — re-run `apes nest install` to resume supervision.')
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -425,6 +425,34 @@ importers:
         specifier: ^2.0.0
         version: 2.2.12(typescript@5.9.3)
 
+  apps/openape-nest:
+    dependencies:
+      '@openape/cli-auth':
+        specifier: workspace:*
+        version: link:../../packages/cli-auth
+      ofetch:
+        specifier: ^1.4.1
+        version: 1.5.1
+    devDependencies:
+      '@antfu/eslint-config':
+        specifier: 'catalog:'
+        version: 7.7.2(@typescript-eslint/rule-tester@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(@typescript-eslint/typescript-estree@8.57.0(typescript@5.9.3))(@typescript-eslint/utils@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.30)(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.19.15)(happy-dom@18.0.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.19.15
+      eslint:
+        specifier: ^9.35.0
+        version: 9.39.4(jiti@2.6.1)
+      tsup:
+        specifier: 'catalog:'
+        version: 8.5.1(@microsoft/api-extractor@7.58.1(@types/node@22.19.15))(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.15)(happy-dom@18.0.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+
   apps/openape-troop:
     dependencies:
       '@iconify-json/lucide':


### PR DESCRIPTION
Per [plan 01KR5TXQXWDC1YDESJJYTPFFMK](https://plans.openape.ai/plans/01KR5TXQXWDC1YDESJJYTPFFMK). New @openape/nest daemon + apes nest CLI verbs. Migration scanner + Stage 1.5 (_openape_nest user) follow.