### PR TITLE
fix(apes): nest install writes bridge-model to both ~/litellm/.env and the nest's own

### DIFF
--- a/.changeset/apes-nest-install-bridge-model.md
+++ b/.changeset/apes-nest-install-bridge-model.md
@@ -1,0 +1,14 @@
+---
+"@openape/apes": patch
+---
+
+`apes nest install --bridge-model <m>` now writes the
+`APE_CHAT_BRIDGE_MODEL=<m>` line to BOTH `~/litellm/.env` and the
+nest's own `~/.openape/nest/litellm/.env`. Previously it only wrote
+the first. Since the nest daemon's launchd plist pins
+`HOME=~/.openape/nest`, every nest-driven spawn (TroopWs handler →
+`apes agents spawn`) read the per-nest litellm/.env — which lacked
+the model line — so the bridge for the new agent crash-looped with
+`fatal: APE_CHAT_BRIDGE_MODEL is not set` on every boot. Patrick-
+shell-driven spawns worked because they read `~/litellm/.env`
+directly.

--- a/packages/apes/src/commands/nest/install.ts
+++ b/packages/apes/src/commands/nest/install.ts
@@ -102,31 +102,37 @@ function installAdapter(): boolean {
 }
 
 /**
- * Write `APE_CHAT_BRIDGE_MODEL=<value>` to `~/litellm/.env`. The same
+ * Write `APE_CHAT_BRIDGE_MODEL=<value>` to `~/litellm/.env` AND to
+ * the nest's own `litellm/.env` (under `NEST_DATA_DIR`). The same
  * file resolveBridgeConfig (in lib/llm-bridge.ts) reads at
- * `apes [nest|agents] spawn` time. Idempotent: replaces the
- * line in place if it already exists, appends otherwise. Creates the
- * file (and ~/litellm/) on first call.
+ * `apes [nest|agents] spawn` time — but it resolves the path via
+ * `homedir()`, so:
  *
- * Why ~/litellm/.env and not the central /etc/openape/litellm.env:
- * fresh installs (no privilege-isolation migration yet) only have the
- * user-home file. The central file is the optional post-migration
- * upgrade — see migrate-to-service-user.sh which symlinks both
- * locations to /etc/openape/litellm.env so writing to ~/litellm/.env
- * keeps working for both layouts.
+ *   - Patrick-driven spawn (`apes agents spawn …` from a shell)
+ *     reads `~/litellm/.env`.
+ *   - Nest-driven spawn (TroopWs handler running as the daemon)
+ *     reads `~/.openape/nest/litellm/.env` because the launchd plist
+ *     pins `HOME=NEST_DATA_DIR` for the daemon process.
+ *
+ * Writing to both keeps the model default consistent between the
+ * two entry points — without this, freshly-installed nests had no
+ * `APE_CHAT_BRIDGE_MODEL` line and the bridge crash-looped on every
+ * spawn-from-troop-UI with `fatal: APE_CHAT_BRIDGE_MODEL is not set`.
+ *
+ * Idempotent: replaces an existing line in place, appends otherwise.
  */
 function writeBridgeModelDefault(model: string): void {
-  const envDir = join(homedir(), 'litellm')
-  const envFile = join(envDir, '.env')
-  mkdirSync(envDir, { recursive: true })
-  let lines: string[] = []
-  if (existsSync(envFile)) {
-    lines = readFileSync(envFile, 'utf8').split('\n').filter(l => !l.startsWith('APE_CHAT_BRIDGE_MODEL='))
+  for (const envDir of [join(homedir(), 'litellm'), join(NEST_DATA_DIR, 'litellm')]) {
+    const envFile = join(envDir, '.env')
+    mkdirSync(envDir, { recursive: true })
+    let lines: string[] = []
+    if (existsSync(envFile)) {
+      lines = readFileSync(envFile, 'utf8').split('\n').filter(l => !l.startsWith('APE_CHAT_BRIDGE_MODEL='))
+    }
+    lines.push(`APE_CHAT_BRIDGE_MODEL=${model}`)
+    while (lines.length > 0 && lines.at(-1)!.trim() === '') lines.pop()
+    writeFileSync(envFile, `${lines.join('\n')}\n`, { mode: 0o600 })
   }
-  lines.push(`APE_CHAT_BRIDGE_MODEL=${model}`)
-  // Trim trailing blanks then ensure file ends with one newline
-  while (lines.length > 0 && lines.at(-1)!.trim() === '') lines.pop()
-  writeFileSync(envFile, `${lines.join('\n')}\n`, { mode: 0o600 })
 }
 
 function findBinary(name: string): string {


### PR DESCRIPTION
## Summary

Diagnosed today: fresh agents spawned via the troop UI (\`apes agents spawn\` invoked by the nest's TroopWs handler) had \`.env\` files missing \`APE_CHAT_BRIDGE_MODEL\`. ape-agent crash-looped at boot: \`fatal: APE_CHAT_BRIDGE_MODEL is not set\`. Patrick-shell spawns worked fine.

Root cause: \`apes nest install --bridge-model\` only wrote the model line to \`~/litellm/.env\` (Patrick's home). But the nest daemon's launchd plist pins \`HOME=~/.openape/nest\`, so \`resolveBridgeConfig\` inside daemon-driven spawns reads from \`~/.openape/nest/litellm/.env\` — which had no model.

Fix: write to both paths. Idempotent on both, replaces existing lines in place.

The ape-task \`01KRF1GCE752DZZTTRFBMSNK2Y\` was tracking this regression — closing with this PR.

## Test plan

- [x] Local turbo lint/typecheck/test green
- [ ] CI green
- [ ] After release + nest reinstall on the mini: spawn a fresh agent from troop UI, bridge .env contains all three lines, bridge boots without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)