### PR TITLE
feat(apes): nest capability-grant for zero-prompt spawn

### DIFF
--- a/.changeset/feat-nest-capability-grant.md
+++ b/.changeset/feat-nest-capability-grant.md
@@ -1,0 +1,7 @@
+---
+'@openape/apes': minor
+---
+
+`apes nest install` now bundles + writes an `apes-agents.toml` shapes adapter to `~/.openape/shapes/adapters/`, and a new `apes nest authorize` command requests a single capability-grant covering all agent names via selector glob `name=*`. After approving once as Always, every nest-driven `apes agents spawn|destroy|sync` reuses the grant silently — selectorValueMatches treats `*` as a regex glob (existing logic in @openape/grants).
+
+Without the adapter, plain run-grants do exact-arg matching and never reuse across different agent names; this closes that gap so the nest-daemon's zero-prompt spawn loop actually works.

--- a/packages/apes/src/commands/nest/apes-agents-adapter.ts
+++ b/packages/apes/src/commands/nest/apes-agents-adapter.ts
@@ -1,0 +1,65 @@
+// Bundled `apes-agents` shapes adapter — written into
+// ~/.openape/shapes/adapters/apes-agents.toml by `apes nest install`.
+// Inlined as a TS constant (vs. shipping the .toml file) because tsup
+// only bundles JS/TS — a sibling .toml gets stripped from dist.
+
+export const APES_AGENTS_ADAPTER_TOML = `schema = "openape-shapes/v1"
+
+# Adapter for the \`apes agents\` subtree — written by \`apes nest install\`.
+# A capability-grant with selector \`name=*\` covers any agent name
+# (selectorValueMatches treats '*' as a glob), letting the nest spawn
+# and destroy without per-agent DDISA prompts.
+
+[cli]
+id = "apes-agents"
+executable = "apes"
+audience = "shapes"
+version = "1"
+
+# ══════════════════════════════════════════════════════
+# AGENT LIFECYCLE — spawn / destroy / sync
+# ══════════════════════════════════════════════════════
+
+[[operation]]
+id = "agents.spawn"
+command = ["agents", "spawn"]
+positionals = ["name"]
+display = "Spawn agent {name}"
+action = "create"
+risk = "high"
+resource_chain = ["agents:name={name}"]
+
+[[operation]]
+id = "agents.destroy"
+command = ["agents", "destroy"]
+positionals = ["name"]
+display = "Destroy agent {name}"
+action = "delete"
+risk = "critical"
+resource_chain = ["agents:name={name}"]
+
+[[operation]]
+id = "agents.sync"
+command = ["agents", "sync"]
+display = "Sync agent state with troop"
+action = "edit"
+risk = "low"
+resource_chain = ["agents:*"]
+
+[[operation]]
+id = "agents.list"
+command = ["agents", "list"]
+display = "List agents"
+action = "list"
+risk = "low"
+resource_chain = ["agents:*"]
+
+[[operation]]
+id = "agents.allow"
+command = ["agents", "allow"]
+positionals = ["name", "peer_email"]
+display = "Allow agent {name} to accept contact requests from {peer_email}"
+action = "edit"
+risk = "medium"
+resource_chain = ["agents:name={name}", "allowlist:email={peer_email}"]
+`

--- a/packages/apes/src/commands/nest/authorize.ts
+++ b/packages/apes/src/commands/nest/authorize.ts
@@ -1,0 +1,65 @@
+// `apes nest authorize` — request the capability-grant that lets the
+// nest-daemon spawn/destroy/sync any agent without a per-call DDISA
+// approval prompt.
+//
+// Why a capability-grant (not a plain `apes run --approval=always`):
+// findExistingGrant does exact-arg matching on plain run-grants — a
+// grant approved for `apes agents spawn igor7` won't reuse for
+// `apes agents spawn igor8`. Capability-grants take resource/action
+// patterns + selector globs (`name=*`), which DO match across agent
+// names via selectorValueMatches's '*'-as-glob behaviour.
+//
+// Backed by the bundled `apes-agents.toml` adapter that
+// `apes nest install` wrote into ~/.openape/shapes/adapters/.
+
+import { execFileSync } from 'node:child_process'
+import { defineCommand } from 'citty'
+import consola from 'consola'
+
+export const authorizeNestCommand = defineCommand({
+  meta: {
+    name: 'authorize',
+    description: 'Request the always-capability-grant the nest needs for zero-prompt spawn/destroy',
+  },
+  args: {
+    'reason': {
+      type: 'string',
+      description: 'Reason shown in the DDISA approval UI',
+    },
+    'wait': {
+      type: 'boolean',
+      description: 'Block until the grant is approved (default: print URL + exit 0)',
+    },
+  },
+  async run({ args }) {
+    const reason = (args.reason as string)
+      ?? 'nest-managed agent lifecycle (spawn / destroy / sync) — approve as Always'
+
+    consola.info('Requesting capability-grant for `apes-agents` (selector name=* covers all agent names)...')
+    consola.info('')
+    consola.info('When the IdP approval page opens, choose **Always** so the nest can re-use the grant on every spawn.')
+    consola.info('')
+
+    const cmdArgs = [
+      'grants', 'request-capability', 'apes-agents',
+      '--resource', 'agents:*',
+      '--selector', 'name=*',
+      '--action', 'create',
+      '--action', 'delete',
+      '--action', 'edit',
+      '--action', 'list',
+      '--approval=always',
+      '--reason', reason,
+      '--run-as', 'root',
+    ]
+    if (args.wait) cmdArgs.push('--wait')
+    try {
+      // execFile (not shell) so the reason / selector args can't be
+      // mis-quoted into something the shell would re-parse.
+      execFileSync('apes', cmdArgs, { stdio: 'inherit' })
+    }
+    catch (err) {
+      throw new Error(err instanceof Error ? err.message : String(err))
+    }
+  },
+})

--- a/packages/apes/src/commands/nest/index.ts
+++ b/packages/apes/src/commands/nest/index.ts
@@ -1,4 +1,5 @@
 import { defineCommand } from 'citty'
+import { authorizeNestCommand } from './authorize'
 import { installNestCommand } from './install'
 import { statusNestCommand } from './status'
 import { uninstallNestCommand } from './uninstall'
@@ -6,10 +7,11 @@ import { uninstallNestCommand } from './uninstall'
 export const nestCommand = defineCommand({
   meta: {
     name: 'nest',
-    description: 'Manage the local Nest control-plane daemon (install, status, uninstall). The Nest hosts agents on this computer — once installed, `apes agents spawn` is fast (no per-spawn DDISA approvals) and per-agent launchd plists are replaced by a single supervised process tree.',
+    description: 'Manage the local Nest control-plane daemon (install, authorize, status, uninstall). The Nest hosts agents on this computer — once installed + authorized, `apes agents spawn` is fast (no per-spawn DDISA approvals) and per-agent launchd plists are replaced by a single supervised process tree.',
   },
   subCommands: {
     install: installNestCommand,
+    authorize: authorizeNestCommand,
     status: statusNestCommand,
     uninstall: uninstallNestCommand,
   },

--- a/packages/apes/src/commands/nest/install.ts
+++ b/packages/apes/src/commands/nest/install.ts
@@ -16,9 +16,10 @@
 import { execFileSync } from 'node:child_process'
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { homedir, userInfo } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { defineCommand } from 'citty'
 import consola from 'consola'
+import { APES_AGENTS_ADAPTER_TOML } from './apes-agents-adapter'
 
 const PLIST_LABEL = 'ai.openape.nest'
 
@@ -73,6 +74,25 @@ function buildPlist(args: PlistArgs): string {
 `
 }
 
+/**
+ * Bundled `apes-agents` shapes adapter — written into
+ * `~/.openape/shapes/adapters/` so a capability-grant with selector
+ * `name=*` can cover any agent name (selectorValueMatches glob).
+ * Without this adapter, every spawn/destroy hits exact-arg matching
+ * and the always-grant doesn't reuse.
+ */
+function installAdapter(): boolean {
+  const target = join(homedir(), '.openape', 'shapes', 'adapters', 'apes-agents.toml')
+  mkdirSync(dirname(target), { recursive: true })
+  let existing = ''
+  try { existing = readFileSync(target, 'utf8') }
+  catch { /* not yet */ }
+  if (existing === APES_AGENTS_ADAPTER_TOML) return false
+  writeFileSync(target, APES_AGENTS_ADAPTER_TOML, { mode: 0o644 })
+  consola.success(`Wrote shapes adapter ${target}`)
+  return true
+}
+
 function findBinary(name: string): string {
   for (const dir of [
     join(homedir(), '.bun', 'bin'),
@@ -111,6 +131,9 @@ export const installNestCommand = defineCommand({
     consola.info(`  apes binary: ${apesBin}`)
     consola.info(`  HTTP port:   ${port}`)
 
+    // Adapter first — capability-grants need it.
+    installAdapter()
+
     mkdirSync(join(homeDir, 'Library', 'LaunchAgents'), { recursive: true })
 
     const desired = buildPlist({ nestBin, apesBin, homeDir, port })
@@ -138,13 +161,11 @@ export const installNestCommand = defineCommand({
     consola.success(`Nest daemon bootstrapped — http://127.0.0.1:${port}`)
 
     consola.info('')
-    consola.info('Next: approve the always-grant for nest-managed spawn/destroy.')
-    consola.info('Run this once and choose "Always" when the IdP UI prompts:')
+    consola.info('Next: request the capability-grant that lets the nest spawn/destroy any agent without per-call approval:')
     consola.info('')
-    consola.info('  apes run --as root --approval=always --reason "nest-managed agent spawn" \\')
-    consola.info('    -- apes agents spawn _grant_pattern_seed_')
+    consola.info('  apes nest authorize')
     consola.info('')
-    consola.info('(The seed-spawn will fail because "_grant_pattern_seed_" is not a valid')
-    consola.info('agent name — that\'s expected. The grant just needs to be approved-as-always.)')
+    consola.info('That requests an `apes-agents` capability-grant covering all agent names (selector glob `name=*`)')
+    consola.info('from your DDISA inbox; approve it once as `always` and the nest API runs silently from then on.')
   },
 })


### PR DESCRIPTION
Plain run-grants exact-match args; capability-grants with selector glob name=* reuse across agent names. Adds apes-agents adapter + apes nest authorize.