### PR TITLE
fix(nest): bridge supervisor YOLO + --wait + registry path

### DIFF
--- a/.changeset/fix-nest-bridge-supervisor.md
+++ b/.changeset/fix-nest-bridge-supervisor.md
@@ -1,0 +1,12 @@
+---
+'@openape/nest': patch
+'@openape/apes': patch
+---
+
+Fix nest bridge supervisor — three bugs that conspired to flood the human with approval prompts on every supervisor restart:
+
+1. **Wrong YOLO pattern**: The default nest YOLO allow-pattern was `apes run --as * -- openape-chat-bridge`, but escapes-helper unwraps the `apes run --as <agent> --` prefix before submitting the grant request to the IdP. So the actual target string the YOLO evaluator saw was just `openape-chat-bridge`. The pattern is now `openape-chat-bridge` (just the inner command) — `apes nest authorize` re-runs apply the corrected default.
+
+2. **Missing `--wait`**: The supervisor invoked `apes run --as <agent> -- openape-chat-bridge` without `--wait`. Even when YOLO auto-approved the grant server-side, the CLI returned exit 75 (EX_TEMPFAIL) the moment the grant was created — before the CLI observed the approval. Added `--wait` to mirror the spawn-handler.
+
+3. **Doubly-nested registry path**: `agents.json` was written to `~/.openape/nest/.openape/nest/agents.json` because `homedir()` already returned `~/.openape/nest` (the launchd-set daemon HOME) and the registry then joined `.openape/nest/` again on top. Registry now lives directly at `$HOME/agents.json`. Existing installs need a one-time `mv ~/.openape/nest/.openape/nest/agents.json ~/.openape/nest/agents.json`.

--- a/apps/openape-nest/src/lib/registry.ts
+++ b/apps/openape-nest/src/lib/registry.ts
@@ -39,7 +39,13 @@ interface RegistryFile {
   agents: AgentEntry[]
 }
 
-const REGISTRY_DIR = join(homedir(), '.openape', 'nest')
+// The nest daemon's launchd plist sets HOME=~/.openape/nest, so
+// homedir() already points at the nest's data dir. Joining
+// `.openape/nest/agents.json` on top of that produces a doubly-nested
+// path (`~/.openape/nest/.openape/nest/agents.json`) that the YOLO
+// log search and humans never find. Keep the registry directly under
+// the data dir.
+const REGISTRY_DIR = homedir()
 const REGISTRY_PATH = join(REGISTRY_DIR, 'agents.json')
 
 function emptyRegistry(): RegistryFile {

--- a/apps/openape-nest/src/lib/supervisor.ts
+++ b/apps/openape-nest/src/lib/supervisor.ts
@@ -98,7 +98,12 @@ export class Supervisor {
     // that matches the command pattern (see findExistingGrant). The
     // human approves the always-grant once during `apes nest install`;
     // every supervisor restart from then on is silent (no human prompt).
-    const args = ['run', '--as', agent.name, '--', 'openape-chat-bridge']
+    // `--wait` is mandatory: even though YOLO auto-approves the grant
+    // server-side, `apes run` without `--wait` returns exit 75
+    // (EX_TEMPFAIL) the moment the grant is created — before the CLI
+    // observes the approval. Same lesson as the nest API spawn handler
+    // (apps/openape-nest/src/api/agents.ts).
+    const args = ['run', '--as', agent.name, '--wait', '--', 'openape-chat-bridge']
     const child = spawn(this.deps.apesBin, args, {
       stdio: ['ignore', 'pipe', 'pipe'],
       detached: false,

--- a/packages/apes/src/commands/nest/authorize.ts
+++ b/packages/apes/src/commands/nest/authorize.ts
@@ -32,10 +32,12 @@ const DEFAULT_ALLOW_PATTERNS = [
   // — `bash *` would be unsafe.
   'bash *apes-spawn-*setup.sh',
   // Bridge invocation the supervisor uses to keep agent processes
-  // running. Pattern is intentionally precise — not a generic
-  // `apes run --as *` wildcard — so a compromised nest can't pivot
-  // to running arbitrary commands as arbitrary users.
-  'apes run --as * -- openape-chat-bridge',
+  // running. The grant request escapes-helper sends to the IdP
+  // contains the *inner* command only — `apes run --as <agent> --`
+  // is the wrapper that gets unwrapped before grant creation. So
+  // the YOLO target string is just `openape-chat-bridge`, not the
+  // full wrapped invocation.
+  'openape-chat-bridge',
 ]
 
 export const authorizeNestCommand = defineCommand({


### PR DESCRIPTION
Three bugs in the nest bridge supervisor that conspired to spam human approvals on every supervisor cycle. See changeset.