### PR TITLE
feat(apes): bash agent tool — DDISA-gated ape-shell

### DIFF
--- a/.changeset/agent-bash-tool.md
+++ b/.changeset/agent-bash-tool.md
@@ -1,0 +1,9 @@
+---
+"@openape/apes": minor
+---
+
+New agent tool: `bash`. Lets the LLM run shell commands on the agent host via `ape-shell`. Every command goes through the OpenApe DDISA grant cycle — auto-approved by a matching YOLO scope or push-notified to the owner for one-tap approval. Runs as the agent's macOS user, so file/network access is jailed to what that user can already see. Returns `stdout`, `stderr`, and `exit_code` (plus a `timed_out` flag if the wall-clock cap is hit).
+
+Risk level in the troop tool catalog: `high`. Default-on for new agents (consistent with the "all tools enabled by default" behavior introduced in 1.18.0); owners can narrow per agent in the troop UI.
+
+For repeated patterns (e.g. `git status` in a coding-helper agent's workspace) set up a YOLO scope so approvals don't pile up.

--- a/apps/openape-chat/package.json
+++ b/apps/openape-chat/package.json
@@ -9,7 +9,7 @@
     "dev": "nuxt dev --port 3007",
     "typecheck": "nuxi prepare && nuxt typecheck",
     "lint": "eslint .",
-    "test": "vitest run"
+    "test": "nuxi prepare && vitest run"
   },
   "dependencies": {
     "@iconify-json/lucide": "^1.2.90",

--- a/apps/openape-troop/server/tool-catalog.json
+++ b/apps/openape-troop/server/tool-catalog.json
@@ -54,6 +54,12 @@
       "description": "Search inbox via o365-cli with a query string.",
       "inputs": "{ q: string, limit?: number }",
       "risk": "low"
+    },
+    {
+      "name": "bash",
+      "description": "Run a shell command on the agent host via ape-shell. Every command goes through the DDISA grant cycle — auto-approved by a matching YOLO scope or owner push notification. Runs as the agent's macOS user; file/network access is limited to what that user can see. Returns stdout, stderr, exit code.",
+      "inputs": "{ cmd: string, timeout_ms?: number }",
+      "risk": "high"
     }
   ]
 }

--- a/packages/apes/src/lib/agent-tools/bash.ts
+++ b/packages/apes/src/lib/agent-tools/bash.ts
@@ -1,0 +1,94 @@
+import { spawn } from 'node:child_process'
+import type { ToolDefinition } from './index'
+
+const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000
+const MAX_STDIO_BYTES = 64 * 1024
+
+// Spawning `ape-shell -c <cmd>` (instead of building the inner
+// `apes run --shell -- bash -c …` ourselves) keeps the tool aligned
+// with what the human owner types interactively. ape-shell rewrites
+// to the same `apes run --shell` flow, so the grant cycle and the
+// shapes-adapter detection are identical to a terminal invocation.
+// APE_WAIT=1 forces the blocking path — the tool must return a
+// result, not exit-75 with grant-pending instructions.
+const BIN = 'ape-shell'
+
+function capStdio(s: string): string {
+  const buf = Buffer.from(s, 'utf8')
+  if (buf.byteLength <= MAX_STDIO_BYTES) return s
+  return `${buf.subarray(0, MAX_STDIO_BYTES).toString('utf8')}\n[truncated to ${MAX_STDIO_BYTES} bytes]`
+}
+
+export const bashTools: ToolDefinition[] = [
+  {
+    name: 'bash',
+    description:
+      'Run a shell command on the agent host. Every invocation goes through the OpenApe DDISA grant cycle — auto-approved if the owner has a matching YOLO scope, otherwise the owner gets a push notification to approve. Runs as the agent\'s macOS user, so file/network access is limited to what that user can see. Returns stdout, stderr, and exit code. For repeated command patterns ask the owner to set up a YOLO scope so approvals don\'t pile up.',
+    parameters: {
+      type: 'object',
+      properties: {
+        cmd: {
+          type: 'string',
+          description: 'Shell command to run, e.g. `ls -la ~/Documents`, `git status`, `curl -fsSL https://example.com`. The whole string is passed to `bash -c`; quote internally as needed.',
+        },
+        timeout_ms: {
+          type: 'number',
+          description: 'Wall-clock cap for the whole approval-and-run cycle in milliseconds. Default 300000 (5 min). Approval waits count against this budget.',
+        },
+      },
+      required: ['cmd'],
+    },
+    execute: async (args: unknown) => {
+      const a = args as { cmd?: unknown, timeout_ms?: unknown }
+      if (typeof a.cmd !== 'string' || a.cmd.trim() === '') {
+        throw new Error('cmd must be a non-empty string')
+      }
+      const timeout = typeof a.timeout_ms === 'number' && a.timeout_ms > 0
+        ? a.timeout_ms
+        : DEFAULT_TIMEOUT_MS
+
+      return await new Promise<unknown>((resolveResult) => {
+        const child = spawn(BIN, ['-c', a.cmd as string], {
+          env: { ...process.env, APE_WAIT: '1' },
+          stdio: ['ignore', 'pipe', 'pipe'],
+        })
+        let stdout = ''
+        let stderr = ''
+        let timedOut = false
+        let spawnError: Error | null = null
+
+        child.stdout!.on('data', (chunk: Buffer) => { stdout += chunk.toString('utf8') })
+        child.stderr!.on('data', (chunk: Buffer) => { stderr += chunk.toString('utf8') })
+        child.on('error', (err) => { spawnError = err as Error })
+
+        const timer = setTimeout(() => {
+          timedOut = true
+          child.kill('SIGTERM')
+          // Force-kill if SIGTERM doesn't take in 5s — happens when the
+          // child is wedged waiting on an upstream grant approval.
+          setTimeout(() => {
+            try { child.kill('SIGKILL') }
+            catch { /* already dead */ }
+          }, 5000)
+        }, timeout)
+
+        child.on('close', (code) => {
+          clearTimeout(timer)
+          if (spawnError) {
+            resolveResult({
+              error: spawnError.message,
+              hint: `Could not exec '${BIN}'. The agent host needs @openape/apes installed globally so ape-shell is on PATH.`,
+            })
+            return
+          }
+          resolveResult({
+            stdout: capStdio(stdout),
+            stderr: capStdio(stderr),
+            exit_code: code ?? -1,
+            ...(timedOut ? { timed_out: true } : {}),
+          })
+        })
+      })
+    },
+  },
+]

--- a/packages/apes/src/lib/agent-tools/index.ts
+++ b/packages/apes/src/lib/agent-tools/index.ts
@@ -11,6 +11,7 @@
 // the registry it can use. Unknown names abort the run before any
 // LLM call so the model can't invent a tool we haven't shipped.
 
+import { bashTools } from './bash'
 import { fileTools } from './file'
 import { httpTools } from './http'
 import { mailTools } from './mail'
@@ -32,6 +33,7 @@ const ALL_TOOLS: ToolDefinition[] = [
   ...fileTools,
   ...tasksTools,
   ...mailTools,
+  ...bashTools,
 ]
 
 export const TOOLS: Record<string, ToolDefinition> = Object.fromEntries(

--- a/packages/apes/test/agent-tools.test.ts
+++ b/packages/apes/test/agent-tools.test.ts
@@ -5,7 +5,7 @@ import { homedir } from 'node:os'
 
 describe('tool registry', () => {
   it('TOOLS has the expected keys', () => {
-    for (const name of ['time.now', 'http.get', 'http.post', 'file.read', 'file.write', 'tasks.list', 'tasks.create', 'mail.list', 'mail.search']) {
+    for (const name of ['time.now', 'http.get', 'http.post', 'file.read', 'file.write', 'tasks.list', 'tasks.create', 'mail.list', 'mail.search', 'bash']) {
       expect(TOOLS[name]).toBeDefined()
     }
   })
@@ -29,6 +29,23 @@ describe('tool registry', () => {
       function: expect.objectContaining({ name: 'time_now' }),
     })
     expect((out[0]!.function as Record<string, unknown>).execute).toBeUndefined()
+  })
+})
+
+describe('bash tool', () => {
+  it('rejects empty + non-string cmd before spawning anything', async () => {
+    const bash = TOOLS.bash!
+    await expect(bash.execute({})).rejects.toThrow(/cmd must be a non-empty string/)
+    await expect(bash.execute({ cmd: '' })).rejects.toThrow(/cmd must be a non-empty string/)
+    await expect(bash.execute({ cmd: '   ' })).rejects.toThrow(/cmd must be a non-empty string/)
+    await expect(bash.execute({ cmd: 42 as unknown as string })).rejects.toThrow(/cmd must be a non-empty string/)
+  })
+
+  it('declares cmd as the only required parameter', () => {
+    const params = TOOLS.bash!.parameters as { properties: Record<string, unknown>, required: string[] }
+    expect(params.required).toEqual(['cmd'])
+    expect(params.properties.cmd).toBeDefined()
+    expect(params.properties.timeout_ms).toBeDefined()
   })
 })
 


### PR DESCRIPTION
## Why
Up to 1.19.0 the agent could only do what shipped in the catalog (time/http/file/tasks/mail). Patrick wants an *open-ended* tool: \"run any shell command, but every command goes through the OpenApe grant cycle.\"

That's exactly what `ape-shell` already does for humans at the terminal. The agent variant just wires the LLM tool-call to the same flow.

## What
- New tool `bash` registered in `packages/apes/src/lib/agent-tools/bash.ts`
- LLM calls `bash({ cmd: \"ls ~/Documents\" })` → tool spawns `ape-shell -c <cmd>` with `APE_WAIT=1`
- ape-shell rewrites to `apes run --shell -- bash -c <cmd>`, hits the shapes adapter, creates a DDISA grant
- Auto-approved by matching YOLO scope or push-notified to the owner
- Returns `{ stdout, stderr, exit_code }` (capped at 64KB per stream, with `[truncated to N bytes]` marker)
- Optional `timeout_ms` (default 5min) covers the whole approval-and-run cycle; SIGTERM + 5s SIGKILL fallback on timeout

## Security
- Runs as the agent's macOS user (already jailed)
- **Every** command flows through DDISA — owner retains visibility/control
- Risk level `high` in `tool-catalog.json` so the UI shows it appropriately
- Default-on for new agents (matches the 1.18.0 \"all tools by default\" behavior); owners narrow per agent

## Test plan
- [x] Lint + typecheck + 11 unit tests green
- [x] bash tool registered in TOOLS registry + catalog
- [x] Empty/non-string cmd rejected before spawning
- [ ] After publish + bridge upgrade: ask agent in chat \"please ls my home directory\" → bridge calls `bash({ cmd: 'ls ~' })` → owner gets push approval → output returns to chat
- [ ] Set up a YOLO scope for `ls *` and verify auto-approval round-trip