### PR TITLE
feat(chat): iOS safe-area + bigger tap targets on mobile

### DIFF
--- a/apps/openape-chat/app/assets/css/main.css
+++ b/apps/openape-chat/app/assets/css/main.css
@@ -19,3 +19,46 @@
   }
 }
 
+/*
+ * iOS safe-area + tap-target tweaks.
+ *
+ * `viewport-fit=cover` + `apple-mobile-web-app-status-bar-style=black-translucent`
+ * (both in nuxt.config.ts) tell iOS to overlay the status bar on our content
+ * and expose the inset env() values. The rules below use those values so
+ * sticky headers don't draw under the notch/dynamic island, and so the
+ * fixed compose bar at the bottom clears the home indicator.
+ *
+ * Apple's HIG calls for a 44pt minimum tap target on touch surfaces. Nuxt
+ * UI's `size="sm"` buttons are 30px — fine on desktop, easy to miss on a
+ * phone. We size up all UButton instances inside headers and nav rails
+ * (the spots the user is most likely to mis-tap into) to 44px on touch
+ * viewports only. Desktop keeps the tighter visual rhythm.
+ */
+
+/* Total height of the sticky header — used as the `top:` value for the
+ * thread-tabs nav that sits beneath it. Computed at runtime so the
+ * offset tracks env(safe-area-inset-top) per device. The 3.25rem term
+ * matches the header's py-3 + button height. */
+:root {
+  --chat-header-height: calc(env(safe-area-inset-top) + 3.25rem);
+}
+
+/* Safe-area helpers. The header in each page applies `.safe-pt` so the
+ * notch/dynamic island doesn't crash into the title row. */
+.safe-pt {
+  padding-top: max(env(safe-area-inset-top), 0px);
+}
+.safe-pb {
+  padding-bottom: max(env(safe-area-inset-bottom), 0px);
+}
+
+@media (hover: none) and (pointer: coarse) {
+  /* Bigger tap targets for header / nav buttons on phones + tablets.
+   * Desktop is untouched — the visual scale there is fine. */
+  header button,
+  header a[role="button"],
+  nav[aria-label] button {
+    min-width: 2.75rem;
+    min-height: 2.75rem;
+  }
+}

--- a/apps/openape-chat/app/components/UpdateAvailable.vue
+++ b/apps/openape-chat/app/components/UpdateAvailable.vue
@@ -36,7 +36,7 @@ async function reload() {
   >
     <div
       v-if="needRefresh"
-      class="fixed top-3 inset-x-3 md:top-4 md:left-auto md:right-4 md:w-80 z-50 rounded-lg shadow-lg bg-zinc-900 border border-zinc-700 p-3 flex items-center gap-3"
+      class="fixed top-[calc(env(safe-area-inset-top)+0.75rem)] inset-x-3 md:top-4 md:left-auto md:right-4 md:w-80 z-50 rounded-lg shadow-lg bg-zinc-900 border border-zinc-700 p-3 flex items-center gap-3"
     >
       <UIcon name="i-lucide-download" class="text-primary-400 size-5 shrink-0" />
       <div class="flex-1 text-sm">

--- a/apps/openape-chat/app/pages/index.vue
+++ b/apps/openape-chat/app/pages/index.vue
@@ -136,7 +136,7 @@ function isAgent(email: string): boolean {
 
 <template>
   <div class="min-h-dvh flex flex-col">
-    <header class="sticky top-0 z-10 flex items-center gap-2 px-4 py-3 border-b border-zinc-800 bg-zinc-950/95 backdrop-blur">
+    <header class="safe-pt sticky top-0 z-10 flex items-center gap-2 px-4 py-3 border-b border-zinc-800 bg-zinc-950/95 backdrop-blur">
       <div class="flex-1 min-w-0">
         <h1 class="font-semibold text-lg leading-tight">
           OpenApe Chat

--- a/apps/openape-chat/app/pages/rooms/[id].vue
+++ b/apps/openape-chat/app/pages/rooms/[id].vue
@@ -292,7 +292,7 @@ async function createThread(): Promise<void> {
 
 <template>
   <div class="min-h-dvh flex flex-col">
-    <header class="sticky top-0 z-10 flex items-center gap-2 px-3 py-3 border-b border-zinc-800 bg-zinc-950/95 backdrop-blur">
+    <header class="safe-pt sticky top-0 z-10 flex items-center gap-2 px-3 py-3 border-b border-zinc-800 bg-zinc-950/95 backdrop-blur">
       <UButton
         to="/"
         icon="i-lucide-arrow-left"
@@ -320,7 +320,7 @@ async function createThread(): Promise<void> {
 
     <nav
       v-if="roomInfo && visibleThreads.length"
-      class="sticky top-[52px] z-10 flex items-center gap-1 px-2 py-1 border-b border-zinc-800 bg-zinc-950/95 backdrop-blur overflow-x-auto"
+      class="sticky top-[var(--chat-header-height)] z-10 flex items-center gap-1 px-2 py-1 border-b border-zinc-800 bg-zinc-950/95 backdrop-blur overflow-x-auto"
       aria-label="Threads"
     >
       <button

--- a/apps/openape-chat/nuxt.config.ts
+++ b/apps/openape-chat/nuxt.config.ts
@@ -25,6 +25,14 @@ export default defineNuxtConfig({
         { rel: 'apple-touch-icon', href: '/icon-512.png', sizes: '512x512' },
       ],
       meta: [
+        // viewport-fit=cover is the prerequisite for env(safe-area-inset-*).
+        // Without it iOS doesn't expose the inset values, so headers/inputs
+        // still draw flush with the notch/dynamic island and the home
+        // indicator. Pairing it with apple-mobile-web-app-status-bar-style
+        // = 'black-translucent' below tells iOS to overlay the status bar
+        // on our content — we then compensate with safe-area-inset-top
+        // padding in the sticky header (see assets/css/main.css).
+        { name: 'viewport', content: 'width=device-width, initial-scale=1, viewport-fit=cover' },
         { name: 'theme-color', content: '#18181b' },
         { name: 'description', content: 'Team rooms and DMs for humans and agents.' },
         { name: 'apple-mobile-web-app-capable', content: 'yes' },


### PR DESCRIPTION
## Why
On iOS the chat app was drawing under the dynamic island/notch and over the home indicator (no `viewport-fit=cover`, no `env(safe-area-inset-*)` usage on stickies). Header buttons were 30px — under Apple HIG's 44pt minimum touch target.

Side-by-side screenshots from Patrick showed it next to Claude Code: same screen size, Claude Code has clean safe-area padding + chunky buttons; OpenApe Chat had the status bar overlapping the room title.

## Changes
- `viewport-fit=cover` so iOS actually populates `env(safe-area-inset-*)`
- Sticky headers in `/` and `/rooms/[id]` get `.safe-pt` (= `env(safe-area-inset-top)` padding)
- Thread-tabs nav now sticks at `--chat-header-height` so it tracks the dynamic header height per device (not a hardcoded `top-[52px]`)
- `UpdateAvailable` banner respects safe-area-inset-top
- 44pt min tap targets on header + nav buttons via `(hover: none) and (pointer: coarse)` media query — desktop unchanged

`SendBox` already had `env(safe-area-inset-bottom)` padding for the home indicator, so the compose bar already cleared it once viewport-fit was switched on.

## Test plan
- [x] Build + lint + typecheck green
- [ ] Hit chat.openape.ai on iPhone after deploy → verify header clears dynamic island, thread tabs stick under the new header height, home indicator doesn't overlap compose bar