### PR TITLE
fix(nest): read agents.json from same path apes-cli writes to (Phase G drift)

### DIFF
--- a/.changeset/nest-registry-path-resolution.md
+++ b/.changeset/nest-registry-path-resolution.md
@@ -1,0 +1,18 @@
+---
+"@openape/nest": patch
+---
+
+Fix the nest daemon reading a stale `agents.json`. Phase G moved
+the canonical registry to `/var/openape/nest/agents.json` (system
+location, group-readable by `_openape_nest`) and the apes-cli's
+`apes agents spawn` writes there. But the nest daemon was still
+reading `~/.openape/nest/agents.json` (per-user, pre-Phase-G
+location), so freshly spawned agents never showed up in the
+in-process supervisor — bridges never started, no first-sync to
+troop, and the spawned agent stayed invisible in the troop UI even
+though it existed at the IdP.
+
+Now uses the same `resolveRegistryPath()` logic as
+`packages/apes/src/lib/nest-registry.ts`: prefer
+`/var/openape/nest/agents.json` if present, fall back to the
+per-user path otherwise.

--- a/apps/openape-nest/src/lib/registry.ts
+++ b/apps/openape-nest/src/lib/registry.ts
@@ -39,14 +39,22 @@ interface RegistryFile {
   agents: AgentEntry[]
 }
 
-// The nest daemon's launchd plist sets HOME=~/.openape/nest, so
-// homedir() already points at the nest's data dir. Joining
-// `.openape/nest/agents.json` on top of that produces a doubly-nested
-// path (`~/.openape/nest/.openape/nest/agents.json`) that the YOLO
-// log search and humans never find. Keep the registry directly under
-// the data dir.
-const REGISTRY_DIR = homedir()
-export const REGISTRY_PATH = join(REGISTRY_DIR, 'agents.json')
+// Registry path resolution — kept in lockstep with
+// `packages/apes/src/lib/nest-registry.ts:resolveRegistryPath()`
+// so the writer (apes-cli during `apes agents spawn`) and the
+// reader (this daemon) target the same file. Phase G migrated the
+// canonical location to `/var/openape/nest/agents.json` (group-readable
+// by `_openape_nest`); pre-migration installs still keep the file
+// under the nest's HOME=~/.openape/nest/. Drift between writer and
+// reader manifests as "spawned agent never picked up by supervisor"
+// — exactly the bug this resolves.
+function resolveRegistryPath(): string {
+  if (existsSync('/var/openape/nest/agents.json')) return '/var/openape/nest/agents.json'
+  if (existsSync('/var/openape/nest')) return '/var/openape/nest/agents.json'
+  return join(homedir(), 'agents.json')
+}
+export const REGISTRY_PATH = resolveRegistryPath()
+const REGISTRY_DIR = REGISTRY_PATH.replace(/\/agents\.json$/, '')
 
 function emptyRegistry(): RegistryFile {
   return { version: 1, agents: [] }


### PR DESCRIPTION
## Summary

Found while testing PR #406/#407 end-to-end: a spawn from the troop UI succeeded (\`apes agents list\` shows it, macOS user exists, /var/openape/homes/<name>/ created), but the agent didn't appear in the troop UI's /agents list. Root cause: the nest daemon was reading the registry from a path the writer no longer used.

Phase G moved the canonical \`agents.json\` location to \`/var/openape/nest/agents.json\` (system-level, group-readable by \`_openape_nest\`). \`packages/apes/src/lib/nest-registry.ts\` has the new resolver. The nest daemon's \`apps/openape-nest/src/lib/registry.ts\` was pinned to the old per-user path.

Result: \`apes agents spawn\` wrote to /var/openape/..., the nest watched ~/.openape/nest/.../agents.json, supervisor never saw the new agent, no bridge → no first-sync → invisible in troop UI even though IdP-registered.

## Test plan

- [x] Local turbo lint/typecheck/test green
- [ ] After deploy: \`apes agents spawn\` from troop UI → agent appears in troop /agents within ~5s of spawn-result
- [ ] Bridge daemon starts → chat-friend-request fires → owner gets it on chat.openape.ai

Closes the ape-task tracked as 01KRF1GCE752DZZTTRFBMSNK2Y.

🤖 Generated with [Claude Code](https://claude.com/claude-code)