### PR TITLE
feat: per-agent tool whitelist

### DIFF
--- a/.changeset/per-agent-tools.md
+++ b/.changeset/per-agent-tools.md
@@ -1,0 +1,16 @@
+---
+'@openape/apes': minor
+'@openape/chat-bridge': minor
+---
+
+Per-agent tool whitelist — owner-controlled via troop, default all-tools-enabled on first sync.
+
+**What changed**:
+- `openape-troop`: `agents` table gains a `tools text` column (JSON string array, defaults to `'[]'` for legacy rows). New agents on first sync get the full `tool-catalog.json` list as their default — owner narrows via `PATCH /api/agents/<name>` (the existing endpoint now also accepts `tools: string[]`).
+- `GET /api/agents/me/tasks` returns the agent's `tools[]` alongside `system_prompt` and `tasks`.
+- `apes agents sync` writes the resolved tool list into `~/.openape/agent/agent.json` (alongside `systemPrompt`).
+- `@openape/chat-bridge` reads `tools[]` from `agent.json` on every new chat thread, replacing the legacy `APE_CHAT_BRIDGE_TOOLS` env var as the source of truth. The env var stays as a fallback when `agent.json` doesn't have a `tools` field (e.g. before the next sync).
+
+**Net effect**: tools are now per-agent + owner-editable. Defaults to all 9 shipped tools (`time.now`, `http.get`, `http.post`, `file.read`, `file.write`, `tasks.list`, `tasks.create`, `mail.list`, `mail.search`) so new agents are immediately useful in chat. Owner narrows when needed.
+
+Existing agents (`tools=[]` from migration) get nothing in chat until they sync — recommended one-time fix: `PATCH /api/agents/<name>` with `tools: [<full list>]` per agent, or just `apes agents sync` once and the agent re-registers (which doesn't run the default-all path because the row already exists). For Patrick's local fleet, simplest is a single SQL update on the troop DB to set `tools='[…]'` on existing rows.

--- a/apps/openape-chat-bridge/src/bridge.ts
+++ b/apps/openape-chat-bridge/src/bridge.ts
@@ -65,6 +65,30 @@ function resolveSystemPrompt(envFallback: string): string {
   catch { return envFallback }
 }
 
+/**
+ * Resolve the agent's tool whitelist for chat-bridge runtime.
+ * Source of truth (priority order):
+ *   1. `~/.openape/agent/agent.json` (`tools[]` written by the
+ *      latest `apes agents sync` from troop) — the live owner-
+ *      controlled config.
+ *   2. `APE_CHAT_BRIDGE_TOOLS` env var (legacy fallback) — the
+ *      deprecated mechanism left in place so old deployments
+ *      keep working until they sync.
+ *   3. `[]` — pure-chat agent, no tools.
+ */
+function resolveTools(envFallback: string[]): string[] {
+  if (existsSync(AGENT_CONFIG_PATH)) {
+    try {
+      const parsed = JSON.parse(readFileSync(AGENT_CONFIG_PATH, 'utf8')) as { tools?: unknown }
+      if (Array.isArray(parsed.tools)) {
+        return parsed.tools.filter((t): t is string => typeof t === 'string')
+      }
+    }
+    catch { /* fall through */ }
+  }
+  return envFallback
+}
+
 const DEFAULT_ENDPOINT = 'https://chat.openape.ai'
 const DEFAULT_APES_BIN = 'apes'
 const DEFAULT_MAX_STEPS = 10
@@ -306,7 +330,10 @@ class Bridge {
       chat: this.chat,
       runtimeConfig: this.runtimeConfig(),
       systemPrompt: resolveSystemPrompt(this.cfg.systemPrompt),
-      tools: this.cfg.tools,
+      // Tools resolve from agent.json (latest sync from troop) on
+      // every new thread, so owner edits in the troop UI take
+      // effect after the next sync without a bridge restart.
+      tools: resolveTools(this.cfg.tools),
       maxSteps: this.cfg.maxSteps,
       log,
     })

--- a/apps/openape-troop/server/api/agents/[name].patch.ts
+++ b/apps/openape-troop/server/api/agents/[name].patch.ts
@@ -1,15 +1,24 @@
 import { and, eq } from 'drizzle-orm'
 import { z } from 'zod'
+import toolCatalog from '../../tool-catalog.json'
 import { useDb } from '../../database/drizzle'
 import { agents } from '../../database/schema'
 import { requireOwner } from '../../utils/auth'
 
-// Update agent-level metadata that the owner is allowed to edit. Only
-// `systemPrompt` for now — host-id / hostname / pubkey are agent-side
-// state set on first sync and shouldn't be owner-mutable. Add fields
-// here as the owner-facing surface grows.
+const KNOWN_TOOL_NAMES = new Set<string>(
+  (toolCatalog as { tools: Array<{ name: string }> }).tools.map(t => t.name),
+)
+
+// Update agent-level metadata that the owner is allowed to edit.
+// `systemPrompt` and `tools` whitelist — host-id / hostname / pubkey
+// are agent-side state set on first sync and shouldn't be
+// owner-mutable. Add fields here as the owner-facing surface grows.
 const bodySchema = z.object({
   system_prompt: z.string().max(8000).optional(),
+  tools: z.array(z.string()).optional().refine(
+    arr => arr === undefined || arr.every(t => KNOWN_TOOL_NAMES.has(t)),
+    { message: 'tools list contains unknown tool names — see /api/tool-catalog' },
+  ),
 })
 
 export default defineEventHandler(async (event) => {
@@ -30,6 +39,7 @@ export default defineEventHandler(async (event) => {
   const db = useDb()
   const updates: Record<string, unknown> = {}
   if (body.data.system_prompt !== undefined) updates.systemPrompt = body.data.system_prompt
+  if (body.data.tools !== undefined) updates.tools = body.data.tools
 
   const result = await db
     .update(agents)

--- a/apps/openape-troop/server/api/agents/me/sync.post.ts
+++ b/apps/openape-troop/server/api/agents/me/sync.post.ts
@@ -1,9 +1,14 @@
 import { eq } from 'drizzle-orm'
 import { z } from 'zod'
+import toolCatalog from '../../../tool-catalog.json'
 import { useDb } from '../../../database/drizzle'
 import { agents } from '../../../database/schema'
 import { parseAgentEmail } from '../../../utils/agent-email'
 import { requireAgent } from '../../../utils/auth'
+
+// Default tool whitelist for first-time agent sync — all currently-
+// shipped tools are enabled. Owners narrow via the troop UI later.
+const ALL_TOOL_NAMES: string[] = (toolCatalog as { tools: Array<{ name: string }> }).tools.map(t => t.name)
 
 const bodySchema = z.object({
   hostname: z.string().min(1).max(253),
@@ -84,6 +89,8 @@ export default defineEventHandler(async (event) => {
     hostId: body.data.host_id,
     hostname: body.data.hostname,
     pubkeySsh: body.data.pubkey_ssh ?? null,
+    // Default-all-tools on first sync. Owner can later narrow via UI.
+    tools: ALL_TOOL_NAMES,
     firstSeenAt: now,
     lastSeenAt: now,
     createdAt: now,

--- a/apps/openape-troop/server/api/agents/me/tasks.get.ts
+++ b/apps/openape-troop/server/api/agents/me/tasks.get.ts
@@ -13,7 +13,7 @@ export default defineEventHandler(async (event) => {
   const agentEmail = await requireAgent(event)
   const db = useDb()
   const agent = await db
-    .select({ systemPrompt: agents.systemPrompt })
+    .select({ systemPrompt: agents.systemPrompt, tools: agents.tools })
     .from(agents)
     .where(eq(agents.email, agentEmail))
     .get()
@@ -23,6 +23,10 @@ export default defineEventHandler(async (event) => {
     .where(eq(tasks.agentEmail, agentEmail))
   return {
     system_prompt: agent?.systemPrompt ?? '',
+    // tools[] = whitelist for chat-bridge runtime + cron task fallback.
+    // The bridge writes this into ~/.openape/agent/agent.json on every
+    // sync; bridge reads it from there at boot for live chat tool-calls.
+    tools: agent?.tools ?? [],
     tasks: taskList,
   }
 })

--- a/apps/openape-troop/server/database/schema.ts
+++ b/apps/openape-troop/server/database/schema.ts
@@ -24,6 +24,12 @@ export const agents = sqliteTable('agents', {
   // the imperative job description; per-chat user-input is the human's
   // current message.
   systemPrompt: text('system_prompt').notNull().default(''),
+  // Tool whitelist — JSON string array of tool names from
+  // `tool-catalog.json`. New agents start with all-tools-enabled
+  // on first sync; owners narrow via the troop UI (or PATCH
+  // `/api/agents/:email/tools`). The chat-bridge reads this list
+  // from `~/.openape/agent/agent.json` after each sync.
+  tools: text('tools', { mode: 'json' }).notNull().$type<string[]>().default([]),
   firstSeenAt: integer('first_seen_at'),
   lastSeenAt: integer('last_seen_at'),
   createdAt: integer('created_at').notNull(),

--- a/apps/openape-troop/server/plugins/02.database.ts
+++ b/apps/openape-troop/server/plugins/02.database.ts
@@ -50,6 +50,13 @@ export default defineNitroPlugin(async () => {
       await db.run(sql`ALTER TABLE agents ADD COLUMN system_prompt TEXT NOT NULL DEFAULT ''`)
     }
     catch { /* column exists */ }
+    // Phase H: tool whitelist per agent. Default '[]' for existing
+    // pre-refactor rows; new agents land via the sync.post handler
+    // which writes the all-tools list.
+    try {
+      await db.run(sql`ALTER TABLE agents ADD COLUMN tools TEXT NOT NULL DEFAULT '[]'`)
+    }
+    catch { /* column exists */ }
     try {
       await db.run(sql`ALTER TABLE tasks RENAME COLUMN system_prompt TO user_prompt`)
     }

--- a/packages/apes/src/commands/agents/sync.ts
+++ b/packages/apes/src/commands/agents/sync.ts
@@ -97,8 +97,9 @@ export const syncAgentCommand = defineCommand({
     })
     consola.info(sync.first_sync ? '✓ first sync — agent registered' : '✓ presence updated')
 
-    const { system_prompt: systemPrompt, tasks } = await client.listTasks()
+    const { system_prompt: systemPrompt, tools, tasks } = await client.listTasks()
     consola.info(`Pulled ${tasks.length} task${tasks.length === 1 ? '' : 's'}`)
+    consola.info(`Tools enabled: ${tools.length === 0 ? '(none)' : tools.join(', ')}`)
 
     // Sync runs as ROOT in production (the launchd plist sets
     // UserName=root so it can write /Library/LaunchDaemons/ and
@@ -137,7 +138,7 @@ export const syncAgentCommand = defineCommand({
     const agentJsonPath = join(agentDir, 'agent.json')
     writeFileSync(
       agentJsonPath,
-      `${JSON.stringify({ systemPrompt }, null, 2)}\n`,
+      `${JSON.stringify({ systemPrompt, tools }, null, 2)}\n`,
       { mode: 0o600 },
     )
     chownToAgent(agentJsonPath)

--- a/packages/apes/src/lib/troop-client.ts
+++ b/packages/apes/src/lib/troop-client.ts
@@ -36,6 +36,14 @@ export interface AgentTasksResponse {
    * owner hasn't set one.
    */
   system_prompt: string
+  /**
+   * Tool whitelist for chat-bridge runtime. Cron tasks have their own
+   * per-task `tools[]` (see TaskSpec); this is the list the bridge
+   * exposes to the LLM during live chat-thread turns. Empty array =
+   * no tools (pure chat). Defaults to "all known tools" on first
+   * sync — owner narrows via troop UI.
+   */
+  tools: string[]
   tasks: TaskSpec[]
 }
 


### PR DESCRIPTION
Owner-controlled per-agent tool selection in troop. New agents default to all-tools.