### PR TITLE
fix(apes): spawn uses server-resolved owner_email

### DIFF
--- a/.changeset/fix-spawn-owner-email.md
+++ b/.changeset/fix-spawn-owner-email.md
@@ -1,0 +1,5 @@
+---
+'@openape/apes': patch
+---
+
+Fix `apes agents spawn` writing the wrong `owner_email` into the new agent's `auth.json` when the spawn happens through a Nest (or any non-human caller). The IdP's `/api/enroll` resolves the owner transitively (the human at the top of the chain), but the cli was still writing `auth.email` (= the local caller, e.g. the Nest itself) into the agent's local auth.json. Result: the agent's auth.json carried the Nest's email as `owner_email`, and troop's `/api/agents/me/sync` rejected the call with a 400 because the owner-domain encoded in the agent's email (`patrick+hofmann_eco`) didn't match the locally-stored `owner_email`'s domain (`id.openape.ai`). Now uses `registration.owner` from the IdP response, matching what the server actually persisted.

--- a/packages/apes/src/commands/agents/spawn.ts
+++ b/packages/apes/src/commands/agents/spawn.ts
@@ -154,7 +154,15 @@ export const spawnAgentCommand = defineCommand({
         email: registration.email,
         expiresAt: Math.floor(Date.now() / 1000) + expiresIn,
         keyPath: `${homeDir}/.ssh/id_ed25519`,
-        ownerEmail: auth.email,
+        // The IdP resolves the owner transitively (when the caller
+        // is itself an agent — e.g. a Nest spawning a child — the
+        // human at the top of the chain becomes owner). Use the
+        // server-resolved owner, not the local caller's auth.email,
+        // otherwise the agent's auth.json will carry the Nest's
+        // email and troop will reject sync calls because the
+        // encoded owner-domain in the agent email doesn't match
+        // the auth.json's owner_email domain.
+        ownerEmail: registration.owner,
       })
 
       const includeClaudeHook = !args['no-claude-hook']


### PR DESCRIPTION
Nest-spawned agents write the wrong owner_email locally (caller's email instead of human owner from /api/enroll), breaking troop sync.