### PR TITLE
feat: nest ↔ troop control-plane (WS push + remote spawn)

### DIFF
--- a/.claude/plans/nest-troop-ws.md
+++ b/.claude/plans/nest-troop-ws.md
@@ -165,11 +165,11 @@ Auth-Handshake (auf `wss://troop.openape.ai/api/nest-ws?token=…`):
 
 ## Progress
 
-- [ ] `[YYYY-MM-DD HH:MM]` Milestone 1: WS-Endpoint in troop + Echo-Test
-- [ ] `[YYYY-MM-DD HH:MM]` Milestone 2: Nest WS-client mit reconnect
-- [ ] `[YYYY-MM-DD HH:MM]` Milestone 3: Config-update push-flow
-- [ ] `[YYYY-MM-DD HH:MM]` Milestone 4: Spawn-intent flow + UI
-- [ ] `[YYYY-MM-DD HH:MM]` Milestone 5: Online-Badge + Status-API
+- [x] `[2026-05-12]` Milestone 1: WS-Endpoint in troop + Echo-Test — `server/routes/api/nest-ws.ts` + nest-registry + spawn-intents + 11 unit tests
+- [x] `[2026-05-12]` Milestone 2: Nest WS-client mit reconnect — `src/lib/troop-ws.ts` wired into nest's index.ts
+- [x] `[2026-05-12]` Milestone 3: Config-update push-flow — PATCH/PUT/DELETE handlers broadcastToOwner; nest re-syncs via `apes run --as <name> -- apes agents sync`
+- [x] `[2026-05-12]` Milestone 4: Spawn-intent flow + UI — `/api/agents/spawn-intent` POST + `/api/agents/spawn-intent/:id` GET + `SpawnAgentDialog.vue` + "+ Spawn agent" CTA on agents-index
+- [x] `[2026-05-12]` Milestone 5: Online-Badge + Status-API — `/api/nest/hosts` GET + ● live / ○ poll badge on agent-detail header
 
 ## Surprises & Discoveries
 

--- a/.claude/plans/nest-troop-ws.md
+++ b/.claude/plans/nest-troop-ws.md
@@ -1,0 +1,200 @@
+# Plan: Nest ↔ Troop WebSocket Control-Plane
+
+> Self-contained. Future-Patrick (or another agent) reads this top-to-bottom and produces a working result without any prior context.
+
+## Purpose / Big Picture
+
+- **Ziel:** Owner ändert in der troop UI eine Agent-Konfiguration (system prompt, tools, skills, SOUL) oder klickt „Spawn new agent" — der lokale Nest-Daemon auf dem Mac führt den Change in unter einer Sekunde aus statt nach max. 5 min sync poll. Spawn-Operationen lösen weiterhin den DDISA-Grant-Cycle aus (Push an Patrick's iPhone), aber die *Auslösung* kommt jetzt von troop.
+- **Kontext:** Heute pollen Bridges alle 5 min `apes agents sync`. Edits in troop landen also mit bis zu 5 min Verzögerung beim Agent. Spawning erfordert physischen Zugriff auf den Mac (`apes nest spawn`). Beides ist friction für den 2026-Workflow „Patrick am iPhone, Mac im Schrank".
+- **Scope:**
+  - **Drin:** Persistenter WebSocket Nest → troop, Frame-Protokoll mit `config-update` und `spawn-intent`, in-memory Connection-Registry in troop, „Online"-Badge + „Spawn"-Wizard in troop UI, automatische `apes agents sync` Trigger beim config-update.
+  - **Nicht drin:** Cross-Region/Cross-Tenant deployment, Mehrfach-Owner-Approval (DDISA delegation grants existieren schon, nicht Teil dieses Plans), Persistente Nest-Host Registry in troop DB (kann später kommen), Edge-Polling-Tuning („Polina") — 5min poll bleibt als Cold-Path-Fallback unverändert.
+
+## Repo-Orientierung
+
+- **Projekt:** `openape-monorepo` unter `~/Companies/private/repos/openape/openape-monorepo/`
+- **Relevante Module:**
+  - `apps/openape-nest/src/index.ts` — Nest daemon entry, schon long-running CLIENT-only
+  - `apps/openape-nest/src/lib/pm2-supervisor.ts` — managed bridges
+  - `apps/openape-nest/src/lib/troop-sync.ts` — existing 5min poll (bleibt als fallback)
+  - `apps/openape-troop/server/routes/api/ws.ts` — existiert nicht; das ist neu
+  - `apps/openape-chat/server/routes/api/ws.ts` — funktionierende WS-Vorlage (auth, ping, registerPeer, close-cleanup, focus-frame parsing)
+  - `apps/openape-troop/server/api/agents/[name].patch.ts` — wo PATCH-Hook für config-update broadcast kommt
+  - `apps/openape-troop/server/api/agents/[name]/skills/*.ts` — gleicher Hook für skill changes
+  - `apps/openape-troop/app/pages/agents/[name].vue` — wo „online"-badge gerendert wird
+  - `apps/openape-troop/app/pages/index.vue` — wo „Spawn new agent" CTA hin sollte
+  - `packages/cli-auth/` — Token-refresh pattern den nest weiter benutzt
+- **Tech-Stack:** Nuxt 4 (troop), nitro WebSocket via crossws, Node 22 daemon (nest), drizzle-orm. Auth via DDISA JWTs aus `~/.config/apes/auth.json` (nest) und SP-session-cookies (troop UI).
+- **Dev-Setup:**
+  - Troop dev: `pnpm --filter @openape/troop dev` (Port 3010)
+  - Nest dev: `apps/openape-nest` hat kein dev-server — geht über `node .output/server/index.mjs` oder pm2 in production. Für Test: `node apps/openape-nest/dist/index.mjs --once`
+  - Beide CI-grün via `pnpm turbo run build lint typecheck test --filter='./apps/openape-nest' --filter='./apps/openape-troop'`
+
+## Frame-Protokoll
+
+```ts
+// nest → troop
+type NestHello   = { type: 'hello', host_id: string, hostname: string, version: string }
+type NestHeartbeat = { type: 'heartbeat' }
+type NestSpawnResult = { type: 'spawn-result', intent_id: string, ok: boolean, agent_email?: string, error?: string }
+
+// troop → nest
+type TroopConfigUpdate = { type: 'config-update', agent_email: string }  // nest re-syncs the named agent
+type TroopSpawnIntent  = { type: 'spawn-intent', intent_id: string, name: string, bridge: { key?: string, base_url?: string, model?: string }, soul?: string, skills?: Array<{name,description,body}> }
+type TroopDestroyIntent = { type: 'destroy-intent', intent_id: string, name: string }   // Phase-2, nicht im MVP
+type TroopReload = { type: 'reload-bridge', name: string }
+```
+
+Auth-Handshake (auf `wss://troop.openape.ai/api/nest-ws?token=…`):
+- Token = DDISA-JWT mit `act: human` aus `~/.config/apes/auth.json` (owner-bearer), gleiches Pattern wie chat-bridge → chat
+- Troop verifiziert via JWKS, extrahiert `sub = ownerEmail`
+- Connection-Registry-Key: `(ownerEmail, host_id aus hello frame)` — host-id wird gegen pinned-id pro owner geprüft (analog zu `agents.host_id` pinning)
+
+## Milestones
+
+### Milestone 1: WS-Endpoint in troop + Echo-Test
+
+**Ziel:** Nest kann WS aufbauen, troop antwortet mit hello-ack. Kein Business-Logic.
+
+**Schritte:**
+1. Create `apps/openape-troop/server/routes/api/nest-ws.ts` modeled after `apps/openape-chat/server/routes/api/ws.ts`:
+   - JWKS-based JWT verify (use `@openape/core`'s `createRemoteJWKS` + `verifyJWT`, point at `id.openape.ai/.well-known/jwks.json`)
+   - On open: re-verify token from `peer.request.url`, extract `sub` as ownerEmail. Reject with 1008 if `act !== 'human'`.
+   - On hello frame: store `(ownerEmail, host_id, peer)` in a `Map<string, NestPeer>`, key by `${ownerEmail}::${host_id}`
+   - On close: remove from registry
+   - For now: log received frames to console, echo back `{ type: 'ack' }`
+2. New helper: `apps/openape-troop/server/utils/nest-registry.ts` — `getNestPeer(email, host)`, `setNestPeer(...)`, `forEachOwnerPeer(email, fn)`
+3. New `pnpm vitest` test: spawn a mock WS client, connect with a valid mock JWT, send hello, expect ack — basic protocol contract test.
+
+**Akzeptanzkriterien:**
+- [ ] `pnpm turbo run test --filter='./apps/openape-troop'` enthält neuen `nest-ws.test.ts`, alle grün
+- [ ] Lokal via `wscat -c 'ws://localhost:3010/api/nest-ws?token=…'` → empfange `hello`, sende `{"type":"hello","host_id":"test","hostname":"test","version":"0"}` → bekomme `{"type":"ack"}`
+
+**Rollback:** Branch verwerfen, der Endpoint ist additiv.
+
+### Milestone 2: Nest WS-client mit reconnect
+
+**Ziel:** Nest baut beim Boot eine WS-Verbindung zu troop auf und hält sie offen. Sendet hello, sendet 30s heartbeats. Reconnect bei Disconnect mit exponentiellem Backoff (1s → 30s).
+
+**Schritte:**
+1. Create `apps/openape-nest/src/lib/troop-ws.ts`:
+   - Reads token via `@openape/cli-auth`'s `ensureFreshIdpAuth()` (same pattern as bridge.ts)
+   - Connects to `wss://troop.openape.ai/api/nest-ws?token=…`
+   - On open: send `hello` (with `host_id` from IOPlatformUUID + hostname from `os.hostname()` + `version` from package.json)
+   - 30s heartbeat ping; close after 90s of no pong (server-pong is browser/crossws default)
+   - On close: `scheduleReconnect()` with expo backoff
+   - Frame router: stub handlers for `config-update`, `spawn-intent` (just log for now, no-op execution)
+2. Wire into `apps/openape-nest/src/index.ts` — start the WS-client alongside pm2-supervisor + troop-sync
+3. New `apps/openape-nest/test/troop-ws.test.ts`: mock WS server, expect hello+heartbeat sequence
+
+**Akzeptanzkriterien:**
+- [ ] `pnpm turbo run test --filter='./apps/openape-nest'` grün, neuer test included
+- [ ] In troop's nest-registry log appears: `nest connected: patrick@hofmann.eco / Mac-mini-von-Patrick.fritz.box`
+- [ ] Kill troop process → nest log zeigt reconnect attempts mit expo backoff
+- [ ] Restart troop → nest reconnected within 30s
+
+**Rollback:** Disable WS-client in nest's index.ts; existing 5min-poll remains functional.
+
+### Milestone 3: Config-update push-flow
+
+**Ziel:** Owner saved system-prompt/tools/skills/soul change in troop UI → nest empfängt config-update über WS → nest triggert `apes agents sync` für den betroffenen Agent (YOLO-allowed, kein push-prompt) → bridge sieht neue agent.json beim nächsten Thread.
+
+**Schritte:**
+1. Troop PATCH-handlers (`apps/openape-troop/server/api/agents/[name].patch.ts` + skills index.put.ts + [skillName].delete.ts) hooken nach erfolgreicher DB-write: `forEachOwnerPeer(ownerEmail, peer => peer.send({type:'config-update', agent_email}))`
+2. Nest WS-client (`troop-ws.ts`) frame-router: bei `config-update` → spawn `apes agents sync` als den Agent (`apes run --as <name> -- apes agents sync`). Reuse YOLO-policy `apes agents sync` so kein Patrick-prompt.
+3. Sync schreibt agent.json + SOUL.md + skills/*/SKILL.md auf disk. Bridge liest pro Thread eh frisch → instant.
+
+**Akzeptanzkriterien:**
+- [ ] In troop UI: tools toggle bei igor30 → reload-Befehl in nest log innerhalb 1s
+- [ ] On agent host: `cat /var/openape/homes/igor30/.openape/agent/agent.json` zeigt neue tools binnen ~5s (sync wall-clock)
+- [ ] Neue chat-message an igor30 → bridge sieht die neuen tools (verifizierbar via tool_call log oder durch tool-spezifische Anfrage)
+
+**Rollback:** Entferne die `forEachOwnerPeer`-Aufrufe aus den PATCH-handlers — config-changes propagieren wieder nur über den 5min-poll.
+
+### Milestone 4: Spawn-intent flow + UI
+
+**Ziel:** Owner klickt „+ Spawn agent" in troop UI → Wizard mit Name, Bridge-Key, Base-URL, Model, optional SOUL.md / Skills → POST `/api/agents/spawn-intent` → troop pushed intent über WS an nest → nest führt `apes agents spawn` aus → DDISA-grant push an Patrick → er approved → spawn fertig, troop UI flippt auf „✓ spawned".
+
+**Schritte:**
+1. New troop API endpoint `apps/openape-troop/server/api/agents/spawn-intent.post.ts`:
+   - Owner-only (requireOwner)
+   - Validates body (name regex, optional bridge config)
+   - Picks first online nest for owner (multi-mac wizard kommt später)
+   - Generates `intent_id` UUID, stores intent in `pendingIntents: Map<id, { resolve, reject, timeout }>` mit 5min timeout
+   - Sends `spawn-intent` frame, returns `{ intent_id }`
+2. Nest frame-router handler for `spawn-intent`:
+   - Validates frame
+   - Runs `apes agents spawn <name> --bridge-key … --bridge-base-url … --bridge-model …` via execFile
+   - On success: send `spawn-result` `{ intent_id, ok: true, agent_email }`
+   - On error: send `spawn-result` `{ intent_id, ok: false, error }`
+3. Troop WS-server receives `spawn-result`, resolves the pending intent in `pendingIntents`
+4. Endpoint returns the resolved result to the UI via a follow-up GET `/api/agents/spawn-intent/<id>` (or via polling, or via streaming — keep it simple with polling every 2s)
+5. UI:
+   - New component `apps/openape-troop/app/components/SpawnAgentDialog.vue` — form + submit + poll loop until result
+   - „+ Spawn agent" CTA on `pages/index.vue`
+
+**Akzeptanzkriterien:**
+- [ ] In troop UI: click „Spawn agent" → form → submit → Patrick's iPhone bekommt push für DDISA-grant approval
+- [ ] After approval: troop UI shows „✓ spawned: <name>" within 60s
+- [ ] `apes agents list` on the mac includes the new agent
+
+**Rollback:** Hide UI button, keep endpoint inactive — old `apes nest spawn` CLI path bleibt funktional.
+
+### Milestone 5: Online-Badge + Status-API
+
+**Ziel:** Troop UI zeigt pro Agent-Detail-Seite einen Online/Offline-Status („nest connected" / „nest offline — 5min poll fallback").
+
+**Schritte:**
+1. New endpoint `GET /api/nest/hosts` (owner-only): returns array of `{ host_id, hostname, last_seen_at, version }` from in-memory nest-registry
+2. Agent-detail page (`pages/agents/[name].vue`) polls `/api/nest/hosts` every 30s, renders a small badge: green dot + „live (host)" or gray dot + „polling (offline)"
+
+**Akzeptanzkriterien:**
+- [ ] Open troop /agents/igor30 → green „live" badge visible
+- [ ] Kill nest process on Mac → within 30s the badge flips to gray „polling"
+- [ ] Restart nest → green again
+
+**Rollback:** Hide badge — purely cosmetic.
+
+### (Optional) Prototyping-Milestone
+
+> Bei Unsicherheit über WS-auth-handshake mit JWKS in nitro/crossws context: 30min Spike.
+
+**Ziel:** Verify dass `peer.request.url` in nitro's crossws handler den `?token=` Query-Param trägt und JWKS verify in dem Context funktioniert.
+**Vorgehen:** Replicate apps/openape-chat/server/routes/api/ws.ts wireup, log peer.request.url, manual wscat connect.
+**Ergebnis:** Token-Pfad bestätigt, Milestone 1 unblocked.
+
+## Progress
+
+- [ ] `[YYYY-MM-DD HH:MM]` Milestone 1: WS-Endpoint in troop + Echo-Test
+- [ ] `[YYYY-MM-DD HH:MM]` Milestone 2: Nest WS-client mit reconnect
+- [ ] `[YYYY-MM-DD HH:MM]` Milestone 3: Config-update push-flow
+- [ ] `[YYYY-MM-DD HH:MM]` Milestone 4: Spawn-intent flow + UI
+- [ ] `[YYYY-MM-DD HH:MM]` Milestone 5: Online-Badge + Status-API
+
+## Surprises & Discoveries
+
+(Wird beim Implementieren laufend gefüllt — z.B. wenn crossws ein anderes peer-API hat als chat's WS handler annimmt.)
+
+## Decision Log
+
+| Datum | Entscheidung | Begründung | Alternativen verworfen |
+|-------|-------------|------------|----------------------|
+| 2026-05-12 | WS-Auth via DDISA-Bearer (owner-token aus `~/.config/apes/auth.json`), gleiches Pattern wie chat-bridge → chat | Bekanntes funktionierendes Pattern, kein neues auth-surface | Per-Mac SSH-key signature (komplexer, kein benefit); separate API-key (yet-another credential to manage) |
+| 2026-05-12 | Connection-Registry in-memory only (Map), keine DB-tabelle | Nests reconnecten auto, kein Persistence-Need. Cross-region später wird eigene Story | DB-table `nest_hosts`: overkill für aktuellen scope |
+| 2026-05-12 | Config-update Trigger ist nur `agent_email` (kein diff im frame) | Idempotent, einfacher, nest macht eh ein vollständiges sync. Auch besser für race-conditions bei mehreren rapid changes | Frame mit kompletten payload: doppelte source-of-truth, schwerer zu validieren |
+| 2026-05-12 | Spawn-intent via polling der intent-id, nicht via streaming response | Einfacher UI-State, kein streaming-WS-fanout zum browser, ~60s wall-clock akzeptabel | SSE/streaming response: mehr code, marginaler UX-win |
+| 2026-05-12 | 5min troop-sync bleibt aktiv parallel zur WS | Cold-path-fallback wenn WS down (Mac sleeping, network flaky). Kein duplicate-write-risk weil sync idempotent | WS-only: zu fragil für edge-conditions |
+
+## Session-Checkliste
+
+1. Plan lesen, Progress-Section prüfen
+2. `git log --oneline -10` seit letztem commit
+3. Dev-server: `pnpm --filter @openape/troop dev` (port 3010) + lokal nest gebaut (`pnpm --filter @openape/nest build`)
+4. Baseline: hit `http://localhost:3010/` → troop login funktioniert; nest läuft ohne errors
+5. Nächsten offenen Milestone identifizieren, dann implementieren
+6. Nach jedem Milestone committen + Akzeptanzkriterien e2e prüfen (UI im Browser, WS via wscat, fs-zustand via `apes run --as`)
+7. Progress + Discoveries aktualisieren
+
+## Outcomes & Retrospective
+
+(Erst nach Abschluss aller Milestones ausfüllen.)

--- a/apps/openape-nest/package.json
+++ b/apps/openape-nest/package.json
@@ -26,11 +26,13 @@
   "dependencies": {
     "@openape/cli-auth": "workspace:*",
     "@openape/core": "workspace:*",
-    "ofetch": "^1.4.1"
+    "ofetch": "^1.4.1",
+    "ws": "^8.18.0"
   },
   "devDependencies": {
     "@antfu/eslint-config": "catalog:",
     "@types/node": "catalog:",
+    "@types/ws": "^8.5.13",
     "eslint": "catalog:",
     "tsup": "catalog:",
     "typescript": "catalog:",

--- a/apps/openape-nest/src/index.ts
+++ b/apps/openape-nest/src/index.ts
@@ -25,6 +25,7 @@ import process from 'node:process'
 import { listAgents, REGISTRY_PATH } from './lib/registry'
 import { Pm2Supervisor } from './lib/pm2-supervisor'
 import { TroopSync } from './lib/troop-sync'
+import { readNestVersion, TroopWs } from './lib/troop-ws'
 
 const APES_BIN = process.env.OPENAPE_APES_BIN ?? 'apes'
 const RECONCILE_DEBOUNCE_MS = 1000
@@ -35,6 +36,7 @@ function log(line: string): void {
 
 const supervisor = new Pm2Supervisor({ apesBin: APES_BIN, log })
 const troopSync = new TroopSync({ apesBin: APES_BIN, log })
+const troopWs = new TroopWs({ apesBin: APES_BIN, log, version: readNestVersion() })
 
 async function reconcile(): Promise<void> {
   try {
@@ -48,6 +50,7 @@ async function reconcile(): Promise<void> {
 
 void reconcile()
 troopSync.start()
+troopWs.start()
 
 // Watch the registry file for changes. fs.watch fires once per
 // "something happened" — debounce with a small timer because some
@@ -69,6 +72,7 @@ catch (err) {
 process.on('SIGTERM', () => {
   log('nest: SIGTERM — stopping')
   troopSync.stop()
+  troopWs.stop()
   if (reconcileTimer) clearTimeout(reconcileTimer)
   process.exit(0)
 })
@@ -76,6 +80,7 @@ process.on('SIGTERM', () => {
 process.on('SIGINT', () => {
   log('nest: SIGINT — stopping')
   troopSync.stop()
+  troopWs.stop()
   if (reconcileTimer) clearTimeout(reconcileTimer)
   process.exit(0)
 })

--- a/apps/openape-nest/src/lib/troop-ws.ts
+++ b/apps/openape-nest/src/lib/troop-ws.ts
@@ -1,0 +1,312 @@
+// WebSocket client to the troop control-plane endpoint
+// (`wss://troop.openape.ai/api/nest-ws`). Connects on boot, keeps the
+// connection alive with 30s heartbeats, reconnects with exponential
+// backoff when troop disappears, and routes inbound frames to the
+// right handler:
+//
+//   config-update { agent_email }   → re-sync the named agent
+//                                     (`apes run --as <name> -- apes agents sync`).
+//                                     YOLO-allowed, no Patrick-prompt.
+//   spawn-intent  { intent_id, ... } → run `apes agents spawn …` and
+//                                     report success/failure back via
+//                                     `spawn-result` (this is the only
+//                                     intent type that triggers a DDISA
+//                                     push to Patrick's iPhone — the
+//                                     usual grant cycle).
+//   reload-bridge { name }          → pm2 reload openape-bridge-<name>,
+//                                     no sync (used after manual
+//                                     agent.json edits in rare cases).
+//
+// The 5-min `troop-sync.ts` polling loop stays running in parallel as
+// a cold-path fallback for whenever the WS connection is down (Mac
+// sleeping, troop deploying, flaky network).
+
+import { execFile, execFileSync } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import { readFileSync } from 'node:fs'
+import { hostname, networkInterfaces } from 'node:os'
+import { ensureFreshIdpAuth, NotLoggedInError } from '@openape/cli-auth'
+import WebSocket from 'ws'
+
+const HEARTBEAT_INTERVAL_MS = 30_000
+const RECONNECT_BASE_MS = 1_000
+const RECONNECT_MAX_MS = 30_000
+
+interface SpawnIntentFrame {
+  type: 'spawn-intent'
+  intent_id: string
+  name: string
+  bridge?: { key?: string, base_url?: string, model?: string }
+  soul?: string
+  skills?: Array<{ name: string, description: string, body: string }>
+}
+
+interface ConfigUpdateFrame {
+  type: 'config-update'
+  agent_email: string
+}
+
+interface ReloadBridgeFrame {
+  type: 'reload-bridge'
+  name: string
+}
+
+type InboundFrame = SpawnIntentFrame | ConfigUpdateFrame | ReloadBridgeFrame | { type: string }
+
+export interface TroopWsOptions {
+  /** Default: `wss://troop.openape.ai`. Override via env `OPENAPE_TROOP_WS_URL`. */
+  troopUrl?: string
+  apesBin: string
+  log: (line: string) => void
+  /** package.json version of @openape/nest — surfaces in the troop UI's
+   *  online-badge tooltip and in audit logs. */
+  version?: string
+}
+
+export class TroopWs {
+  private socket: WebSocket | null = null
+  private heartbeatTimer: NodeJS.Timeout | null = null
+  private reconnectTimer: NodeJS.Timeout | null = null
+  private reconnectAttempts = 0
+  private stopped = false
+  private readonly troopUrl: string
+  private readonly hostId: string
+  private readonly hostname: string
+
+  constructor(private opts: TroopWsOptions) {
+    this.troopUrl = (opts.troopUrl ?? process.env.OPENAPE_TROOP_WS_URL ?? 'wss://troop.openape.ai').replace(/\/$/, '')
+    this.hostId = readHostId()
+    this.hostname = hostname()
+  }
+
+  start(): void {
+    this.stopped = false
+    void this.connect()
+  }
+
+  stop(): void {
+    this.stopped = true
+    if (this.reconnectTimer) clearTimeout(this.reconnectTimer)
+    if (this.heartbeatTimer) clearInterval(this.heartbeatTimer)
+    this.reconnectTimer = null
+    this.heartbeatTimer = null
+    if (this.socket) {
+      try { this.socket.close() }
+      catch { /* already closed */ }
+      this.socket = null
+    }
+  }
+
+  private async connect(): Promise<void> {
+    if (this.stopped) return
+    let token: string
+    try {
+      const auth = await ensureFreshIdpAuth()
+      token = auth.access_token
+    }
+    catch (err) {
+      if (err instanceof NotLoggedInError) {
+        this.opts.log('troop-ws: not logged in (apes login) — skip connect, will retry')
+      }
+      else {
+        this.opts.log(`troop-ws: auth refresh failed: ${err instanceof Error ? err.message : String(err)}`)
+      }
+      this.scheduleReconnect()
+      return
+    }
+
+    const url = `${this.troopUrl}/api/nest-ws?token=${encodeURIComponent(token)}`
+    const ws = new WebSocket(url)
+    this.socket = ws
+
+    ws.on('open', () => {
+      this.reconnectAttempts = 0
+      this.opts.log(`troop-ws: connected to ${this.troopUrl}`)
+      ws.send(JSON.stringify({
+        type: 'hello',
+        host_id: this.hostId,
+        hostname: this.hostname,
+        version: this.opts.version ?? 'unknown',
+      }))
+      this.heartbeatTimer = setInterval(() => {
+        try { ws.send(JSON.stringify({ type: 'heartbeat' })) }
+        catch { /* socket closed mid-tick; close handler will reconnect */ }
+      }, HEARTBEAT_INTERVAL_MS)
+    })
+
+    ws.on('message', (data: WebSocket.RawData) => {
+      const text = typeof data === 'string'
+        ? data
+        : Buffer.isBuffer(data) ? data.toString('utf8') : ''
+      if (!text) return
+      let frame: InboundFrame
+      try { frame = JSON.parse(text) as InboundFrame }
+      catch { return }
+      this.handleFrame(frame).catch((err) => {
+        this.opts.log(`troop-ws: frame handler error: ${err instanceof Error ? err.message : String(err)}`)
+      })
+    })
+
+    ws.on('close', (code, reason) => {
+      this.opts.log(`troop-ws: disconnected (${code}${reason.length > 0 ? ` ${reason.toString()}` : ''}) — reconnecting`)
+      if (this.heartbeatTimer) {
+        clearInterval(this.heartbeatTimer)
+        this.heartbeatTimer = null
+      }
+      this.socket = null
+      this.scheduleReconnect()
+    })
+
+    ws.on('error', (err) => {
+      this.opts.log(`troop-ws: socket error: ${err.message}`)
+      // close handler also fires; let it schedule the reconnect.
+    })
+  }
+
+  private scheduleReconnect(): void {
+    if (this.stopped) return
+    if (this.reconnectTimer) return
+    const attempt = Math.min(this.reconnectAttempts, 5)
+    this.reconnectAttempts++
+    const delay = Math.min(RECONNECT_BASE_MS * 2 ** attempt, RECONNECT_MAX_MS)
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null
+      void this.connect()
+    }, delay)
+  }
+
+  private async handleFrame(frame: InboundFrame): Promise<void> {
+    if (frame.type === 'welcome') {
+      // ack from troop after auth — nothing to do.
+      return
+    }
+    if (frame.type === 'ack') {
+      // server-ack for hello frame — nothing to do.
+      return
+    }
+    if (frame.type === 'config-update') {
+      await this.handleConfigUpdate(frame as ConfigUpdateFrame)
+      return
+    }
+    if (frame.type === 'spawn-intent') {
+      await this.handleSpawnIntent(frame as SpawnIntentFrame)
+      return
+    }
+    if (frame.type === 'reload-bridge') {
+      await this.handleReloadBridge(frame as ReloadBridgeFrame)
+    }
+    // Unknown frame types: ignore. Forward-compat for future troop
+    // versions that send frames an older nest doesn't recognize.
+  }
+
+  private async handleConfigUpdate(frame: ConfigUpdateFrame): Promise<void> {
+    // Map agent_email → local agent slug (the part before '+'/'-'-hash).
+    // We use the same convention agents/sync.ts has: `<name>-<hash>+<owner-local>+<owner-domain>@<idp>`.
+    const local = frame.agent_email.split('+')[0]
+    if (!local) return
+    const dash = local.lastIndexOf('-')
+    const name = dash > 0 ? local.slice(0, dash) : local
+    this.opts.log(`troop-ws: config-update for ${name} — running sync`)
+    await this.runApes(['run', '--as', name, '--wait', '--', 'apes', 'agents', 'sync'], `config-update sync ${name}`)
+  }
+
+  private async handleSpawnIntent(frame: SpawnIntentFrame): Promise<void> {
+    this.opts.log(`troop-ws: spawn-intent ${frame.name} (intent ${frame.intent_id})`)
+    const args = ['agents', 'spawn', frame.name]
+    if (frame.bridge?.key) args.push('--bridge-key', frame.bridge.key)
+    if (frame.bridge?.base_url) args.push('--bridge-base-url', frame.bridge.base_url)
+    if (frame.bridge?.model) args.push('--bridge-model', frame.bridge.model)
+    try {
+      const { stdout } = await runWithCapture(this.opts.apesBin, args)
+      // Parse the spawned agent email out of the spawn output line:
+      //   "✔ Registered as <email>"
+      const match = stdout.match(/Registered as\s+(\S+@\S+)/)
+      const agentEmail = match?.[1]
+      this.send({ type: 'spawn-result', intent_id: frame.intent_id, ok: true, agent_email: agentEmail })
+    }
+    catch (err) {
+      const error = err instanceof Error ? err.message : String(err)
+      this.send({ type: 'spawn-result', intent_id: frame.intent_id, ok: false, error })
+    }
+  }
+
+  private async handleReloadBridge(frame: ReloadBridgeFrame): Promise<void> {
+    this.opts.log(`troop-ws: reload-bridge ${frame.name}`)
+    await this.runApes(
+      ['run', '--as', frame.name, '--wait', '--', 'pm2', 'reload', `openape-bridge-${frame.name}`, '--update-env'],
+      `reload-bridge ${frame.name}`,
+    )
+  }
+
+  private async runApes(args: string[], label: string): Promise<void> {
+    try { await runWithCapture(this.opts.apesBin, args) }
+    catch (err) {
+      this.opts.log(`troop-ws: ${label} failed: ${err instanceof Error ? err.message : String(err)}`)
+    }
+  }
+
+  private send(frame: Record<string, unknown>): void {
+    const ws = this.socket
+    if (!ws || ws.readyState !== WebSocket.OPEN) return
+    try { ws.send(JSON.stringify(frame)) }
+    catch (err) {
+      this.opts.log(`troop-ws: send failed: ${err instanceof Error ? err.message : String(err)}`)
+    }
+  }
+}
+
+function runWithCapture(bin: string, args: string[]): Promise<{ stdout: string, stderr: string }> {
+  return new Promise((resolve, reject) => {
+    execFile(bin, args, { maxBuffer: 4 * 1024 * 1024 }, (err, stdout, stderr) => {
+      if (err) {
+        const msg = stderr.toString() || err.message
+        reject(new Error(msg.split('\n').filter(Boolean).slice(-3).join(' / ')))
+        return
+      }
+      resolve({ stdout: stdout.toString(), stderr: stderr.toString() })
+    })
+  })
+}
+
+/**
+ * Stable per-host identifier. On macOS we read `IOPlatformUUID` via
+ * ioreg if available (same source `apes agents sync` pins on). As a
+ * portable fallback we hash MAC addresses + hostname — gives a stable
+ * value across boots on Linux/CI without requiring elevated privs.
+ */
+function readHostId(): string {
+  try {
+    if (process.platform === 'darwin') {
+      const out = execFileSync('/usr/sbin/ioreg', ['-d2', '-c', 'IOPlatformExpertDevice'], { encoding: 'utf8' })
+      const match = out.match(/"IOPlatformUUID"\s*=\s*"([^"]+)"/)
+      if (match) return match[1]!
+    }
+  }
+  catch { /* fall through to hash-based id */ }
+  return hashBasedHostId()
+}
+
+function hashBasedHostId(): string {
+  const nics = networkInterfaces()
+  const macs: string[] = []
+  for (const list of Object.values(nics)) {
+    if (!list) continue
+    for (const nic of list) {
+      if (!nic.mac || nic.mac === '00:00:00:00:00:00' || nic.internal) continue
+      macs.push(nic.mac)
+    }
+  }
+  const seed = `${hostname()}|${macs.toSorted().join(',')}`
+  return createHash('sha256').update(seed).digest('hex').slice(0, 32)
+}
+
+// Read this package's version once at boot. Falls back to 'unknown'
+// when the dist/ layout puts package.json out of reach (tests).
+export function readNestVersion(): string {
+  try {
+    const root = new URL('../../package.json', import.meta.url)
+    const pkg = JSON.parse(readFileSync(root, 'utf8'))
+    return typeof pkg.version === 'string' ? pkg.version : 'unknown'
+  }
+  catch { return 'unknown' }
+}

--- a/apps/openape-nest/tsconfig.json
+++ b/apps/openape-nest/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2022",
+    "target": "ES2023",
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "strict": true,

--- a/apps/openape-troop/app/components/SpawnAgentDialog.vue
+++ b/apps/openape-troop/app/components/SpawnAgentDialog.vue
@@ -1,0 +1,192 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+
+interface NestHost {
+  host_id: string
+  hostname: string
+  version: string
+  last_seen_at: number
+}
+
+const open = defineModel<boolean>('open', { default: false })
+
+const hosts = ref<NestHost[]>([])
+const hostsError = ref('')
+const loadingHosts = ref(false)
+
+async function loadHosts() {
+  loadingHosts.value = true
+  hostsError.value = ''
+  try { hosts.value = await ($fetch as any)('/api/nest/hosts') }
+  catch (err: any) {
+    hostsError.value = err?.data?.statusMessage || err?.message || 'failed to load nest hosts'
+  }
+  finally {
+    loadingHosts.value = false
+  }
+}
+
+watch(open, (now) => { if (now) loadHosts() })
+
+// Reset form whenever the dialog opens. We don't pre-fill from the
+// previous spawn — names are unique per owner so reusing would
+// guarantee a 409 anyway, and the bridge config is per-agent.
+const form = ref({
+  name: '',
+  host_id: '',
+  bridge_key: '',
+  bridge_base_url: '',
+  bridge_model: '',
+})
+const submitting = ref(false)
+const intentId = ref('')
+const result = ref<null | { ok: boolean, agent_email?: string, error?: string }>(null)
+const pollTimer = ref<ReturnType<typeof setTimeout> | null>(null)
+
+watch(open, (now) => {
+  if (!now) return
+  form.value = { name: '', host_id: '', bridge_key: '', bridge_base_url: '', bridge_model: '' }
+  intentId.value = ''
+  result.value = null
+})
+
+const canSubmit = computed(() =>
+  !submitting.value
+  && !intentId.value
+  && form.value.name.length > 0
+  && /^[a-z][a-z0-9-]{0,23}$/.test(form.value.name)
+  && hosts.value.length > 0,
+)
+
+async function submit() {
+  if (!canSubmit.value) return
+  submitting.value = true
+  try {
+    const body: Record<string, string> = { name: form.value.name }
+    if (form.value.host_id) body.host_id = form.value.host_id
+    if (form.value.bridge_key) body.bridge_key = form.value.bridge_key
+    if (form.value.bridge_base_url) body.bridge_base_url = form.value.bridge_base_url
+    if (form.value.bridge_model) body.bridge_model = form.value.bridge_model
+    const res = await ($fetch as any)('/api/agents/spawn-intent', { method: 'POST', body })
+    intentId.value = res.intent_id
+    pollResult()
+  }
+  catch (err: any) {
+    result.value = { ok: false, error: err?.data?.statusMessage || err?.message || 'spawn failed' }
+  }
+  finally {
+    submitting.value = false
+  }
+}
+
+async function pollResult() {
+  if (!intentId.value) return
+  try {
+    const res = await ($fetch as any)(`/api/agents/spawn-intent/${intentId.value}`)
+    if (res.pending) {
+      // Patrick is still on the approve-grant screen on his iPhone.
+      // Re-check in 2s. The intent map auto-prunes after 30min so we
+      // don't poll forever — but the UI dialog will close on dismiss.
+      pollTimer.value = setTimeout(pollResult, 2000)
+      return
+    }
+    result.value = { ok: res.ok, agent_email: res.agent_email, error: res.error }
+  }
+  catch (err: any) {
+    result.value = { ok: false, error: err?.data?.statusMessage || err?.message || 'poll failed' }
+  }
+}
+
+function close() {
+  if (pollTimer.value) clearTimeout(pollTimer.value)
+  pollTimer.value = null
+  open.value = false
+}
+</script>
+
+<template>
+  <UModal v-model:open="open">
+    <template #content>
+      <div class="p-5 space-y-4">
+        <div class="flex items-start justify-between gap-3">
+          <div>
+            <h3 class="text-lg font-semibold">
+              Spawn agent
+            </h3>
+            <p class="text-xs text-muted">
+              Runs <code>apes agents spawn</code> on the selected Mac. You'll get a DDISA grant request on your iPhone — approve to complete.
+            </p>
+          </div>
+          <UButton variant="ghost" size="sm" icon="i-lucide-x" :disabled="submitting" @click="close" />
+        </div>
+
+        <UAlert v-if="hostsError" color="error" :title="hostsError" />
+        <UAlert
+          v-else-if="!loadingHosts && hosts.length === 0"
+          color="warning"
+          title="No connected nest"
+          description="Start the nest daemon on a Mac (apes nest install + run) and refresh. The legacy `apes nest spawn` CLI path still works as a fallback."
+        />
+
+        <UFormField v-if="hosts.length > 1" label="Host" description="You have multiple Macs connected — pick the one to spawn on.">
+          <USelect
+            v-model="form.host_id"
+            :items="hosts.map(h => ({ label: `${h.hostname} (${h.version})`, value: h.host_id }))"
+            :disabled="!!intentId"
+          />
+        </UFormField>
+
+        <UFormField label="Name" description="lowercase, [a-z0-9-], max 24 chars">
+          <UInput v-model="form.name" placeholder="igor31" :disabled="!!intentId" />
+        </UFormField>
+
+        <details class="text-xs text-muted">
+          <summary class="cursor-pointer select-none">
+            Bridge overrides (optional)
+          </summary>
+          <div class="space-y-3 mt-3">
+            <UFormField label="LITELLM_API_KEY" description="Defaults to ~/litellm/.env on the host.">
+              <UInput v-model="form.bridge_key" type="password" placeholder="sk-… or token" :disabled="!!intentId" />
+            </UFormField>
+            <UFormField label="LITELLM_BASE_URL" description="Defaults to http://127.0.0.1:4000/v1">
+              <UInput v-model="form.bridge_base_url" placeholder="https://iurio.headwai.org/openai" :disabled="!!intentId" />
+            </UFormField>
+            <UFormField label="APE_CHAT_BRIDGE_MODEL" description="Required by the bridge at runtime.">
+              <UInput v-model="form.bridge_model" placeholder="gpt-5.4" :disabled="!!intentId" />
+            </UFormField>
+          </div>
+        </details>
+
+        <div v-if="intentId && !result" class="rounded border border-amber-500/40 bg-amber-500/10 p-3 text-sm flex items-start gap-2">
+          <UIcon name="i-lucide-loader-circle" class="animate-spin shrink-0 size-4 mt-0.5" />
+          <div>
+            <div class="font-medium">
+              Waiting for DDISA approval…
+            </div>
+            <div class="text-xs text-muted mt-1">
+              Check your iPhone — Patrick approves the as=root grant in the OpenApe app. This dialog updates automatically when the spawn completes.
+            </div>
+          </div>
+        </div>
+
+        <UAlert v-if="result?.ok" color="success" :title="`Spawned: ${result.agent_email ?? form.name}`" />
+        <UAlert v-if="result && !result.ok" color="error" title="Spawn failed" :description="result.error" />
+
+        <div class="flex justify-end gap-2">
+          <UButton variant="ghost" :disabled="submitting" @click="close">
+            {{ result?.ok ? 'Close' : 'Cancel' }}
+          </UButton>
+          <UButton
+            v-if="!result?.ok"
+            color="primary"
+            :loading="submitting"
+            :disabled="!canSubmit"
+            @click="submit"
+          >
+            Spawn
+          </UButton>
+        </div>
+      </div>
+    </template>
+  </UModal>
+</template>

--- a/apps/openape-troop/app/pages/agents/[name].vue
+++ b/apps/openape-troop/app/pages/agents/[name].vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useOpenApeAuth } from '#imports'
 
 const route = useRoute()
@@ -79,6 +79,30 @@ async function load() {
 
 watch(user, (u) => { if (u) load() }, { immediate: true })
 onMounted(() => { if (!user.value) navigateTo('/login') })
+
+// Live-nest indicator. Polls /api/nest/hosts every 30s. If any
+// connected nest covers this owner's hosts, the agent is on a
+// host that propagates config-updates over WS instead of the 5min
+// poll. Pure UX surface — never gates any action.
+interface NestHost { host_id: string, hostname: string, version: string, last_seen_at: number }
+const nestHosts = ref<NestHost[]>([])
+let nestHostsTimer: ReturnType<typeof setInterval> | null = null
+async function loadNestHosts() {
+  try { nestHosts.value = await ($fetch as any)('/api/nest/hosts') }
+  catch { /* badge silently falls back to "offline" */ }
+}
+onMounted(() => {
+  void loadNestHosts()
+  nestHostsTimer = setInterval(loadNestHosts, 30_000)
+})
+onBeforeUnmount(() => { if (nestHostsTimer) clearInterval(nestHostsTimer) })
+
+const nestOnline = computed(() => nestHosts.value.length > 0)
+const nestLabel = computed(() => {
+  if (!nestOnline.value) return 'nest offline — falling back to 5min poll'
+  const names = nestHosts.value.map(h => h.hostname).join(', ')
+  return `live · ${names}`
+})
 
 // Agent-level system prompt editor — saved on blur via PATCH
 // /api/agents/[name]. The bridge daemon re-reads agent.json on every
@@ -372,6 +396,13 @@ const statusColor: Record<Run['status'], string> = { running: 'info', ok: 'succe
       </UButton>
       <span v-if="detail" class="font-mono font-semibold truncate flex-1">
         🦍 {{ detail.agent.agentName }}
+      </span>
+      <span
+        class="text-xs px-2 py-0.5 rounded-full whitespace-nowrap"
+        :class="nestOnline ? 'text-emerald-400 bg-emerald-500/10' : 'text-zinc-500 bg-zinc-800/50'"
+        :title="nestLabel"
+      >
+        {{ nestOnline ? '● live' : '○ poll' }}
       </span>
     </header>
 

--- a/apps/openape-troop/app/pages/agents/index.vue
+++ b/apps/openape-troop/app/pages/agents/index.vue
@@ -24,6 +24,7 @@ interface AgentRow {
 const agents = ref<AgentRow[]>([])
 const loading = ref(true)
 const error = ref('')
+const showSpawn = ref(false)
 
 async function load() {
   loading.value = true
@@ -78,16 +79,27 @@ const statusColor: Record<NonNullable<AgentRow['lastRunStatus']>, string> = {
           Troop
         </h1>
       </div>
-      <UButton
-        variant="ghost"
-        size="sm"
-        icon="i-lucide-log-out"
-        :ui="{ base: 'shrink-0' }"
-        @click="logout"
-      >
-        <span class="hidden sm:inline">Logout</span>
-      </UButton>
+      <div class="flex items-center gap-2 shrink-0">
+        <UButton
+          color="primary"
+          size="sm"
+          icon="i-lucide-plus"
+          @click="showSpawn = true"
+        >
+          <span class="hidden sm:inline">Spawn agent</span>
+        </UButton>
+        <UButton
+          variant="ghost"
+          size="sm"
+          icon="i-lucide-log-out"
+          :ui="{ base: 'shrink-0' }"
+          @click="logout"
+        >
+          <span class="hidden sm:inline">Logout</span>
+        </UButton>
+      </div>
     </header>
+    <SpawnAgentDialog v-model:open="showSpawn" @update:open="(v) => { if (!v) load() }" />
 
     <main class="px-4 sm:px-6 py-6 max-w-5xl mx-auto">
       <h2 class="text-2xl font-bold mb-1">

--- a/apps/openape-troop/nuxt.config.ts
+++ b/apps/openape-troop/nuxt.config.ts
@@ -3,7 +3,13 @@ export default defineNuxtConfig({
   // asyncContext is required for `useEvent()` to resolve in Vercel
   // Serverless and is good practice on traditional servers too — see
   // openape-monorepo MEMORY.md for the gotcha.
-  nitro: { experimental: { asyncContext: true } },
+  // websocket: true enables the crossws WS server, required for the
+  // /api/nest-ws control-plane endpoint that lets local nest daemons
+  // push instant config-updates + receive spawn-intents (see
+  // .claude/plans/nest-troop-ws.md). asyncContext stays on for
+  // useEvent()-based session lookups in PATCH handlers that hook
+  // the broadcast on the way out.
+  nitro: { experimental: { asyncContext: true, websocket: true } },
   modules: ['@nuxt/ui', '@openape/nuxt-auth-sp'],
   css: ['~/assets/css/main.css'],
   devtools: { enabled: true },

--- a/apps/openape-troop/server/api/agents/[name].patch.ts
+++ b/apps/openape-troop/server/api/agents/[name].patch.ts
@@ -4,6 +4,7 @@ import toolCatalog from '../../tool-catalog.json'
 import { useDb } from '../../database/drizzle'
 import { agents } from '../../database/schema'
 import { requireOwner } from '../../utils/auth'
+import { broadcastToOwner } from '../../utils/nest-registry'
 
 const KNOWN_TOOL_NAMES = new Set<string>(
   (toolCatalog as { tools: Array<{ name: string }> }).tools.map(t => t.name),
@@ -56,5 +57,19 @@ export default defineEventHandler(async (event) => {
   if (result.length === 0) {
     throw createError({ statusCode: 404, statusMessage: 'agent not found' })
   }
-  return result[0]
+
+  // Fan-out: any connected nest for this owner gets a config-update
+  // ping carrying the agent's email. The nest re-syncs the named
+  // agent (`apes agents sync` as <name>, YOLO-allowed, no
+  // grant-prompt) which writes fresh agent.json + SOUL.md + skills
+  // to disk within ~1s. Bridge picks them up on the next thread.
+  // Zero connected nests → silent no-op; the legacy 5-min poll is
+  // still running and will catch up at the next tick.
+  const agent = result[0]!
+  broadcastToOwner(agent.ownerEmail, {
+    type: 'config-update',
+    agent_email: agent.email,
+  })
+
+  return agent
 })

--- a/apps/openape-troop/server/api/agents/[name]/skills/[skillName].delete.ts
+++ b/apps/openape-troop/server/api/agents/[name]/skills/[skillName].delete.ts
@@ -2,6 +2,7 @@ import { and, eq } from 'drizzle-orm'
 import { useDb } from '../../../../database/drizzle'
 import { agents, agentSkills } from '../../../../database/schema'
 import { requireOwner } from '../../../../utils/auth'
+import { broadcastToOwner } from '../../../../utils/nest-registry'
 
 // Delete a skill (hard delete — to "soft disable" use PUT with
 // `enabled: false`). After the next sync the agent host's
@@ -31,5 +32,10 @@ export default defineEventHandler(async (event) => {
   if (deleted.length === 0) {
     throw createError({ statusCode: 404, statusMessage: 'skill not found' })
   }
+  broadcastToOwner(owner.toLowerCase(), {
+    type: 'config-update',
+    agent_email: agent.email,
+  })
+
   return { ok: true, name: deleted[0]!.name }
 })

--- a/apps/openape-troop/server/api/agents/[name]/skills/index.put.ts
+++ b/apps/openape-troop/server/api/agents/[name]/skills/index.put.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import { useDb } from '../../../../database/drizzle'
 import { agents, agentSkills } from '../../../../database/schema'
 import { requireOwner } from '../../../../utils/auth'
+import { broadcastToOwner } from '../../../../utils/nest-registry'
 
 // Upsert a skill — name is the natural key (per agent). Body is the
 // full SKILL.md content the agent will land on disk after sync, so
@@ -65,5 +66,10 @@ export default defineEventHandler(async (event) => {
       updatedAt: now,
     })
   }
+  broadcastToOwner(owner.toLowerCase(), {
+    type: 'config-update',
+    agent_email: agent.email,
+  })
+
   return { ok: true, name: parsed.data.name }
 })

--- a/apps/openape-troop/server/api/agents/spawn-intent.post.ts
+++ b/apps/openape-troop/server/api/agents/spawn-intent.post.ts
@@ -1,0 +1,72 @@
+import { randomUUID } from 'node:crypto'
+import { z } from 'zod'
+import { listNestPeersForOwner } from '../../utils/nest-registry'
+import { createSpawnIntent } from '../../utils/spawn-intents'
+import { requireOwner } from '../../utils/auth'
+
+// POST /api/agents/spawn-intent — owner-side request to spawn a new
+// agent on one of their connected Macs. Returns immediately with
+// an intent_id; the actual spawn runs on the nest, gated by the
+// usual DDISA-grant approval flow (Patrick taps Approve on iPhone).
+//
+// The endpoint doesn't hold the HTTP connection open for that window
+// (could be minutes if Patrick is away from his phone). The UI polls
+// `/api/agents/spawn-intent/:id` until result lands, or until the
+// owner gives up — the intent map auto-prunes after 30min either way.
+
+const AGENT_NAME_REGEX = /^[a-z][a-z0-9-]{0,23}$/
+
+const bodySchema = z.object({
+  name: z.string().regex(AGENT_NAME_REGEX, 'name must match /^[a-z][a-z0-9-]{0,23}$/'),
+  // Optional: if the owner has multiple Macs connected, pick one.
+  // Omitted = first connected nest.
+  host_id: z.string().optional(),
+  bridge_key: z.string().optional(),
+  bridge_base_url: z.string().url().optional(),
+  bridge_model: z.string().optional(),
+})
+
+export default defineEventHandler(async (event) => {
+  const owner = await requireOwner(event)
+  const parsed = bodySchema.safeParse(await readBody(event))
+  if (!parsed.success) {
+    throw createError({ statusCode: 400, statusMessage: parsed.error.issues[0]?.message ?? 'invalid body' })
+  }
+
+  const peers = listNestPeersForOwner(owner)
+  if (peers.length === 0) {
+    throw createError({
+      statusCode: 503,
+      statusMessage: 'no connected nest — make sure the nest daemon is running on the host where you want this agent. The legacy `apes nest spawn` CLI path still works as a fallback.',
+    })
+  }
+  const target = parsed.data.host_id
+    ? peers.find(p => p.hostId === parsed.data.host_id)
+    : peers[0]
+  if (!target) {
+    throw createError({ statusCode: 404, statusMessage: `no nest found for host_id ${parsed.data.host_id}` })
+  }
+
+  const intentId = randomUUID()
+  createSpawnIntent(intentId)
+
+  const ok = target.send({
+    type: 'spawn-intent',
+    intent_id: intentId,
+    name: parsed.data.name,
+    bridge: {
+      key: parsed.data.bridge_key,
+      base_url: parsed.data.bridge_base_url,
+      model: parsed.data.bridge_model,
+    },
+  })
+  if (!ok) {
+    throw createError({ statusCode: 503, statusMessage: 'nest dropped before intent was delivered — retry in a few seconds' })
+  }
+
+  return {
+    intent_id: intentId,
+    host_id: target.hostId,
+    hostname: target.hostname,
+  }
+})

--- a/apps/openape-troop/server/api/agents/spawn-intent/[id].get.ts
+++ b/apps/openape-troop/server/api/agents/spawn-intent/[id].get.ts
@@ -1,0 +1,33 @@
+import { getSpawnIntent } from '../../../utils/spawn-intents'
+import { requireOwner } from '../../../utils/auth'
+
+// GET /api/agents/spawn-intent/:id — UI polls this every ~2s after
+// posting a spawn-intent. Three possible response shapes:
+//
+//   200 { pending: true }                       — nest hasn't replied yet
+//   200 { pending: false, ok: true,  agent_email }  — spawn succeeded
+//   200 { pending: false, ok: false, error }    — nest reported failure
+//   404                                         — unknown intent (pruned)
+//
+// Auth: owner-only. We don't bind intents to owner-email server-side
+// (the in-memory map is keyed only by uuid), so any owner asking
+// after their *own* intent-id will hit a record they themselves
+// created milliseconds earlier. Cross-owner leakage is bounded by
+// the unguessable UUID, but tightening this with an owner-bound map
+// is a quick follow-up once we add a second owner.
+export default defineEventHandler(async (event) => {
+  await requireOwner(event)
+  const id = getRouterParam(event, 'id')
+  if (!id) throw createError({ statusCode: 400, statusMessage: 'missing intent id' })
+
+  const intent = getSpawnIntent(id)
+  if (!intent) throw createError({ statusCode: 404, statusMessage: 'intent not found' })
+
+  if (!intent.result) return { pending: true }
+  return {
+    pending: false,
+    ok: intent.result.ok,
+    agent_email: intent.result.agentEmail,
+    error: intent.result.error,
+  }
+})

--- a/apps/openape-troop/server/api/nest/hosts.get.ts
+++ b/apps/openape-troop/server/api/nest/hosts.get.ts
@@ -1,0 +1,17 @@
+import { listNestPeersForOwner } from '../../utils/nest-registry'
+import { requireOwner } from '../../utils/auth'
+
+// GET /api/nest/hosts — return the owner's currently-connected
+// nest daemons. UI uses this for the live-status badge on each
+// agent-detail page ("● live: Mac-mini-von-Patrick" vs
+// "○ polling — nest offline"), and for the host-picker in the
+// spawn-agent dialog when the owner has multiple connected Macs.
+export default defineEventHandler(async (event) => {
+  const owner = await requireOwner(event)
+  return listNestPeersForOwner(owner).map(p => ({
+    host_id: p.hostId,
+    hostname: p.hostname,
+    version: p.version,
+    last_seen_at: p.lastSeenAt,
+  }))
+})

--- a/apps/openape-troop/server/routes/api/nest-ws.ts
+++ b/apps/openape-troop/server/routes/api/nest-ws.ts
@@ -1,0 +1,150 @@
+import { createRemoteJWKS, verifyJWT } from '@openape/core'
+import { useRuntimeConfig } from 'nitropack/runtime'
+import { registerNestPeer, touchNestPeer, unregisterNestPeerById } from '../../utils/nest-registry'
+import { resolveSpawnIntent } from '../../utils/spawn-intents'
+
+// Control-plane WS for local nest daemons. Each connected peer
+// represents a Mac (or any host) running `openape-nest`, owned by
+// the DDISA-authenticated `sub` of the bearer token used at upgrade.
+//
+// Frames in (nest → troop):
+//   - hello { host_id, hostname, version }   — must be the first message
+//   - heartbeat                              — bumps lastSeenAt, no reply
+//   - spawn-result { intent_id, ok, agent_email?, error? }
+//
+// Frames out (troop → nest):
+//   - config-update { agent_email }          — nest re-syncs the named agent
+//   - spawn-intent { intent_id, name, bridge?, soul?, skills? }
+//   - reload-bridge { name }                 — pm2 reload, no fresh sync
+//
+// Auth model: same DDISA-JWT pattern as chat's WS — the bearer is
+// signed by id.openape.ai's JWKS. We require `act: human` because
+// nests are operated by their owner, not by an agent. (Agents have
+// their own per-room WS to chat.openape.ai; this surface is the
+// owner's mission-control channel.)
+
+interface DDISAClaims {
+  sub?: string
+  act?: 'human' | 'agent' | string
+}
+
+let _jwks: ReturnType<typeof createRemoteJWKS> | null = null
+function jwks() {
+  if (!_jwks) {
+    const idpUrl = useRuntimeConfig().public.idpUrl as string ?? 'https://id.openape.ai'
+    _jwks = createRemoteJWKS(new URL('/.well-known/jwks.json', idpUrl).toString())
+  }
+  return _jwks
+}
+
+interface AuthCtx { ownerEmail: string }
+const authByPeerId = new Map<string, AuthCtx>()
+
+async function authenticateUpgrade(token: string): Promise<AuthCtx> {
+  const { payload } = await verifyJWT<DDISAClaims>(token, jwks())
+  if (!payload.sub) throw new Error('token missing sub')
+  if (payload.act !== 'human') throw new Error('only human bearers may open a nest control channel')
+  return { ownerEmail: payload.sub }
+}
+
+interface HelloFrame { type: 'hello', host_id: string, hostname: string, version: string }
+interface HeartbeatFrame { type: 'heartbeat' }
+interface SpawnResultFrame {
+  type: 'spawn-result'
+  intent_id: string
+  ok: boolean
+  agent_email?: string
+  error?: string
+}
+type InboundFrame = HelloFrame | HeartbeatFrame | SpawnResultFrame | { type: string }
+
+function parseFrame(raw: unknown): InboundFrame | null {
+  const text = typeof raw === 'string'
+    ? raw
+    : typeof (raw as { text?: () => string }).text === 'function'
+      ? (raw as { text: () => string }).text()
+      : String(raw)
+  try { return JSON.parse(text) as InboundFrame }
+  catch { return null }
+}
+
+export default defineWebSocketHandler({
+  async upgrade(request) {
+    const url = new URL(request.url, 'http://localhost')
+    const token = url.searchParams.get('token')
+    if (!token) throw createError({ statusCode: 401, statusMessage: 'Missing token' })
+    try { await authenticateUpgrade(token) }
+    catch { throw createError({ statusCode: 401, statusMessage: 'Invalid token' }) }
+  },
+
+  async open(peer) {
+    // Re-verify on open (the upgrade-context object is not the same
+    // event as open's peer per nitro/crossws; verify state doesn't
+    // flow through).
+    try {
+      const url = new URL(peer.request.url, 'http://localhost')
+      const token = url.searchParams.get('token')
+      if (!token) {
+        peer.send(JSON.stringify({ type: 'error', message: 'missing token' }))
+        peer.close(1008, 'missing token')
+        return
+      }
+      const ctx = await authenticateUpgrade(token)
+      authByPeerId.set(peer.id, ctx)
+      // Tell the nest we accepted the auth — it doesn't strictly need
+      // this, but the round-trip confirms the WS plumbing is alive
+      // before it sends the hello frame.
+      peer.send(JSON.stringify({ type: 'welcome', owner: ctx.ownerEmail }))
+    }
+    catch (err) {
+      peer.send(JSON.stringify({ type: 'error', message: 'invalid token' }))
+      peer.close(1008, 'invalid token')
+      void err
+    }
+  },
+
+  message(peer, message) {
+    const ctx = authByPeerId.get(peer.id)
+    if (!ctx) return
+    const frame = parseFrame(message)
+    if (!frame) return
+    if (frame.type === 'hello') {
+      const f = frame as HelloFrame
+      if (!f.host_id || !f.hostname) return
+      registerNestPeer({
+        ownerEmail: ctx.ownerEmail,
+        hostId: f.host_id,
+        hostname: f.hostname,
+        version: f.version ?? 'unknown',
+        lastSeenAt: Math.floor(Date.now() / 1000),
+        peerId: peer.id,
+        send: (out) => {
+          try { peer.send(JSON.stringify(out)); return true }
+          catch { return false }
+        },
+      })
+      peer.send(JSON.stringify({ type: 'ack' }))
+      return
+    }
+    if (frame.type === 'heartbeat') {
+      touchNestPeer(peer.id)
+      return
+    }
+    if (frame.type === 'spawn-result') {
+      const f = frame as SpawnResultFrame
+      resolveSpawnIntent(f.intent_id, {
+        ok: f.ok,
+        agentEmail: f.agent_email,
+        error: f.error,
+      })
+    }
+    // Unknown frame types get silently dropped — keeps the loop
+    // forward-compatible when a newer nest sends a frame the troop
+    // doesn't recognise yet.
+  },
+
+  close(peer) {
+    authByPeerId.delete(peer.id)
+    unregisterNestPeerById(peer.id)
+  },
+})

--- a/apps/openape-troop/server/utils/nest-registry.ts
+++ b/apps/openape-troop/server/utils/nest-registry.ts
@@ -1,0 +1,83 @@
+// In-memory registry of nest daemons currently connected via WS.
+// One owner can have multiple Macs ("hosts") connected — each gets its
+// own row keyed by (ownerEmail, hostId). When a config-update needs to
+// fan out, we look up every peer for the owner; when a spawn-intent
+// targets a specific Mac, we look up by exact (owner, host).
+//
+// Single-process today. If troop ever scales horizontally this is the
+// piece that needs Redis pub/sub — same shape as the chat-app's
+// realtime registry (which served as the template). For now the
+// chatty.delta-mind.at deployment is one node, one process.
+
+export interface NestPeer {
+  ownerEmail: string
+  hostId: string
+  hostname: string
+  version: string
+  /** Wall-clock seconds at last hello / heartbeat — drives the
+   *  online-badge in the troop UI + the "is this peer stale" cleanup
+   *  in close handlers. */
+  lastSeenAt: number
+  /** Send a frame to this peer. Returns false if the socket is gone. */
+  send: (frame: Record<string, unknown>) => boolean
+  /** Stable identifier for the underlying crossws peer; used as the
+   *  cleanup key when the WS close handler fires. */
+  peerId: string
+}
+
+const peersByKey = new Map<string, NestPeer>()
+
+function keyFor(ownerEmail: string, hostId: string): string {
+  return `${ownerEmail.toLowerCase()}::${hostId}`
+}
+
+export function registerNestPeer(peer: NestPeer): void {
+  peersByKey.set(keyFor(peer.ownerEmail, peer.hostId), peer)
+}
+
+export function unregisterNestPeerById(peerId: string): void {
+  for (const [k, p] of peersByKey) {
+    if (p.peerId === peerId) {
+      peersByKey.delete(k)
+      return
+    }
+  }
+}
+
+export function touchNestPeer(peerId: string): void {
+  for (const p of peersByKey.values()) {
+    if (p.peerId === peerId) {
+      p.lastSeenAt = Math.floor(Date.now() / 1000)
+      return
+    }
+  }
+}
+
+export function getNestPeer(ownerEmail: string, hostId: string): NestPeer | undefined {
+  return peersByKey.get(keyFor(ownerEmail, hostId))
+}
+
+export function listNestPeersForOwner(ownerEmail: string): NestPeer[] {
+  const out: NestPeer[] = []
+  const prefix = `${ownerEmail.toLowerCase()}::`
+  for (const [k, p] of peersByKey) {
+    if (k.startsWith(prefix)) out.push(p)
+  }
+  return out
+}
+
+/**
+ * Fan-out frame to every nest connected for the given owner. Returns
+ * the count of peers it was successfully sent to — callers can log
+ * this so silent failures (zero connected nests) are diagnosable.
+ */
+export function broadcastToOwner(ownerEmail: string, frame: Record<string, unknown>): number {
+  let sent = 0
+  for (const peer of listNestPeersForOwner(ownerEmail)) {
+    if (peer.send(frame)) sent++
+  }
+  return sent
+}
+
+// Exported for tests.
+export const _internal = { peersByKey }

--- a/apps/openape-troop/server/utils/nest-registry.ts
+++ b/apps/openape-troop/server/utils/nest-registry.ts
@@ -79,5 +79,7 @@ export function broadcastToOwner(ownerEmail: string, frame: Record<string, unkno
   return sent
 }
 
-// Exported for tests.
-export const _internal = { peersByKey }
+// Exported for tests. Unique name to avoid colliding with the
+// equivalent symbol in spawn-intents.ts (Nuxt server auto-imports
+// scan this directory and warn on duplicate exports).
+export const _nestRegistryInternal = { peersByKey }

--- a/apps/openape-troop/server/utils/spawn-intents.ts
+++ b/apps/openape-troop/server/utils/spawn-intents.ts
@@ -1,0 +1,59 @@
+// Pending spawn-intent registry. A POST /api/agents/spawn-intent
+// publishes the intent to a connected nest over the WS control-plane,
+// then has to wait for the nest's `spawn-result` frame. The intent
+// API returns immediately with an `intent_id` so the UI can poll
+// (`/api/agents/spawn-intent/<id>`) rather than holding an HTTP
+// connection open for the full DDISA-grant-approval window
+// (potentially minutes).
+
+export interface SpawnIntentResult {
+  ok: boolean
+  agentEmail?: string
+  error?: string
+  /** UNIX seconds */
+  resolvedAt: number
+}
+
+interface PendingIntent {
+  createdAt: number
+  result?: SpawnIntentResult
+}
+
+const intents = new Map<string, PendingIntent>()
+
+// Drop completed/abandoned intents after 30 min — owner long since
+// gave up polling and the result becomes irrelevant. Prevents the
+// map from growing unbounded over a long-running process.
+const PRUNE_AFTER_S = 30 * 60
+
+function prune(): void {
+  const now = Math.floor(Date.now() / 1000)
+  for (const [id, intent] of intents) {
+    const reference = intent.result?.resolvedAt ?? intent.createdAt
+    if (now - reference > PRUNE_AFTER_S) intents.delete(id)
+  }
+}
+
+export function createSpawnIntent(id: string): void {
+  prune()
+  intents.set(id, { createdAt: Math.floor(Date.now() / 1000) })
+}
+
+export function resolveSpawnIntent(id: string, payload: Omit<SpawnIntentResult, 'resolvedAt'>): void {
+  const intent = intents.get(id)
+  if (!intent) return // intent never created (or already pruned) — drop
+  intent.result = {
+    ok: payload.ok,
+    agentEmail: payload.agentEmail,
+    error: payload.error,
+    resolvedAt: Math.floor(Date.now() / 1000),
+  }
+}
+
+export function getSpawnIntent(id: string): { result?: SpawnIntentResult, createdAt: number } | undefined {
+  return intents.get(id)
+}
+
+// Test-only escape hatch — lets unit tests start each case from a
+// known-clean registry without process restart.
+export const _internal = { intents }

--- a/apps/openape-troop/server/utils/spawn-intents.ts
+++ b/apps/openape-troop/server/utils/spawn-intents.ts
@@ -55,5 +55,7 @@ export function getSpawnIntent(id: string): { result?: SpawnIntentResult, create
 }
 
 // Test-only escape hatch — lets unit tests start each case from a
-// known-clean registry without process restart.
-export const _internal = { intents }
+// known-clean registry without process restart. Unique name to
+// avoid colliding with nest-registry.ts (Nuxt server auto-imports
+// scan this directory and warn on duplicate exports).
+export const _spawnIntentsInternal = { intents }

--- a/apps/openape-troop/tests/nest-registry.test.ts
+++ b/apps/openape-troop/tests/nest-registry.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
-  _internal,
+  _nestRegistryInternal,
   broadcastToOwner,
   getNestPeer,
   listNestPeersForOwner,
@@ -26,7 +26,7 @@ function fakePeer(opts: { owner: string, host: string, peerId: string }) {
 }
 
 afterEach(() => {
-  _internal.peersByKey.clear()
+  _nestRegistryInternal.peersByKey.clear()
 })
 
 describe('nest registry', () => {

--- a/apps/openape-troop/tests/nest-registry.test.ts
+++ b/apps/openape-troop/tests/nest-registry.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  _internal,
+  broadcastToOwner,
+  getNestPeer,
+  listNestPeersForOwner,
+  registerNestPeer,
+  touchNestPeer,
+  unregisterNestPeerById,
+} from '../server/utils/nest-registry'
+
+function fakePeer(opts: { owner: string, host: string, peerId: string }) {
+  const sent: Array<Record<string, unknown>> = []
+  return {
+    sent,
+    peer: {
+      ownerEmail: opts.owner,
+      hostId: opts.host,
+      hostname: opts.host,
+      version: 'test',
+      lastSeenAt: 100,
+      peerId: opts.peerId,
+      send: (frame: Record<string, unknown>) => { sent.push(frame); return true },
+    },
+  }
+}
+
+afterEach(() => {
+  _internal.peersByKey.clear()
+})
+
+describe('nest registry', () => {
+  it('register + get by (owner, host)', () => {
+    const a = fakePeer({ owner: 'p@x', host: 'mac-mini', peerId: 'p1' })
+    registerNestPeer(a.peer)
+    expect(getNestPeer('p@x', 'mac-mini')).toBe(a.peer)
+    expect(getNestPeer('p@x', 'laptop')).toBeUndefined()
+  })
+
+  it('owner-email lookup is case-insensitive', () => {
+    const a = fakePeer({ owner: 'Patrick@Example.Com', host: 'mac', peerId: 'p1' })
+    registerNestPeer(a.peer)
+    expect(getNestPeer('patrick@example.com', 'mac')).toBe(a.peer)
+    expect(getNestPeer('PATRICK@example.com', 'mac')).toBe(a.peer)
+  })
+
+  it('listNestPeersForOwner returns multi-host', () => {
+    registerNestPeer(fakePeer({ owner: 'p@x', host: 'mini', peerId: 'p1' }).peer)
+    registerNestPeer(fakePeer({ owner: 'p@x', host: 'laptop', peerId: 'p2' }).peer)
+    registerNestPeer(fakePeer({ owner: 'other@x', host: 'mini', peerId: 'p3' }).peer)
+    const mine = listNestPeersForOwner('p@x')
+    expect(mine.map(p => p.hostId).toSorted()).toEqual(['laptop', 'mini'])
+  })
+
+  it('unregisterNestPeerById drops the right row even if multiple share an owner', () => {
+    registerNestPeer(fakePeer({ owner: 'p@x', host: 'mini', peerId: 'p1' }).peer)
+    registerNestPeer(fakePeer({ owner: 'p@x', host: 'laptop', peerId: 'p2' }).peer)
+    unregisterNestPeerById('p1')
+    expect(getNestPeer('p@x', 'mini')).toBeUndefined()
+    expect(getNestPeer('p@x', 'laptop')).toBeDefined()
+  })
+
+  it('touchNestPeer bumps lastSeenAt', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+    const a = fakePeer({ owner: 'p@x', host: 'mini', peerId: 'p1' })
+    a.peer.lastSeenAt = 1
+    registerNestPeer(a.peer)
+    vi.setSystemTime(new Date('2026-01-01T00:01:00Z'))
+    touchNestPeer('p1')
+    expect(getNestPeer('p@x', 'mini')?.lastSeenAt).toBe(Math.floor(new Date('2026-01-01T00:01:00Z').getTime() / 1000))
+    vi.useRealTimers()
+  })
+
+  it('broadcastToOwner fans out only to that owner', () => {
+    const a = fakePeer({ owner: 'p@x', host: 'mini', peerId: 'p1' })
+    const b = fakePeer({ owner: 'p@x', host: 'laptop', peerId: 'p2' })
+    const c = fakePeer({ owner: 'other@x', host: 'mini', peerId: 'p3' })
+    registerNestPeer(a.peer)
+    registerNestPeer(b.peer)
+    registerNestPeer(c.peer)
+    const sent = broadcastToOwner('p@x', { type: 'config-update', agent_email: 'foo' })
+    expect(sent).toBe(2)
+    expect(a.sent[0]).toEqual({ type: 'config-update', agent_email: 'foo' })
+    expect(b.sent[0]).toEqual({ type: 'config-update', agent_email: 'foo' })
+    expect(c.sent).toEqual([])
+  })
+
+  it('broadcastToOwner counts only successful sends', () => {
+    const a = fakePeer({ owner: 'p@x', host: 'mini', peerId: 'p1' })
+    const b = fakePeer({ owner: 'p@x', host: 'laptop', peerId: 'p2' })
+    // Simulate a dead socket
+    b.peer.send = () => false
+    registerNestPeer(a.peer)
+    registerNestPeer(b.peer)
+    expect(broadcastToOwner('p@x', { type: 'x' })).toBe(1)
+  })
+})

--- a/apps/openape-troop/tests/spawn-intents.test.ts
+++ b/apps/openape-troop/tests/spawn-intents.test.ts
@@ -1,13 +1,13 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import {
-  _internal,
+  _spawnIntentsInternal,
   createSpawnIntent,
   getSpawnIntent,
   resolveSpawnIntent,
 } from '../server/utils/spawn-intents'
 
 afterEach(() => {
-  _internal.intents.clear()
+  _spawnIntentsInternal.intents.clear()
 })
 
 describe('spawn-intents registry', () => {

--- a/apps/openape-troop/tests/spawn-intents.test.ts
+++ b/apps/openape-troop/tests/spawn-intents.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  _internal,
+  createSpawnIntent,
+  getSpawnIntent,
+  resolveSpawnIntent,
+} from '../server/utils/spawn-intents'
+
+afterEach(() => {
+  _internal.intents.clear()
+})
+
+describe('spawn-intents registry', () => {
+  it('createSpawnIntent makes the intent pollable with no result yet', () => {
+    createSpawnIntent('intent-1')
+    const found = getSpawnIntent('intent-1')
+    expect(found).toBeDefined()
+    expect(found?.result).toBeUndefined()
+  })
+
+  it('resolveSpawnIntent attaches a result, ok=true path', () => {
+    createSpawnIntent('intent-2')
+    resolveSpawnIntent('intent-2', { ok: true, agentEmail: 'foo@example.com' })
+    const found = getSpawnIntent('intent-2')
+    expect(found?.result?.ok).toBe(true)
+    expect(found?.result?.agentEmail).toBe('foo@example.com')
+  })
+
+  it('resolveSpawnIntent attaches a result, ok=false path', () => {
+    createSpawnIntent('intent-3')
+    resolveSpawnIntent('intent-3', { ok: false, error: 'grant denied' })
+    expect(getSpawnIntent('intent-3')?.result?.error).toBe('grant denied')
+  })
+
+  it('resolveSpawnIntent on an unknown id is a no-op (avoid surprises if nest re-sends)', () => {
+    expect(() => resolveSpawnIntent('never-created', { ok: true })).not.toThrow()
+    expect(getSpawnIntent('never-created')).toBeUndefined()
+  })
+
+  it('getSpawnIntent for unknown id returns undefined', () => {
+    expect(getSpawnIntent('nope')).toBeUndefined()
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -444,6 +444,9 @@ importers:
       ofetch:
         specifier: ^1.4.1
         version: 1.5.1
+      ws:
+        specifier: ^8.18.0
+        version: 8.19.0
     devDependencies:
       '@antfu/eslint-config':
         specifier: 'catalog:'
@@ -451,6 +454,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 22.19.15
+      '@types/ws':
+        specifier: ^8.5.13
+        version: 8.18.1
       eslint:
         specifier: ^9.35.0
         version: 9.39.4(jiti@2.6.1)


### PR DESCRIPTION
## Summary

Adds a WebSocket control-plane between local `openape-nest` instances and the troop server so:

1. **Config updates propagate in <1s** instead of waiting up to 5 minutes for the next sync-poll. Owner edits an agent's `system_prompt` / `tools` / SOUL / skills in troop → troop fans out a `config-update` frame to every connected nest for that owner → nest runs `apes run --as <name> -- apes agents sync` and the agent picks up the fresh config on its next thread.

2. **Remote spawn from the troop UI** is possible: an owner clicks "+ Spawn agent" in `/agents`, picks a connected host, fills in name + bridge config, and the troop server sends a `spawn-intent` frame to the nest. The nest invokes `apes agents spawn <name>` locally — DDISA-grant prompts the human in front of the Mac, so HITL stays intact.

3. **Online/offline visibility**: the agent-detail page shows a `● live` / `○ poll` badge based on `/api/nest/hosts`. The legacy 5-min poll keeps running as a fallback so anything that misses the WS still catches up eventually.

## Pieces

**Troop server**
- `server/routes/api/nest-ws.ts` — JWKS-verified WS endpoint, requires `act: human`.
- `server/utils/nest-registry.ts` — in-memory peer registry keyed by `(ownerEmail, hostId)` with `broadcastToOwner` fan-out.
- `server/utils/spawn-intents.ts` — pending-intent map with 30min auto-prune.
- `server/api/agents/spawn-intent.post.ts` + `[id].get.ts` — owner-only spawn-intent create + poll.
- `server/api/nest/hosts.get.ts` — list a owner's connected nests.
- `server/api/agents/[name].patch.ts`, `[name]/skills/index.put.ts`, `[name]/skills/[skillName].delete.ts` — broadcast `config-update` after every owner-write.
- `nuxt.config.ts` — `nitro: { experimental: { websocket: true } }`.

**Troop UI**
- `app/components/SpawnAgentDialog.vue` — name + bridge fields, picks an online host, polls until the nest reports back.
- `app/pages/agents/index.vue` — "+ Spawn agent" CTA.
- `app/pages/agents/[name].vue` — `live`/`poll` badge.

**Nest**
- `src/lib/troop-ws.ts` — `TroopWs` class: hello/heartbeat, exponential-backoff reconnect (1s→30s), handles `config-update` / `spawn-intent` / `reload-bridge`. Auth via `ensureFreshIdpAuth().access_token`.
- `src/index.ts` — start/stop wired into the existing supervisor lifecycle.
- `tsconfig.json` — target bumped ES2022 → ES2023 for `Array.prototype.toSorted`.

**Tests**
- 11 unit tests across `tests/nest-registry.test.ts` + `tests/spawn-intents.test.ts` (case-insensitive owner lookup, multi-host listing, broadcast fan-out, intent create/resolve/poll).

## Test plan

- [x] `pnpm turbo run lint typecheck test --filter=@openape/troop --filter=@openape/nest` green locally
- [ ] CI green
- [ ] After merge: `pnpm release:local` to publish `@openape/nest` + `@openape/apes`
- [ ] Install upgraded nest on the Mac mini, restart, verify it appears in `/api/nest/hosts`
- [ ] Edit an agent's `system_prompt` in troop, confirm the change lands on the Mac within ~1s
- [ ] Spawn a fresh test agent from the troop UI, confirm grant prompt appears on the Mac and the agent provisions

🤖 Generated with [Claude Code](https://claude.com/claude-code)