### PR TITLE
feat(troop): nest-ws accepts act:agent (nest uses its own DDISA identity)

### DIFF
--- a/.claude/plans/nest-identity.md
+++ b/.claude/plans/nest-identity.md
@@ -1,0 +1,150 @@
+# Plan: Nest WS-Auth via existing DDISA-Agent-Identity
+
+> Self-contained plan: ein Agent ohne Vorwissen kann diesen Plan top-down
+> abarbeiten und kommt zu einem funktionierenden Ergebnis.
+
+## Purpose / Big Picture
+
+- **Ziel:** Der `@openape/nest`-Daemon verbindet sich erfolgreich zur troop-WS
+  (`● live`-Badge in troop-UI sichtbar), config-update propagiert in <2s,
+  "+ Spawn agent" aus troop funktioniert end-to-end.
+- **Kontext:** PR #405 hat client+server gebaut, aber der WS-server enforced
+  `act: human`. Der Nest hat schon eine eigene DDISA-Agent-Identity (via
+  `apes nest enroll`), die mit `act: agent` signiert. Server-Auth muss also
+  lockern statt nest-bootstrap neu zu bauen.
+- **Discovery beim Plan:** Während des Plans hab ich entdeckt, dass das
+  ganze nest-identity-Setup bereits existiert (`apes nest enroll`,
+  `apes nest install` mit User-LaunchAgent + HOME=~/.openape/nest, mit
+  auth.json die einen `act:agent` JWT enthält). Mein vorheriger Fehler:
+  ich hatte den User-LaunchAgent entfernt zugunsten eines legacy
+  System-LaunchDaemon (HOME=/var/openape/nest, KEINE identity). Cleanup
+  + Server-Auth-Lockerung sind die einzigen echten Schritte.
+
+## Repo-Orientierung
+
+- **Projekt:** OpenApe monorepo
+- **Relevante Dateien:**
+  - `apps/openape-troop/server/routes/api/nest-ws.ts` — derzeit `act: human` enforcement (ZIEL der Änderung)
+  - `apps/openape-troop/server/utils/auth.ts` — `requireAgent`-Pattern (Vorbild)
+  - `apps/openape-troop/server/utils/agent-email.ts` — `parseAgentEmail` (extrahiert owner-domain aus agent-email)
+  - `apps/openape-nest/src/lib/troop-ws.ts` — Client-side (verwendet schon `ensureFreshIdpAuth()` — kommt mit act:agent token zurück wenn HOME richtig)
+  - `apps/openape-troop/server/utils/nest-registry.ts` — in-memory peer registry (genügt — keine DB-Tabelle nötig)
+- **Existing tooling:**
+  - `apes nest install` — schreibt User-LaunchAgent plist, HOME=~/.openape/nest
+  - `apes nest enroll` — registriert nest als DDISA-Agent im IdP, schreibt auth.json
+- **Tech-Stack:** Node.js 22, h3, jose, crossws
+- **Dev-Setup:**
+  - lint+typecheck: `pnpm turbo run lint typecheck --filter=@openape/troop`
+  - dev: `cd apps/openape-troop && pnpm dev`
+
+## Hintergrund: Aktueller State und Identity-Architektur
+
+**Identity ist schon da:**
+```
+~/.openape/nest/
+├── .ssh/
+│   ├── id_ed25519           (private key, 0600)
+│   └── id_ed25519.pub       (ssh-ed25519 …)
+└── .config/apes/
+    └── auth.json            { access_token (act:agent), email: nest-…@id.openape.ai, … }
+```
+
+**Mini state heute** (nach versehentlichem cleanup vorhin):
+- System-LaunchDaemon `/Library/LaunchDaemons/ai.openape.nest.plist` — UserName=`_openape_nest`, HOME=`/var/openape/nest` (KEINE identity dort) — soll WEG
+- User-LaunchAgent `~/Library/LaunchAgents/ai.openape.nest.plist` — soll wiederhergestellt werden via `apes nest install`
+
+## Milestones
+
+### Milestone 1: troop WS akzeptiert act:agent
+
+**Ziel:** Server-side WS-handshake erfolgt mit `act:agent` JWT; ownerEmail
+wird aus `parseAgentEmail(claims.sub).ownerLocalpart + '@' + ownerDomain`
+abgeleitet. Bestehender `act:human`-Pfad bleibt für künftige UI-Direct-Connect.
+
+**Schritte:**
+1. `apps/openape-troop/server/routes/api/nest-ws.ts`:
+   - JWKS-verify bleibt
+   - Statt `if (claims.act !== 'human') reject`: 
+     - `act:human` → `ownerEmail = claims.sub` (wie bisher)
+     - `act:agent` → `parsed = parseAgentEmail(claims.sub)`; `ownerEmail = parsed.ownerLocalpart + '@' + parsed.ownerDomain.replaceAll('_','.')` (reverse von domain-encoding)
+     - sonst reject
+   - **Achtung:** `parseAgentEmail` encodet domain mit `_` statt `.` (`hofmann_eco` → `hofmann.eco`). Hilfsfunktion in agent-email.ts checken — bei Bedarf Helper `ownerEmailFromAgentEmail` extrahieren.
+2. **Skip:** Keine separate `nests` DB-Tabelle. In-memory peer registry deckt alles ab. `/api/nest/hosts.get.ts` listet schon aus dem in-memory registry.
+
+**Akzeptanzkriterien:**
+- [ ] `pnpm turbo run lint typecheck test --filter=@openape/troop` grün
+- [ ] Vitest-test: act:agent JWT für `nest-…+patrick+hofmann_eco@id.openape.ai` resolved zu `patrick@hofmann.eco` und WS-handshake akzeptiert
+- [ ] Vitest-test: act:agent JWT mit nicht-derivable owner-format → reject
+
+**Rollback:** Code-revert; legacy 5min-poll bleibt unbehelligt.
+
+### Milestone 2: Mini cleanup — System-LaunchDaemon weg, User-LaunchAgent wiederherstellen
+
+**Ziel:** Nur EIN nest-daemon läuft, mit korrekter HOME und identity.
+
+**Schritte:**
+1. `apes run --as root -- launchctl bootout system/ai.openape.nest`
+2. `apes run --as root -- rm /Library/LaunchDaemons/ai.openape.nest.plist`
+3. `apes nest install` (als Patrick) → recreated User-LaunchAgent
+4. `tail -f ~/Library/Logs/openape-nest.log` — `troop-ws: connected as …@id.openape.ai` sollte erscheinen (vorausgesetzt M1 ist live geshippt → erfordert troop-deploy)
+
+**Akzeptanzkriterien:**
+- [ ] `ps -ef | grep openape-nest | grep -v grep` zeigt genau eine Zeile, uid 501 (patrickhofmann)
+- [ ] `launchctl print system/ai.openape.nest` → "Could not find" (System-Daemon weg)
+- [ ] `launchctl print gui/$(id -u)/ai.openape.nest` zeigt running, pid > 0
+- [ ] nest-log zeigt `troop-ws: connected …` (nicht "not logged in — retry")
+
+**Rollback:** `apes nest uninstall` + falls nötig System-Daemon plist von git restore.
+
+### Milestone 3: E2E am mini
+
+**Ziel:** Spawn-from-troop + config-update beide nachweislich live.
+
+**Schritte:**
+1. Edit `igor19`'s `system_prompt` in troop-UI → nest-log innerhalb <2s: `apes run --as igor19 -- apes agents sync` mit success.
+2. troop-UI "+ Spawn agent" → name=`testbot`, host=mini, bridge=… → submit. Am mini: escapes-grant-prompt (DDISA via phone/laptop). Approve. → spawn success in UI. `testbot` erscheint in `/agents`.
+3. `apes agents destroy testbot` (cleanup).
+
+**Akzeptanzkriterien:**
+- [ ] config-update <2s gemessen
+- [ ] Spawn-Flow komplett durchgeführt
+- [ ] `apes agents list` zeigt neuen agent danach, nach destroy ist er weg
+
+**Rollback:** Wenn etwas hängt: `launchctl bootout gui/$(id -u)/ai.openape.nest`. config-update fällt zurück auf 5min-poll, spawn-UI zeigt "no nest connected" — beides graceful.
+
+## Progress
+
+- [ ] `[YYYY-MM-DD HH:MM]` Milestone 1: WS-server akzeptiert act:agent
+- [ ] `[YYYY-MM-DD HH:MM]` Milestone 2: Mini cleanup
+- [ ] `[YYYY-MM-DD HH:MM]` Milestone 3: E2E
+
+## Surprises & Discoveries
+
+- 2026-05-12 — Identity-Stack ist bereits gebaut: `apes nest enroll`,
+  `apes nest install`, eigenes auth.json mit act:agent JWT, alles in
+  `~/.openape/nest/`. Nur die troop-WS-server-side war zu streng.
+- 2026-05-12 — Mini hatte heute morgen DOPPELTE Daemons (legacy System +
+  korrekter User). Beim cleanup hab ich den falschen entfernt.
+
+## Decision Log
+
+| Datum | Entscheidung | Begründung | Verworfen |
+|-------|-------------|------------|-----------|
+| 2026-05-12 | Keine `nests` DB-Tabelle, in-memory registry reicht | Nest ist transient (kein langlebiges state), peer-registry ist schon richtig dimensioniert | DB-Tabelle — würde extra migration und sync brauchen ohne Mehrwert |
+| 2026-05-12 | act:agent + parseAgentEmail für owner-resolution, kein extra exchange | Verwendet bestehende derivation, kein extra endpoint/token-store | `/api/cli/exchange` mirror — extra layer, kein Mehrwert für nest's bedarf |
+| 2026-05-12 | Mini: User-LaunchAgent ist die korrekte Architektur | `apes nest install` schreibt genau das; HOME=~/.openape/nest matcht enroll-output | System-LaunchDaemon mit `_openape_nest` user — wäre sauberer Isolation aber bricht enroll/auth-pfad (kein human auth.json greifbar) |
+
+## Session-Checkliste
+
+1. Plan lesen, Progress prüfen
+2. `git status` clean; richtige branch (`feat/nest-identity`)
+3. `pnpm turbo run lint typecheck test --filter=@openape/troop` baseline
+4. M1 implementieren + committen
+5. PR aufmachen, CI grün abwarten, mergen
+6. `pnpm release:local` → troop deployen (über GH Actions Deploy-Workflow)
+7. M2: Mini cleanup (System-Daemon entfernen, `apes nest install`)
+8. M3: E2E-Verifikation
+
+## Outcomes & Retrospective
+
+> nach Abschluss füllen

--- a/apps/openape-troop/server/routes/api/nest-ws.ts
+++ b/apps/openape-troop/server/routes/api/nest-ws.ts
@@ -1,5 +1,6 @@
 import { createRemoteJWKS, verifyJWT } from '@openape/core'
 import { useRuntimeConfig } from 'nitropack/runtime'
+import { parseAgentEmail } from '../../utils/agent-email'
 import { registerNestPeer, touchNestPeer, unregisterNestPeerById } from '../../utils/nest-registry'
 import { resolveSpawnIntent } from '../../utils/spawn-intents'
 
@@ -17,11 +18,21 @@ import { resolveSpawnIntent } from '../../utils/spawn-intents'
 //   - spawn-intent { intent_id, name, bridge?, soul?, skills? }
 //   - reload-bridge { name }                 — pm2 reload, no fresh sync
 //
-// Auth model: same DDISA-JWT pattern as chat's WS — the bearer is
-// signed by id.openape.ai's JWKS. We require `act: human` because
-// nests are operated by their owner, not by an agent. (Agents have
-// their own per-room WS to chat.openape.ai; this surface is the
-// owner's mission-control channel.)
+// Auth model: same DDISA-JWT pattern as chat's WS — bearer signed
+// by id.openape.ai's JWKS. We accept two flavours of caller:
+//
+//   - `act: human` — owner-direct connection (UI/dev tooling).
+//     ownerEmail = JWT `sub`.
+//   - `act: agent` — the nest itself, signed with its own DDISA
+//     keypair (see `apes nest enroll`). The agent email encodes
+//     its owner (`<name>-<hash>+<owner-local>+<owner-domain>@id…`),
+//     so we resolve ownerEmail from parseAgentEmail. This is the
+//     normal daemon path — the nest reads its act:agent JWT from
+//     `~/.openape/nest/.config/apes/auth.json` and uses it as
+//     bearer here.
+//
+// Either way the WS connection is owner-scoped — broadcasts and
+// spawn-intents fan out per ownerEmail.
 
 interface DDISAClaims {
   sub?: string
@@ -43,8 +54,17 @@ const authByPeerId = new Map<string, AuthCtx>()
 async function authenticateUpgrade(token: string): Promise<AuthCtx> {
   const { payload } = await verifyJWT<DDISAClaims>(token, jwks())
   if (!payload.sub) throw new Error('token missing sub')
-  if (payload.act !== 'human') throw new Error('only human bearers may open a nest control channel')
-  return { ownerEmail: payload.sub }
+  if (payload.act === 'human') {
+    return { ownerEmail: payload.sub.toLowerCase() }
+  }
+  if (payload.act === 'agent') {
+    const parsed = parseAgentEmail(payload.sub)
+    if (!parsed) {
+      throw new Error('agent token sub does not match the agent+owner email pattern')
+    }
+    return { ownerEmail: parsed.ownerEmail }
+  }
+  throw new Error('token must be act:human or act:agent')
 }
 
 interface HelloFrame { type: 'hello', host_id: string, hostname: string, version: string }

--- a/apps/openape-troop/server/utils/agent-email.ts
+++ b/apps/openape-troop/server/utils/agent-email.ts
@@ -17,7 +17,9 @@
 
 export interface ParsedAgentEmail {
   agentName: string
+  ownerLocalpart: string
   ownerDomain: string
+  ownerEmail: string
 }
 
 const OWNER_HASH_RE = /^(.+)-([a-f0-9]{8})$/
@@ -32,16 +34,22 @@ export function parseAgentEmail(email: string): ParsedAgentEmail | null {
   if (parts.length < 3) return null
 
   const namePart = parts[0]!
+  const ownerLocalpart = parts[1]!
   // Owner-domain is everything after the second `+`, joined back with
   // `+` in case of weird edge cases (shouldn't happen for valid
   // domains but we don't want to lose data).
   const ownerDomain = parts.slice(2).join('+').replace(/_/g, '.')
-  if (!ownerDomain || !namePart) return null
+  if (!ownerDomain || !ownerLocalpart || !namePart) return null
 
   // Strip the 8-char ownerHash suffix if present so the stored
   // agentName matches what the user typed.
   const m = namePart.match(OWNER_HASH_RE)
   const agentName = m ? m[1]! : namePart
 
-  return { agentName, ownerDomain }
+  return {
+    agentName,
+    ownerLocalpart,
+    ownerDomain,
+    ownerEmail: `${ownerLocalpart}@${ownerDomain}`,
+  }
 }

--- a/apps/openape-troop/server/utils/nest-registry.ts
+++ b/apps/openape-troop/server/utils/nest-registry.ts
@@ -14,14 +14,18 @@ export interface NestPeer {
   hostId: string
   hostname: string
   version: string
-  /** Wall-clock seconds at last hello / heartbeat — drives the
+  /**
+   * Wall-clock seconds at last hello / heartbeat — drives the
    *  online-badge in the troop UI + the "is this peer stale" cleanup
-   *  in close handlers. */
+   *  in close handlers.
+   */
   lastSeenAt: number
   /** Send a frame to this peer. Returns false if the socket is gone. */
   send: (frame: Record<string, unknown>) => boolean
-  /** Stable identifier for the underlying crossws peer; used as the
-   *  cleanup key when the WS close handler fires. */
+  /**
+   * Stable identifier for the underlying crossws peer; used as the
+   *  cleanup key when the WS close handler fires.
+   */
   peerId: string
 }
 

--- a/apps/openape-troop/tests/agent-email.test.ts
+++ b/apps/openape-troop/tests/agent-email.test.ts
@@ -4,27 +4,52 @@ import { parseAgentEmail } from '../server/utils/agent-email'
 describe('parseAgentEmail', () => {
   it('parses the canonical hash-suffixed format from deriveAgentEmail', () => {
     const got = parseAgentEmail('igor4-cb6bf26a+patrick+hofmann_eco@id.openape.ai')
-    expect(got).toEqual({ agentName: 'igor4', ownerDomain: 'hofmann.eco' })
+    expect(got).toEqual({
+      agentName: 'igor4',
+      ownerLocalpart: 'patrick',
+      ownerDomain: 'hofmann.eco',
+      ownerEmail: 'patrick@hofmann.eco',
+    })
   })
 
   it('preserves hyphens in the agent name (only the trailing 8-hex hash is stripped)', () => {
     const got = parseAgentEmail('agent-bot1-aabbccdd+patrick+hofmann_eco@id.openape.ai')
-    expect(got).toEqual({ agentName: 'agent-bot1', ownerDomain: 'hofmann.eco' })
+    expect(got).toEqual({
+      agentName: 'agent-bot1',
+      ownerLocalpart: 'patrick',
+      ownerDomain: 'hofmann.eco',
+      ownerEmail: 'patrick@hofmann.eco',
+    })
   })
 
   it('accepts the older format without owner-hash suffix', () => {
     const got = parseAgentEmail('agenta+patrick+hofmann_eco@id.openape.ai')
-    expect(got).toEqual({ agentName: 'agenta', ownerDomain: 'hofmann.eco' })
+    expect(got).toEqual({
+      agentName: 'agenta',
+      ownerLocalpart: 'patrick',
+      ownerDomain: 'hofmann.eco',
+      ownerEmail: 'patrick@hofmann.eco',
+    })
   })
 
   it('handles dotted owner-domains (encoded as underscores)', () => {
     const got = parseAgentEmail('alice-12345678+pete+example_co_uk@id.openape.ai')
-    expect(got).toEqual({ agentName: 'alice', ownerDomain: 'example.co.uk' })
+    expect(got).toEqual({
+      agentName: 'alice',
+      ownerLocalpart: 'pete',
+      ownerDomain: 'example.co.uk',
+      ownerEmail: 'pete@example.co.uk',
+    })
   })
 
   it('lowercases the input', () => {
     const got = parseAgentEmail('IGOR4-CB6BF26A+Patrick+Hofmann_Eco@id.openape.ai')
-    expect(got).toEqual({ agentName: 'igor4', ownerDomain: 'hofmann.eco' })
+    expect(got).toEqual({
+      agentName: 'igor4',
+      ownerLocalpart: 'patrick',
+      ownerDomain: 'hofmann.eco',
+      ownerEmail: 'patrick@hofmann.eco',
+    })
   })
 
   it('rejects non-agent addresses (no `+` subaddressing)', () => {
@@ -37,5 +62,11 @@ describe('parseAgentEmail', () => {
 
   it('rejects strings without an @', () => {
     expect(parseAgentEmail('alice-12345678+patrick+hofmann_eco')).toBeNull()
+  })
+
+  it('resolves a nest-style agent email to its owner', () => {
+    const got = parseAgentEmail('nest-minivonpatrick-cb6bf26a+patrick+hofmann_eco@id.openape.ai')
+    expect(got?.ownerEmail).toBe('patrick@hofmann.eco')
+    expect(got?.agentName).toBe('nest-minivonpatrick')
   })
 })


### PR DESCRIPTION
## Summary

Unblocks PR #405. The nest daemon already has its own DDISA-agent identity (created by \`apes nest enroll\`, lives at \`~/.openape/nest/.config/apes/auth.json\` with an \`act:agent\` IdP-signed JWT). The previous WS-server enforced \`act:human\` only, so the daemon was perpetually stuck in 'not logged in — retry' even though it was a fully-enrolled DDISA agent.

## Pieces

- \`server/routes/api/nest-ws.ts\` — \`authenticateUpgrade\` now accepts \`act:human\` (owner-direct) or \`act:agent\` (the nest daemon). For agent tokens, ownerEmail is recovered from \`parseAgentEmail(jwt.sub)\` — no DB lookup needed, the IdP's email derivation already encodes the owner.
- \`server/utils/agent-email.ts\` — \`ParsedAgentEmail\` now exposes \`ownerLocalpart\` + \`ownerEmail\`. The localpart was already being parsed, just not surfaced.
- \`tests/agent-email.test.ts\` — updated expectations; added an explicit nest-email → owner-email test.
- \`server/utils/nest-registry.ts\` — drive-by jsdoc reformat from \`eslint --fix\`.
- \`.claude/plans/nest-identity.md\` — design notes + decisions for the simpler-than-expected scope.

## Test plan

- [x] \`pnpm turbo run lint typecheck test --filter=@openape/troop\` green
- [ ] CI green
- [ ] After merge + deploy: on the Mac mini, restart the User-LaunchAgent → nest-log shows \`troop-ws: connected as nest-…@id.openape.ai\`
- [ ] Edit an agent's system_prompt in troop → propagates to mini in <2s (vs 5min polling)
- [ ] Spawn an agent from the troop UI → escapes-grant prompt fires on the mini, spawn completes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)