### PR TITLE
fix(nest): test-time guard against writing to production registry

### DIFF
--- a/.changeset/nest-test-guard.md
+++ b/.changeset/nest-test-guard.md
@@ -1,0 +1,13 @@
+---
+"@openape/nest": patch
+---
+
+Test-time safety guard: `OPENAPE_NEST_REGISTRY_PATH` env override
+in `resolveRegistryPath()`. Without it, `pnpm test` on a dev
+machine that has a real nest installed (the post-Phase-G
+`/var/openape/nest/` directory exists) hits the real production
+registry — and the existing "shrugs off corrupt JSON" vitest case
+writes `{not json` to whatever `REGISTRY_PATH` resolves to.
+Happened in practice once and lost the production agents.json
+until manual reconstruction. The vitest setup now sets the
+override so the test stays sandboxed to its tmpdir.

--- a/apps/openape-nest/src/lib/registry.ts
+++ b/apps/openape-nest/src/lib/registry.ts
@@ -45,10 +45,15 @@ interface RegistryFile {
 // reader (this daemon) target the same file. Phase G migrated the
 // canonical location to `/var/openape/nest/agents.json` (group-readable
 // by `_openape_nest`); pre-migration installs still keep the file
-// under the nest's HOME=~/.openape/nest/. Drift between writer and
-// reader manifests as "spawned agent never picked up by supervisor"
-// — exactly the bug this resolves.
+// under the nest's HOME=~/.openape/nest/.
+//
+// `OPENAPE_NEST_REGISTRY_PATH` overrides everything — mandatory so
+// `pnpm test` on a dev machine that has a real nest installed (the
+// post-Phase-G `/var/openape/nest/` exists) doesn't have the
+// vitest "corrupt-json" case clobber production data. Production
+// setups don't set the override; this is purely a test-time guard.
 function resolveRegistryPath(): string {
+  if (process.env.OPENAPE_NEST_REGISTRY_PATH) return process.env.OPENAPE_NEST_REGISTRY_PATH
   if (existsSync('/var/openape/nest/agents.json')) return '/var/openape/nest/agents.json'
   if (existsSync('/var/openape/nest')) return '/var/openape/nest/agents.json'
   return join(homedir(), 'agents.json')

--- a/apps/openape-nest/test/registry.test.ts
+++ b/apps/openape-nest/test/registry.test.ts
@@ -7,6 +7,13 @@ let tmp: string
 
 beforeEach(() => {
   tmp = mkdtempSync(join(tmpdir(), 'nest-registry-'))
+  // OPENAPE_NEST_REGISTRY_PATH override is mandatory — without it
+  // resolveRegistryPath() falls back to checking `/var/openape/nest/`,
+  // which on a dev box hosting a real nest install means every
+  // write in this test (including the deliberately-corrupt
+  // "{not json" case) clobbers the production registry. We lived
+  // through that exact outage once — see #408 follow-up.
+  vi.stubEnv('OPENAPE_NEST_REGISTRY_PATH', join(tmp, 'agents.json'))
   vi.stubEnv('HOME', tmp)
   vi.resetModules()
 })


### PR DESCRIPTION
## Summary

PR #408's registry-path resolver prefers \`/var/openape/nest/agents.json\` when present — but the existing vitest "corrupt JSON" case writes \`{not json\` to whatever \`REGISTRY_PATH\` resolves to. On any dev machine with a real nest installed, that means \`pnpm test --filter=@openape/nest\` corrupts the production registry. I lived through it once today (lost stephan + ape-agent-iurio + igor30 entries) and had to reconstruct from \`/var/openape/homes/\` + dscl.

Add \`OPENAPE_NEST_REGISTRY_PATH\` env override at the top of \`resolveRegistryPath\`; vitest setup pins it to the per-case tmpdir. Production doesn't set it — same behavior as before.

Should have shipped with #408. Splitting it out to land fast before anyone else runs the test suite on a real nest box.

## Test plan

- [x] Local turbo lint/typecheck/test green
- [ ] CI green
- [ ] After merge: \`pnpm test --filter=@openape/nest\` on a box with /var/openape/nest/ doesn't touch the real file

🤖 Generated with [Claude Code](https://claude.com/claude-code)