### PR TITLE
feat(agent): align SKILL.md frontmatter with OpenClaw nested metadata

### DIFF
--- a/.changeset/skill-frontmatter-align-openclaw.md
+++ b/.changeset/skill-frontmatter-align-openclaw.md
@@ -1,0 +1,26 @@
+---
+"@openape/ape-agent": minor
+---
+
+Align SKILL.md frontmatter with OpenClaw's nested-metadata pattern so a clawhub.ai-published skill drops into our runtime without modification.
+
+**New supported shapes** (back-compat to the flat legacy form):
+
+```yaml
+metadata:
+  openclaw:
+    requires:
+      bins: [o365-cli]        # host-PATH binary eligibility
+  openape:
+    requires_tools: [mail.list]  # our tool-whitelist eligibility
+```
+
+The parser now uses the `yaml` package (added as a runtime dep) instead of a hand-rolled regex pass, so nested YAML structures Just Work. Reads:
+
+- `metadata.openape.requires_tools` (canonical for us)
+- `metadata.openclaw.requires.bins` (canonical for OpenClaw — we honor it as binary-eligibility)
+- legacy top-level `requires_tools` (existing skills keep parsing)
+
+**Binary eligibility** (`requires_bins`) is new: skills declaring a host CLI prerequisite get filtered out when the binary isn't on PATH. Reuses the bundled `mail` skill's case — the o365-cli binary may not be installed on every agent host.
+
+Default-skills updated to the namespaced form as a reference; existing user-written skills continue to parse with either shape.

--- a/apps/openape-ape-agent/default-skills/bash/SKILL.md
+++ b/apps/openape-ape-agent/default-skills/bash/SKILL.md
@@ -1,7 +1,9 @@
 ---
 name: bash
 description: When a task can't be done with the other curated tools (file.read, http.get, tasks.create, mail.list, etc.), use bash — runs any shell command on the agent host through the DDISA grant cycle.
-requires_tools: [bash]
+metadata:
+  openape:
+    requires_tools: [bash]
 ---
 
 # Shell access via ape-shell

--- a/apps/openape-ape-agent/default-skills/file/SKILL.md
+++ b/apps/openape-ape-agent/default-skills/file/SKILL.md
@@ -1,7 +1,9 @@
 ---
 name: file
 description: When the user asks you to read, write, or check a file in your home directory, use the file.read / file.write tools — they're $HOME-jailed and safer than bash cat.
-requires_tools: [file.read]
+metadata:
+  openape:
+    requires_tools: [file.read]
 ---
 
 # Files in $HOME

--- a/apps/openape-ape-agent/default-skills/http/SKILL.md
+++ b/apps/openape-ape-agent/default-skills/http/SKILL.md
@@ -1,7 +1,9 @@
 ---
 name: http
 description: When the user asks to fetch a webpage, hit a REST API, or POST JSON to an endpoint, use the http.get / http.post tools — never invent URLs.
-requires_tools: [http.get]
+metadata:
+  openape:
+    requires_tools: [http.get]
 ---
 
 # HTTP fetch

--- a/apps/openape-ape-agent/default-skills/mail/SKILL.md
+++ b/apps/openape-ape-agent/default-skills/mail/SKILL.md
@@ -1,7 +1,15 @@
 ---
 name: mail
 description: When the user asks about their inbox — what's there, search for an email, recent unread — use mail.list / mail.search.
-requires_tools: [mail.list]
+metadata:
+  openape:
+    requires_tools: [mail.list]
+  openclaw:
+    # If the o365-cli binary isn't on PATH the underlying tool fails
+    # at runtime — skip the skill from the prompt so the LLM doesn't
+    # try to use it on a host where it can't run.
+    requires:
+      bins: [o365-cli]
 ---
 
 # Inbox (o365-cli)

--- a/apps/openape-ape-agent/default-skills/tasks/SKILL.md
+++ b/apps/openape-ape-agent/default-skills/tasks/SKILL.md
@@ -1,7 +1,15 @@
 ---
 name: tasks
 description: When the user wants to see, create, or schedule a task/reminder/wiedervorlage on their personal task list, use tasks.list / tasks.create.
-requires_tools: [tasks.list]
+metadata:
+  openape:
+    requires_tools: [tasks.list]
+  openclaw:
+    # The bash escape-hatch path uses ape-tasks; surface it as a soft
+    # dependency so on a host without ape-tasks the LLM is told this
+    # skill doesn't apply.
+    requires:
+      bins: [ape-tasks]
 ---
 
 # Personal tasks (ape-tasks)

--- a/apps/openape-ape-agent/default-skills/time/SKILL.md
+++ b/apps/openape-ape-agent/default-skills/time/SKILL.md
@@ -1,7 +1,9 @@
 ---
 name: time
 description: When the user asks for the current time, date, or wants a sanity-check that the runtime is alive, use the time.now tool — never guess.
-requires_tools: [time.now]
+metadata:
+  openape:
+    requires_tools: [time.now]
 ---
 
 # Time and date

--- a/apps/openape-ape-agent/package.json
+++ b/apps/openape-ape-agent/package.json
@@ -30,7 +30,8 @@
     "@openape/cli-auth": "workspace:*",
     "jose": "catalog:",
     "ofetch": "^1.4.1",
-    "ws": "^8.18.0"
+    "ws": "^8.18.0",
+    "yaml": "^2.8.0"
   },
   "devDependencies": {
     "@antfu/eslint-config": "catalog:",

--- a/apps/openape-ape-agent/src/skills.ts
+++ b/apps/openape-ape-agent/src/skills.ts
@@ -27,10 +27,12 @@
 // shadowed by an agent-side skill of the same name — that's how an
 // owner overrides the bundled `bash` skill with their own variant.
 
+import { execFileSync } from 'node:child_process'
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { parse as parseYaml } from 'yaml'
 
 export interface Skill {
   name: string
@@ -41,9 +43,21 @@ export interface Skill {
    * Optional eligibility filter. If any required tool name is *not*
    * in the agent's enabled `tools[]`, the skill is dropped from the
    * formatted prompt — the agent shouldn't see a skill it can't
-   * execute. Tools list comes from agent.json.
+   * execute. Tools list comes from agent.json. Sourced from either
+   * the legacy top-level `requires_tools` or the nested
+   * `metadata.openape.requires_tools`.
    */
   requiresTools?: string[]
+  /**
+   * Optional eligibility filter on host-PATH binaries. Mirrors
+   * OpenClaw's `metadata.openclaw.requires.bins` — a skill that
+   * expects `o365-cli` to be installed lists it here, and we drop
+   * the skill from the prompt on hosts where the binary is missing.
+   * Resolved via `which` once per scan; result is cached for the
+   * lifetime of the process. Sourced from either openclaw or
+   * openape metadata namespaces — same semantics.
+   */
+  requiresBins?: string[]
 }
 
 const SKILLS_SUBDIR = ['.openape', 'agent', 'skills']
@@ -73,24 +87,49 @@ export function readSoul(home: string = homedir()): string | null {
 }
 
 /**
- * Parse YAML-ish frontmatter from the head of a SKILL.md. We accept
- * the openclaw format:
+ * Parse YAML frontmatter from the head of a SKILL.md. We accept three
+ * frontmatter shapes so a SKILL.md published on clawhub.ai (the
+ * OpenClaw skill registry) drops into our runtime without
+ * modification:
  *
+ *   # Legacy / openape-flat (current default-skills):
  *   ---
  *   name: <slug>
  *   description: <one-liner>
- *   requires_tools: [time.now, http.get]   # optional
+ *   requires_tools: [time.now, http.get]
  *   ---
- *   <markdown body…>
+ *
+ *   # OpenClaw-aligned (what clawhub.ai skills use):
+ *   ---
+ *   name: <slug>
+ *   description: <one-liner>
+ *   metadata:
+ *     openclaw:
+ *       emoji: 📊
+ *       os: ["darwin"]
+ *       requires:
+ *         bins: ["o365-cli"]
+ *   ---
+ *
+ *   # openape-namespaced (additive — coexists with openclaw block):
+ *   ---
+ *   name: <slug>
+ *   description: <one-liner>
+ *   metadata:
+ *     openape:
+ *       requires_tools: [mail.list]
+ *   ---
  *
  * Returns `null` if no frontmatter is found or the required `name`
  * and `description` fields are missing — those are the only two
- * fields the rest of the system depends on.
+ * fields the rest of the system depends on. Falls back to legacy
+ * flat keys when the metadata block is absent.
  */
 export function parseFrontmatter(content: string): {
   name: string
   description: string
   requiresTools?: string[]
+  requiresBins?: string[]
 } | null {
   const trimmed = content.trimStart()
   if (!trimmed.startsWith('---')) return null
@@ -98,42 +137,78 @@ export function parseFrontmatter(content: string): {
   if (closeIdx < 0) return null
   const fmBlock = trimmed.slice(3, closeIdx).trim()
 
-  const fields: Record<string, string> = {}
-  let arrayKey: string | null = null
-  let arrayBuf: string[] = []
-  for (const rawLine of fmBlock.split('\n')) {
-    const line = rawLine.replace(/\r$/, '')
-    if (arrayKey) {
-      const m = line.match(/^[\t ]*-[\t ]+(\S.*)$/)
-      if (m) { arrayBuf.push(m[1]!.trim()); continue }
-      fields[arrayKey] = arrayBuf.join(',')
-      arrayKey = null
-      arrayBuf = []
-    }
-    const kv = line.match(/^([a-z_]\w*)[\t ]*:[\t ]?(.*)$/i)
-    if (!kv) continue
-    const [, key, value] = kv
-    if (value!.trim() === '') {
-      arrayKey = key!
-      arrayBuf = []
-      continue
-    }
-    // Inline array: `[a, b]`
-    const inlineArray = value!.match(/^\[(.*)\]$/)
-    if (inlineArray) {
-      fields[key!] = inlineArray[1]!.split(',').map(s => s.trim().replace(/^["']|["']$/g, '')).filter(Boolean).join(',')
-      continue
-    }
-    fields[key!] = value!.trim().replace(/^["']|["']$/g, '')
-  }
-  if (arrayKey) fields[arrayKey] = arrayBuf.join(',')
+  let parsed: unknown
+  try { parsed = parseYaml(fmBlock) }
+  catch { return null }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null
+  const fields = parsed as Record<string, unknown>
 
-  if (!fields.name || !fields.description) return null
-  const requiresTools = fields.requires_tools
-    ? fields.requires_tools.split(',').map(s => s.trim()).filter(Boolean)
-    : undefined
-  return { name: fields.name, description: fields.description, requiresTools }
+  const name = typeof fields.name === 'string' ? fields.name.trim() : ''
+  const description = typeof fields.description === 'string' ? fields.description.trim() : ''
+  if (!name || !description) return null
+
+  function asStringArray(v: unknown): string[] | undefined {
+    if (!Array.isArray(v)) return undefined
+    const out = v
+      .map(x => typeof x === 'string' ? x.trim() : '')
+      .filter(s => s.length > 0)
+    return out.length > 0 ? out : undefined
+  }
+
+  // Tool eligibility: openape namespace first, then top-level
+  // requires_tools (legacy/back-compat). OpenClaw doesn't have a
+  // direct equivalent — they use `requires.bins` instead.
+  const meta = (fields.metadata && typeof fields.metadata === 'object' && !Array.isArray(fields.metadata))
+    ? fields.metadata as Record<string, unknown>
+    : {}
+  const openapeMeta = (meta.openape && typeof meta.openape === 'object' && !Array.isArray(meta.openape))
+    ? meta.openape as Record<string, unknown>
+    : {}
+  const openclawMeta = (meta.openclaw && typeof meta.openclaw === 'object' && !Array.isArray(meta.openclaw))
+    ? meta.openclaw as Record<string, unknown>
+    : {}
+
+  const requiresTools = asStringArray(openapeMeta.requires_tools) ?? asStringArray(fields.requires_tools)
+
+  // Binary eligibility: openclaw namespace canonical form, also
+  // accept openape.requires.bins as a mirror. Top-level
+  // `requires_bins` is supported as a legacy/flat alias.
+  function readRequiresBins(scope: Record<string, unknown>): string[] | undefined {
+    const requires = scope.requires
+    if (requires && typeof requires === 'object' && !Array.isArray(requires)) {
+      return asStringArray((requires as Record<string, unknown>).bins)
+    }
+    return undefined
+  }
+  const requiresBins
+    = readRequiresBins(openclawMeta)
+      ?? readRequiresBins(openapeMeta)
+      ?? asStringArray(fields.requires_bins)
+
+  return { name, description, requiresTools, requiresBins }
 }
+
+// Cache binary-on-PATH lookups for the lifetime of the process.
+// The skills scan runs on every new ThreadSession, so we'd otherwise
+// re-shell out to `which o365-cli` many times per chat session for
+// no gain — paths don't change at runtime.
+const binCheckCache = new Map<string, boolean>()
+
+function hasBinaryOnPath(bin: string): boolean {
+  const cached = binCheckCache.get(bin)
+  if (cached !== undefined) return cached
+  let found = false
+  try {
+    execFileSync('/usr/bin/which', [bin], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] })
+    found = true
+  }
+  catch { /* missing */ }
+  binCheckCache.set(bin, found)
+  return found
+}
+
+// Test-only: reset the cache so unit tests don't leak across cases.
+export const _internalSkillsCacheReset = () => binCheckCache.clear()
 
 /**
  * Scan a directory of `<name>/SKILL.md` skills and return the parsed
@@ -165,6 +240,7 @@ export function scanSkillsDir(dir: string): Skill[] {
       description: fm.description,
       filePath: skillPath,
       requiresTools: fm.requiresTools,
+      requiresBins: fm.requiresBins,
     })
   }
   return out
@@ -201,6 +277,10 @@ export function composeSkills(home: string, enabledTools: string[]): Skill[] {
     if (s.requiresTools && s.requiresTools.length > 0) {
       const allPresent = s.requiresTools.every(t => enabled.has(t))
       if (!allPresent) continue
+    }
+    if (s.requiresBins && s.requiresBins.length > 0) {
+      const allBinsPresent = s.requiresBins.every(b => hasBinaryOnPath(b))
+      if (!allBinsPresent) continue
     }
     out.push(s)
   }

--- a/apps/openape-ape-agent/test/skills.test.ts
+++ b/apps/openape-ape-agent/test/skills.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import {
+  _internalSkillsCacheReset,
   composeSkills,
   composeSystemPrompt,
   formatSkillsBlock,
@@ -17,6 +18,7 @@ describe('skills loader', () => {
   let home: string
   beforeEach(() => {
     home = mkdtempSync(join(tmpdir(), 'ape-agent-skills-'))
+    _internalSkillsCacheReset()
   })
   afterEach(() => {
     rmSync(home, { recursive: true, force: true })
@@ -46,14 +48,45 @@ describe('skills loader', () => {
       expect(fm).toEqual({ name: 'foo', description: 'a tool that foos' })
     })
 
-    it('parses requires_tools as inline array', () => {
+    it('parses legacy top-level requires_tools as inline array', () => {
       const fm = parseFrontmatter('---\nname: foo\ndescription: d\nrequires_tools: [a, b, c]\n---\nbody')
       expect(fm?.requiresTools).toEqual(['a', 'b', 'c'])
     })
 
-    it('parses requires_tools as block array', () => {
+    it('parses legacy top-level requires_tools as block array', () => {
       const fm = parseFrontmatter('---\nname: foo\ndescription: d\nrequires_tools:\n  - a\n  - b\n---')
       expect(fm?.requiresTools).toEqual(['a', 'b'])
+    })
+
+    it('reads openape-namespaced requires_tools from nested metadata', () => {
+      const fm = parseFrontmatter('---\nname: foo\ndescription: d\nmetadata:\n  openape:\n    requires_tools: [time.now, http.get]\n---')
+      expect(fm?.requiresTools).toEqual(['time.now', 'http.get'])
+    })
+
+    it('reads openclaw-namespaced requires.bins from nested metadata', () => {
+      const fm = parseFrontmatter('---\nname: foo\ndescription: d\nmetadata:\n  openclaw:\n    requires:\n      bins: [o365-cli]\n---')
+      expect(fm?.requiresBins).toEqual(['o365-cli'])
+    })
+
+    it('openape namespace wins over legacy top-level requires_tools', () => {
+      const fm = parseFrontmatter('---\nname: foo\ndescription: d\nrequires_tools: [legacy]\nmetadata:\n  openape:\n    requires_tools: [winner]\n---')
+      expect(fm?.requiresTools).toEqual(['winner'])
+    })
+
+    it('accepts both openclaw + openape blocks side-by-side (the cross-runtime case)', () => {
+      const fm = parseFrontmatter(`---
+name: foo
+description: d
+metadata:
+  openclaw:
+    emoji: 📊
+    requires:
+      bins: [o365-cli]
+  openape:
+    requires_tools: [mail.list]
+---`)
+      expect(fm?.requiresTools).toEqual(['mail.list'])
+      expect(fm?.requiresBins).toEqual(['o365-cli'])
     })
 
     it('returns null when no frontmatter or required fields missing', () => {
@@ -136,6 +169,25 @@ describe('skills loader', () => {
       const names = skills.map(s => s.name)
       expect(names).toContain('free')
       expect(names).not.toContain('needs-mail')
+    })
+
+    it('drops skills whose required binaries aren\'t on host PATH', () => {
+      mkdirSync(join(skillsDir(home), 'needs-fictional-binary'), { recursive: true })
+      writeFileSync(
+        join(skillsDir(home), 'needs-fictional-binary', 'SKILL.md'),
+        // A binary that obviously won't be on PATH — `which` will fail.
+        '---\nname: needs-fictional-binary\ndescription: D\nmetadata:\n  openclaw:\n    requires:\n      bins: [openape-not-a-real-bin-zz9plural9z]\n---',
+      )
+      mkdirSync(join(skillsDir(home), 'has-shell'), { recursive: true })
+      writeFileSync(
+        join(skillsDir(home), 'has-shell', 'SKILL.md'),
+        // `sh` is on every macOS / Linux box → eligibility passes.
+        '---\nname: has-shell\ndescription: D\nmetadata:\n  openclaw:\n    requires:\n      bins: [sh]\n---',
+      )
+      const skills = composeSkills(home, [])
+      const names = skills.map(s => s.name)
+      expect(names).toContain('has-shell')
+      expect(names).not.toContain('needs-fictional-binary')
     })
 
     it('agent-side skill shadows a default-skill of the same name', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,6 +254,9 @@ importers:
       ws:
         specifier: ^8.18.0
         version: 8.19.0
+      yaml:
+        specifier: ^2.8.0
+        version: 2.8.2
     devDependencies:
       '@antfu/eslint-config':
         specifier: 'catalog:'


### PR DESCRIPTION
## Why
Patrick: \"Wir sollten uns aber Struktur-skillmäßig mit dem Platzhirsch abstimmen.\"

A SKILL.md published on **clawhub.ai** (the OpenClaw skill registry, ~50 skills today, growing) uses the nested-metadata shape:

\`\`\`yaml
metadata:
  openclaw:
    emoji: 📊
    os: [darwin]
    requires:
      bins: [o365-cli]
\`\`\`

Our previous flat \`requires_tools\` top-level key didn't read it. A skill author writing once should land on both runtimes — that's the cross-pollination payoff if we ever wire the clawhub install flow.

## Tool-comparison findings (for the record)

OpenClaw's \"core\" tools (bash/read/write/edit/find/grep/ls) come from **Anthropic's pi-agent-core** — OpenClaw inherits, doesn't define. So there's nothing OpenClaw-specific to copy in terms of tool *descriptions*. Our bash description is actually richer than Anthropic's because it explains the DDISA grant cycle.

What OpenClaw adds on top: web_search, web_fetch, pdf, image/video/music gen, cron, sessions_*, update_plan. None of those align 1:1 with our tools, and most are skill-distance from our use case. **No tool renames or additions in this PR.**

## What this PR changes
- New supported frontmatter shapes (back-compat with the legacy flat form):
  - \`metadata.openape.requires_tools\` (canonical for our tool whitelist)
  - \`metadata.openclaw.requires.bins\` (canonical for OpenClaw — we honor as host-PATH binary eligibility)
- Parser switched from hand-rolled regex to \`yaml@2.8.0\` (added as runtime dep) for robust nested YAML
- New \`requires_bins\` eligibility filter: skills are dropped when their declared binary isn't on \`/usr/bin/which\`. Cached per-process.
- Default-skills (mail, tasks, etc.) migrated to the namespaced form as a reference

## Test plan
- [x] 35 unit tests green (5 new: nested metadata parsing, binary eligibility filter, openape-wins-over-legacy, cross-runtime mixed openclaw+openape block)
- [x] Lint + typecheck + build green (11 turbo tasks)
- [ ] After deploy + upgrade: pull a SKILL.md from clawhub.ai (e.g. \`url2md\`) verbatim — confirm it parses and gets correctly filtered (won't enable since its python script isn't on PATH but we won't crash either)