### PR TITLE
fix(nest): time-out spawn-intent execFile + log the result

### DIFF
--- a/apps/openape-ape-agent/src/thread-session.ts
+++ b/apps/openape-ape-agent/src/thread-session.ts
@@ -128,7 +128,7 @@ export class ThreadSession {
             this.deps.log(`[${this.deps.roomId}/${this.deps.threadId.slice(0, 8)}] tool_result: ${name}`)
             void setStatus(null)
           },
-          onToolError: ({ name, error }) => {
+          onToolError: ({ name, error }: { name: string, error: string }) => {
             this.deps.log(`[${this.deps.roomId}/${this.deps.threadId.slice(0, 8)}] tool_error: ${name} → ${error}`)
             void setStatus(null)
           },

--- a/apps/openape-nest/src/lib/pm2-supervisor.ts
+++ b/apps/openape-nest/src/lib/pm2-supervisor.ts
@@ -135,9 +135,11 @@ export class Pm2Supervisor {
     }
   }
 
-  /** Best-effort cleanup — called on Nest shutdown. We don't kill
+  /**
+   * Best-effort cleanup — called on Nest shutdown. We don't kill
    *  the per-agent pm2-daemons; they should keep running so bridges
-   *  stay alive across Nest restarts. No-op for now. */
+   *  stay alive across Nest restarts. No-op for now.
+   */
   async stopAll(): Promise<void> {
     /* deliberately empty — per-agent pm2 outlives the Nest */
   }
@@ -194,7 +196,8 @@ export class Pm2Supervisor {
     }
   }
 
-  /** Run a pm2 subcommand AS the agent — escapes-helper does the
+  /**
+   * Run a pm2 subcommand AS the agent — escapes-helper does the
    *  setuid switch, then exec's pm2 in the agent's uid.
    *
    *  cwd: the agent process inherits cwd from the spawning Nest

--- a/apps/openape-nest/src/lib/troop-ws.ts
+++ b/apps/openape-nest/src/lib/troop-ws.ts
@@ -58,8 +58,10 @@ export interface TroopWsOptions {
   troopUrl?: string
   apesBin: string
   log: (line: string) => void
-  /** package.json version of @openape/nest — surfaces in the troop UI's
-   *  online-badge tooltip and in audit logs. */
+  /**
+   * package.json version of @openape/nest — surfaces in the troop UI's
+   *  online-badge tooltip and in audit logs.
+   */
   version?: string
 }
 
@@ -222,10 +224,12 @@ export class TroopWs {
       //   "✔ Registered as <email>"
       const match = stdout.match(/Registered as\s+(\S+@\S+)/)
       const agentEmail = match?.[1]
+      this.opts.log(`troop-ws: spawn-result ${frame.name} ok agent=${agentEmail ?? '?'}`)
       this.send({ type: 'spawn-result', intent_id: frame.intent_id, ok: true, agent_email: agentEmail })
     }
     catch (err) {
       const error = err instanceof Error ? err.message : String(err)
+      this.opts.log(`troop-ws: spawn-result ${frame.name} FAIL: ${error}`)
       this.send({ type: 'spawn-result', intent_id: frame.intent_id, ok: false, error })
     }
   }
@@ -257,8 +261,23 @@ export class TroopWs {
 
 function runWithCapture(bin: string, args: string[]): Promise<{ stdout: string, stderr: string }> {
   return new Promise((resolve, reject) => {
-    execFile(bin, args, { maxBuffer: 4 * 1024 * 1024 }, (err, stdout, stderr) => {
+    // `apes agents spawn` ends up starting a pm2 daemon for the new
+    // agent, and pm2 inherits stdio FDs from its parent chain. Node's
+    // execFile won't resolve until those FDs close — so without a
+    // timeout the promise hangs forever even though the spawn is
+    // already "done" from the user's POV. troop-sync uses the same
+    // 60s cap for the same reason. We bump to 120s here because
+    // first-time spawns also have an npm-install step.
+    execFile(bin, args, { maxBuffer: 4 * 1024 * 1024, timeout: 120_000 }, (err, stdout, stderr) => {
       if (err) {
+        // `signal: 'SIGTERM'` means we hit the timeout. Treat that as
+        // "spawn likely succeeded but stdio never closed" — caller
+        // verifies via the agent's troop-sync result anyway.
+        const isTimeout = (err as { signal?: string }).signal === 'SIGTERM'
+        if (isTimeout) {
+          resolve({ stdout: stdout.toString(), stderr: stderr.toString() })
+          return
+        }
         const msg = stderr.toString() || err.message
         reject(new Error(msg.split('\n').filter(Boolean).slice(-3).join(' / ')))
         return


### PR DESCRIPTION
## Summary

End-to-end test of PR #406 surfaced a real issue: \`apes agents spawn\` starts a pm2 daemon for the new agent, and pm2 keeps inherited stdio FDs open forever. Node's \`execFile()\` never resolves, even though the spawn is done from the user's POV (agent created, user provisioned, IdP-registered). The result: no \`spawn-result\` frame ever goes back to troop, so the UI sits on "Spawning…" forever.

\`troop-sync.ts\` had already paid this tax with a 60s cap. Adopting the same pattern here (120s — first-time spawns include an npm-install) and treating the SIGTERM timeout as a non-error.

Also logs the spawn-result outcome to nest-log so future debugging doesn't need tcpdump.

## Test plan

- [x] lint+typecheck+test green
- [ ] CI green
- [ ] After deploy + nest upgrade: re-trigger "+ Spawn agent" → nest-log shows \`troop-ws: spawn-result <name> ok agent=…\` within 120s, troop UI moves out of "Spawning…"

🤖 Generated with [Claude Code](https://claude.com/claude-code)