### PR TITLE
fix: code-debt cleanups (delegate flag + delegation audit)

### DIFF
--- a/.changeset/code-debts-cleanup.md
+++ b/.changeset/code-debts-cleanup.md
@@ -1,0 +1,11 @@
+---
+'@openape/apes': patch
+---
+
+Three small code-debt fixes:
+
+1. **`apes grants delegate --approval`** now actually works. The CLI was sending `approval: <value>` in the request body but the server reads `grant_type`. Result: every delegation got `grant_type: 'once'` regardless of `--approval timed|always`. Now the body uses the wire name `grant_type`. (CLI flag stays `--approval` for UX continuity — that's the term humans see in the IdP grant-approval UI.)
+
+2. **`registerAgentAtIdp` audit logs**. When an agent enrolls, the code paths `tryDelegatedEnrollToken` either succeeds (logs `[agent-bootstrap] using delegated token from grant <id> (sub=<owner>, act=<delegate>)`) or falls back (logs `[agent-bootstrap] no enroll-agent delegation from <owner> to <delegate> — falling back to direct enroll`). Surfaces during rollout whether the new token-exchange path is firing or whether the IdP's transitive-ownership fallback in `/api/enroll` is still doing the work.
+
+3. **`/api/enroll` transitive-ownership audit**. The fallback that walks the user store to attribute ownership when an agent enrols a sub-agent now logs a structured warning whenever it fires, including the operator command the human should run to set up the proper delegation grant. Same idea: visibility before removal.

--- a/apps/openape-free-idp/server/api/enroll.post.ts
+++ b/apps/openape-free-idp/server/api/enroll.post.ts
@@ -89,6 +89,14 @@ export default defineEventHandler(async (event) => {
   const callerRecord = await userStore.findByEmail(email)
   if (callerRecord?.type === 'agent' && callerRecord.owner) {
     effectiveOwner = callerRecord.owner
+    // Audit signal during the rollout: agent-side delegation flow
+    // (registerAgentAtIdp's tryDelegatedEnrollToken) is supposed to
+    // mint a token whose `sub` is already the human owner — so when
+    // we DO see an agent's email coming through here, it means the
+    // delegation path didn't fire (either the agent has no
+    // delegation grant, or the token-exchange failed). Counts as a
+    // signal to track until we can confidently remove this fallback.
+    console.warn(`[enroll] transitive-ownership fallback fired: caller=${email} → owner=${effectiveOwner} (agent has no delegation; consider running \`apes grants delegate --to ${email} --at enroll-agent --approval always\` from the owner)`)
   }
 
   const existingOwned = await userStore.findByOwner(effectiveOwner)

--- a/packages/apes/src/commands/grants/delegate.ts
+++ b/packages/apes/src/commands/grants/delegate.ts
@@ -43,10 +43,15 @@ export const delegateCommand = defineCommand({
     const idp = getIdpUrl()!
     const delegationsUrl = await getDelegationsEndpoint(idp)
 
+    // Server expects `grant_type`, not `approval`. The CLI flag stays
+    // named `--approval` for UX continuity (matches the term humans
+    // see in the IdP grant-approval UI), but the request body must
+    // carry the wire name. Without this rename the server always
+    // defaults to grant_type='once' regardless of the flag value.
     const body: Record<string, unknown> = {
       delegate: args.to,
       audience: args.at,
-      approval: args.approval,
+      grant_type: args.approval,
     }
 
     if (args.scopes) {

--- a/packages/apes/src/lib/agent-bootstrap.ts
+++ b/packages/apes/src/lib/agent-bootstrap.ts
@@ -75,7 +75,15 @@ async function tryDelegatedEnrollToken(idp?: string): Promise<string | null> {
     if (!idpUrl) return null
 
     const grantId = await findEnrollDelegationGrantId(idpUrl, ownerEmail, myEmail)
-    if (!grantId) return null
+    if (!grantId) {
+      // Visible signal during the rollout window so we can tell when
+      // a Nest is still falling back to /api/enroll's transitive-
+      // ownership heuristic (and therefore why removing that
+      // heuristic would break it). Stays at debug volume so it
+      // doesn't pollute the spawn flow's stdout.
+      console.warn(`[agent-bootstrap] no enroll-agent delegation from ${ownerEmail} to ${myEmail} — falling back to direct enroll`)
+      return null
+    }
 
     const result = await exchangeWithDelegation({
       idp: idpUrl,
@@ -83,9 +91,11 @@ async function tryDelegatedEnrollToken(idp?: string): Promise<string | null> {
       audience: ENROLL_AUDIENCE,
       delegationGrantId: grantId,
     })
+    console.log(`[agent-bootstrap] using delegated token from grant ${grantId} (sub=${ownerEmail}, act=${myEmail})`)
     return result.access_token
   }
-  catch {
+  catch (err) {
+    console.warn(`[agent-bootstrap] delegated-enroll exchange failed: ${err instanceof Error ? err.message : String(err)} — falling back to direct enroll`)
     return null
   }
 }


### PR DESCRIPTION
Three fixes: delegate --approval bug, agent-bootstrap audit log, enroll.post.ts transitive-ownership warning.