### PR TITLE
feat(ape-agent): backfill chat history on first turn (no more memory loss across bridge restart)

### DIFF
--- a/.changeset/ape-agent-backfill-history.md
+++ b/.changeset/ape-agent-backfill-history.md
@@ -1,0 +1,13 @@
+---
+"@openape/ape-agent": minor
+---
+
+Backfill chat history from the server when a ThreadSession is first
+created. Without this, a bridge restart left the agent with empty
+`history` — it would respond to the next message without knowing
+anything that happened earlier in the same thread, even though the
+chat server has the full transcript. Now the first turn after
+construction fetches the last 50 messages via
+`GET /api/rooms/:id/messages?thread_id=…` and seeds them into
+history. Failures are non-fatal: the bridge logs and continues with
+empty history (matching the pre-backfill behaviour).

--- a/apps/openape-ape-agent/src/bridge.ts
+++ b/apps/openape-ape-agent/src/bridge.ts
@@ -345,6 +345,7 @@ class Bridge {
           }),
         }
       },
+      selfEmail: this.selfEmail,
       maxSteps: this.cfg.maxSteps,
       log,
     })

--- a/apps/openape-ape-agent/src/chat-api.ts
+++ b/apps/openape-ape-agent/src/chat-api.ts
@@ -12,6 +12,25 @@ export interface PostedMessage {
   createdAt: number
 }
 
+/**
+ * One row from `GET /api/rooms/:id/messages?thread_id=...`. Used by
+ * the bridge to backfill chat history into a freshly-created
+ * ThreadSession so the agent doesn't 'forget' the conversation
+ * after a process restart.
+ */
+export interface HistoryMessage {
+  id: string
+  roomId: string
+  threadId: string
+  senderEmail: string
+  senderAct: 'human' | 'agent'
+  body: string
+  replyTo: string | null
+  createdAt: number
+  /** Server snake-case field — tolerated as fallback. */
+  reply_to?: string | null
+}
+
 export interface ContactView {
   peerEmail: string
   myStatus: 'accepted' | 'pending' | 'blocked'
@@ -46,6 +65,20 @@ export class ChatApi {
       body: payload,
     })
     return result
+  }
+
+  /**
+   * Fetch the most recent `limit` messages in a thread, oldest-first.
+   * Used by ThreadSession to seed `history` so the agent has the
+   * full conversation context after a bridge restart — otherwise it
+   * only sees messages that arrived via WS since the process boot.
+   */
+  async listMessages(roomId: string, threadId: string, limit = 50): Promise<HistoryMessage[]> {
+    const url = `${this.endpoint}/api/rooms/${encodeURIComponent(roomId)}/messages?thread_id=${encodeURIComponent(threadId)}&limit=${limit}`
+    return await ofetch<HistoryMessage[]>(url, {
+      method: 'GET',
+      headers: { Authorization: await this.bearer() },
+    })
   }
 
   async requestContact(peerEmail: string): Promise<ContactView> {

--- a/apps/openape-ape-agent/src/thread-session.ts
+++ b/apps/openape-ape-agent/src/thread-session.ts
@@ -41,6 +41,11 @@ export interface ThreadSessionDeps {
    * concrete `ToolDefinition[]`.
    */
   resolveConfig: () => { systemPrompt: string, tools: string[] }
+  /**
+   * Agent's own DDISA email — used to classify backfilled messages:
+   * `senderEmail === selfEmail` → role='assistant', else → 'user'.
+   */
+  selfEmail: string
   maxSteps: number
   /** Logger sink — bridge typically forwards to stderr. */
   log: (line: string) => void
@@ -50,6 +55,14 @@ export class ThreadSession {
   private active: ActiveTurn | undefined
   private queue: Array<{ body: string, replyToMessageId: string }> = []
   private history: ChatMessage[] = []
+  /**
+   * Whether we've already backfilled history from the chat server.
+   * Done lazily on the first turn so a freshly-created ThreadSession
+   * (e.g. after a bridge restart) sees the full conversation context,
+   * not just the message that woke it up. We skip the message that
+   * triggered the turn — runLoop adds it via `userMessage`.
+   */
+  private backfilled = false
 
   constructor(private deps: ThreadSessionDeps) {}
 
@@ -118,6 +131,14 @@ export class ThreadSession {
     // that synced after this thread opened still takes effect on
     // this very turn — without dropping the message history.
     const { systemPrompt, tools } = this.deps.resolveConfig()
+
+    // Backfill history from the chat server on the first turn after
+    // this ThreadSession was created. Without this the agent only
+    // remembers messages received via WS since the bridge process
+    // booted — a restart wipes context. Done after posting the
+    // placeholder (so the user immediately sees the typing indicator)
+    // and before runLoop (so it gets the full context).
+    await this.backfillHistoryOnce(replyToMessageId, body)
     try {
       const result = await runLoop({
         config: this.deps.runtimeConfig,
@@ -164,6 +185,39 @@ export class ThreadSession {
       const message = err instanceof Error ? err.message : String(err)
       this.deps.log(`runtime error (room=${this.deps.roomId} thread=${this.deps.threadId}): ${message}`)
       await this.failTurn(`(runtime error: ${message})`)
+    }
+  }
+
+  /**
+   * Fetch recent chat history for this thread and seed `this.history`.
+   * Idempotent — only runs once per ThreadSession instance. Skips the
+   * placeholder we just posted plus the inbound message that triggered
+   * this turn (runLoop's `userMessage` handles that one).
+   *
+   * Failures are non-fatal: we log and continue with empty history.
+   * That preserves the pre-backfill behaviour rather than failing the
+   * turn over a transient chat-server hiccup.
+   */
+  private async backfillHistoryOnce(currentMessageId: string, currentBody: string): Promise<void> {
+    if (this.backfilled) return
+    this.backfilled = true
+    try {
+      const rows = await this.deps.chat.listMessages(this.deps.roomId, this.deps.threadId, 50)
+      // The list returns oldest-first. Drop:
+      //   - the current inbound message (runLoop adds it via userMessage)
+      //   - our own placeholder (empty body, streaming=true, just posted)
+      //   - any other empty body (cron task placeholders mid-stream)
+      for (const row of rows) {
+        if (row.id === currentMessageId) continue
+        if (!row.body || row.body.length === 0) continue
+        if (row.body === currentBody && row.senderEmail !== this.deps.selfEmail) continue
+        const role: ChatMessage['role'] = row.senderEmail === this.deps.selfEmail ? 'assistant' : 'user'
+        this.history.push({ role, content: row.body })
+      }
+      this.deps.log(`[${this.deps.roomId}/${this.deps.threadId.slice(0, 8)}] backfilled ${this.history.length} message(s) from chat history`)
+    }
+    catch (err) {
+      this.deps.log(`[${this.deps.roomId}/${this.deps.threadId.slice(0, 8)}] backfill failed (continuing with empty history): ${err instanceof Error ? err.message : String(err)}`)
     }
   }
 


### PR DESCRIPTION
## Summary

Patrick noticed: after the bridge restarts, agents seem to 'forget' earlier messages in an existing chat thread. Root cause: \`ThreadSession.history\` is in-process only. Server has the full transcript, the bridge never asks for it. Restart → empty history → agent answers the next message with no context, even though the user sees a long conversation in the chat UI.

## Pieces

- \`chat-api.ts\` — adds \`listMessages(roomId, threadId, limit)\` wrapper around the existing \`GET /api/rooms/:id/messages?thread_id=…\` endpoint.
- \`thread-session.ts\` — new \`backfillHistoryOnce()\` runs at the top of the first turn after construction. Seeds \`this.history\` from the server. Idempotent (only runs once per ThreadSession). Filters: current inbound msg, empty bodies, the placeholder we just posted. Roles set via \`senderEmail === selfEmail\`.
- \`bridge.ts\` — passes \`selfEmail\` into ThreadSessionDeps.
- Backfill failures log + continue with empty history (= pre-backfill behaviour).

## Test plan

- [x] Local turbo lint/typecheck/test green (35 tests pass)
- [ ] CI green
- [ ] After release + bridge upgrade on mini: restart \`pm2 reload openape-bridge-stephan\`, send a message in an existing thread referencing something said earlier → agent answers with context

🤖 Generated with [Claude Code](https://claude.com/claude-code)