### PR TITLE
fix(nuxt-auth-sp): configurable post-login redirect (troop landed on /dashboard 404)

### DIFF
--- a/.changeset/nuxt-auth-sp-post-login-redirect.md
+++ b/.changeset/nuxt-auth-sp-post-login-redirect.md
@@ -1,0 +1,7 @@
+---
+"@openape/nuxt-auth-sp": minor
+---
+
+`nuxt-auth-sp` hardcoded `/dashboard` as the post-login destination in two places (server-side OIDC callback + client-side already-signed-in fast-path). That assumption fits openape-chat (which has a `/dashboard.vue`) but breaks openape-troop (which doesn't — its root is the agent list at `/`). Users completing OIDC at id.openape.ai landed on a 404.
+
+Both paths now read from a new `openapeSp.postLoginRedirect` module option (default `/dashboard` for back-compat). The `<OpenApeAuth>` component takes a matching `post-login-redirect` prop so SPs can wire the client-side fast-path explicitly. troop's nuxt.config + login.vue now point to `/`.

--- a/apps/openape-troop/app/pages/login.vue
+++ b/apps/openape-troop/app/pages/login.vue
@@ -18,6 +18,7 @@ useSeoMeta({ title: 'Sign in' })
             title="Sign in to Troop"
             subtitle="Enter your email to manage your agents"
             button-text="Continue"
+            post-login-redirect="/"
           />
         </UCard>
       </div>

--- a/apps/openape-troop/nuxt.config.ts
+++ b/apps/openape-troop/nuxt.config.ts
@@ -50,6 +50,10 @@ export default defineNuxtConfig({
     sessionSecret: process.env.NUXT_OPENAPE_SP_SESSION_SECRET || 'change-me-troop-secret-at-least-32-chars-long',
     openapeUrl: process.env.NUXT_OPENAPE_URL ?? '',
     fallbackIdpUrl: process.env.NUXT_OPENAPE_SP_FALLBACK_IDP_URL || 'https://id.openape.ai',
+    // troop's root page is the agent list — there's no /dashboard.
+    // Without this the SP module's default would 404 after every
+    // successful OIDC callback.
+    postLoginRedirect: '/',
   },
 
   runtimeConfig: {

--- a/modules/nuxt-auth-sp/src/module.ts
+++ b/modules/nuxt-auth-sp/src/module.ts
@@ -55,6 +55,15 @@ export interface ModuleOptions {
   openapeUrl: string
   fallbackIdpUrl: string
   routes: boolean
+  /**
+   * Where to send the user after a successful login (in `OpenApeAuth.vue`'s
+   * already-logged-in onMounted check + after the OIDC callback exchange).
+   * Path is treated as same-origin; full URLs are valid for off-site
+   * redirects. Default: `/dashboard` (back-compat for openape-chat which
+   * has that page; troop, which doesn't, overrides to `/`).
+   * Env: `NUXT_OPENAPE_SP_POST_LOGIN_REDIRECT`.
+   */
+  postLoginRedirect: string
   manifest?: ManifestConfig
 }
 
@@ -73,6 +82,7 @@ export default defineNuxtModule<ModuleOptions>({
     openapeUrl: '',
     fallbackIdpUrl: 'https://id.openape.at',
     routes: true,
+    postLoginRedirect: '/dashboard',
   },
   setup(options, nuxt) {
     const { resolve } = createResolver(import.meta.url)

--- a/modules/nuxt-auth-sp/src/runtime/components/OpenApeAuth.vue
+++ b/modules/nuxt-auth-sp/src/runtime/components/OpenApeAuth.vue
@@ -3,11 +3,19 @@ import { onMounted, ref } from 'vue'
 import { navigateTo, useOpenApeAuth, useRoute } from '#imports'
 import { DEFAULT_OAUTH_ERROR_MESSAGES } from '../composables/useOpenApeOAuthError'
 
-defineProps({
+const props = defineProps({
   title: { type: String, required: false, default: 'Sign in' },
   subtitle: { type: String, required: false, default: 'Enter your email to continue' },
   buttonText: { type: String, required: false, default: 'Continue' },
   placeholder: { type: String, required: false, default: 'you@example.com' },
+  /**
+   * Where to navigate when the user is already signed in (the
+   * onMounted fast-path). Server-side OIDC callback uses its own
+   * config (`openapeSp.postLoginRedirect`); this prop is just the
+   * client-side equivalent so SPs without a `/dashboard` page
+   * (e.g. troop) don't 404 on re-visit while signed in.
+   */
+  postLoginRedirect: { type: String, required: false, default: '/dashboard' },
 })
 const emit = defineEmits(['error'])
 const { user, loading, fetchUser, login } = useOpenApeAuth()
@@ -18,7 +26,7 @@ const route = useRoute()
 onMounted(async () => {
   await fetchUser()
   if (user.value) {
-    navigateTo('/dashboard')
+    navigateTo(props.postLoginRedirect)
   }
   if (typeof route.query.error === 'string' && route.query.error) {
     const code = route.query.error

--- a/modules/nuxt-auth-sp/src/runtime/server/api/callback.get.ts
+++ b/modules/nuxt-auth-sp/src/runtime/server/api/callback.get.ts
@@ -41,7 +41,13 @@ export default defineEventHandler(async (event) => {
       authorizationDetails: result.authorizationDetails,
     })
 
-    return sendRedirect(event, '/dashboard')
+    // Where to land after a successful login. SPs override via the
+    // `openapeSp.postLoginRedirect` module option (default `/dashboard`
+    // for back-compat). Keeping a single source of truth here so
+    // `OpenApeAuth.vue`'s already-logged-in fast-path and the callback
+    // exit agree on the destination.
+    const { postLoginRedirect } = getSpConfig()
+    return sendRedirect(event, postLoginRedirect || '/dashboard')
   }
   catch (err: unknown) {
     clearFlowState(event)

--- a/modules/nuxt-auth-sp/src/runtime/server/utils/sp-config.ts
+++ b/modules/nuxt-auth-sp/src/runtime/server/utils/sp-config.ts
@@ -7,11 +7,22 @@ const FLOW_COOKIE = 'openape-flow'
 
 export function getSpConfig() {
   const config = useRuntimeConfig()
+  // The module's auto-generated runtime-config type doesn't always
+  // reflect new fields immediately during standalone typecheck of
+  // this module (a consumer-side `nuxi prepare` is what regenerates
+  // it). Cast to a forward-compatible shape so this file builds in
+  // isolation as well — at runtime the defu in module.ts always
+  // populates these.
+  const sp = config.openapeSp as unknown as Record<string, string | undefined>
   return {
-    clientId: (config.openapeSp.clientId || 'sp.example.com').trim(),
-    openapeUrl: (config.openapeSp.openapeUrl || '').trim(),
-    spName: (config.openapeSp.spName || 'OpenApe Service Provider').trim(),
-    fallbackIdpUrl: (config.openapeSp.fallbackIdpUrl || 'https://id.openape.at').trim(),
+    clientId: (sp.clientId || 'sp.example.com').trim(),
+    openapeUrl: (sp.openapeUrl || '').trim(),
+    spName: (sp.spName || 'OpenApe Service Provider').trim(),
+    fallbackIdpUrl: (sp.fallbackIdpUrl || 'https://id.openape.at').trim(),
+    // Default `/dashboard` matches the original hardcoded value so
+    // existing SPs (chat) keep working. troop overrides to `/` via
+    // its nuxt.config — see `openapeSp.postLoginRedirect`.
+    postLoginRedirect: (sp.postLoginRedirect || '/dashboard').trim(),
   }
 }
 


### PR DESCRIPTION
## Why
Patrick: \"redirect uri bei troop ist scheinbar https://troop.openape.ai/dashboard — die gibt es gar nicht\"

Root cause: \`nuxt-auth-sp\` hardcoded \`/dashboard\` in two places:
- \`server/api/callback.get.ts:44\` — sendRedirect after OIDC token exchange
- \`components/OpenApeAuth.vue:21\` — onMounted fast-path when user is already signed in

That assumption fits openape-chat (has a /dashboard.vue) but breaks openape-troop (root is the agent list at /). Anyone completing OIDC for troop landed on a 404.

## What changed
- **Module option**: new \`openapeSp.postLoginRedirect: string\` (default \`/dashboard\` — back-compat)
- **Server**: \`callback.get.ts\` reads it via \`getSpConfig()\`
- **Component**: \`<OpenApeAuth>\` takes a matching \`post-login-redirect\` prop
- **troop**: \`nuxt.config.ts\` sets \`postLoginRedirect: '/'\` + \`login.vue\` passes the prop to \`<OpenApeAuth>\`

Chat unaffected (uses default).

## Test plan
- [x] Lint + typecheck + tests green (14 turbo tasks)
- [ ] After deploy: sign out of troop, sign in → land at / (agent list), not /dashboard
- [ ] Sign out of chat, sign in → land at /dashboard (back-compat works)