### PR TITLE
feat(agent): SOUL.md + skills (OpenClaw lazy-load pattern)

### DIFF
--- a/.changeset/agent-skills-soul.md
+++ b/.changeset/agent-skills-soul.md
@@ -1,0 +1,25 @@
+---
+"@openape/ape-agent": minor
+"@openape/apes": minor
+---
+
+Agent skills (SKILL.md) + SOUL.md, modeled on OpenClaw's lazy-load skill pattern.
+
+**`@openape/ape-agent`** gains a system-prompt composer that scans `~/.openape/agent/skills/*/SKILL.md` + `~/.openape/agent/SOUL.md` on every new chat thread and injects an `<available_skills>` block into the LLM system prompt. The LLM loads each skill's body lazily via the `file.read` tool when the task description matches — keeps the cold-start prompt small even as the skill catalog grows. SOUL.md is always-on (no lazy load) — persona, language preferences, hard rules.
+
+Default skills for the six built-in tool families (`time`, `http`, `file`, `tasks`, `mail`, `bash`) ship bundled with the package under `default-skills/`. They get merged with agent-side skills (same-name agent skill wins) and filtered against the agent's enabled tools — a skill whose `requires_tools` aren't enabled is dropped from the prompt.
+
+**`@openape/apes`** — `apes agents sync` now writes:
+
+- `~/.openape/agent/SOUL.md` (from troop's `soul` column)
+- `~/.openape/agent/skills/<name>/SKILL.md` for each enabled row in troop's `agent_skills` table
+
+The sync is a one-way mirror: rows deleted/disabled in troop get pruned from disk on the next sync. Existing agents pick up the feature on first sync after the deploy; their SOUL is empty and their skills list is empty until the owner adds some in the troop UI.
+
+**Troop** (separate app, not versioned here) adds:
+
+- `agents.soul TEXT NOT NULL DEFAULT ''`
+- new `agent_skills` table: `(agent_email, name)` primary key, `description`, `body`, `enabled`
+- `PATCH /api/agents/:name` accepts `soul: string`
+- `GET /api/agents/:name/skills`, `PUT /api/agents/:name/skills`, `DELETE /api/agents/:name/skills/:skillName`
+- Agent detail page: SOUL.md textarea + Skills CRUD (modal editor)

--- a/apps/openape-ape-agent/default-skills/bash/SKILL.md
+++ b/apps/openape-ape-agent/default-skills/bash/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: bash
+description: When a task can't be done with the other curated tools (file.read, http.get, tasks.create, mail.list, etc.), use bash — runs any shell command on the agent host through the DDISA grant cycle.
+requires_tools: [bash]
+---
+
+# Shell access via ape-shell
+
+## What this is
+
+The `bash` tool spawns `ape-shell -c '<cmd>'` on the agent host. `ape-shell` is the human owner's interactive shell wrapper — every command goes through the OpenApe DDISA grant cycle:
+
+- Auto-approved if a YOLO scope matches (owner has pre-approved this command pattern)
+- Otherwise the owner gets a push notification on their phone with the exact command to approve or deny
+- Approval takes ~3–15s typically; budget is 5min before the call times out
+
+You run as the agent's hidden macOS user, so the filesystem and network you see are what *that* user sees — already jailed.
+
+## When to prefer bash over a curated tool
+
+Curated tools (time.now, http.get, file.read, tasks.list, mail.list) are **always preferred** when they apply:
+
+- Faster (no grant cycle)
+- Structured JSON returns instead of stdout parsing
+- Lower risk score (visible to the owner in troop UI)
+
+Reach for `bash` when:
+
+- The curated tool doesn't cover the case (e.g. `git status`, `iurio cases search`, `o365-cli mail trash <id>`)
+- You need to chain commands with pipes / loops / redirects
+- You need an auth header the deny-list strips (e.g. `curl -H 'Authorization: …'`)
+
+## Patterns
+
+Read system info:
+
+```
+bash({ "cmd": "uname -a && uptime" })
+```
+
+Run a CLI:
+
+```
+bash({ "cmd": "ape-tasks list --status open,doing --json" })
+bash({ "cmd": "iurio cases search 'foo'" })
+```
+
+Quote-heavy commands — wrap in single-quotes outside, escape inside:
+
+```
+bash({ "cmd": "find ~/Downloads -name '*.pdf' -mtime -7 -exec ls -lh {} +" })
+```
+
+Long-running command — use the `timeout_ms` param (default 5 min):
+
+```
+bash({ "cmd": "pnpm test", "timeout_ms": 180000 })
+```
+
+## Anti-patterns
+
+- **Don't** use `bash date` for the time — call `time.now` (in-process, no grant).
+- **Don't** use `bash cat ~/notes.md` for a $HOME read — call `file.read` (no grant).
+- **Don't** retry a denied/timed-out approval automatically — the owner saw the prompt and chose. Surface the timeout clearly and ask what they'd like to do.
+- **Don't** chain destructive commands in one call (`rm -rf … && …`). One destructive command per approval so the owner can decide each.
+
+## Response shape
+
+```json
+{
+  "stdout": "...",
+  "stderr": "...",
+  "exit_code": 0,
+  "timed_out": false
+}
+```
+
+Non-zero `exit_code` means the command failed — read `stderr` and decide whether to retry with a corrected command, surface the error to the user, or ask for guidance. **Don't** pretend it succeeded.

--- a/apps/openape-ape-agent/default-skills/file/SKILL.md
+++ b/apps/openape-ape-agent/default-skills/file/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: file
+description: When the user asks you to read, write, or check a file in your home directory, use the file.read / file.write tools — they're $HOME-jailed and safer than bash cat.
+requires_tools: [file.read]
+---
+
+# Files in $HOME
+
+## Jail
+
+Both tools are restricted to the agent's `$HOME` directory:
+
+- `path` is resolved relative to `$HOME` (`~/` prefix accepted, or plain `notes.md`)
+- `..` segments that would escape `$HOME` are rejected
+- 1 MB cap per read/write — anything bigger gets truncated (read) or rejected (write)
+
+For files **outside** `$HOME` (e.g. `/etc/...`, another user's directory), use `bash` with `cat`/`tee` — that goes through the DDISA grant cycle so the owner can approve broad-fs reads explicitly.
+
+## Patterns
+
+Read a JSON config:
+
+```
+file.read({ "path": "~/.openape/agent/agent.json" })
+```
+
+Append a note (read-modify-write — there's no `file.append`):
+
+```
+const r = file.read({ "path": "notes.md" })
+file.write({ "path": "notes.md", "content": r.content + "\n- new line\n" })
+```
+
+## Conventions
+
+- Paths in user prompts ("save this to notes.md") → relative to `$HOME`. Don't prefix with `/Users/...`.
+- Binary files don't round-trip via these tools (UTF-8 only). Use `bash` for non-text I/O.

--- a/apps/openape-ape-agent/default-skills/http/SKILL.md
+++ b/apps/openape-ape-agent/default-skills/http/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: http
+description: When the user asks to fetch a webpage, hit a REST API, or POST JSON to an endpoint, use the http.get / http.post tools — never invent URLs.
+requires_tools: [http.get]
+---
+
+# HTTP fetch
+
+## When to use
+
+- `http.get` — read content from any HTTPS URL (webpages, REST endpoints, JSON APIs)
+- `http.post` — POST JSON to an HTTPS URL
+
+Both are bounded:
+
+- Response capped at 1 MB (anything longer is truncated)
+- Headers go through a deny-list (no `Authorization` for arbitrary hosts, no `Cookie`)
+- HTTP-only URLs are rejected — HTTPS required
+
+For commands that go beyond simple HTTP (auth, mTLS, complex curl flags, multipart upload), use the `bash` tool with `curl` instead.
+
+## Patterns
+
+Fetch JSON:
+
+```
+http.get({
+  "url": "https://api.example.com/users/42",
+  "headers": { "Accept": "application/json" }
+})
+```
+
+POST JSON:
+
+```
+http.post({
+  "url": "https://api.example.com/notes",
+  "body": { "title": "from agent", "body": "..." },
+  "headers": { "Content-Type": "application/json" }
+})
+```
+
+## Anti-patterns
+
+- Don't synthesize URLs ("I think it's at /api/v1/foo") — ask the user for the exact endpoint or use `http.get` only after you've seen it in their message or in a tool result.
+- Don't paginate by manually incrementing offsets without checking the API's actual contract — read response shape first.
+- For auth that needs `Authorization: Bearer …`, the deny-list strips it. Use `bash` with `curl` if you need it.

--- a/apps/openape-ape-agent/default-skills/mail/SKILL.md
+++ b/apps/openape-ape-agent/default-skills/mail/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: mail
+description: When the user asks about their inbox — what's there, search for an email, recent unread — use mail.list / mail.search.
+requires_tools: [mail.list]
+---
+
+# Inbox (o365-cli)
+
+## What this is
+
+Read access to the owner's Microsoft 365 inbox via the `o365-cli` tool on the agent host. The host must have `o365-cli` installed and authenticated (the owner's CLI session). If it isn't, both tools fail with a clear setup error.
+
+## When to use
+
+- `mail.list` — recent inbox messages. Optional `unread_only: true`. Default limit 20.
+- `mail.search` — keyword/from/subject search. Pass a query string.
+
+For writing, archiving, replying, or moving messages: use `bash` with explicit `o365-cli` subcommands (see `o365-cli mail --help`). Those go through the DDISA grant cycle so the owner approves each mutation.
+
+## Patterns
+
+Latest 10 unread:
+
+```
+mail.list({ "limit": 10, "unread_only": true })
+```
+
+Search by sender:
+
+```
+mail.search({ "q": "from:smaurer@deloitte.at", "limit": 20 })
+```
+
+## Conventions
+
+- Don't draft replies inside the agent if the user just asked "what's in my inbox" — listing is read-only, replies are explicit.
+- When the user wants to triage ("welche kann ich archivieren?"), list first, then offer specific candidates with message IDs — do NOT auto-move anything.
+- Account names: there are usually two — owner's primary email (Delta Mind) and a secondary (Legal Tech / DOCPIT). Ask which one if it matters.

--- a/apps/openape-ape-agent/default-skills/tasks/SKILL.md
+++ b/apps/openape-ape-agent/default-skills/tasks/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: tasks
+description: When the user wants to see, create, or schedule a task/reminder/wiedervorlage on their personal task list, use tasks.list / tasks.create.
+requires_tools: [tasks.list]
+---
+
+# Personal tasks (ape-tasks)
+
+## What this is
+
+The owner's personal task list at https://tasks.openape.ai — same one their `ape-tasks` CLI on Mac and the iOS app use. You're allowed to read it and add to it via the `tasks.list` and `tasks.create` tools.
+
+## When to use
+
+Use `tasks.create` whenever the user asks for any of:
+
+- "Reminder me to X tomorrow"
+- "Wiedervorlage in 2 Tagen"
+- "Add to my todo: …"
+- "Schedule X for next week"
+
+Use `tasks.list` when they ask "what's on my list", "any open tasks", "remind me what's due".
+
+## Create — parameters
+
+```
+tasks.create({
+  "title": "<short title>",
+  "notes": "<optional longer body>",
+  "priority": "low" | "med" | "high",      // default med
+  "due_at": "<ISO 8601 or relative: +2h | +1d | tomorrow 9am>"
+})
+```
+
+For wiedervorlage (mail-eskalation) the owner has a separate flow via `ape-tasks new --remind-at ...` — that path triggers email reminders. If the user wants a *reminder* (not just a todo), prefer:
+
+```
+bash({ "cmd": "ape-tasks new --title '...' --remind-at '+2d' --context-summary '...' --context-url '...'" })
+```
+
+…because the CLI has more knobs than the tool exposes (assignee, remind-at, context-url).
+
+## Conventions
+
+- Always convert relative dates from the user prompt to an absolute date in your response: "in 2 Tagen" → "am 13. Mai 2026".
+- Don't create duplicate tasks — `tasks.list` first if the user might have one already.
+- If the user asks for "remind me on …" and you only have `tasks.create`, set `due_at` and explain that the **list** will surface it, but no push notification fires unless they used `ape-tasks --remind-at`.

--- a/apps/openape-ape-agent/default-skills/time/SKILL.md
+++ b/apps/openape-ape-agent/default-skills/time/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: time
+description: When the user asks for the current time, date, or wants a sanity-check that the runtime is alive, use the time.now tool — never guess.
+requires_tools: [time.now]
+---
+
+# Time and date
+
+## When to use
+
+The `time.now` tool returns the current UTC timestamp as ISO 8601, plus the epoch in seconds and the agent host's timezone offset in minutes. Call it any time the user asks "what time is it", "what day", "how long ago was X", or as a quick "are you alive?" probe.
+
+## How to use
+
+```
+time.now({})
+```
+
+No arguments. Response shape:
+
+```json
+{
+  "iso": "2026-05-11T07:14:44Z",
+  "epoch_seconds": 1778383484,
+  "timezone_offset_minutes": 120
+}
+```
+
+## Conventions
+
+- Always report time in **both** UTC and the user's local clock when the offset is non-zero. Example: "Es ist 07:14 UTC, also 09:14 bei dir (UTC+2)."
+- For relative-time questions ("vor 3 Tagen"), compute from `epoch_seconds` — don't rely on the LLM's internal clock guess.
+- Do NOT call `bash` with `date` for the time — `time.now` is in-process and skips the DDISA grant cycle.

--- a/apps/openape-ape-agent/package.json
+++ b/apps/openape-ape-agent/package.json
@@ -11,6 +11,7 @@
   },
   "files": [
     "dist",
+    "default-skills",
     "README.md"
   ],
   "publishConfig": {

--- a/apps/openape-ape-agent/src/bridge.ts
+++ b/apps/openape-ape-agent/src/bridge.ts
@@ -45,6 +45,7 @@ import type { RuntimeConfig } from '@openape/apes'
 import { ChatApi } from './chat-api'
 import { CronRunner } from './cron-runner'
 import { readAgentIdentity, readAllowlist, shouldAutoAccept } from './identity'
+import { composeSystemPrompt } from './skills'
 import { ThreadSession } from './thread-session'
 
 const AGENT_CONFIG_PATH = join(homedir(), '.openape', 'agent', 'agent.json')
@@ -329,11 +330,16 @@ class Bridge {
       threadId,
       chat: this.chat,
       runtimeConfig: this.runtimeConfig(),
-      systemPrompt: resolveSystemPrompt(this.cfg.systemPrompt),
       // Tools resolve from agent.json (latest sync from troop) on
       // every new thread, so owner edits in the troop UI take
       // effect after the next sync without a bridge restart.
+      // SOUL.md + skills are merged into the system prompt the same
+      // way — picked up per-thread without restart.
       tools: resolveTools(this.cfg.tools),
+      systemPrompt: composeSystemPrompt({
+        base: resolveSystemPrompt(this.cfg.systemPrompt),
+        enabledTools: resolveTools(this.cfg.tools),
+      }),
       maxSteps: this.cfg.maxSteps,
       log,
     })

--- a/apps/openape-ape-agent/src/skills.ts
+++ b/apps/openape-ape-agent/src/skills.ts
@@ -1,0 +1,276 @@
+// Skills + SOUL loader for the agent runtime.
+//
+// Pattern lifted from OpenClaw's skill-contract.ts (see
+// `Companies/delta-mind/repos/openclaw/src/agents/skills/`): the LLM
+// gets a *list* of available skills in its system prompt — each entry is
+// just `name`, `description`, and an on-disk location. The agent loads
+// the full SKILL.md body lazily, via the regular `file.read` tool, when
+// the task matches the description. That keeps cold-start context small
+// even as the skill catalog grows.
+//
+// SOUL.md is the always-on counterpart: a single markdown file that
+// describes who the agent is, language preferences, tone, hard rules.
+// We merge it ahead of the task-time system prompt so it's the first
+// thing the model sees.
+//
+// Layout (all under the agent's $HOME):
+//
+//     ~/.openape/agent/
+//       agent.json                   ← tools + base systemPrompt (from troop)
+//       SOUL.md                      ← always-on persona / rules
+//       skills/
+//         <name>/SKILL.md            ← lazy-loaded skill instructions
+//
+// The bridge also bundles a default skills directory (see
+// `default-skills/` in this package). Those are merged with the agent's
+// own skills before formatting the prompt. Default skills can be
+// shadowed by an agent-side skill of the same name — that's how an
+// owner overrides the bundled `bash` skill with their own variant.
+
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+export interface Skill {
+  name: string
+  description: string
+  /** Absolute on-disk path to the SKILL.md the agent should load with file.read. */
+  filePath: string
+  /**
+   * Optional eligibility filter. If any required tool name is *not*
+   * in the agent's enabled `tools[]`, the skill is dropped from the
+   * formatted prompt — the agent shouldn't see a skill it can't
+   * execute. Tools list comes from agent.json.
+   */
+  requiresTools?: string[]
+}
+
+const SKILLS_SUBDIR = ['.openape', 'agent', 'skills']
+const SOUL_PATH_PARTS = ['.openape', 'agent', 'SOUL.md']
+
+export function soulPath(home: string = homedir()): string {
+  return join(home, ...SOUL_PATH_PARTS)
+}
+
+export function skillsDir(home: string = homedir()): string {
+  return join(home, ...SKILLS_SUBDIR)
+}
+
+/**
+ * Read the agent's SOUL.md if present, else return null. Errors
+ * (permission denied, broken symlinks) get swallowed — SOUL is a soft
+ * input, not a fail-fast prerequisite.
+ */
+export function readSoul(home: string = homedir()): string | null {
+  const path = soulPath(home)
+  if (!existsSync(path)) return null
+  try {
+    const body = readFileSync(path, 'utf8').trim()
+    return body.length > 0 ? body : null
+  }
+  catch { return null }
+}
+
+/**
+ * Parse YAML-ish frontmatter from the head of a SKILL.md. We accept
+ * the openclaw format:
+ *
+ *   ---
+ *   name: <slug>
+ *   description: <one-liner>
+ *   requires_tools: [time.now, http.get]   # optional
+ *   ---
+ *   <markdown body…>
+ *
+ * Returns `null` if no frontmatter is found or the required `name`
+ * and `description` fields are missing — those are the only two
+ * fields the rest of the system depends on.
+ */
+export function parseFrontmatter(content: string): {
+  name: string
+  description: string
+  requiresTools?: string[]
+} | null {
+  const trimmed = content.trimStart()
+  if (!trimmed.startsWith('---')) return null
+  const closeIdx = trimmed.indexOf('\n---', 3)
+  if (closeIdx < 0) return null
+  const fmBlock = trimmed.slice(3, closeIdx).trim()
+
+  const fields: Record<string, string> = {}
+  let arrayKey: string | null = null
+  let arrayBuf: string[] = []
+  for (const rawLine of fmBlock.split('\n')) {
+    const line = rawLine.replace(/\r$/, '')
+    if (arrayKey) {
+      const m = line.match(/^[\t ]*-[\t ]+(\S.*)$/)
+      if (m) { arrayBuf.push(m[1]!.trim()); continue }
+      fields[arrayKey] = arrayBuf.join(',')
+      arrayKey = null
+      arrayBuf = []
+    }
+    const kv = line.match(/^([a-z_]\w*)[\t ]*:[\t ]?(.*)$/i)
+    if (!kv) continue
+    const [, key, value] = kv
+    if (value!.trim() === '') {
+      arrayKey = key!
+      arrayBuf = []
+      continue
+    }
+    // Inline array: `[a, b]`
+    const inlineArray = value!.match(/^\[(.*)\]$/)
+    if (inlineArray) {
+      fields[key!] = inlineArray[1]!.split(',').map(s => s.trim().replace(/^["']|["']$/g, '')).filter(Boolean).join(',')
+      continue
+    }
+    fields[key!] = value!.trim().replace(/^["']|["']$/g, '')
+  }
+  if (arrayKey) fields[arrayKey] = arrayBuf.join(',')
+
+  if (!fields.name || !fields.description) return null
+  const requiresTools = fields.requires_tools
+    ? fields.requires_tools.split(',').map(s => s.trim()).filter(Boolean)
+    : undefined
+  return { name: fields.name, description: fields.description, requiresTools }
+}
+
+/**
+ * Scan a directory of `<name>/SKILL.md` skills and return the parsed
+ * list. Skills whose frontmatter is malformed or whose file can't be
+ * read are silently skipped — better to lose one skill than break the
+ * boot path with a syntax error.
+ */
+export function scanSkillsDir(dir: string): Skill[] {
+  if (!existsSync(dir)) return []
+  let entries: string[]
+  try { entries = readdirSync(dir) }
+  catch { return [] }
+
+  const out: Skill[] = []
+  for (const entry of entries) {
+    const skillPath = join(dir, entry, 'SKILL.md')
+    if (!existsSync(skillPath)) continue
+    let st
+    try { st = statSync(skillPath) }
+    catch { continue }
+    if (!st.isFile()) continue
+    let body: string
+    try { body = readFileSync(skillPath, 'utf8') }
+    catch { continue }
+    const fm = parseFrontmatter(body)
+    if (!fm) continue
+    out.push({
+      name: fm.name,
+      description: fm.description,
+      filePath: skillPath,
+      requiresTools: fm.requiresTools,
+    })
+  }
+  return out
+}
+
+/**
+ * Resolve the bundled `default-skills/` directory that ships with the
+ * ape-agent package. `__dirname` after tsup bundling sits next to
+ * `bridge.mjs`; the `default-skills/` folder is published alongside
+ * it (see `files` in package.json + the post-build copy step).
+ */
+export function defaultSkillsDir(): string {
+  // import.meta.url works for both ESM and tsup's bundled output
+  const here = dirname(fileURLToPath(import.meta.url))
+  return resolve(here, '..', 'default-skills')
+}
+
+/**
+ * Compose the final skill list the agent sees. Default skills load
+ * first, then agent-side skills override by name. The result is
+ * deduplicated (last-write-wins on name) and filtered against the
+ * agent's enabled tools — a skill whose `requiresTools` aren't in
+ * `enabledTools` is dropped, so the agent never sees a skill it
+ * can't actually execute.
+ */
+export function composeSkills(home: string, enabledTools: string[]): Skill[] {
+  const enabled = new Set(enabledTools)
+  const byName = new Map<string, Skill>()
+  for (const s of scanSkillsDir(defaultSkillsDir())) byName.set(s.name, s)
+  for (const s of scanSkillsDir(skillsDir(home))) byName.set(s.name, s)
+
+  const out: Skill[] = []
+  for (const s of byName.values()) {
+    if (s.requiresTools && s.requiresTools.length > 0) {
+      const allPresent = s.requiresTools.every(t => enabled.has(t))
+      if (!allPresent) continue
+    }
+    out.push(s)
+  }
+  // Stable order: by name. Helps prompt-cache stay warm across boots.
+  out.sort((a, b) => a.name.localeCompare(b.name))
+  return out
+}
+
+function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;')
+}
+
+/**
+ * Format the skill list as an `<available_skills>` block for the
+ * system prompt. The wording mirrors OpenClaw's formatter so the
+ * model picks up on the established convention: name + description
+ * stay in the prompt, body gets loaded on demand via the file.read
+ * tool when the task matches.
+ */
+export function formatSkillsBlock(skills: Skill[]): string {
+  if (skills.length === 0) return ''
+  const lines = [
+    '',
+    'The following skills provide specialized instructions for specific tasks.',
+    'Use the file.read tool to load a skill\'s file when the user\'s task matches its description.',
+    'When a skill file references a relative path, resolve it against the skill directory (parent of SKILL.md) and use that absolute path in tool commands.',
+    '',
+    '<available_skills>',
+  ]
+  for (const s of skills) {
+    lines.push('  <skill>')
+    lines.push(`    <name>${escapeXml(s.name)}</name>`)
+    lines.push(`    <description>${escapeXml(s.description)}</description>`)
+    lines.push(`    <location>${escapeXml(s.filePath)}</location>`)
+    lines.push('  </skill>')
+  }
+  lines.push('</available_skills>')
+  return lines.join('\n')
+}
+
+/**
+ * Build the final system prompt the agent runtime sends to the LLM:
+ *
+ *   <SOUL.md, if any>
+ *
+ *   <available_skills>…</available_skills>
+ *
+ *   <base systemPrompt from agent.json>
+ *
+ * Each section is omitted when empty so we don't pollute the prompt
+ * with empty blocks.
+ */
+export function composeSystemPrompt(input: {
+  base: string
+  home?: string
+  enabledTools: string[]
+}): string {
+  const home = input.home ?? homedir()
+  const parts: string[] = []
+  const soul = readSoul(home)
+  if (soul) parts.push(soul)
+  const skills = composeSkills(home, input.enabledTools)
+  const skillsBlock = formatSkillsBlock(skills)
+  if (skillsBlock) parts.push(skillsBlock)
+  const base = input.base?.trim()
+  if (base) parts.push(base)
+  return parts.join('\n\n')
+}

--- a/apps/openape-ape-agent/test/skills.test.ts
+++ b/apps/openape-ape-agent/test/skills.test.ts
@@ -1,0 +1,184 @@
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  composeSkills,
+  composeSystemPrompt,
+  formatSkillsBlock,
+  parseFrontmatter,
+  readSoul,
+  scanSkillsDir,
+  skillsDir,
+  soulPath,
+} from '../src/skills'
+
+describe('skills loader', () => {
+  let home: string
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'ape-agent-skills-'))
+  })
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true })
+  })
+
+  it('soulPath / skillsDir compose under the given home', () => {
+    expect(soulPath(home)).toBe(join(home, '.openape', 'agent', 'SOUL.md'))
+    expect(skillsDir(home)).toBe(join(home, '.openape', 'agent', 'skills'))
+  })
+
+  it('readSoul returns null when the file is missing or empty', () => {
+    expect(readSoul(home)).toBeNull()
+    mkdirSync(join(home, '.openape', 'agent'), { recursive: true })
+    writeFileSync(soulPath(home), '   \n  \n')
+    expect(readSoul(home)).toBeNull()
+  })
+
+  it('readSoul returns trimmed content when present', () => {
+    mkdirSync(join(home, '.openape', 'agent'), { recursive: true })
+    writeFileSync(soulPath(home), '\n\nYou are Patrick\'s agent. Be brief.\n\n')
+    expect(readSoul(home)).toBe('You are Patrick\'s agent. Be brief.')
+  })
+
+  describe('parseFrontmatter', () => {
+    it('parses name + description from a YAML block', () => {
+      const fm = parseFrontmatter('---\nname: foo\ndescription: a tool that foos\n---\nbody')
+      expect(fm).toEqual({ name: 'foo', description: 'a tool that foos' })
+    })
+
+    it('parses requires_tools as inline array', () => {
+      const fm = parseFrontmatter('---\nname: foo\ndescription: d\nrequires_tools: [a, b, c]\n---\nbody')
+      expect(fm?.requiresTools).toEqual(['a', 'b', 'c'])
+    })
+
+    it('parses requires_tools as block array', () => {
+      const fm = parseFrontmatter('---\nname: foo\ndescription: d\nrequires_tools:\n  - a\n  - b\n---')
+      expect(fm?.requiresTools).toEqual(['a', 'b'])
+    })
+
+    it('returns null when no frontmatter or required fields missing', () => {
+      expect(parseFrontmatter('# just a markdown heading\nno fm')).toBeNull()
+      expect(parseFrontmatter('---\nname: foo\n---\nbody')).toBeNull()
+      expect(parseFrontmatter('---\ndescription: d\n---\nbody')).toBeNull()
+    })
+
+    it('strips surrounding quotes from values', () => {
+      const fm = parseFrontmatter('---\nname: "foo"\ndescription: \'a quoted desc\'\n---')
+      expect(fm).toEqual({ name: 'foo', description: 'a quoted desc' })
+    })
+  })
+
+  describe('scanSkillsDir', () => {
+    it('returns empty when the dir does not exist', () => {
+      expect(scanSkillsDir('/nonexistent/path/here')).toEqual([])
+    })
+
+    it('reads each `<name>/SKILL.md` and parses frontmatter', () => {
+      const dir = join(home, 'skills')
+      mkdirSync(join(dir, 'alpha'), { recursive: true })
+      mkdirSync(join(dir, 'beta'), { recursive: true })
+      writeFileSync(join(dir, 'alpha', 'SKILL.md'), '---\nname: alpha\ndescription: A\n---\nbody A')
+      writeFileSync(join(dir, 'beta', 'SKILL.md'), '---\nname: beta\ndescription: B\nrequires_tools: [http.get]\n---\nbody B')
+
+      const skills = scanSkillsDir(dir)
+      expect(skills).toHaveLength(2)
+      const names = skills.map(s => s.name).sort()
+      expect(names).toEqual(['alpha', 'beta'])
+      const beta = skills.find(s => s.name === 'beta')!
+      expect(beta.requiresTools).toEqual(['http.get'])
+      expect(beta.filePath).toBe(join(dir, 'beta', 'SKILL.md'))
+    })
+
+    it('silently skips skills without valid frontmatter', () => {
+      const dir = join(home, 'skills')
+      mkdirSync(join(dir, 'good'), { recursive: true })
+      mkdirSync(join(dir, 'broken'), { recursive: true })
+      writeFileSync(join(dir, 'good', 'SKILL.md'), '---\nname: good\ndescription: G\n---')
+      writeFileSync(join(dir, 'broken', 'SKILL.md'), '# no frontmatter')
+      const skills = scanSkillsDir(dir)
+      expect(skills.map(s => s.name)).toEqual(['good'])
+    })
+  })
+
+  describe('formatSkillsBlock', () => {
+    it('returns empty string when there are no skills', () => {
+      expect(formatSkillsBlock([])).toBe('')
+    })
+
+    it('builds an <available_skills> XML block with name + description + location', () => {
+      const out = formatSkillsBlock([
+        { name: 'a', description: 'first', filePath: '/p/a/SKILL.md' },
+        { name: 'b', description: 'second & special <chars>', filePath: '/p/b/SKILL.md' },
+      ])
+      expect(out).toContain('<available_skills>')
+      expect(out).toContain('<name>a</name>')
+      expect(out).toContain('<description>first</description>')
+      expect(out).toContain('<location>/p/a/SKILL.md</location>')
+      // XML-escapes special chars in description
+      expect(out).toContain('second &amp; special &lt;chars&gt;')
+    })
+  })
+
+  describe('composeSkills — eligibility + override', () => {
+    it('drops skills whose required tools are not enabled', () => {
+      mkdirSync(join(skillsDir(home), 'needs-mail'), { recursive: true })
+      writeFileSync(
+        join(skillsDir(home), 'needs-mail', 'SKILL.md'),
+        '---\nname: needs-mail\ndescription: D\nrequires_tools: [mail.list]\n---',
+      )
+      mkdirSync(join(skillsDir(home), 'free'), { recursive: true })
+      writeFileSync(
+        join(skillsDir(home), 'free', 'SKILL.md'),
+        '---\nname: free\ndescription: D\n---',
+      )
+      // Only time.now enabled — needs-mail must be filtered out.
+      const skills = composeSkills(home, ['time.now'])
+      const names = skills.map(s => s.name)
+      expect(names).toContain('free')
+      expect(names).not.toContain('needs-mail')
+    })
+
+    it('agent-side skill shadows a default-skill of the same name', () => {
+      // We can't easily delete bundled default-skills from a test, but we
+      // can verify that a same-name agent skill overrides one of them. The
+      // bundled `bash` skill says "DDISA grant cycle…"; write an override.
+      mkdirSync(join(skillsDir(home), 'bash'), { recursive: true })
+      writeFileSync(
+        join(skillsDir(home), 'bash', 'SKILL.md'),
+        '---\nname: bash\ndescription: agent-side override of bash skill\n---\nbody',
+      )
+      const skills = composeSkills(home, ['bash'])
+      const bash = skills.find(s => s.name === 'bash')!
+      expect(bash.description).toBe('agent-side override of bash skill')
+      expect(bash.filePath).toBe(join(skillsDir(home), 'bash', 'SKILL.md'))
+    })
+  })
+
+  describe('composeSystemPrompt', () => {
+    it('returns the base prompt unchanged when no SOUL + no skills + no tools', () => {
+      // No SOUL.md written; tools=[] filters out every default skill that
+      // requires_tools.
+      const out = composeSystemPrompt({ base: 'base prompt', home, enabledTools: [] })
+      expect(out).toBe('base prompt')
+    })
+
+    it('prepends SOUL.md when present', () => {
+      mkdirSync(join(home, '.openape', 'agent'), { recursive: true })
+      writeFileSync(soulPath(home), 'I am the soul.')
+      const out = composeSystemPrompt({ base: 'base', home, enabledTools: [] })
+      expect(out.startsWith('I am the soul.')).toBe(true)
+      expect(out.endsWith('base')).toBe(true)
+    })
+
+    it('includes the available_skills block when a skill is eligible', () => {
+      mkdirSync(join(skillsDir(home), 'noreqs'), { recursive: true })
+      writeFileSync(
+        join(skillsDir(home), 'noreqs', 'SKILL.md'),
+        '---\nname: noreqs\ndescription: a skill with no required tools\n---',
+      )
+      const out = composeSystemPrompt({ base: 'base', home, enabledTools: [] })
+      expect(out).toContain('<available_skills>')
+      expect(out).toContain('<name>noreqs</name>')
+    })
+  })
+})

--- a/apps/openape-troop/app/pages/agents/[name].vue
+++ b/apps/openape-troop/app/pages/agents/[name].vue
@@ -22,6 +22,9 @@ interface Agent {
    *  to the LLM during live thread turns. Defaults to all known tools
    *  on first sync; owner narrows here. */
   tools: string[]
+  /** Always-on persona / hard rules — markdown. Lands at
+   *  `~/.openape/agent/SOUL.md` after sync. */
+  soul: string
   firstSeenAt: number | null
   lastSeenAt: number | null
   createdAt: number
@@ -144,6 +147,111 @@ async function saveTools() {
   }
   finally {
     toolsSaving.value = false
+  }
+}
+
+// SOUL.md — always-on persona / hard rules. Saved on demand via the
+// same PATCH endpoint as system_prompt. Larger cap than system_prompt
+// (32KB vs 8KB) because owners may inline policy + style guides.
+const soulDraft = ref('')
+const soulSaving = ref(false)
+const soulError = ref('')
+const soulDirty = computed(() => soulDraft.value !== (detail.value?.agent.soul ?? ''))
+
+watch(detail, (d) => {
+  if (d) soulDraft.value = d.agent.soul ?? ''
+}, { immediate: true })
+
+async function saveSoul() {
+  if (!soulDirty.value) return
+  soulSaving.value = true
+  soulError.value = ''
+  try {
+    await ($fetch as any)(`/api/agents/${agentName.value}`, {
+      method: 'PATCH',
+      body: { soul: soulDraft.value },
+    })
+    if (detail.value) detail.value.agent.soul = soulDraft.value
+  }
+  catch (err: any) {
+    soulError.value = err?.data?.statusMessage || err?.message || 'save failed'
+  }
+  finally {
+    soulSaving.value = false
+  }
+}
+
+// Skills — per-agent SKILL.md catalog. Each row → one
+// `<name>/SKILL.md` on the agent host after sync. CRUD via dedicated
+// endpoints under /api/agents/[name]/skills/.
+interface Skill {
+  agentEmail: string
+  name: string
+  description: string
+  body: string
+  enabled: boolean
+  createdAt: number
+  updatedAt: number
+}
+const skills = ref<Skill[]>([])
+const skillsError = ref('')
+const skillEditor = ref<{ open: boolean, isNew: boolean, name: string, description: string, body: string, enabled: boolean }>({
+  open: false,
+  isNew: true,
+  name: '',
+  description: '',
+  body: '',
+  enabled: true,
+})
+const skillSaving = ref(false)
+
+async function loadSkills() {
+  if (!agentName.value) return
+  skillsError.value = ''
+  try { skills.value = await ($fetch as any)(`/api/agents/${agentName.value}/skills`) }
+  catch (err: any) { skillsError.value = err?.data?.statusMessage || err?.message || 'failed to load skills' }
+}
+watch(detail, (d) => { if (d) loadSkills() })
+
+function openCreateSkill() {
+  skillEditor.value = { open: true, isNew: true, name: '', description: '', body: '', enabled: true }
+}
+function openEditSkill(s: Skill) {
+  skillEditor.value = { open: true, isNew: false, name: s.name, description: s.description, body: s.body, enabled: s.enabled }
+}
+async function saveSkill() {
+  if (!agentName.value) return
+  skillSaving.value = true
+  skillsError.value = ''
+  try {
+    await ($fetch as any)(`/api/agents/${agentName.value}/skills`, {
+      method: 'PUT',
+      body: {
+        name: skillEditor.value.name,
+        description: skillEditor.value.description,
+        body: skillEditor.value.body,
+        enabled: skillEditor.value.enabled,
+      },
+    })
+    skillEditor.value.open = false
+    await loadSkills()
+  }
+  catch (err: any) {
+    skillsError.value = err?.data?.statusMessage || err?.message || 'save failed'
+  }
+  finally {
+    skillSaving.value = false
+  }
+}
+async function deleteSkill(name: string) {
+  if (!agentName.value) return
+  if (!confirm(`Delete skill '${name}'? This is permanent — to keep it but hide it from the agent use 'disabled'.`)) return
+  try {
+    await ($fetch as any)(`/api/agents/${agentName.value}/skills/${encodeURIComponent(name)}`, { method: 'DELETE' })
+    await loadSkills()
+  }
+  catch (err: any) {
+    skillsError.value = err?.data?.statusMessage || err?.message || 'delete failed'
   }
 }
 
@@ -419,6 +527,128 @@ const statusColor: Record<Run['status'], string> = { running: 'info', ok: 'succe
             </UButton>
           </div>
         </UCard>
+
+        <!-- SOUL.md — always-on persona / hard rules -->
+        <UCard>
+          <template #header>
+            <div class="flex items-center justify-between gap-3">
+              <h2 class="text-lg font-semibold">
+                SOUL.md
+              </h2>
+              <UBadge v-if="soulDirty" color="warning" variant="subtle" size="xs">
+                unsaved
+              </UBadge>
+              <UBadge v-else-if="soulDraft" color="success" variant="subtle" size="xs">
+                {{ soulDraft.length }} chars
+              </UBadge>
+            </div>
+          </template>
+          <p class="text-xs text-muted mb-3">
+            Always-on persona, language preferences, hard rules. Rendered as the first block of the
+            system prompt the LLM sees, ahead of skills + base system prompt. Markdown. Lands at
+            <code class="text-zinc-300">~/.openape/agent/SOUL.md</code> after the next sync (~5min).
+          </p>
+          <UTextarea
+            v-model="soulDraft"
+            placeholder="You are Patrick's agent. Be brief. Antworte standardmäßig auf Deutsch, technische Erklärungen auf Englisch."
+            :rows="6"
+            autoresize
+            :disabled="soulSaving"
+          />
+          <UAlert v-if="soulError" color="error" :title="soulError" class="mt-3" />
+          <div v-if="soulDirty" class="flex justify-end mt-3">
+            <UButton size="sm" color="primary" :loading="soulSaving" @click="saveSoul">
+              Save SOUL.md
+            </UButton>
+          </div>
+        </UCard>
+
+        <!-- Skills — lazy-load SKILL.md catalog -->
+        <UCard :ui="{ body: 'p-0' }">
+          <template #header>
+            <div class="flex items-center justify-between">
+              <div>
+                <h2 class="text-lg font-semibold">
+                  Skills
+                </h2>
+                <p class="text-xs text-muted mt-1">
+                  Lazy-loaded SKILL.md instructions. The agent sees name + description in every
+                  system prompt; the body is read on demand via the file.read tool when the task
+                  matches.
+                </p>
+              </div>
+              <UButton color="primary" size="sm" icon="i-lucide-plus" @click="openCreateSkill">
+                New skill
+              </UButton>
+            </div>
+          </template>
+
+          <UAlert v-if="skillsError" color="error" :title="skillsError" class="m-4" />
+          <div v-if="skills.length === 0" class="p-6 text-center text-muted text-sm">
+            No custom skills yet — the agent runs with the default skills bundled in
+            <code class="text-zinc-300">@openape/ape-agent</code> (one per built-in tool).
+          </div>
+          <ul v-else class="divide-y divide-(--ui-border)">
+            <li v-for="s in skills" :key="s.name">
+              <button
+                type="button"
+                class="w-full text-left px-4 py-3 active:bg-zinc-900 transition-colors flex items-start gap-3"
+                @click="openEditSkill(s)"
+              >
+                <div class="flex-1 min-w-0">
+                  <div class="flex items-center gap-2 flex-wrap mb-1">
+                    <span class="font-medium text-base">{{ s.name }}</span>
+                    <UBadge v-if="!s.enabled" color="neutral" variant="subtle" size="xs">
+                      disabled
+                    </UBadge>
+                  </div>
+                  <div class="text-xs text-muted line-clamp-2">
+                    {{ s.description }}
+                  </div>
+                </div>
+                <UButton
+                  size="sm"
+                  color="error"
+                  variant="ghost"
+                  icon="i-lucide-trash-2"
+                  aria-label="Delete skill"
+                  @click.stop="deleteSkill(s.name)"
+                />
+              </button>
+            </li>
+          </ul>
+        </UCard>
+
+        <!-- Skill editor modal -->
+        <UModal v-model:open="skillEditor.open">
+          <template #content>
+            <div class="p-5 space-y-4">
+              <h3 class="text-lg font-semibold">
+                {{ skillEditor.isNew ? 'New skill' : `Edit ${skillEditor.name}` }}
+              </h3>
+              <UFormField label="Name" :description="skillEditor.isNew ? 'lowercase, [a-z0-9-], max 32 — becomes the directory name on disk' : 'name is immutable after creation'">
+                <UInput v-model="skillEditor.name" :disabled="!skillEditor.isNew || skillSaving" placeholder="iurio" />
+              </UFormField>
+              <UFormField label="Description" description="One-liner the LLM sees in every system prompt; tells it when to load this skill">
+                <UInput v-model="skillEditor.description" :disabled="skillSaving" placeholder="When the user asks about IURIO projects, cases, or documents, load this." />
+              </UFormField>
+              <UFormField label="Body (markdown)" description="Full SKILL.md content — workflows, commands, conventions">
+                <UTextarea v-model="skillEditor.body" :rows="14" :disabled="skillSaving" placeholder="# IURIO CLI usage…" />
+              </UFormField>
+              <UFormField label="Enabled" description="Disabled skills stay on disk but the agent doesn't see them.">
+                <USwitch v-model="skillEditor.enabled" :disabled="skillSaving" />
+              </UFormField>
+              <div class="flex justify-end gap-2">
+                <UButton variant="ghost" :disabled="skillSaving" @click="skillEditor.open = false">
+                  Cancel
+                </UButton>
+                <UButton color="primary" :loading="skillSaving" @click="saveSkill">
+                  Save
+                </UButton>
+              </div>
+            </div>
+          </template>
+        </UModal>
 
         <!-- Tasks -->
         <UCard :ui="{ body: 'p-0' }">

--- a/apps/openape-troop/server/api/agents/[name].patch.ts
+++ b/apps/openape-troop/server/api/agents/[name].patch.ts
@@ -15,6 +15,11 @@ const KNOWN_TOOL_NAMES = new Set<string>(
 // owner-mutable. Add fields here as the owner-facing surface grows.
 const bodySchema = z.object({
   system_prompt: z.string().max(8000).optional(),
+  // SOUL.md content — always-on persona / rules. Bigger cap than
+  // system_prompt because owners may inline policy + style guides
+  // here, and the agent only loads it once per turn (not per tool
+  // call).
+  soul: z.string().max(32_000).optional(),
   tools: z.array(z.string()).optional().refine(
     arr => arr === undefined || arr.every(t => KNOWN_TOOL_NAMES.has(t)),
     { message: 'tools list contains unknown tool names — see /api/tool-catalog' },
@@ -40,6 +45,7 @@ export default defineEventHandler(async (event) => {
   const updates: Record<string, unknown> = {}
   if (body.data.system_prompt !== undefined) updates.systemPrompt = body.data.system_prompt
   if (body.data.tools !== undefined) updates.tools = body.data.tools
+  if (body.data.soul !== undefined) updates.soul = body.data.soul
 
   const result = await db
     .update(agents)

--- a/apps/openape-troop/server/api/agents/[name]/skills/[skillName].delete.ts
+++ b/apps/openape-troop/server/api/agents/[name]/skills/[skillName].delete.ts
@@ -1,0 +1,35 @@
+import { and, eq } from 'drizzle-orm'
+import { useDb } from '../../../../database/drizzle'
+import { agents, agentSkills } from '../../../../database/schema'
+import { requireOwner } from '../../../../utils/auth'
+
+// Delete a skill (hard delete — to "soft disable" use PUT with
+// `enabled: false`). After the next sync the agent host's
+// `~/.openape/agent/skills/<name>/SKILL.md` will be removed too,
+// because the sync command does a one-way mirror from troop.
+export default defineEventHandler(async (event) => {
+  const owner = await requireOwner(event)
+  const name = getRouterParam(event, 'name')
+  const skillName = getRouterParam(event, 'skillName')
+  if (!name || !skillName) {
+    throw createError({ statusCode: 400, statusMessage: 'name and skillName are required' })
+  }
+
+  const db = useDb()
+  const agent = await db
+    .select({ email: agents.email })
+    .from(agents)
+    .where(and(eq(agents.ownerEmail, owner.toLowerCase()), eq(agents.agentName, name)))
+    .get()
+  if (!agent) throw createError({ statusCode: 404, statusMessage: 'agent not found' })
+
+  const deleted = await db
+    .delete(agentSkills)
+    .where(and(eq(agentSkills.agentEmail, agent.email), eq(agentSkills.name, skillName)))
+    .returning({ name: agentSkills.name })
+
+  if (deleted.length === 0) {
+    throw createError({ statusCode: 404, statusMessage: 'skill not found' })
+  }
+  return { ok: true, name: deleted[0]!.name }
+})

--- a/apps/openape-troop/server/api/agents/[name]/skills/index.get.ts
+++ b/apps/openape-troop/server/api/agents/[name]/skills/index.get.ts
@@ -1,0 +1,27 @@
+import { and, eq } from 'drizzle-orm'
+import { useDb } from '../../../../database/drizzle'
+import { agents, agentSkills } from '../../../../database/schema'
+import { requireOwner } from '../../../../utils/auth'
+
+// List the agent's skills (owner-side view — includes disabled rows
+// so the toggle has a thing to flip). The agent's own /me/tasks
+// endpoint filters disabled rows out before sending to the runtime.
+export default defineEventHandler(async (event) => {
+  const owner = await requireOwner(event)
+  const name = getRouterParam(event, 'name')
+  if (!name) throw createError({ statusCode: 400, statusMessage: 'name is required' })
+
+  const db = useDb()
+  const agent = await db
+    .select({ email: agents.email })
+    .from(agents)
+    .where(and(eq(agents.ownerEmail, owner.toLowerCase()), eq(agents.agentName, name)))
+    .get()
+  if (!agent) throw createError({ statusCode: 404, statusMessage: 'agent not found' })
+
+  const rows = await db
+    .select()
+    .from(agentSkills)
+    .where(eq(agentSkills.agentEmail, agent.email))
+  return rows
+})

--- a/apps/openape-troop/server/api/agents/[name]/skills/index.put.ts
+++ b/apps/openape-troop/server/api/agents/[name]/skills/index.put.ts
@@ -1,0 +1,69 @@
+import { and, eq } from 'drizzle-orm'
+import { z } from 'zod'
+import { useDb } from '../../../../database/drizzle'
+import { agents, agentSkills } from '../../../../database/schema'
+import { requireOwner } from '../../../../utils/auth'
+
+// Upsert a skill — name is the natural key (per agent). Body is the
+// full SKILL.md content the agent will land on disk after sync, so
+// the owner can paste in markdown directly. We validate that name
+// matches our slug convention so the path is safe to use as a dir
+// name on the agent host (it becomes `skills/<name>/SKILL.md`).
+const SKILL_NAME_REGEX = /^[a-z][a-z0-9-]{0,31}$/
+
+const bodySchema = z.object({
+  name: z.string().regex(SKILL_NAME_REGEX, 'name must match /^[a-z][a-z0-9-]{0,31}$/'),
+  description: z.string().min(1).max(500),
+  body: z.string().min(1).max(64_000),
+  enabled: z.boolean().optional().default(true),
+})
+
+export default defineEventHandler(async (event) => {
+  const owner = await requireOwner(event)
+  const name = getRouterParam(event, 'name')
+  if (!name) throw createError({ statusCode: 400, statusMessage: 'name is required' })
+
+  const parsed = bodySchema.safeParse(await readBody(event))
+  if (!parsed.success) {
+    throw createError({ statusCode: 400, statusMessage: parsed.error.issues[0]?.message ?? 'invalid body' })
+  }
+
+  const db = useDb()
+  const agent = await db
+    .select({ email: agents.email })
+    .from(agents)
+    .where(and(eq(agents.ownerEmail, owner.toLowerCase()), eq(agents.agentName, name)))
+    .get()
+  if (!agent) throw createError({ statusCode: 404, statusMessage: 'agent not found' })
+
+  const now = Math.floor(Date.now() / 1000)
+  const existing = await db
+    .select({ name: agentSkills.name })
+    .from(agentSkills)
+    .where(and(eq(agentSkills.agentEmail, agent.email), eq(agentSkills.name, parsed.data.name)))
+    .get()
+
+  if (existing) {
+    await db
+      .update(agentSkills)
+      .set({
+        description: parsed.data.description,
+        body: parsed.data.body,
+        enabled: parsed.data.enabled,
+        updatedAt: now,
+      })
+      .where(and(eq(agentSkills.agentEmail, agent.email), eq(agentSkills.name, parsed.data.name)))
+  }
+  else {
+    await db.insert(agentSkills).values({
+      agentEmail: agent.email,
+      name: parsed.data.name,
+      description: parsed.data.description,
+      body: parsed.data.body,
+      enabled: parsed.data.enabled,
+      createdAt: now,
+      updatedAt: now,
+    })
+  }
+  return { ok: true, name: parsed.data.name }
+})

--- a/apps/openape-troop/server/api/agents/me/tasks.get.ts
+++ b/apps/openape-troop/server/api/agents/me/tasks.get.ts
@@ -1,19 +1,25 @@
-import { eq } from 'drizzle-orm'
+import { and, eq } from 'drizzle-orm'
 import { useDb } from '../../../database/drizzle'
-import { agents, tasks } from '../../../database/schema'
+import { agents, agentSkills, tasks } from '../../../database/schema'
 import { requireAgent } from '../../../utils/auth'
 
-// Agent reads its own task list + agent-level config (systemPrompt).
-// No owner gate — the JWT's sub is the agent email and we filter rows
-// on it. Returns the full spec the agent needs to:
+// Agent reads its own task list + agent-level config. No owner gate —
+// the JWT's sub is the agent email and we filter rows on it.
+// Returns the full spec the agent needs to:
 //   - materialise launchd plists for cron tasks
-//   - hydrate `~/.openape/agent/agent.json` (systemPrompt, used by both
-//     the bridge daemon and the run command as the LLM `system` message)
+//   - hydrate `~/.openape/agent/agent.json` (systemPrompt + tools)
+//   - hydrate `~/.openape/agent/SOUL.md` (always-on persona / rules)
+//   - hydrate `~/.openape/agent/skills/<name>/SKILL.md` (lazy-load
+//     instruction documents the agent's LLM loads on demand)
 export default defineEventHandler(async (event) => {
   const agentEmail = await requireAgent(event)
   const db = useDb()
   const agent = await db
-    .select({ systemPrompt: agents.systemPrompt, tools: agents.tools })
+    .select({
+      systemPrompt: agents.systemPrompt,
+      tools: agents.tools,
+      soul: agents.soul,
+    })
     .from(agents)
     .where(eq(agents.email, agentEmail))
     .get()
@@ -21,12 +27,23 @@ export default defineEventHandler(async (event) => {
     .select()
     .from(tasks)
     .where(eq(tasks.agentEmail, agentEmail))
+  // Only enabled skills get sent to the agent. Disabled rows stay in
+  // the troop UI so the owner can toggle them back without re-typing
+  // the body, but the LLM never sees them in the meantime.
+  const skillRows = await db
+    .select({
+      name: agentSkills.name,
+      description: agentSkills.description,
+      body: agentSkills.body,
+    })
+    .from(agentSkills)
+    .where(and(eq(agentSkills.agentEmail, agentEmail), eq(agentSkills.enabled, true)))
   return {
     system_prompt: agent?.systemPrompt ?? '',
     // tools[] = whitelist for chat-bridge runtime + cron task fallback.
-    // The bridge writes this into ~/.openape/agent/agent.json on every
-    // sync; bridge reads it from there at boot for live chat tool-calls.
     tools: agent?.tools ?? [],
+    soul: agent?.soul ?? '',
+    skills: skillRows,
     tasks: taskList,
   }
 })

--- a/apps/openape-troop/server/database/schema.ts
+++ b/apps/openape-troop/server/database/schema.ts
@@ -30,6 +30,13 @@ export const agents = sqliteTable('agents', {
   // `/api/agents/:email/tools`). The chat-bridge reads this list
   // from `~/.openape/agent/agent.json` after each sync.
   tools: text('tools', { mode: 'json' }).notNull().$type<string[]>().default([]),
+  // Always-on persona / hard rules — rendered as the first block of
+  // the system prompt the LLM sees, ahead of skills + base system
+  // prompt. Free-form markdown; the OpenClaw `AGENTS.md` / `SOUL.md`
+  // pattern. Empty string means "no extra rules" — defaults are fine.
+  // Distributed to agents via `apes agents sync` which writes the
+  // body to `~/.openape/agent/SOUL.md`.
+  soul: text('soul').notNull().default(''),
   firstSeenAt: integer('first_seen_at'),
   lastSeenAt: integer('last_seen_at'),
   createdAt: integer('created_at').notNull(),
@@ -61,6 +68,29 @@ export const tasks = sqliteTable('tasks', {
   updatedAt: integer('updated_at').notNull(),
 }, table => [
   primaryKey({ columns: [table.agentEmail, table.taskId] }),
+])
+
+// agent_skills — per-agent skill catalog (OpenClaw-style SKILL.md
+// metadata). Each row turns into a `<name>/SKILL.md` file on the
+// agent host after sync. The agent runtime injects a short
+// `<available_skills>` block listing `name` + `description` into
+// every system prompt; the body itself is loaded lazily by the LLM
+// via the file.read tool when the task matches the description.
+// Empty/missing rows = the agent runs with only its built-in default
+// skills (shipped in the ape-agent npm package).
+export const agentSkills = sqliteTable('agent_skills', {
+  agentEmail: text('agent_email').notNull(),
+  name: text('name').notNull(),
+  description: text('description').notNull(),
+  body: text('body').notNull(),
+  // Soft-disable a skill without deleting it. Owner-controlled toggle
+  // in the troop UI; disabled skills are excluded from the agent's
+  // sync payload so the LLM never sees them.
+  enabled: integer('enabled', { mode: 'boolean' }).notNull().default(true),
+  createdAt: integer('created_at').notNull(),
+  updatedAt: integer('updated_at').notNull(),
+}, table => [
+  primaryKey({ columns: [table.agentEmail, table.name] }),
 ])
 
 // runs — execution history. Trace is JSON; capped at ~16KB by the API

--- a/apps/openape-troop/server/plugins/02.database.ts
+++ b/apps/openape-troop/server/plugins/02.database.ts
@@ -57,6 +57,25 @@ export default defineNitroPlugin(async () => {
       await db.run(sql`ALTER TABLE agents ADD COLUMN tools TEXT NOT NULL DEFAULT '[]'`)
     }
     catch { /* column exists */ }
+    // Skills feature (#404-ish): per-agent persona via SOUL.md + a
+    // catalog of `<name>/SKILL.md` lazy-load instructions. Both are
+    // distributed via `apes agents sync`. Default '' / no rows for
+    // existing agents — they keep working with just default skills
+    // shipped in the ape-agent package.
+    try {
+      await db.run(sql`ALTER TABLE agents ADD COLUMN soul TEXT NOT NULL DEFAULT ''`)
+    }
+    catch { /* column exists */ }
+    await db.run(sql`CREATE TABLE IF NOT EXISTS agent_skills (
+      agent_email TEXT NOT NULL,
+      name TEXT NOT NULL,
+      description TEXT NOT NULL,
+      body TEXT NOT NULL,
+      enabled INTEGER NOT NULL DEFAULT 1,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      PRIMARY KEY (agent_email, name)
+    )`)
     try {
       await db.run(sql`ALTER TABLE tasks RENAME COLUMN system_prompt TO user_prompt`)
     }

--- a/packages/apes/src/commands/agents/sync.ts
+++ b/packages/apes/src/commands/agents/sync.ts
@@ -1,4 +1,4 @@
-import { chownSync, existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
+import { chownSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { defineCommand } from 'citty'
@@ -97,9 +97,11 @@ export const syncAgentCommand = defineCommand({
     })
     consola.info(sync.first_sync ? '✓ first sync — agent registered' : '✓ presence updated')
 
-    const { system_prompt: systemPrompt, tools, tasks } = await client.listTasks()
+    const { system_prompt: systemPrompt, tools, soul, skills, tasks } = await client.listTasks()
     consola.info(`Pulled ${tasks.length} task${tasks.length === 1 ? '' : 's'}`)
     consola.info(`Tools enabled: ${tools.length === 0 ? '(none)' : tools.join(', ')}`)
+    consola.info(`Skills: ${skills.length === 0 ? '(none)' : skills.map(s => s.name).join(', ')}`)
+    consola.info(`SOUL.md: ${soul.length > 0 ? `${soul.length} chars` : '(empty)'}`)
 
     // Sync runs as ROOT in production (the launchd plist sets
     // UserName=root so it can write /Library/LaunchDaemons/ and
@@ -148,6 +150,42 @@ export const syncAgentCommand = defineCommand({
       const path = join(TASK_CACHE_DIR, `${task.taskId}.json`)
       writeFileSync(path, `${JSON.stringify(task, null, 2)}\n`, { mode: 0o600 })
       chownToAgent(path)
+    }
+
+    // SOUL.md — always-on persona. Write empty string deliberately
+    // (don't delete the file) so the agent runtime sees the owner's
+    // explicit decision to clear rules rather than treating it as
+    // "not yet synced".
+    const soulPath = join(agentDir, 'SOUL.md')
+    writeFileSync(soulPath, soul.endsWith('\n') ? soul : `${soul}\n`, { mode: 0o600 })
+    chownToAgent(soulPath)
+
+    // Skills mirror — one-way sync from troop. Anything currently
+    // on disk that's not in the response gets pruned, so disabling
+    // or deleting a skill in troop UI takes effect on the next sync
+    // (instead of leaving stale SKILL.md files behind that the
+    // available_skills block would still list).
+    const skillsDir = join(agentDir, 'skills')
+    mkdirSync(skillsDir, { recursive: true })
+    chownToAgent(skillsDir)
+    const incomingNames = new Set(skills.map(s => s.name))
+    // Prune
+    try {
+      for (const entry of readdirSync(skillsDir)) {
+        if (incomingNames.has(entry)) continue
+        try { rmSync(join(skillsDir, entry), { recursive: true, force: true }) }
+        catch { /* best-effort prune; next sync retries */ }
+      }
+    }
+    catch { /* directory just created, nothing to prune */ }
+    // Write
+    for (const skill of skills) {
+      const skillDir = join(skillsDir, skill.name)
+      mkdirSync(skillDir, { recursive: true })
+      chownToAgent(skillDir)
+      const skillPath = join(skillDir, 'SKILL.md')
+      writeFileSync(skillPath, skill.body.endsWith('\n') ? skill.body : `${skill.body}\n`, { mode: 0o600 })
+      chownToAgent(skillPath)
     }
 
     // Cron tasks no longer get a per-task launchd plist (#347 was the

--- a/packages/apes/src/lib/troop-client.ts
+++ b/packages/apes/src/lib/troop-client.ts
@@ -28,6 +28,15 @@ export interface TaskSpec {
   updatedAt: number
 }
 
+export interface SkillSpec {
+  /** Slug — becomes the directory name on disk (`skills/<name>/SKILL.md`). */
+  name: string
+  /** One-line summary the LLM sees in the system prompt's available_skills block. */
+  description: string
+  /** Full SKILL.md content the agent runtime writes to disk after sync. */
+  body: string
+}
+
 /** Response from /api/agents/me/tasks — agent config + task list. */
 export interface AgentTasksResponse {
   /**
@@ -44,6 +53,16 @@ export interface AgentTasksResponse {
    * sync — owner narrows via troop UI.
    */
   tools: string[]
+  /**
+   * Always-on persona / hard rules — markdown body that lands at
+   * `~/.openape/agent/SOUL.md` after sync. Empty string when unset.
+   */
+  soul: string
+  /**
+   * Lazy-load skill catalog — only enabled rows from agent_skills.
+   * Each one lands at `~/.openape/agent/skills/<name>/SKILL.md`.
+   */
+  skills: SkillSpec[]
   tasks: TaskSpec[]
 }
 


### PR DESCRIPTION
## Why

Patrick asked how OpenClaw tells its agents to use specific tools, and whether we should copy the pattern. Short answer: yes — OpenClaw's lazy-load skill model is the right fit for us.

The pattern (lifted from `Companies/delta-mind/repos/openclaw/src/agents/skills/`):

- Each capability is a `<name>/SKILL.md` markdown doc with YAML frontmatter (`name`, `description`, optional `requires_tools`)
- The agent runtime injects a short `<available_skills>` list (name + description + location) into every system prompt
- The LLM reads the full body **on demand** via the `file.read` tool when the task description matches — cold prompt stays small even with 50+ skills
- SOUL.md is the always-on counterpart — persona, language, hard rules, in every system prompt without a read

## Scope (1 + 2 per Patrick)

✅ ape-agent: SOUL.md + skills loader, system-prompt composer, default-skills for our 10 built-in tools
✅ troop: schema (`agents.soul` + `agent_skills` table) + sync flow + CRUD API + UI
✅ apes CLI: sync writes SOUL.md + skills mirror

## Tool-review (separately asked)

Compared OpenClaw's 21 built-in tools against our 10. Findings:

- **Gaps we can fill via skills, not new tools**: web_search (curl Tavily), pdf (vision models cover most), update_plan (ape-tasks already)
- **Skip**: image/video/music gen, tts — out of scope, provider-specific
- **Keep**: all current 10. They're well-curated, structured returns, lower DDISA-grant overhead than bash

Conclusion: no tools added or removed in this PR. Skills carry the "domain knowledge"; bash is the escape-hatch.

## Files

**`@openape/ape-agent`** (npm package)
- `src/skills.ts` — frontmatter parser, scan, eligibility filter, composer
- `default-skills/{time,http,file,tasks,mail,bash}/SKILL.md` — bundled defaults
- `src/bridge.ts` — wire composer into ThreadSession creation
- `test/skills.test.ts` — 18 unit tests (parse, scan, filter, override, compose)

**`@openape/troop`** (chatty.delta-mind.at)
- schema: `agents.soul TEXT` + `agent_skills(agent_email, name, description, body, enabled)`
- `/api/agents/me/tasks` returns soul + enabled skills
- `PATCH /api/agents/:name` accepts soul
- new `/api/agents/:name/skills` GET/PUT/DELETE
- agent detail UI: SOUL textarea + Skills CRUD modal

**`@openape/apes`** (CLI)
- `troop-client.ts`: extended response shape
- `agents/sync.ts`: writes SOUL.md + skills mirror, prunes stale rows

## Test plan
- [x] Lint + typecheck + tests green (19 turbo tasks, 30 ape-agent tests)
- [ ] After deploy + bridge upgrade:
  - [ ] Existing agents: no behavior change (default skills bundled, SOUL empty)
  - [ ] Add a custom skill via troop UI → sync → verify SKILL.md lands in agent home
  - [ ] Set SOUL.md in troop → sync → verify SOUL.md lands + persona changes
  - [ ] Disable a skill in troop → sync → verify SKILL.md gets pruned + LLM no longer sees it
- [ ] ape-agent-iurio: add a skill `iurio` that documents the IURIO CLI patterns, verify the agent loads it on iurio-related questions