### PR TITLE
fix(idp): user-confirmed PWA updates — auto-reload was killing WebAuthn

### DIFF
--- a/apps/openape-free-idp/app/app.vue
+++ b/apps/openape-free-idp/app/app.vue
@@ -19,5 +19,8 @@ useSeoMeta({
 <template>
   <NuxtLayout>
     <NuxtPage />
+    <ClientOnly>
+      <UpdateAvailable />
+    </ClientOnly>
   </NuxtLayout>
 </template>

--- a/apps/openape-free-idp/app/components/UpdateAvailable.vue
+++ b/apps/openape-free-idp/app/components/UpdateAvailable.vue
@@ -1,0 +1,58 @@
+<script setup lang="ts">
+import { useRegisterSW } from 'virtual:pwa-register/vue'
+
+// vite-pwa's `registerType: 'autoUpdate'` default behaviour (without
+// onNeedRefresh override) is to skipWaiting + window.location.reload()
+// the moment a new SW takes control. That reload kills any in-flight
+// WebAuthn promise — Patrick saw "click passkey → nothing happens"
+// because a hourly periodic-update fired while macOS was showing the
+// TouchID prompt, reloading /login under him. The next click worked
+// because the new SW was already active.
+//
+// Mirror chat's pattern: intercept onNeedRefresh, show a banner, let
+// the user confirm the reload at a safe moment. Mounted globally from
+// app.vue so it's available on every IdP page.
+const { needRefresh, updateServiceWorker } = useRegisterSW({
+  immediate: true,
+  onRegisteredSW(_url: string, registration: ServiceWorkerRegistration | undefined) {
+    if (!registration) return
+    document.addEventListener('visibilitychange', () => {
+      if (document.visibilityState === 'visible') {
+        registration.update().catch(() => {})
+      }
+    })
+  },
+})
+
+async function reload() {
+  await updateServiceWorker(true)
+}
+</script>
+
+<template>
+  <Transition
+    enter-active-class="transition duration-300 ease-out"
+    enter-from-class="opacity-0 translate-y-4"
+    enter-to-class="opacity-100 translate-y-0"
+    leave-active-class="transition duration-200 ease-in"
+    leave-to-class="opacity-0 translate-y-4"
+  >
+    <div
+      v-if="needRefresh"
+      class="fixed top-[calc(env(safe-area-inset-top)+0.75rem)] inset-x-3 md:top-4 md:left-auto md:right-4 md:w-80 z-50 rounded-lg shadow-lg bg-zinc-900 border border-zinc-700 p-3 flex items-center gap-3"
+    >
+      <UIcon name="i-lucide-download" class="text-primary-400 size-5 shrink-0" />
+      <div class="flex-1 text-sm">
+        <p class="font-medium">
+          Update available
+        </p>
+        <p class="text-zinc-400">
+          A newer version of OpenApe ID is ready.
+        </p>
+      </div>
+      <UButton size="sm" color="primary" @click="reload">
+        Reload
+      </UButton>
+    </div>
+  </Transition>
+</template>


### PR DESCRIPTION
## Symptom
Patrick mid-login on chat.openape.ai → id.openape.ai/login:
1. Click *Sign in with Passkey* → TouchID prompt
2. Approve → **nothing happens visibly**
3. Click again → TouchID prompt again
4. Approve → redirected back to chat, logged in

## Root cause
Confirmed via nginx access log (\`/var/log/nginx/access.log\` on chatty):
```
T+0   POST /api/webauthn/login/options        200
T+2   GET  /login?...     (forced reload)     200
T+6   GET  /login?...     (forced reload)     200
T+13  POST /api/webauthn/login/options        200
T+15  POST /api/webauthn/login/verify         200    ← only succeeds second time
T+15  GET  /api/me                             200
T+15  GET  /authorize → 302 → back to chat
```
No verify happened on the first attempt — the page reloaded between TouchID approval and the server roundtrip.

The reload comes from \`@vite-pwa/nuxt\` with \`registerType: 'autoUpdate'\`. Its default behaviour (no \`onNeedRefresh\` override) is:
- New SW detected via periodic update (\`periodicSyncForUpdates: 60 * 60\`)
- \`skipWaiting()\` + \`controllerchange\` listener
- → \`window.location.reload()\` *immediately*

When the reload happens during a WebAuthn \`navigator.credentials.get()\` promise, the promise dies. Patrick saw the TouchID prompt vanish; no verify POST was ever sent.

## Fix
Port the same pattern \`openape-chat\` already has: an \`UpdateAvailable\` banner that lets the user confirm the reload at a safe moment. Mounts globally in \`app.vue\` under \`<ClientOnly>\`.

\`registerType: 'autoUpdate'\` is kept — the override hooks make it behave like prompt-mode for refresh, while still skipping the waiting phase for the new SW assets.

## Test plan
- [x] Build + lint + typecheck green
- [ ] After deploy: log into chat.openape.ai from a session that hasn't refreshed the SW recently → confirm passkey works on first try; if an update is pending, see the banner instead of a hidden reload.