### PR TITLE
fix(ape-agent): live config updates in existing chat threads

### DIFF
--- a/.changeset/ape-agent-live-config.md
+++ b/.changeset/ape-agent-live-config.md
@@ -1,0 +1,10 @@
+---
+"@openape/ape-agent": minor
+---
+
+Re-read `agent.json` per turn so live edits in the troop UI take
+effect in existing chat threads — not just on freshly-opened ones.
+`ThreadSessionDeps` now takes a `resolveConfig` closure instead of
+frozen `systemPrompt` + `tools` fields; the closure is called at
+the top of every turn. In-memory chat history is preserved so the
+ongoing conversation continues seamlessly with the new config.

--- a/.changeset/nest-registry-path-resolution.md
+++ b/.changeset/nest-registry-path-resolution.md
@@ -1,0 +1,18 @@
+---
+"@openape/nest": patch
+---
+
+Fix the nest daemon reading a stale `agents.json`. Phase G moved
+the canonical registry to `/var/openape/nest/agents.json` (system
+location, group-readable by `_openape_nest`) and the apes-cli's
+`apes agents spawn` writes there. But the nest daemon was still
+reading `~/.openape/nest/agents.json` (per-user, pre-Phase-G
+location), so freshly spawned agents never showed up in the
+in-process supervisor — bridges never started, no first-sync to
+troop, and the spawned agent stayed invisible in the troop UI even
+though it existed at the IdP.
+
+Now uses the same `resolveRegistryPath()` logic as
+`packages/apes/src/lib/nest-registry.ts`: prefer
+`/var/openape/nest/agents.json` if present, fall back to the
+per-user path otherwise.

--- a/apps/openape-ape-agent/src/bridge.ts
+++ b/apps/openape-ape-agent/src/bridge.ts
@@ -330,16 +330,21 @@ class Bridge {
       threadId,
       chat: this.chat,
       runtimeConfig: this.runtimeConfig(),
-      // Tools resolve from agent.json (latest sync from troop) on
-      // every new thread, so owner edits in the troop UI take
-      // effect after the next sync without a bridge restart.
-      // SOUL.md + skills are merged into the system prompt the same
-      // way — picked up per-thread without restart.
-      tools: resolveTools(this.cfg.tools),
-      systemPrompt: composeSystemPrompt({
-        base: resolveSystemPrompt(this.cfg.systemPrompt),
-        enabledTools: resolveTools(this.cfg.tools),
-      }),
+      // Resolve tools + systemPrompt on every turn from agent.json
+      // (latest sync from troop). Owner edits in the troop UI thus
+      // take effect on the very next message in an existing thread —
+      // not just on a freshly-opened one. SOUL.md + skills get merged
+      // into the system prompt the same way.
+      resolveConfig: () => {
+        const tools = resolveTools(this.cfg.tools)
+        return {
+          tools,
+          systemPrompt: composeSystemPrompt({
+            base: resolveSystemPrompt(this.cfg.systemPrompt),
+            enabledTools: tools,
+          }),
+        }
+      },
       maxSteps: this.cfg.maxSteps,
       log,
     })

--- a/apps/openape-ape-agent/src/cron-runner.ts
+++ b/apps/openape-ape-agent/src/cron-runner.ts
@@ -124,8 +124,10 @@ function readSystemPrompt(): string {
 }
 
 export interface CronRunnerDeps {
-  /** Resolved at bridge boot — model + LiteLLM proxy details. The
-   * cron runner shares it with chat threads. */
+  /**
+   * Resolved at bridge boot — model + LiteLLM proxy details. The
+   * cron runner shares it with chat threads.
+   */
   runtimeConfig: RuntimeConfig
   chat: ChatApi
   /** Owner email — where DMs go. Resolved from the contacts list at fire time. */

--- a/apps/openape-ape-agent/src/thread-session.ts
+++ b/apps/openape-ape-agent/src/thread-session.ts
@@ -10,7 +10,7 @@
 // alive. Per-thread message history that used to live in the
 // subprocess's RpcSessionMap now lives on the ThreadSession itself.
 
-import type { ChatMessage, RuntimeConfig, ToolDefinition } from '@openape/apes'
+import type { ChatMessage, RuntimeConfig } from '@openape/apes'
 import { runLoop, taskTools } from '@openape/apes'
 import type { ChatApi } from './chat-api'
 import type { Throttle } from './throttle'
@@ -31,8 +31,16 @@ export interface ThreadSessionDeps {
   chat: ChatApi
   /** LiteLLM proxy + model — the bridge resolves these from its env. */
   runtimeConfig: RuntimeConfig
-  systemPrompt: string
-  tools: string[]
+  /**
+   * Resolve systemPrompt + tools at the start of every turn rather
+   * than freezing them at construction. Lets owner edits in the
+   * troop UI (which sync to `~/.openape/agent/agent.json` via
+   * `apes agents sync`) take effect on the next message in an
+   * existing thread — not just on freshly-opened threads.
+   * `tools` is the string list that `taskTools()` resolves to the
+   * concrete `ToolDefinition[]`.
+   */
+  resolveConfig: () => { systemPrompt: string, tools: string[] }
   maxSteps: number
   /** Logger sink — bridge typically forwards to stderr. */
   log: (line: string) => void
@@ -42,14 +50,13 @@ export class ThreadSession {
   private active: ActiveTurn | undefined
   private queue: Array<{ body: string, replyToMessageId: string }> = []
   private history: ChatMessage[] = []
-  private resolvedTools: ToolDefinition[]
 
-  constructor(private deps: ThreadSessionDeps) {
-    this.resolvedTools = taskTools(deps.tools)
-  }
+  constructor(private deps: ThreadSessionDeps) {}
 
-  /** No-op placeholder kept for API compatibility with the previous
-   *  RPC-listener model where dispose() detached the listener. */
+  /**
+   * No-op placeholder kept for API compatibility with the previous
+   *  RPC-listener model where dispose() detached the listener.
+   */
   dispose(): void {}
 
   /** Forward an inbound chat message to the runtime. Queues if a turn is in flight. */
@@ -106,12 +113,17 @@ export class ThreadSession {
     // Run the agent loop in-process. Same code path the legacy
     // `apes agents serve --rpc` subprocess used; we just call it
     // directly instead of marshaling through stdio.
+    //
+    // Resolve config NOW (not at construction) so a troop-UI edit
+    // that synced after this thread opened still takes effect on
+    // this very turn — without dropping the message history.
+    const { systemPrompt, tools } = this.deps.resolveConfig()
     try {
       const result = await runLoop({
         config: this.deps.runtimeConfig,
-        systemPrompt: this.deps.systemPrompt,
+        systemPrompt,
         userMessage: body,
-        tools: this.resolvedTools,
+        tools: taskTools(tools),
         maxSteps: this.deps.maxSteps,
         history: this.history,
         handlers: {

--- a/apps/openape-nest/src/lib/registry.ts
+++ b/apps/openape-nest/src/lib/registry.ts
@@ -39,14 +39,22 @@ interface RegistryFile {
   agents: AgentEntry[]
 }
 
-// The nest daemon's launchd plist sets HOME=~/.openape/nest, so
-// homedir() already points at the nest's data dir. Joining
-// `.openape/nest/agents.json` on top of that produces a doubly-nested
-// path (`~/.openape/nest/.openape/nest/agents.json`) that the YOLO
-// log search and humans never find. Keep the registry directly under
-// the data dir.
-const REGISTRY_DIR = homedir()
-export const REGISTRY_PATH = join(REGISTRY_DIR, 'agents.json')
+// Registry path resolution — kept in lockstep with
+// `packages/apes/src/lib/nest-registry.ts:resolveRegistryPath()`
+// so the writer (apes-cli during `apes agents spawn`) and the
+// reader (this daemon) target the same file. Phase G migrated the
+// canonical location to `/var/openape/nest/agents.json` (group-readable
+// by `_openape_nest`); pre-migration installs still keep the file
+// under the nest's HOME=~/.openape/nest/. Drift between writer and
+// reader manifests as "spawned agent never picked up by supervisor"
+// — exactly the bug this resolves.
+function resolveRegistryPath(): string {
+  if (existsSync('/var/openape/nest/agents.json')) return '/var/openape/nest/agents.json'
+  if (existsSync('/var/openape/nest')) return '/var/openape/nest/agents.json'
+  return join(homedir(), 'agents.json')
+}
+export const REGISTRY_PATH = resolveRegistryPath()
+const REGISTRY_DIR = REGISTRY_PATH.replace(/\/agents\.json$/, '')
 
 function emptyRegistry(): RegistryFile {
   return { version: 1, agents: [] }


### PR DESCRIPTION
## Summary

Found while testing the troop control-plane: editing an agent's \`system_prompt\` in the troop UI synced to disk via the existing WS push (PR #406/#407), but the running bridge kept using the OLD prompt for any chat thread that was already open. The freeze happened at \`ThreadSession\` construction — only freshly-opened threads picked up the change.

Trade-off considered: \`pm2 reload\` would also work but resets the per-thread in-memory chat history, so the agent forgets the ongoing conversation. The closure approach preserves history; the next message runs under the latest config, the model still remembers what came before.

## Pieces

- \`ThreadSessionDeps\`: \`systemPrompt: string\` + \`tools: string[]\` → \`resolveConfig: () => { systemPrompt, tools }\` (closure)
- \`ThreadSession.startTurn\`: calls \`resolveConfig()\` at the start of every turn, passes fresh values to \`runLoop\`
- \`bridge.ts.getOrCreateThread\`: wraps the existing \`resolveSystemPrompt\` + \`resolveTools\` reads in a closure so each turn re-reads \`~/.openape/agent/agent.json\`

## Test plan

- [x] Local turbo lint/typecheck/test green
- [ ] CI green
- [ ] After release + nest+bridge upgrade on the mini: edit stephan's system_prompt in troop → send a message in an existing thread → reply matches the new prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)