### PR TITLE
fix(nest): /var/openape/agents/ created with group-write + setgid

### DIFF
--- a/.changeset/nest-agents-dir-perms.md
+++ b/.changeset/nest-agents-dir-perms.md
@@ -1,0 +1,21 @@
+---
+"@openape/nest": patch
+---
+
+`/var/openape/agents/` (where the pm2-supervisor writes per-agent
+ecosystem.config.js + start.sh) now gets created with mode 2775
+(`drwxrwsr-x` — group-write + setgid) instead of 755. Without this,
+the nest daemon (running as the human user) couldn't mkdir/write
+under the dir because root had created it with stricter perms on
+an earlier install — pm2-supervisor logged `EACCES: permission
+denied` on every reconcile and bridges never started for agents
+spawned via the troop UI.
+
+Two-tier fix:
+- `migrate-to-service-user.sh` pre-creates `/var/openape/agents/`
+  with the right perms (root-only operation, runs at install/upgrade).
+- `pm2-supervisor.ts` re-asserts the setgid bit on every reconcile
+  via an explicit chmod after the mkdir, since mkdir's mode is
+  masked by the process umask and setgid usually doesn't survive.
+  Repair fails silently if the daemon isn't group-owner — operators
+  on legacy installs re-run `migrate-to-service-user.sh`.

--- a/apps/openape-nest/scripts/migrate-to-service-user.sh
+++ b/apps/openape-nest/scripts/migrate-to-service-user.sh
@@ -76,6 +76,23 @@ else
   echo "  WARN: $OLD_DATA_DIR not found, $NEW_DATA_DIR is empty"
 fi
 
+echo "=== 3b. Provision /var/openape/agents/ (pm2-supervisor work dir) ==="
+# The nest daemon runs as the human user (Patrick) but writes per-agent
+# pm2 ecosystem.config.js + start.sh files into /var/openape/agents/.
+# Patrick needs group-write so a non-root mkdir-then-write works; the
+# setgid bit on the parent makes new entries inherit GROUP_NAME so they
+# stay accessible after a recursive chown elsewhere. Without this the
+# pm2-supervisor logs "EACCES: permission denied, mkdir" on every
+# reconcile and bridges never start for agents spawned via the troop UI.
+AGENTS_DIR=/var/openape/agents
+mkdir -p $AGENTS_DIR
+chown $USER_NAME:$GROUP_NAME $AGENTS_DIR
+chmod 2775 $AGENTS_DIR   # drwxrwsr-x — group-write + setgid
+# Bring any existing subdirs (legacy agents from before this fix) in
+# line so the supervisor can rewrite their ecosystem files.
+find $AGENTS_DIR -mindepth 1 -type d -exec chmod 2775 {} \; 2>/dev/null || true
+find $AGENTS_DIR -mindepth 1 -type f -exec chmod g+rw {} \; 2>/dev/null || true
+
 echo "=== 4. Boot out user-domain plist if present ==="
 if [ -f "$USER_PLIST" ]; then
   launchctl bootout gui/501/ai.openape.nest 2>/dev/null || true

--- a/apps/openape-nest/src/lib/pm2-supervisor.ts
+++ b/apps/openape-nest/src/lib/pm2-supervisor.ts
@@ -26,7 +26,7 @@
 // apes-run are the only sane channel.
 
 import { execFile } from 'node:child_process'
-import { mkdirSync, writeFileSync } from 'node:fs'
+import { chmodSync, existsSync, mkdirSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import process from 'node:process'
 import { promisify } from 'node:util'
@@ -37,8 +37,32 @@ const execFileAsync = promisify(execFile)
 // when pm2 (running as the agent uid) opens the file. The Nest's
 // own private state stays under /var/openape/nest/ at mode 750;
 // these per-agent ecosystem files are mechanically generated and
-// hold no secrets, so 755 dir + 644 file is fine.
+// hold no secrets, so 2775 dir + 664 file is fine.
 const AGENTS_DIR = '/var/openape/agents'
+
+// `drwxrwsr-x` (group-write + setgid). Lets the nest daemon (running
+// as the human user, member of _openape_nest group) create + rewrite
+// per-agent files under here, while each agent's pm2 (running as
+// the agent uid, NOT in the group) still has world-read to load its
+// own ecosystem.config.js. Setgid propagates the parent's group on
+// every new entry, so a recursive chown elsewhere won't strand files
+// outside the group.
+const SHARED_DIR_MODE = 0o2775
+
+function ensureSharedDir(path: string): void {
+  // mkdir's mode is masked by the process umask — the setgid bit
+  // (S_ISGID) routinely gets stripped. Explicit chmod after the
+  // mkdir is the reliable way to set it.
+  mkdirSync(path, { recursive: true, mode: SHARED_DIR_MODE })
+  if (existsSync(path)) {
+    // Best-effort: if the dir already existed with stricter perms
+    // from a pre-fix install, repair it. If we lack permission (not
+    // group-owner / not root), the chmod fails silently and the
+    // operator needs to re-run `migrate-to-service-user.sh` once.
+    try { chmodSync(path, SHARED_DIR_MODE) }
+    catch { /* not group-owner; relies on out-of-band fix */ }
+  }
+}
 
 export interface Pm2SupervisorDeps {
   apesBin: string
@@ -145,18 +169,31 @@ export class Pm2Supervisor {
   }
 
   private async startOrReload(agentName: string): Promise<void> {
-    // Materialise the ecosystem file under /var/openape/nest/agents/
-    // (the Nest's data dir, owned by _openape_nest). The agent's pm2
-    // reads it via apes-run+escapes — escapes inherits ENV but the
-    // working dir flips to the agent's $HOME, so we use the absolute
-    // path.
-    // Ensure the parent + per-agent dirs are world-traversable so
-    // agents (different uids) can read their own ecosystem.config.js.
-    mkdirSync(AGENTS_DIR, { recursive: true, mode: 0o755 })
+    // Materialise the ecosystem file under /var/openape/agents/. The
+    // dir hierarchy here is shared between the nest daemon (writer,
+    // runs as the human user) and the agent's pm2 (reader, runs as
+    // the agent uid via apes-run+escapes). escapes inherits ENV but
+    // the working dir flips to the agent's $HOME, so absolute paths
+    // are mandatory.
+    //
+    // Perms model: parent `/var/openape/agents/` is pre-provisioned
+    // by `migrate-to-service-user.sh` as `_openape_nest:_openape_nest
+    // drwxrwsr-x` (group-write + setgid). The setgid bit propagates
+    // the group on every new entry, so the nest can mkdir/write here
+    // as a regular group member. ensureSharedDir below re-asserts the
+    // setgid + group-write bits on the parent because:
+    //   1. `mkdirSync(..., { mode })` gets masked by the process's
+    //      umask — the setgid bit usually doesn't survive,
+    //   2. previously-existing parent dirs from old installs may
+    //      still carry the pre-fix `drwxr-xr-x` perms; if Patrick is
+    //      in the group the chmodSync repairs them in place,
+    //      otherwise it silently fails and the operator runs
+    //      `migrate-to-service-user.sh` (which has root).
+    ensureSharedDir(AGENTS_DIR)
     const dir = join(AGENTS_DIR, agentName)
-    mkdirSync(dir, { recursive: true, mode: 0o755 })
+    ensureSharedDir(dir)
     const path = ecosystemPath(agentName)
-    writeFileSync(path, ecosystemContents(this.deps.apesBin, agentName), { mode: 0o644 })
+    writeFileSync(path, ecosystemContents(this.deps.apesBin, agentName), { mode: 0o664 })
 
     // Drop the per-agent start.sh next to the ecosystem file. Going
     // through a script (not a `bash -c "..."` one-liner) sidesteps
@@ -165,7 +202,7 @@ export class Pm2Supervisor {
     // anything past the script-string into positional args
     // ($0, $1, ...) — silently dropping the redirects we expected.
     const startPath = startScriptPath(agentName)
-    writeFileSync(startPath, startScriptContents(agentName), { mode: 0o755 })
+    writeFileSync(startPath, startScriptContents(agentName), { mode: 0o775 })
     void path
 
     // Run start.sh — pm2 startOrReload's exit code is unreliable


### PR DESCRIPTION
## Summary

Yesterday's WS-driven spawn path hit EACCES on every reconcile because \`/var/openape/agents/\` was created with mode 0o755 — the nest daemon (running as Patrick, member of \`_openape_nest\` group) had no write access. Manual \`chmod g+ws\` on the mini fixed it then; this PR makes the fix permanent across all installs.

## Pieces

- \`migrate-to-service-user.sh\` — pre-creates \`/var/openape/agents/\` with mode \`2775\` (drwxrwsr-x: group-write + setgid). Setgid propagates the group on every new entry. Also includes a repair pass over existing subdirs from legacy installs.
- \`pm2-supervisor.ts\` — new \`ensureSharedDir()\` helper that does mkdir + explicit chmod after, since mkdir's mode arg is masked by the process umask (setgid bit doesn't survive). Best-effort repair: if the dir exists with stricter perms and the nest isn't the group-owner, the chmod silently fails and the operator re-runs the migrate script.
- Per-agent ecosystem.config.js / start.sh write-modes bumped 644→664 / 755→775 to match the group-shared model.

## Test plan

- [x] Local turbo lint/typecheck/test green
- [ ] CI green
- [ ] After release + nest upgrade: trigger a config-update reconcile, no EACCES in nest-log. Fresh agents spawned via the troop UI on a new mini come online without manual perm fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)