### PR TITLE
feat(chat): suppress push for users already viewing the surface

### DIFF
--- a/apps/openape-chat/app/composables/useChat.ts
+++ b/apps/openape-chat/app/composables/useChat.ts
@@ -39,6 +39,10 @@ interface UseChatHandle {
   // bearer directly to skip the round-trip.
   connect: (opts?: { token?: string }) => Promise<void>
   disconnect: () => void
+  // Send a frame to the server. Safe to call before/after connect — no-op
+  // when the socket isn't open. Used by rooms/[id] to emit focus/blur
+  // frames so the server can suppress push for the active surface.
+  send: (frame: Record<string, unknown>) => void
 }
 
 let _instance: UseChatHandle | null = null
@@ -132,6 +136,12 @@ export function useChat(): UseChatHandle {
     open(token)
   }
 
+  function send(frame: Record<string, unknown>) {
+    if (!socket || socket.readyState !== WebSocket.OPEN) return
+    try { socket.send(JSON.stringify(frame)) }
+    catch { /* socket race — fine, next reconnect will re-sync state */ }
+  }
+
   function disconnect() {
     manualDisconnect = true
     if (reconnectTimer) {
@@ -143,6 +153,6 @@ export function useChat(): UseChatHandle {
     connected.value = false
   }
 
-  _instance = { connected, on, connect, disconnect }
+  _instance = { connected, on, connect, disconnect, send }
   return _instance
 }

--- a/apps/openape-chat/app/pages/rooms/[id].vue
+++ b/apps/openape-chat/app/pages/rooms/[id].vue
@@ -160,9 +160,36 @@ function removeReactionLocal(messageId: string, userEmail: string, emoji: string
 const chat = useChat()
 let off: (() => void) | undefined
 
+// Tell the server which surface we're looking at so it can suppress push
+// notifications for messages that would just be noise (we already see
+// the message stream in this thread). Re-fire on visibility change and
+// after WS reconnect so server-side state stays in sync.
+function sendFocus() {
+  if (typeof document === 'undefined') return
+  if (document.visibilityState !== 'visible') return
+  if (!roomId.value) return
+  chat.send({
+    type: 'focus',
+    room_id: roomId.value,
+    ...(activeThreadId.value ? { thread_id: activeThreadId.value } : {}),
+  })
+}
+function sendBlur() {
+  chat.send({ type: 'blur' })
+}
+function onVisibilityChange() {
+  if (typeof document === 'undefined') return
+  if (document.visibilityState === 'visible') sendFocus()
+  else sendBlur()
+}
+
 onMounted(async () => {
   chat.connect()
   await loadInitial()
+  sendFocus()
+  if (typeof document !== 'undefined') {
+    document.addEventListener('visibilitychange', onVisibilityChange)
+  }
   off = chat.on((frame) => {
     if (frame.room_id !== roomId.value) return
     if (frame.type === 'message') {
@@ -224,10 +251,18 @@ onMounted(async () => {
 
 onBeforeUnmount(() => {
   off?.()
+  sendBlur()
+  if (typeof document !== 'undefined') {
+    document.removeEventListener('visibilitychange', onVisibilityChange)
+  }
 })
 
 watch(roomId, loadInitial)
-watch(activeThreadId, () => { void loadMessages() })
+watch(activeThreadId, () => { void loadMessages(); sendFocus() })
+// Re-emit focus after a reconnect — the server lost our prior state
+// when the WS dropped, otherwise the silent-tab window would notify
+// for messages we're actively viewing.
+watch(() => chat.connected.value, (now) => { if (now) sendFocus() })
 
 async function send(body: string) {
   if (!activeThreadId.value) return

--- a/apps/openape-chat/server/routes/api/ws.ts
+++ b/apps/openape-chat/server/routes/api/ws.ts
@@ -2,6 +2,7 @@ import type { ChatPeer } from '../../utils/realtime'
 import { createRemoteJWKS, verifyJWT } from '@openape/core'
 import { jwtVerify } from 'jose'
 import { useRuntimeConfig } from 'nitropack/runtime'
+import { clearFocusForPeer, setFocus } from '../../utils/focus'
 import { registerPeer, unregisterPeer } from '../../utils/realtime'
 
 interface DDISAClaims {
@@ -129,15 +130,40 @@ export default defineWebSocketHandler({
     }
   },
 
-  message(peer, _message) {
-    // v1 is server-push only. Clients post via REST, the broadcast hub
-    // pushes notifications via this socket. Ping/pong is handled by the
-    // browser/Crossws layer automatically.
-    void peer
-    void _message
+  message(peer, message) {
+    // The bulk of v1 traffic is server→client (post via REST, broadcast
+    // back). The one client→server frame we accept is `focus` / `blur`,
+    // used to suppress push delivery to recipients who are already
+    // looking at the same room+thread on a connected device. Anything
+    // else gets ignored — malformed frames must not poison the loop.
+    const ctx = ctxByPeerId.get(peer.id)
+    if (!ctx) return
+    let frame: { type?: string, room_id?: string, thread_id?: string }
+    try {
+      const raw = typeof message === 'string'
+        ? message
+        : typeof (message as { text?: () => string }).text === 'function'
+          ? (message as { text: () => string }).text()
+          : String(message)
+      frame = JSON.parse(raw) as typeof frame
+    }
+    catch {
+      return
+    }
+    if (frame.type === 'focus' && typeof frame.room_id === 'string') {
+      setFocus(peer.id, {
+        email: ctx.email,
+        roomId: frame.room_id,
+        threadId: typeof frame.thread_id === 'string' ? frame.thread_id : undefined,
+      })
+    }
+    else if (frame.type === 'blur') {
+      clearFocusForPeer(peer.id)
+    }
   },
 
   close(peer) {
+    clearFocusForPeer(peer.id)
     const ctx = ctxByPeerId.get(peer.id)
     if (!ctx) return
     ctxByPeerId.delete(peer.id)

--- a/apps/openape-chat/server/utils/focus.ts
+++ b/apps/openape-chat/server/utils/focus.ts
@@ -1,0 +1,61 @@
+// In-memory registry of which user is currently *focused* on which chat
+// surface. The client sends `focus` / `blur` frames on the WS connection
+// when the user enters/leaves a room+thread (and when the tab toggles
+// visibility). We use it for one thing only: suppress web-push delivery
+// to a recipient who is already looking at the same room+thread on at
+// least one connected device — sending a push there is just noise.
+//
+// Trade-offs:
+//   - Process-local map. If chat ever scales horizontally we'd need to
+//     move it to Redis or rely on sticky sessions. Today it's fine: one
+//     systemd service, one process, all WS connections terminate here.
+//   - Multi-device aware: a single user may have multiple peers focused
+//     at once (e.g. desktop + phone both viewing the same room). The
+//     map is keyed by peer id, not user, so each device contributes one
+//     row. `isUserFocusedOn` returns true if *any* of that user's peers
+//     has the matching focus — that's "if you're looking at this
+//     anywhere, you don't need a push anywhere."
+//   - WS close clears that peer's focus automatically. So crashed tabs
+//     drop out within seconds.
+
+interface FocusRow {
+  email: string
+  roomId: string
+  // thread_id is optional: the client may not yet know which thread it
+  // landed on (loading state), in which case it sends focus with just
+  // a room id. Room-level focus suppresses push for the whole room —
+  // safer than over-notifying.
+  threadId?: string
+}
+
+const focusByPeer = new Map<string, FocusRow>()
+
+export function setFocus(peerId: string, row: FocusRow): void {
+  focusByPeer.set(peerId, row)
+}
+
+export function clearFocusForPeer(peerId: string): void {
+  focusByPeer.delete(peerId)
+}
+
+/**
+ * Returns true when the user has at least one peer focused on this
+ * room (and matching thread, if both sides know one). Used by the
+ * push fan-out to skip delivery to recipients who'd just get a noise
+ * notification for a message they're already staring at.
+ */
+export function isUserFocusedOn(email: string, roomId: string, threadId: string | undefined): boolean {
+  for (const row of focusByPeer.values()) {
+    if (row.email !== email) continue
+    if (row.roomId !== roomId) continue
+    // Thread match: if BOTH sides specify a thread, require equality.
+    // If either side is room-level (no thread), count it as a match
+    // (the user is at least in the room — pushing would be redundant).
+    if (row.threadId && threadId && row.threadId !== threadId) continue
+    return true
+  }
+  return false
+}
+
+// Exported for tests.
+export const _internal = { focusByPeer }

--- a/apps/openape-chat/server/utils/push.ts
+++ b/apps/openape-chat/server/utils/push.ts
@@ -2,6 +2,7 @@ import { eq, inArray } from 'drizzle-orm'
 import webpush from 'web-push'
 import { useDb } from '../database/drizzle'
 import { memberships, pushSubscriptions } from '../database/schema'
+import { isUserFocusedOn } from './focus'
 
 let _configured = false
 
@@ -52,6 +53,10 @@ export async function notifyRoomMembers(roomId: string, senderEmail: string, not
   const recipientEmails = recipients
     .map(r => r.userEmail)
     .filter(e => e !== senderEmail)
+    // Suppress push for users who already have the room+thread open
+    // on a connected device. The focus map is populated by the WS
+    // handler in response to `focus` / `blur` frames from the client.
+    .filter(e => !isUserFocusedOn(e, roomId, notice.thread_id))
   if (recipientEmails.length === 0) return
 
   const subs = await db

--- a/apps/openape-chat/tests/focus.test.ts
+++ b/apps/openape-chat/tests/focus.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { _internal, clearFocusForPeer, isUserFocusedOn, setFocus } from '../server/utils/focus'
+
+afterEach(() => {
+  _internal.focusByPeer.clear()
+})
+
+describe('focus registry — push suppression', () => {
+  it('returns false when nobody is focused', () => {
+    expect(isUserFocusedOn('alice@example.com', 'room-1', 'thread-a')).toBe(false)
+  })
+
+  it('matches the right user + room + thread', () => {
+    setFocus('peer-1', { email: 'alice@example.com', roomId: 'room-1', threadId: 'thread-a' })
+    expect(isUserFocusedOn('alice@example.com', 'room-1', 'thread-a')).toBe(true)
+    expect(isUserFocusedOn('alice@example.com', 'room-1', 'thread-b')).toBe(false)
+    expect(isUserFocusedOn('alice@example.com', 'room-2', 'thread-a')).toBe(false)
+    expect(isUserFocusedOn('bob@example.com', 'room-1', 'thread-a')).toBe(false)
+  })
+
+  it('treats room-level focus (no threadId) as a match for any thread in the room — safer than over-notifying', () => {
+    setFocus('peer-1', { email: 'alice@example.com', roomId: 'room-1' })
+    expect(isUserFocusedOn('alice@example.com', 'room-1', 'thread-a')).toBe(true)
+    expect(isUserFocusedOn('alice@example.com', 'room-1', 'thread-b')).toBe(true)
+    expect(isUserFocusedOn('alice@example.com', 'room-2', 'thread-a')).toBe(false)
+  })
+
+  it('treats incoming message with no threadId as a match for any focused thread in the room', () => {
+    setFocus('peer-1', { email: 'alice@example.com', roomId: 'room-1', threadId: 'thread-a' })
+    expect(isUserFocusedOn('alice@example.com', 'room-1', undefined)).toBe(true)
+  })
+
+  it('multi-device: any peer focused on the room+thread suppresses push', () => {
+    setFocus('peer-desktop', { email: 'alice@example.com', roomId: 'room-1', threadId: 'thread-a' })
+    setFocus('peer-phone', { email: 'alice@example.com', roomId: 'room-2', threadId: 'thread-z' })
+    expect(isUserFocusedOn('alice@example.com', 'room-1', 'thread-a')).toBe(true)
+    expect(isUserFocusedOn('alice@example.com', 'room-2', 'thread-z')).toBe(true)
+    // The other peer's focus is irrelevant for this lookup.
+    expect(isUserFocusedOn('alice@example.com', 'room-3', 'thread-x')).toBe(false)
+  })
+
+  it('clearFocusForPeer drops only that peer\'s row', () => {
+    setFocus('peer-desktop', { email: 'alice@example.com', roomId: 'room-1', threadId: 'thread-a' })
+    setFocus('peer-phone', { email: 'alice@example.com', roomId: 'room-1', threadId: 'thread-a' })
+    clearFocusForPeer('peer-desktop')
+    // Phone is still focused → still suppress.
+    expect(isUserFocusedOn('alice@example.com', 'room-1', 'thread-a')).toBe(true)
+    clearFocusForPeer('peer-phone')
+    expect(isUserFocusedOn('alice@example.com', 'room-1', 'thread-a')).toBe(false)
+  })
+})


### PR DESCRIPTION
## Why
Patrick on iOS, mid-chat:
> wenn ich in einem Chat bin (und die App genau dort offen habe) brauche ich dort genau keine Notifizierung. Sonst immer gerne. Im Chat nicht in der App ja, in der App aber nicht im Chat ja

Current behavior fires a push to every member except the sender — so the device you're typing on bonks every time the other side replies. Annoying, not actionable, drowns the real signal.

## Behavior matrix
| State | Push? |
|---|---|
| App open, this room+thread visible | **no** |
| App open, different room or contact list | yes |
| App in background / tab hidden / device locked | yes |

## Implementation
- **Client (`useChat.ts`)** gains `send(frame)`. `rooms/[id].vue` emits `{ type: 'focus', room_id, thread_id }` on mount, thread change, visibility-visible, and WS reconnect; emits `{ type: 'blur' }` on unmount and visibility-hidden.
- **Server (`utils/focus.ts`)** keeps an in-memory `Map<peerId, { email, roomId, threadId? }>`. WS `message` handler routes focus/blur frames; close handler clears the row. Process-local — fine for the single chatty service today.
- **`utils/push.ts`** filters `recipientEmails` through `isUserFocusedOn(email, roomId, threadId)` before fan-out. Multi-device safe: if any of the user's connected peers is focused, all their push subs are skipped (you saw it on phone, don't ping desktop).

## Test plan
- [x] 6 unit tests on the focus matcher (room+thread, room-only, multi-device, peer cleanup)
- [x] Lint + typecheck + test green
- [ ] Deploy → iOS test: open one chat on phone, send message from another device → no push on phone; switch to room list → next message pushes; lock phone → next message pushes