### PR TITLE
fix(troop): no iOS Safari auto-zoom on input focus (16px floor on touch devices)

### DIFF
--- a/apps/openape-troop/app/assets/css/main.css
+++ b/apps/openape-troop/app/assets/css/main.css
@@ -1,2 +1,19 @@
 @import "tailwindcss";
 @import "@nuxt/ui";
+
+/* iOS Safari zooms into any input whose computed font-size is below
+ * 16px on focus — feels like the page jumps mid-interaction. Nuxt UI
+ * inputs default to a 14px size class on `size="md"` (the implicit
+ * default), so a tap on the agent-name field in the spawn dialog or
+ * the type-the-name confirm field in the destroy modal triggered it.
+ *
+ * Enforcing a 16px minimum on mobile keeps the input bigger than
+ * iOS's zoom threshold without affecting larger viewports (we keep
+ * `size="md"` everywhere; the rule below only widens the type-rule).
+ * `pointer: coarse` targets touch-first devices so a desktop laptop's
+ * narrow window doesn't accidentally get force-bumped fonts. */
+@media (pointer: coarse) {
+  input, select, textarea {
+    font-size: 16px !important;
+  }
+}


### PR DESCRIPTION
## Summary

Patrick reported the troop UI sometimes zooming on iPhone — classic iOS Safari behaviour when an input's computed font-size is below 16px. Nuxt UI's default size renders at 14px (the spawn-agent name field, the destroy-confirm type-the-name field) so a tap pulls the viewport in.

Fix: a small CSS rule in \`main.css\` forcing \`input, select, textarea\` to a 16px floor under \`@media (pointer: coarse)\`. Touch devices only — desktop windows unaffected.

## Test plan

- [x] Local turbo lint/typecheck/test green
- [ ] CI green
- [ ] On the iPhone: tap into the spawn-agent name field; the page no longer zooms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)