### PR TITLE
fix(apes): widen PATH in spawn setup.sh

### DIFF
--- a/.changeset/fix-spawn-setup-path.md
+++ b/.changeset/fix-spawn-setup-path.md
@@ -1,0 +1,5 @@
+---
+'@openape/apes': patch
+---
+
+`apes agents spawn`'s setup.sh now exports a wide PATH at the top — escapes-spawned scripts inherit a minimal PATH that excludes `/usr/sbin` (where chown / dscl / pwpolicy live), so privileged setup hit `chown: command not found` at line 131. Now resolves without forcing absolute paths.

--- a/packages/apes/src/lib/agent-bootstrap.ts
+++ b/packages/apes/src/lib/agent-bootstrap.ts
@@ -169,6 +169,12 @@ done
   return `#!/bin/bash
 set -euo pipefail
 
+# escapes-spawned scripts inherit a minimal PATH that doesn't include
+# /usr/sbin — which is where chown / dscl / pwpolicy live. Force a
+# wide PATH so the privileged setup commands resolve without absolute
+# paths everywhere.
+export PATH="/usr/sbin:/usr/bin:/bin:/sbin:/opt/homebrew/bin:/usr/local/bin"
+
 NAME=${shQuote(name)}
 HOME_DIR=${shQuote(homeDir)}
 SHELL_PATH=${shQuote(shellPath)}


### PR DESCRIPTION
escapes inherits minimal PATH; chown not found.