### PR TITLE
fix(idp): push fires only for pending grants

### DIFF
--- a/.changeset/fix-push-pending-only.md
+++ b/.changeset/fix-push-pending-only.md
@@ -1,0 +1,13 @@
+---
+'@openape/nuxt-auth-idp': minor
+---
+
+Fix backwards push-notification logic. Previously every freshly-inserted grant fired a Web Push to the approver — including grants that the YOLO/standing-grant pre-approval hook was about to auto-approve, because the pre-approval logic runs AFTER the initial grant save. Result felt inverted from the human's perspective: auto-approved grants pinged, while pending grants requesting their own attention often did not (because the human's user row has no `approver` field, so push fan-out was skipped entirely under the old "humans don't approve their own grants" assumption).
+
+Two fixes shipped:
+
+1. **New `defineGrantPendingHook`** extension point in the module. The `POST /api/grants` handler invokes it only on the fall-through path where the grant remains pending after every pre-approval / standing-grant / similarity check has had its say. The drizzle store no longer fires push directly from `save()`.
+
+2. **Approver resolution** now treats the requester themselves as the recipient when no explicit `approver` row is set (the case for humans). Humans need to know about their own pending grants because they ARE their own approver in the UI.
+
+Net effect: pushes go to the right person at the right moment.

--- a/apps/openape-free-idp/server/plugins/08.push-hook.ts
+++ b/apps/openape-free-idp/server/plugins/08.push-hook.ts
@@ -1,0 +1,13 @@
+// Wire the Web Push notifier into the IdP's grant-pending-hook
+// surface. Fires AFTER pre-approval hooks (YOLO etc.) have had a
+// chance to auto-approve — so auto-approved grants don't push, and
+// pending grants that actually need a human do.
+
+import { notifyApproverOfPendingGrant } from '../utils/push'
+
+export default defineNitroPlugin(() => {
+  defineGrantPendingHook(async (grant) => {
+    if (grant.status !== 'pending' || grant.auto_approval_kind) return
+    await notifyApproverOfPendingGrant(grant)
+  })
+})

--- a/apps/openape-free-idp/server/utils/drizzle-grant-store.ts
+++ b/apps/openape-free-idp/server/utils/drizzle-grant-store.ts
@@ -3,7 +3,6 @@ import type { GrantListParams, GrantStore } from '@openape/grants'
 import { and, desc, eq, inArray, lt, sql } from 'drizzle-orm'
 import { useDb } from '../database/drizzle'
 import { grants } from '../database/schema'
-import { notifyApproverOfPendingGrant } from './push'
 
 interface ExtendedGrantStore extends GrantStore {
   findAll: () => Promise<OpenApeGrant[]>
@@ -62,7 +61,6 @@ export function createDrizzleGrantStore(): ExtendedGrantStore {
   return {
     async save(grant) {
       const row = grantToRow(grant)
-      const isInsert = !(await db.select({ id: grants.id }).from(grants).where(eq(grants.id, grant.id)).get())
 
       await db.insert(grants).values(row).onConflictDoUpdate({
         target: grants.id,
@@ -84,16 +82,15 @@ export function createDrizzleGrantStore(): ExtendedGrantStore {
         },
       })
 
-      // Push the approver — only on a fresh insert (not on every save which
-      // is also called for status updates), and only when the grant
-      // actually needs human action. Auto-approved grants (YOLO / standing-
-      // grant match) carry an autoApprovalKind and don't pollute push.
-      // Fire-and-forget: a failing push must never break grant creation.
-      if (isInsert && grant.status === 'pending' && !grant.auto_approval_kind) {
-        void notifyApproverOfPendingGrant(grant).catch((err: unknown) =>
-          console.warn('[push] approver notification failed:', err),
-        )
-      }
+      // Push notifications are no longer fired here. The store's save()
+      // is called BEFORE the index.post.ts handler runs YOLO / standing
+      // grant decisions (which then set status='approved' via a follow-
+      // up updateStatus) — so a push fired here would always go out for
+      // auto-approved grants too, which is exactly the noise we want to
+      // suppress. The handler now fires the push explicitly only on the
+      // fall-through path where the grant remains pending after all
+      // pre-approval hooks have had their say. See `routePushAfterCreate`
+      // in modules/nuxt-auth-idp/src/runtime/server/api/grants/index.post.ts.
     },
 
     async findById(id) {

--- a/apps/openape-free-idp/server/utils/push.ts
+++ b/apps/openape-free-idp/server/utils/push.ts
@@ -23,16 +23,22 @@ function ensureVapidConfigured(): boolean {
  * Best-effort fan-out of a Web Push notification to whoever should
  * approve a freshly-created pending grant.
  *
- * Approver resolution: there's no `approver` column on `grants` today —
- * approver is derived from the requester's user row (`users.approver`).
- * Agents have an explicit approver set when they're enrolled; humans
- * (no `approver` row) get no notification, which is correct since
- * humans don't need someone else to approve their own grants.
+ * Approver resolution:
+ *   1. If the requester has an explicit `approver` row (the case for
+ *      agents, set at enroll time), notify the approver.
+ *   2. If the requester is a human and has no `approver` row, notify
+ *      the requester themselves — humans approve their own grants in
+ *      the IdP UI, so they need to know one's pending. This used to
+ *      `return` early on the assumption that "humans don't need
+ *      someone else to approve their own grants", but the right
+ *      reading is: humans ARE their own approver.
+ *   3. If the requester has no user row at all (shouldn't happen but
+ *      defensively), skip silently.
  *
  * Skips silently when:
  *   - VAPID keys aren't configured (dev environments)
- *   - Requester has no user row, or no `approver` set
- *   - Approver has no push subscriptions
+ *   - Requester has no user row
+ *   - Resolved recipient has no push subscriptions
  *   - The grant is auto-approved (caller is responsible for that check;
  *     this helper assumes status='pending' and !auto_approval_kind)
  *
@@ -48,12 +54,17 @@ export async function notifyApproverOfPendingGrant(grant: OpenApeGrant): Promise
     .from(users)
     .where(eq(users.email, grant.request.requester))
     .get()
-  if (!requester?.approver) return
+  if (!requester) return
+
+  // Recipient = explicit approver if present, else the requester
+  // themselves (human approving their own grant). Agents always have
+  // an approver set at enroll-time; humans typically don't.
+  const recipient = requester.approver ?? requester.email
 
   const subs = await db
     .select()
     .from(pushSubscriptions)
-    .where(eq(pushSubscriptions.userEmail, requester.approver))
+    .where(eq(pushSubscriptions.userEmail, recipient))
   if (subs.length === 0) return
 
   const summary = summarizeRequest(grant.request)

--- a/modules/nuxt-auth-idp/src/runtime/server/api/grants/index.post.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/api/grants/index.post.ts
@@ -4,6 +4,7 @@ import { canonicalizeCliPermission, cliAuthorizationDetailsCover, computeArgvHas
 import { defineEventHandler, readBody, setResponseStatus } from 'h3'
 import { tryBearerAuth } from '../../utils/agent-auth'
 import { useGrantStores } from '../../utils/grant-stores'
+import { runGrantPendingHooks } from '../../utils/grant-pending-hooks'
 import { runPreApprovalHooks } from '../../utils/pre-approval-hooks'
 import { createProblemError } from '../../utils/problem'
 
@@ -220,6 +221,13 @@ export default defineEventHandler(async (event) => {
       const similarResult = findSimilarCliGrants(body, existingGrants)
       if (similarResult) {
         const grant = await createGrant(body, grantStore)
+        // Grant landed in pending state and needs human approval —
+        // fan out a push / mail / etc. via registered hooks.
+        // Fire-and-forget so a slow notification doesn't delay the
+        // grant-creation response.
+        void runGrantPendingHooks(grant).catch(err =>
+          console.warn('[grants/post] pending-hook failed:', err),
+        )
         setResponseStatus(event, 201)
         return { ...grant, similar_grants: similarResult }
       }
@@ -227,6 +235,10 @@ export default defineEventHandler(async (event) => {
   }
 
   const grant = await createGrant(body, grantStore)
+  // Grant landed in pending state — notify the human.
+  void runGrantPendingHooks(grant).catch(err =>
+    console.warn('[grants/post] pending-hook failed:', err),
+  )
   setResponseStatus(event, 201)
   return grant
 })

--- a/modules/nuxt-auth-idp/src/runtime/server/utils/grant-pending-hooks.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/utils/grant-pending-hooks.ts
@@ -1,0 +1,34 @@
+import type { OpenApeGrant } from '@openape/core'
+
+/**
+ * A "grant pending" hook fires AFTER a grant has been created and survived
+ * all pre-approval / standing-grant / similarity checks — i.e. it remains
+ * status='pending' and a human will need to approve it. Consuming apps
+ * register this hook to fan out a push / mail / etc. to the human.
+ *
+ * Why this isn't fired from the grant store's `save()`: pre-approval hooks
+ * (YOLO etc.) run AFTER the initial save and update the grant to approved
+ * via a follow-up `updateStatus`. A push fired at save-time would always
+ * go out, even for grants the YOLO hook is about to auto-approve. That's
+ * the inversion bug this hook fixes.
+ */
+export type GrantPendingHook = (grant: OpenApeGrant) => Promise<void> | void
+
+const hooks: GrantPendingHook[] = []
+
+/** Register a grant-pending hook. Usually called once from a Nitro plugin. */
+export function defineGrantPendingHook(hook: GrantPendingHook): void {
+  hooks.push(hook)
+}
+
+/** Fire-and-forget run of all registered hooks. Errors are logged + swallowed. */
+export async function runGrantPendingHooks(grant: OpenApeGrant): Promise<void> {
+  await Promise.all(hooks.map(async (hook) => {
+    try {
+      await hook(grant)
+    }
+    catch (err) {
+      console.error('[grant-pending-hook] failed:', err)
+    }
+  }))
+}


### PR DESCRIPTION
Auto-approved no longer pings; pending where requester==approver now does.