### PR TITLE
fix(ci): extract nuxt-prepare as own turbo task (kills the .nuxt/tsconfig race)

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -9,7 +9,8 @@
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",
     "lint": "eslint .",
-    "typecheck": "nuxi prepare && nuxt typecheck",
+    "nuxt-prepare": "nuxi prepare",
+    "typecheck": "nuxt typecheck",
     "test": "vitest run --passWithNoTests"
   },
   "dependencies": {

--- a/apps/openape-chat/package.json
+++ b/apps/openape-chat/package.json
@@ -7,9 +7,10 @@
     "postinstall": "nuxt prepare",
     "build": "nuxt build",
     "dev": "nuxt dev --port 3007",
-    "typecheck": "nuxi prepare && nuxt typecheck",
+    "nuxt-prepare": "nuxi prepare",
+    "typecheck": "nuxt typecheck",
     "lint": "eslint .",
-    "test": "nuxi prepare && vitest run"
+    "test": "vitest run"
   },
   "dependencies": {
     "@iconify-json/lucide": "^1.2.90",

--- a/apps/openape-troop/package.json
+++ b/apps/openape-troop/package.json
@@ -12,7 +12,8 @@
     "postinstall": "nuxt prepare",
     "build": "nuxt build",
     "dev": "nuxt dev --port 3010",
-    "typecheck": "nuxi prepare && nuxt typecheck",
+    "nuxt-prepare": "nuxi prepare",
+    "typecheck": "nuxt typecheck",
     "lint": "eslint .",
     "test": "vitest run"
   },

--- a/examples/idp/package.json
+++ b/examples/idp/package.json
@@ -7,7 +7,8 @@
     "postinstall": "nuxt prepare",
     "build": "nuxt build",
     "dev": "nuxt dev --port 3000",
-    "typecheck": "nuxi prepare && nuxt typecheck",
+    "nuxt-prepare": "nuxi prepare",
+    "typecheck": "nuxt typecheck",
     "lint": "eslint ."
   },
   "dependencies": {

--- a/examples/sp/package.json
+++ b/examples/sp/package.json
@@ -7,7 +7,8 @@
     "postinstall": "nuxt prepare",
     "build": "nuxt build",
     "dev": "nuxt dev --port 3001",
-    "typecheck": "nuxi prepare && nuxt typecheck",
+    "nuxt-prepare": "nuxi prepare",
+    "typecheck": "nuxt typecheck",
     "lint": "eslint ."
   },
   "dependencies": {

--- a/turbo.json
+++ b/turbo.json
@@ -6,15 +6,20 @@
       "outputs": ["dist/**", ".output/**", ".vercel/output/**"],
       "cache": true
     },
-    "typecheck": {
+    "nuxt-prepare": {
       "dependsOn": ["^build"],
+      "outputs": [".nuxt/**"],
+      "cache": true
+    },
+    "typecheck": {
+      "dependsOn": ["^build", "nuxt-prepare"],
       "cache": true
     },
     "lint": {
       "cache": true
     },
     "test": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "nuxt-prepare"],
       "cache": true
     },
     "dev": {


### PR DESCRIPTION
## Summary

CI on main has been flapping since yesterday because chat + troop's \`typecheck\` + \`test\` both ran \`nuxi prepare\` in parallel under turbo, clobbering each other's \`.nuxt/tsconfig.json\` mid-read. We rerun-ed every time; the underlying race is still there.

This PR adds a top-level \`nuxt-prepare\` task with \`outputs: [".nuxt/**"]\` and makes \`typecheck\` + \`test\` depend on it. turbo serialises prepare exactly once per package before either consumer runs; cross-package parallelism is unaffected.

## Affected

| Package | typecheck | test |
|---|---|---|
| apps/openape-chat | was \`nuxi prepare && nuxt typecheck\` → \`nuxt typecheck\` | was \`nuxi prepare && vitest run\` → \`vitest run\` |
| apps/openape-troop | was \`nuxi prepare && nuxt typecheck\` → \`nuxt typecheck\` | unchanged |
| apps/docs | was \`nuxi prepare && nuxt typecheck\` → \`nuxt typecheck\` | unchanged |
| examples/idp | was \`nuxi prepare && nuxt typecheck\` → \`nuxt typecheck\` | n/a |
| examples/sp | was \`nuxi prepare && nuxt typecheck\` → \`nuxt typecheck\` | n/a |

Each gains a \`nuxt-prepare: nuxi prepare\` script. turbo.json picks it up via the new task.

## Test plan

- [x] Local \`pnpm turbo run lint typecheck test --filter=@openape/chat --filter=@openape/troop --force\` green
- [ ] CI green (the actual proof — let's see)

🤖 Generated with [Claude Code](https://claude.com/claude-code)