### PR TITLE
feat(chat): streaming-aware messages, no more (edited) on agent replies

### DIFF
--- a/.changeset/chat-streaming-state-polish.md
+++ b/.changeset/chat-streaming-state-polish.md
@@ -1,0 +1,19 @@
+---
+"@openape/ape-agent": minor
+---
+
+Chat-bridge: agent messages stream cleanly without "(edited)" artefacts + tool-call visibility.
+
+**Before**: every agent reply showed "(edited)" because the bridge posted a `…` placeholder and then PATCHed body once per ~300ms while LLM tokens streamed. Each PATCH bumped `edited_at`. Plus there was no signal *what* the agent was doing during tool calls — the user just saw "…" hang for seconds.
+
+**After**: messages carry a `streaming` flag distinct from `edited_at`. While streaming:
+- Empty placeholder renders as a 3-dot typing cursor (pure CSS animation)
+- Body updates from token streams don't bump `edited_at`
+- Tool calls set `streamingStatus` (e.g. `🔧 time.now`) shown as italic subtitle under the cursor — cleared on tool-result / stream-end
+- Web-push fires once on stream-end, not on every chunk
+
+The `(edited)` badge only renders for human edits made >2s after creation (the 2s window swallows the stream-end PATCH that lands milliseconds after the placeholder).
+
+Display-name extraction also fixed: agent emails like `igor30-cb6bf26a+patrick+hofmann_eco@id.openape.ai` now render as just `igor30` with the 🤖 badge — same DDISA identity, much more readable.
+
+Schema migration (idempotent ALTERs): `messages.streaming INTEGER NOT NULL DEFAULT 0` + `messages.streaming_status TEXT`. Existing messages back-compat: `streaming=0`, `streaming_status=null`.

--- a/apps/openape-ape-agent/src/chat-api.ts
+++ b/apps/openape-ape-agent/src/chat-api.ts
@@ -28,13 +28,18 @@ export class ChatApi {
   async postMessage(
     roomId: string,
     body: string,
-    opts: { replyTo?: string, threadId?: string } = {},
+    opts: { replyTo?: string, threadId?: string, streaming?: boolean } = {},
   ): Promise<PostedMessage> {
-    const trimmed = clamp(body, MAX_BODY)
+    // When streaming, empty body is fine — the server holds the
+    // placeholder until the bridge starts patching tokens in. Outside
+    // streaming, fall back to the legacy "…" placeholder so the
+    // server's min-1-char rule keeps passing for compose-side users.
+    const bodyForServer = opts.streaming ? body : clamp(body, MAX_BODY)
     const url = `${this.endpoint}/api/rooms/${encodeURIComponent(roomId)}/messages`
-    const payload: Record<string, unknown> = { body: trimmed }
+    const payload: Record<string, unknown> = { body: bodyForServer }
     if (opts.replyTo) payload.reply_to = opts.replyTo
     if (opts.threadId) payload.thread_id = opts.threadId
+    if (opts.streaming) payload.streaming = true
     const result = await ofetch<PostedMessage>(url, {
       method: 'POST',
       headers: { Authorization: await this.bearer() },
@@ -83,13 +88,41 @@ export class ChatApi {
     })
   }
 
-  async patchMessage(messageId: string, body: string): Promise<void> {
-    const trimmed = clamp(body, MAX_BODY)
+  /**
+   * Update an in-flight or completed message. The server differentiates
+   * three modes via the message's current `streaming` state and the
+   * `streaming` field in this call:
+   *
+   *   - Stream tick: pass `body` only (current accumulated text).
+   *     Server keeps streaming=true and does NOT bump edited_at.
+   *   - Stream end: pass `body` + `streaming: false`. Server clears
+   *     the streaming flag and triggers the user-facing push.
+   *   - Tool-call status: pass `streamingStatus` only (no body).
+   *     Renders as "🔧 time.now" in the typing-subtitle.
+   *   - Tool-call cleared: pass `streamingStatus: null`.
+   */
+  async patchMessage(
+    messageId: string,
+    opts: { body?: string, streaming?: boolean, streamingStatus?: string | null } = {},
+  ): Promise<void> {
     const url = `${this.endpoint}/api/messages/${encodeURIComponent(messageId)}`
+    const payload: Record<string, unknown> = {}
+    if (opts.body !== undefined) {
+      // Outside the streaming-end transition, the server requires a
+      // non-empty body. clamp() preserves that floor while letting the
+      // bridge spam empty-string-during-streaming ticks pass through
+      // for the placeholder-only case.
+      payload.body = opts.streaming === false && opts.body.trim().length === 0
+        ? clamp(opts.body, MAX_BODY)
+        : (opts.body.length <= MAX_BODY ? opts.body : `${opts.body.slice(0, MAX_BODY - 1)}…`)
+    }
+    if (opts.streaming !== undefined) payload.streaming = opts.streaming
+    if (opts.streamingStatus !== undefined) payload.streaming_status = opts.streamingStatus
+    if (Object.keys(payload).length === 0) return
     await ofetch(url, {
       method: 'PATCH',
       headers: { Authorization: await this.bearer() },
-      body: { body: trimmed },
+      body: payload,
     })
   }
 }

--- a/apps/openape-ape-agent/src/thread-session.ts
+++ b/apps/openape-ape-agent/src/thread-session.ts
@@ -62,9 +62,14 @@ export class ThreadSession {
   }
 
   private async startTurn(body: string, replyToMessageId: string): Promise<void> {
-    const placeholder = await this.deps.chat.postMessage(this.deps.roomId, '…', {
+    // Post an empty streaming placeholder. With streaming=true the
+    // server accepts an empty body — clients render it as a typing
+    // indicator instead of a literal "…". The first PATCH lands the
+    // first chunk of LLM output; further patches keep streaming=true.
+    const placeholder = await this.deps.chat.postMessage(this.deps.roomId, '', {
       replyTo: replyToMessageId,
       threadId: this.deps.threadId,
+      streaming: true,
     })
     const turn: ActiveTurn = {
       placeholderId: placeholder.id,
@@ -72,9 +77,13 @@ export class ThreadSession {
       replyToMessageId,
       throttle: createThrottle(async () => {
         if (!this.active || this.active.placeholderId !== placeholder.id) return
-        const text = this.active.accumulated || '…'
+        const text = this.active.accumulated
+        // Empty-body ticks during streaming would be no-ops on the
+        // server. Wait until the first token arrives before the first
+        // PATCH so the UI can keep showing the typing-indicator.
+        if (text.length === 0) return
         try {
-          await this.deps.chat.patchMessage(placeholder.id, text)
+          await this.deps.chat.patchMessage(placeholder.id, { body: text })
         }
         catch (err) {
           this.deps.log(`patch failed (room=${this.deps.roomId} thread=${this.deps.threadId}): ${err instanceof Error ? err.message : String(err)}`)
@@ -82,6 +91,17 @@ export class ThreadSession {
       }, PATCH_INTERVAL_MS),
     }
     this.active = turn
+
+    // Pretty status labels for the tool-call subtitle. The wrench
+    // emoji nudges the UI to render a status-with-icon row under the
+    // typing cursor — e.g. "🔧 time.now". Strings short enough to fit
+    // alongside the cursor on a phone (~30 chars max).
+    const setStatus = async (status: string | null): Promise<void> => {
+      try { await this.deps.chat.patchMessage(placeholder.id, { streamingStatus: status }) }
+      catch (err) {
+        this.deps.log(`status patch failed: ${err instanceof Error ? err.message : String(err)}`)
+      }
+    }
 
     // Run the agent loop in-process. Same code path the legacy
     // `apes agents serve --rpc` subprocess used; we just call it
@@ -102,12 +122,15 @@ export class ThreadSession {
           },
           onToolCall: ({ name }) => {
             this.deps.log(`[${this.deps.roomId}/${this.deps.threadId.slice(0, 8)}] tool_call: ${name}`)
+            void setStatus(`🔧 ${name}`)
           },
           onToolResult: ({ name }) => {
             this.deps.log(`[${this.deps.roomId}/${this.deps.threadId.slice(0, 8)}] tool_result: ${name}`)
+            void setStatus(null)
           },
           onToolError: ({ name, error }) => {
             this.deps.log(`[${this.deps.roomId}/${this.deps.threadId.slice(0, 8)}] tool_error: ${name} → ${error}`)
+            void setStatus(null)
           },
         },
       })
@@ -123,19 +146,34 @@ export class ThreadSession {
       if (result.status === 'error') {
         this.deps.log(`runtime done with status=error (room=${this.deps.roomId} thread=${this.deps.threadId})`)
       }
-      this.endTurn()
+      await this.endTurn()
     }
     catch (err) {
       const message = err instanceof Error ? err.message : String(err)
       this.deps.log(`runtime error (room=${this.deps.roomId} thread=${this.deps.threadId}): ${message}`)
-      this.failTurn(`(runtime error: ${message})`)
+      await this.failTurn(`(runtime error: ${message})`)
     }
   }
 
-  private endTurn(): void {
+  /**
+   * Stream-end: flush any pending throttled body PATCH, then mark the
+   * message as no-longer-streaming. The combined call also triggers
+   * the user-facing push (the placeholder POST suppressed it).
+   */
+  private async endTurn(): Promise<void> {
     const turn = this.active
     if (!turn) return
     turn.throttle.flush()
+    try {
+      await this.deps.chat.patchMessage(turn.placeholderId, {
+        body: turn.accumulated || '(empty response)',
+        streaming: false,
+        streamingStatus: null,
+      })
+    }
+    catch (err) {
+      this.deps.log(`stream-end patch failed: ${err instanceof Error ? err.message : String(err)}`)
+    }
     this.active = undefined
     const next = this.queue.shift()
     if (next) {
@@ -143,11 +181,21 @@ export class ThreadSession {
     }
   }
 
-  private failTurn(message: string): void {
+  private async failTurn(message: string): Promise<void> {
     const turn = this.active
     if (!turn) return
     turn.accumulated = message
     turn.throttle.flush()
+    try {
+      await this.deps.chat.patchMessage(turn.placeholderId, {
+        body: message,
+        streaming: false,
+        streamingStatus: null,
+      })
+    }
+    catch (err) {
+      this.deps.log(`fail-turn patch failed: ${err instanceof Error ? err.message : String(err)}`)
+    }
     this.active = undefined
     const next = this.queue.shift()
     if (next) {

--- a/apps/openape-chat/app/components/MessageBubble.vue
+++ b/apps/openape-chat/app/components/MessageBubble.vue
@@ -9,6 +9,8 @@ interface Props {
     body: string
     createdAt: number
     editedAt: number | null
+    streaming?: boolean
+    streamingStatus?: string | null
   }
   reactions?: Array<{ emoji: string, count: number, mine: boolean }>
   myEmail?: string
@@ -21,6 +23,37 @@ const isMine = computed(() => props.myEmail && props.myEmail === props.message.s
 const time = computed(() =>
   new Date(props.message.createdAt * 1000).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
 )
+
+// Agent emails look like `igor30-cb6bf26a+patrick+hofmann_eco@id.openape.ai`.
+// We render only the human-readable agent name — everything before
+// `-<hash>+...@id.openape.ai`. Falls back to local-part for non-DDISA
+// addresses (humans, federated logins).
+const displayName = computed(() => {
+  const email = props.message.senderEmail
+  if (email.endsWith('@id.openape.ai') && email.includes('+')) {
+    // DDISA agent address: <name>-<ownerHash>+<owner-local>+<owner-domain>@<idp>
+    // → strip everything from the last '-' before '+' onwards.
+    const local = email.split('+')[0]!
+    const dash = local.lastIndexOf('-')
+    return dash > 0 ? local.slice(0, dash) : local
+  }
+  // Human / federated address — drop the @ part for the header chip.
+  return email.split('@')[0] ?? email
+})
+
+// Edit badge applies only when (a) the message isn't currently being
+// streamed and (b) the edit happened more than ~2s after creation.
+// The 2s window swallows the stream-end PATCH that lands within
+// milliseconds of the placeholder POST — without it every agent
+// message would still light up "(edited)" the moment streaming
+// flips false.
+const showEdited = computed(() => {
+  if (props.message.streaming) return false
+  if (!props.message.editedAt) return false
+  return props.message.editedAt - props.message.createdAt > 2
+})
+
+const isStreaming = computed(() => props.message.streaming === true)
 </script>
 
 <template>
@@ -29,19 +62,38 @@ const time = computed(() =>
     :class="isMine ? 'items-end' : 'items-start'"
   >
     <div class="text-xs text-zinc-500 px-1 flex items-center gap-1">
-      <span>{{ message.senderEmail }}</span>
+      <span class="font-medium text-zinc-300">{{ displayName }}</span>
       <span v-if="message.senderAct === 'agent'" title="agent">🤖</span>
       <span>·</span>
       <span>{{ time }}</span>
-      <span v-if="message.editedAt" class="italic">(edited)</span>
+      <span v-if="showEdited" class="italic">(edited)</span>
     </div>
     <div
       class="rounded-2xl px-3 py-2 text-sm whitespace-pre-wrap break-words max-w-[85%] md:max-w-prose"
-      :class="isMine
-        ? 'bg-primary-500 text-zinc-950 rounded-br-md'
-        : 'bg-zinc-800 text-zinc-100 rounded-bl-md'"
+      :class="[
+        isMine
+          ? 'bg-primary-500 text-zinc-950 rounded-br-md'
+          : 'bg-zinc-800 text-zinc-100 rounded-bl-md',
+        isStreaming && message.body.length === 0 ? 'min-w-12' : '',
+      ]"
     >
-      {{ message.body }}
+      <template v-if="message.body.length > 0">{{ message.body }}</template>
+      <!-- Empty + streaming = typing placeholder. The pulsing dots are
+           CSS-only so they keep animating even if the WS hiccups. -->
+      <span v-if="isStreaming && message.body.length === 0" class="inline-flex items-center gap-1">
+        <span class="size-1.5 rounded-full bg-zinc-400 animate-typing-dot" style="animation-delay: 0ms" />
+        <span class="size-1.5 rounded-full bg-zinc-400 animate-typing-dot" style="animation-delay: 200ms" />
+        <span class="size-1.5 rounded-full bg-zinc-400 animate-typing-dot" style="animation-delay: 400ms" />
+      </span>
+    </div>
+    <!-- Tool-call subtitle: only shown while streaming AND a status
+         was set by the bridge's onToolCall handler. Cleared on
+         onToolResult / onToolError or on stream-end. -->
+    <div
+      v-if="isStreaming && message.streamingStatus"
+      class="text-xs text-zinc-500 px-1 italic"
+    >
+      {{ message.streamingStatus }}
     </div>
     <div v-if="reactions && reactions.length" class="flex gap-1 px-1">
       <button
@@ -56,3 +108,14 @@ const time = computed(() =>
     </div>
   </div>
 </template>
+
+<style>
+@keyframes typing-dot {
+  0%, 60%, 100% { opacity: 0.3; transform: translateY(0); }
+  30% { opacity: 1; transform: translateY(-2px); }
+}
+.animate-typing-dot {
+  animation: typing-dot 1.2s ease-in-out infinite;
+  display: inline-block;
+}
+</style>

--- a/apps/openape-chat/app/composables/useChat.ts
+++ b/apps/openape-chat/app/composables/useChat.ts
@@ -9,6 +9,8 @@ interface Message {
   replyTo: string | null
   createdAt: number
   editedAt: number | null
+  streaming?: boolean
+  streamingStatus?: string | null
 }
 
 interface Reaction {

--- a/apps/openape-chat/app/pages/rooms/[id].vue
+++ b/apps/openape-chat/app/pages/rooms/[id].vue
@@ -11,6 +11,14 @@ interface Message {
   replyTo: string | null
   createdAt: number
   editedAt: number | null
+  // Agent-only: true while the bridge is mid-stream. Distinguishes
+  // "still being typed" from "fully posted, then later edited" so the
+  // (edited) badge doesn't fire on every token chunk.
+  streaming?: boolean
+  // Agent-only: ephemeral "what is the agent doing right now"
+  // (e.g. "🔧 time.now"). Rendered as a subtitle under the typing
+  // cursor; cleared when the tool finishes or streaming ends.
+  streamingStatus?: string | null
 }
 
 interface Reaction {

--- a/apps/openape-chat/server/api/messages/[id].patch.ts
+++ b/apps/openape-chat/server/api/messages/[id].patch.ts
@@ -3,10 +3,34 @@ import { z } from 'zod'
 import { useDb } from '../../database/drizzle'
 import { messages } from '../../database/schema'
 import { resolveCaller } from '../../utils/auth'
+import { notifyRoomMembers } from '../../utils/push'
 import { broadcastToRoom } from '../../utils/realtime'
 
+// PATCH /api/messages/:id covers three distinct write paths against the
+// same row, distinguished by the `streaming` field's current/incoming
+// value:
+//
+//   1. Bridge stream-tick (streaming stays true): body update from the
+//      chat-bridge as the LLM streams tokens. The agent's `body` grows
+//      monotonically. We do NOT bump `edited_at` — these aren't human
+//      edits, they're partial output of the in-flight turn.
+//   2. Bridge stream-end (streaming flips true → false): final flush
+//      from the bridge. The full body lands, streaming clears. Still
+//      no `edited_at` bump (the message was never "complete" until
+//      this PATCH; calling that an edit would be misleading).
+//   3. Human edit (streaming already false): the sender goes back and
+//      changes their own message. This bumps `edited_at` like before.
+//
+// Bridge also uses this endpoint to update `streaming_status` (a short
+// "what is the agent currently doing" label — e.g. "🔧 time.now") so
+// the UI can render a typing-subtitle without polluting the body.
 const bodySchema = z.object({
-  body: z.string().trim().min(1).max(10_000),
+  body: z.string().max(10_000).optional(),
+  // Bridge clears this on stream-end; humans never set it.
+  streaming: z.boolean().optional(),
+  // null clears the status (e.g. tool finished); a string sets it.
+  // Bridge writes; humans never read or set it.
+  streaming_status: z.string().max(200).nullable().optional(),
 })
 
 export default defineEventHandler(async (event) => {
@@ -18,6 +42,9 @@ export default defineEventHandler(async (event) => {
   if (!parsed.success) {
     throw createError({ statusCode: 400, statusMessage: parsed.error.message })
   }
+  if (parsed.data.body === undefined && parsed.data.streaming === undefined && parsed.data.streaming_status === undefined) {
+    throw createError({ statusCode: 400, statusMessage: 'no fields to update' })
+  }
 
   const db = useDb()
   const existing = await db.select().from(messages).where(eq(messages.id, id)).get()
@@ -28,13 +55,63 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 403, statusMessage: 'Can only edit own messages' })
   }
 
-  const editedAt = Math.floor(Date.now() / 1000)
-  await db
-    .update(messages)
-    .set({ body: parsed.data.body, editedAt })
-    .where(eq(messages.id, id))
+  // Reject body=empty unless the same call also keeps streaming=true
+  // (placeholder state). Otherwise empty body means "I want to clear
+  // the message", which we don't support — use a delete instead.
+  if (parsed.data.body !== undefined && parsed.data.body.length === 0) {
+    const willStayStreaming = (parsed.data.streaming ?? existing.streaming) === true
+    if (!willStayStreaming) {
+      throw createError({ statusCode: 400, statusMessage: 'body cannot be empty for completed messages' })
+    }
+  }
 
-  const updated = { ...existing, body: parsed.data.body, editedAt }
+  // streaming flag mutations: only agents may toggle. Humans can't set
+  // streaming=true on their own messages (that would skip edit-tracking).
+  const incomingStreaming = parsed.data.streaming
+  if (incomingStreaming !== undefined && caller.act !== 'agent') {
+    throw createError({ statusCode: 403, statusMessage: 'streaming flag is agent-only' })
+  }
+
+  // Decide whether this PATCH counts as a human edit (= bump edited_at).
+  // Path 1 + 2 (bridge stream tick / stream end) do NOT bump.
+  // Path 3 (human edit on a completed message) DOES bump.
+  const wasStreaming = existing.streaming === true
+  const willStream = incomingStreaming ?? existing.streaming
+  const isStreamingWrite = wasStreaming  // bridge is writing while message was in streaming state
+  const editedAt = isStreamingWrite ? existing.editedAt : Math.floor(Date.now() / 1000)
+
+  const updates: Record<string, unknown> = {}
+  if (parsed.data.body !== undefined) updates.body = parsed.data.body
+  if (incomingStreaming !== undefined) updates.streaming = willStream
+  if (parsed.data.streaming_status !== undefined) updates.streamingStatus = parsed.data.streaming_status
+  if (editedAt !== existing.editedAt) updates.editedAt = editedAt
+
+  await db.update(messages).set(updates).where(eq(messages.id, id))
+
+  const updated = {
+    ...existing,
+    ...(parsed.data.body !== undefined ? { body: parsed.data.body } : {}),
+    ...(incomingStreaming !== undefined ? { streaming: willStream } : {}),
+    ...(parsed.data.streaming_status !== undefined ? { streamingStatus: parsed.data.streaming_status } : {}),
+    editedAt,
+  }
+
   await broadcastToRoom(existing.roomId, { type: 'edit', room_id: existing.roomId, payload: updated })
+
+  // Push fan-out: only on stream-end (was streaming, now not). The
+  // initial POST suppresses push for streaming placeholders; this is
+  // the canonical "agent is done typing, ping the human" trigger.
+  // Skip for plain stream-tick patches and human edits.
+  const justFinishedStreaming = wasStreaming && willStream === false
+  if (justFinishedStreaming && updated.body && updated.body.length > 0) {
+    void notifyRoomMembers(existing.roomId, caller.email, {
+      title: caller.email,
+      body: updated.body.length > 140 ? `${updated.body.slice(0, 140)}…` : updated.body,
+      room_id: existing.roomId,
+      thread_id: existing.threadId ?? undefined,
+      sender: caller.email,
+    })
+  }
+
   return updated
 })

--- a/apps/openape-chat/server/api/rooms/[id]/messages.post.ts
+++ b/apps/openape-chat/server/api/rooms/[id]/messages.post.ts
@@ -9,12 +9,20 @@ import { broadcastToRoom } from '../../../utils/realtime'
 import { ensureMainThread, findThreadById } from '../../../utils/threads'
 
 const bodySchema = z.object({
-  body: z.string().trim().min(1).max(10_000),
+  // Empty body allowed only when `streaming: true` is set — the bridge
+  // posts a placeholder before the LLM has produced any tokens.
+  body: z.string().max(10_000),
   reply_to: z.string().uuid().optional(),
   // Optional in v1: when omitted, the message lands in the room's main
   // thread (auto-created on first use). Phase-B-aware clients pass the
   // active thread id explicitly.
   thread_id: z.string().uuid().optional(),
+  // Mark the message as "currently being streamed by the agent". The
+  // chat-bridge sets this when it posts the empty placeholder, then
+  // patches body+streaming=false on stream-end. While streaming=true
+  // the PATCH handler updates body without bumping edited_at, so the
+  // chat UI doesn't show "(edited)" on every chunk.
+  streaming: z.boolean().optional(),
 })
 
 export default defineEventHandler(async (event) => {
@@ -48,6 +56,15 @@ export default defineEventHandler(async (event) => {
     threadId = main.id
   }
 
+  // Streaming is only meaningful from the agent side. Humans don't
+  // partial-send messages, and allowing humans to set streaming=true
+  // would let them bypass edit-tracking on their own messages.
+  const streaming = parsed.data.streaming === true && caller.act === 'agent'
+
+  if (parsed.data.body.length === 0 && !streaming) {
+    throw createError({ statusCode: 400, statusMessage: 'body cannot be empty unless streaming=true' })
+  }
+
   const message = {
     id: randomUUID(),
     roomId: id,
@@ -58,6 +75,8 @@ export default defineEventHandler(async (event) => {
     replyTo: parsed.data.reply_to ?? null,
     createdAt: Math.floor(Date.now() / 1000),
     editedAt: null as number | null,
+    streaming,
+    streamingStatus: null as string | null,
   }
 
   const db = useDb()
@@ -68,13 +87,19 @@ export default defineEventHandler(async (event) => {
   // Web-Push fan-out for offline / installed clients. Best-effort and async
   // — we don't block the REST response on push delivery, and the helper
   // silently no-ops if VAPID isn't configured (dev environments).
-  void notifyRoomMembers(id, caller.email, {
-    title: caller.email,
-    body: parsed.data.body.length > 140 ? `${parsed.data.body.slice(0, 140)}…` : parsed.data.body,
-    room_id: id,
-    thread_id: threadId,
-    sender: caller.email,
-  })
+  //
+  // Don't push the placeholder while streaming — it's empty or "…" and
+  // would just bonk the device for nothing. The final PATCH (streaming
+  // → false) is responsible for triggering the user-visible push.
+  if (!streaming && parsed.data.body.length > 0) {
+    void notifyRoomMembers(id, caller.email, {
+      title: caller.email,
+      body: parsed.data.body.length > 140 ? `${parsed.data.body.slice(0, 140)}…` : parsed.data.body,
+      room_id: id,
+      thread_id: threadId,
+      sender: caller.email,
+    })
+  }
 
   return message
 })

--- a/apps/openape-chat/server/database/schema.ts
+++ b/apps/openape-chat/server/database/schema.ts
@@ -41,6 +41,21 @@ export const messages = sqliteTable('messages', {
   replyTo: text('reply_to'),
   createdAt: integer('created_at').notNull(),
   editedAt: integer('edited_at'),
+  // `streaming` is the agent-side counterpart to `edited_at`: the bridge
+  // posts an empty placeholder + streams chunks via PATCH while the LLM
+  // generates. We need to distinguish "live typing" from "human-edited
+  // after the fact" — without it every agent message would carry a noisy
+  // "(edited)" badge because each token chunk is a PATCH.
+  //
+  // While streaming=true the PATCH handler updates `body` without
+  // bumping `edited_at`. The final flush sets streaming=false; from
+  // that point on, normal edit semantics apply.
+  streaming: integer('streaming', { mode: 'boolean' }).notNull().default(false),
+  // Ephemeral "what is the agent doing right now" — set when a tool
+  // call starts, cleared when it completes. Surfaces in the chat UI as
+  // a subtitle under the typing cursor so the user sees "🔧 time.now"
+  // instead of an opaque pause. Cleared on streaming=false.
+  streamingStatus: text('streaming_status'),
 })
 
 // Phase B: parallel sessions inside a single 1:1 contact (= room).

--- a/apps/openape-chat/server/plugins/02.database.ts
+++ b/apps/openape-chat/server/plugins/02.database.ts
@@ -47,6 +47,15 @@ export default defineNitroPlugin(async () => {
     catch {
       // Already added in a prior boot — sqlite throws on duplicate column.
     }
+    // Streaming-aware messages — separates "agent live-typing" (chunked
+    // PATCHes that arrive while the LLM is mid-completion) from "human
+    // edited after the fact". Without this, every agent message shows
+    // "(edited)" because the chat-bridge's stream-throttle PATCHes the
+    // body once per ~300ms while text_delta events stream in.
+    try { await db.run(sql`ALTER TABLE messages ADD COLUMN streaming INTEGER NOT NULL DEFAULT 0`) }
+    catch { /* column exists */ }
+    try { await db.run(sql`ALTER TABLE messages ADD COLUMN streaming_status TEXT`) }
+    catch { /* column exists */ }
     await db.run(sql`CREATE INDEX IF NOT EXISTS idx_messages_room_created ON messages(room_id, created_at)`)
     await db.run(sql`CREATE INDEX IF NOT EXISTS idx_messages_thread_created ON messages(thread_id, created_at)`)
 

--- a/apps/openape-chat/tests/schema.test.ts
+++ b/apps/openape-chat/tests/schema.test.ts
@@ -18,7 +18,7 @@ beforeEach(async () => {
 
   await db.run(sql`CREATE TABLE rooms (id TEXT PRIMARY KEY, name TEXT NOT NULL, kind TEXT NOT NULL, created_by_email TEXT NOT NULL, created_at INTEGER NOT NULL)`)
   await db.run(sql`CREATE TABLE memberships (room_id TEXT NOT NULL, user_email TEXT NOT NULL, role TEXT NOT NULL DEFAULT 'member', joined_at INTEGER NOT NULL, PRIMARY KEY (room_id, user_email))`)
-  await db.run(sql`CREATE TABLE messages (id TEXT PRIMARY KEY, room_id TEXT NOT NULL, thread_id TEXT, sender_email TEXT NOT NULL, sender_act TEXT NOT NULL, body TEXT NOT NULL, reply_to TEXT, created_at INTEGER NOT NULL, edited_at INTEGER)`)
+  await db.run(sql`CREATE TABLE messages (id TEXT PRIMARY KEY, room_id TEXT NOT NULL, thread_id TEXT, sender_email TEXT NOT NULL, sender_act TEXT NOT NULL, body TEXT NOT NULL, reply_to TEXT, created_at INTEGER NOT NULL, edited_at INTEGER, streaming INTEGER NOT NULL DEFAULT 0, streaming_status TEXT)`)
   await db.run(sql`CREATE TABLE reactions (message_id TEXT NOT NULL, user_email TEXT NOT NULL, emoji TEXT NOT NULL, created_at INTEGER NOT NULL, PRIMARY KEY (message_id, user_email, emoji))`)
   await db.run(sql`CREATE TABLE push_subscriptions (endpoint TEXT PRIMARY KEY, user_email TEXT NOT NULL, p256dh TEXT NOT NULL, auth TEXT NOT NULL, created_at INTEGER NOT NULL)`)
   await db.run(sql`CREATE TABLE threads (id TEXT PRIMARY KEY, room_id TEXT NOT NULL, name TEXT NOT NULL, created_by_email TEXT NOT NULL, created_at INTEGER NOT NULL, archived_at INTEGER)`)


### PR DESCRIPTION
## Why
Patrick on iPhone screenshot: every agent reply ended with \`(edited)\`. Root cause: bridge posts a \`…\` placeholder and PATCHes body each ~300ms while LLM tokens stream — each PATCH bumped \`edited_at\`. Plus there's no signal *what* the agent does during tool calls — user just sees \`…\` hang.

This PR bundles 3 polish items into one coherent chunk because they all touch the same message model:

1. **Streaming flag** separated from \`edited_at\`
2. **Display name** extraction from DDISA agent emails (\`igor30-cb6bf26a+patrick+hofmann_eco@id.openape.ai\` → \`igor30 🤖\`)
3. **Tool-call visibility** via \`streaming_status\` rendered as italic subtitle under typing cursor

## What changed

### Schema
- \`messages.streaming INTEGER NOT NULL DEFAULT 0\`
- \`messages.streaming_status TEXT\`
- Idempotent ALTERs in \`02.database.ts\`

### API
- **POST /api/rooms/:id/messages** accepts \`{ streaming: boolean }\` from agent senders only; permits empty body when streaming; suppresses push fan-out for placeholders.
- **PATCH /api/messages/:id** is now 3 paths: stream-tick (body update, no edited_at bump), stream-end (\`streaming: false\` + final body, triggers push), or human-edit (existing behavior on completed messages).

### Bridge (\`thread-session.ts\`)
- POST empty placeholder with \`streaming: true\`
- Throttled body PATCHes during stream (no empty-body PATCHes — wait for first token)
- \`onToolCall\` → PATCH \`streamingStatus: \"🔧 time.now\"\`
- \`onToolResult\` / \`onToolError\` → PATCH \`streamingStatus: null\`
- Stream-end / fail-turn → PATCH \`streaming: false\` + final body

### UI (\`MessageBubble.vue\`)
- Empty + streaming = pure-CSS 3-dot typing cursor with stagger animation
- \`streamingStatus\` rendered as italic subtitle under the cursor
- \`(edited)\` badge only when edit landed >2s after creation (swallows the stream-end PATCH)
- Display name extracted from DDISA email shape — header chip now reads \`igor30\` + 🤖 instead of the full \`agent+name+ownerdomain@idp\` URL

## Test plan
- [x] Build + lint + typecheck + tests green (16 turbo tasks)
- [x] Schema test updated with new columns
- [ ] After deploy + bridge upgrade:
  - [ ] Send \"Wie spät ist es?\" to igor30 → see typing cursor pulse → see \`🔧 time.now\` subtitle → see final response without (edited) badge
  - [ ] Edit my own message 5s later → (edited) badge appears (human-edit path still works)
  - [ ] Open chat on another device that's not focused → push notification fires once on stream-end (not 300ms × N times)