### PR TITLE
refactor: merge SOUL.md into system_prompt

### DIFF
--- a/.changeset/drop-soul-md.md
+++ b/.changeset/drop-soul-md.md
@@ -1,0 +1,21 @@
+---
+"@openape/apes": minor
+"@openape/ape-agent": patch
+---
+
+Retires the per-agent SOUL.md field — its job (long-form markdown
+persona, always-on rules) is now part of `system_prompt`. One
+concept instead of two overlapping ones. Cleaner UX: troop's
+agent-detail page no longer has a separate SOUL.md card, and the
+spawn-dialog presets pre-fill the merged system_prompt directly.
+
+Limit bumps to 32KB (was 8KB) since system_prompt now carries the
+content that used to live in SOUL.md.
+
+Back-compat: existing `~/.openape/agent/SOUL.md` files on already-
+deployed hosts keep being read by the bridge's `composeSystemPrompt`
+until the operator clears them — so legacy agents don't lose their
+persona on the @openape/ape-agent upgrade. `apes agents sync`
+stops writing the file from this version on; the DB column is
+kept as a tombstone (Drizzle no longer references it, a future
+migration will DROP it).

--- a/apps/openape-ape-agent/src/skills.ts
+++ b/apps/openape-ape-agent/src/skills.ts
@@ -345,6 +345,11 @@ export function composeSystemPrompt(input: {
 }): string {
   const home = input.home ?? homedir()
   const parts: string[] = []
+  // SOUL.md was merged into `base` (system_prompt) — owners now author
+  // a single markdown document there. readSoul() still exists for
+  // legacy installs that haven't run `apes agents sync` post-merge;
+  // honour it if present so we don't strand existing personas, but
+  // new agents never write it.
   const soul = readSoul(home)
   if (soul) parts.push(soul)
   const skills = composeSkills(home, input.enabledTools)

--- a/apps/openape-troop/app/pages/agents/[name].vue
+++ b/apps/openape-troop/app/pages/agents/[name].vue
@@ -22,9 +22,6 @@ interface Agent {
    *  to the LLM during live thread turns. Defaults to all known tools
    *  on first sync; owner narrows here. */
   tools: string[]
-  /** Always-on persona / hard rules — markdown. Lands at
-   *  `~/.openape/agent/SOUL.md` after sync. */
-  soul: string
   firstSeenAt: number | null
   lastSeenAt: number | null
   createdAt: number
@@ -171,37 +168,6 @@ async function saveTools() {
   }
   finally {
     toolsSaving.value = false
-  }
-}
-
-// SOUL.md — always-on persona / hard rules. Saved on demand via the
-// same PATCH endpoint as system_prompt. Larger cap than system_prompt
-// (32KB vs 8KB) because owners may inline policy + style guides.
-const soulDraft = ref('')
-const soulSaving = ref(false)
-const soulError = ref('')
-const soulDirty = computed(() => soulDraft.value !== (detail.value?.agent.soul ?? ''))
-
-watch(detail, (d) => {
-  if (d) soulDraft.value = d.agent.soul ?? ''
-}, { immediate: true })
-
-async function saveSoul() {
-  if (!soulDirty.value) return
-  soulSaving.value = true
-  soulError.value = ''
-  try {
-    await ($fetch as any)(`/api/agents/${agentName.value}`, {
-      method: 'PATCH',
-      body: { soul: soulDraft.value },
-    })
-    if (detail.value) detail.value.agent.soul = soulDraft.value
-  }
-  catch (err: any) {
-    soulError.value = err?.data?.statusMessage || err?.message || 'save failed'
-  }
-  finally {
-    soulSaving.value = false
   }
 }
 
@@ -624,50 +590,6 @@ onBeforeUnmount(() => { if (destroyPollTimer) clearTimeout(destroyPollTimer) })
               <div v-if="toolsDirty" class="flex justify-end mt-3">
                 <UButton size="sm" color="primary" :loading="toolsSaving" @click="saveTools">
                   Save tools
-                </UButton>
-              </div>
-            </div>
-          </details>
-        </UCard>
-
-        <!-- SOUL.md — always-on persona / hard rules -->
-        <UCard :ui="{ body: 'p-0' }">
-          <details class="group">
-            <summary class="cursor-pointer list-none px-4 py-3 flex items-center justify-between gap-2">
-              <div class="flex items-center gap-2 text-sm">
-                <UIcon name="i-lucide-sparkles" class="text-muted size-4" />
-                <span class="font-medium">SOUL.md</span>
-                <UBadge v-if="soulDirty" color="warning" variant="subtle" size="xs">
-                  unsaved
-                </UBadge>
-                <UBadge v-else-if="soulDraft" color="success" variant="subtle" size="xs">
-                  {{ soulDraft.length }} chars
-                </UBadge>
-                <UBadge v-else color="neutral" variant="subtle" size="xs">
-                  empty
-                </UBadge>
-              </div>
-              <UIcon name="i-lucide-chevron-down" class="size-4 text-muted transition-transform group-open:rotate-180" />
-            </summary>
-            <div class="px-4 pb-4 pt-3 border-t border-(--ui-border)">
-              <p class="text-xs text-muted mb-3">
-                Always-on persona, language preferences, hard rules. Rendered as the first block of the
-                system prompt the LLM sees, ahead of skills + base system prompt. Markdown. Lands at
-                <code class="text-zinc-300">~/.openape/agent/SOUL.md</code> after the next sync (~5min).
-              </p>
-              <UTextarea
-                v-model="soulDraft"
-                placeholder="# Persona&#10;&#10;Du bist …&#10;&#10;## Always-on rules&#10;- antworte standardmäßig auf Deutsch&#10;- frag nach wenn etwas unklar ist"
-                :rows="6"
-                autoresize
-                :disabled="soulSaving"
-                class="w-full"
-                :ui="{ base: 'w-full' }"
-              />
-              <UAlert v-if="soulError" color="error" :title="soulError" class="mt-3" />
-              <div v-if="soulDirty" class="flex justify-end mt-3">
-                <UButton size="sm" color="primary" :loading="soulSaving" @click="saveSoul">
-                  Save SOUL.md
                 </UButton>
               </div>
             </div>

--- a/apps/openape-troop/server/api/agents/[name].patch.ts
+++ b/apps/openape-troop/server/api/agents/[name].patch.ts
@@ -15,12 +15,11 @@ const KNOWN_TOOL_NAMES = new Set<string>(
 // are agent-side state set on first sync and shouldn't be
 // owner-mutable. Add fields here as the owner-facing surface grows.
 const bodySchema = z.object({
-  system_prompt: z.string().max(8000).optional(),
-  // SOUL.md content — always-on persona / rules. Bigger cap than
-  // system_prompt because owners may inline policy + style guides
-  // here, and the agent only loads it once per turn (not per tool
-  // call).
-  soul: z.string().max(32_000).optional(),
+  // 32KB cap — system_prompt absorbed the role of the old SOUL.md
+  // field, so owners may inline longer markdown personas / policy
+  // guides here. The bridge reads it on every turn (cheap — small
+  // file read, no LLM round-trip).
+  system_prompt: z.string().max(32_000).optional(),
   tools: z.array(z.string()).optional().refine(
     arr => arr === undefined || arr.every(t => KNOWN_TOOL_NAMES.has(t)),
     { message: 'tools list contains unknown tool names — see /api/tool-catalog' },
@@ -46,7 +45,6 @@ export default defineEventHandler(async (event) => {
   const updates: Record<string, unknown> = {}
   if (body.data.system_prompt !== undefined) updates.systemPrompt = body.data.system_prompt
   if (body.data.tools !== undefined) updates.tools = body.data.tools
-  if (body.data.soul !== undefined) updates.soul = body.data.soul
 
   const result = await db
     .update(agents)

--- a/apps/openape-troop/server/api/agents/me/tasks.get.ts
+++ b/apps/openape-troop/server/api/agents/me/tasks.get.ts
@@ -18,7 +18,6 @@ export default defineEventHandler(async (event) => {
     .select({
       systemPrompt: agents.systemPrompt,
       tools: agents.tools,
-      soul: agents.soul,
     })
     .from(agents)
     .where(eq(agents.email, agentEmail))
@@ -42,7 +41,6 @@ export default defineEventHandler(async (event) => {
     system_prompt: agent?.systemPrompt ?? '',
     // tools[] = whitelist for chat-bridge runtime + cron task fallback.
     tools: agent?.tools ?? [],
-    soul: agent?.soul ?? '',
     skills: skillRows,
     tasks: taskList,
   }

--- a/apps/openape-troop/server/database/schema.ts
+++ b/apps/openape-troop/server/database/schema.ts
@@ -30,13 +30,11 @@ export const agents = sqliteTable('agents', {
   // `/api/agents/:email/tools`). The chat-bridge reads this list
   // from `~/.openape/agent/agent.json` after each sync.
   tools: text('tools', { mode: 'json' }).notNull().$type<string[]>().default([]),
-  // Always-on persona / hard rules — rendered as the first block of
-  // the system prompt the LLM sees, ahead of skills + base system
-  // prompt. Free-form markdown; the OpenClaw `AGENTS.md` / `SOUL.md`
-  // pattern. Empty string means "no extra rules" — defaults are fine.
-  // Distributed to agents via `apes agents sync` which writes the
-  // body to `~/.openape/agent/SOUL.md`.
-  soul: text('soul').notNull().default(''),
+  // (legacy) `soul` text column still exists in the DB for back-compat
+  // with rows written before the SOUL.md + system_prompt merge. New code
+  // doesn't read or write it — the system_prompt above absorbed its role.
+  // Future migration can DROP COLUMN once we're confident no read path
+  // is left. Drizzle doesn't reference it, so it's a benign tombstone.
   firstSeenAt: integer('first_seen_at'),
   lastSeenAt: integer('last_seen_at'),
   createdAt: integer('created_at').notNull(),

--- a/apps/openape-troop/server/routes/api/nest-ws.ts
+++ b/apps/openape-troop/server/routes/api/nest-ws.ts
@@ -20,7 +20,7 @@ import { resolveSpawnIntent } from '../../utils/spawn-intents'
 //
 // Frames out (troop → nest):
 //   - config-update { agent_email }          — nest re-syncs the named agent
-//   - spawn-intent { intent_id, name, bridge?, soul?, skills? }
+//   - spawn-intent { intent_id, name, bridge?, skills? }
 //   - destroy-intent { intent_id, name }     — `apes agents destroy --force`
 //   - reload-bridge { name }                 — pm2 reload, no fresh sync
 //

--- a/packages/apes/src/commands/agents/sync.ts
+++ b/packages/apes/src/commands/agents/sync.ts
@@ -97,11 +97,10 @@ export const syncAgentCommand = defineCommand({
     })
     consola.info(sync.first_sync ? '✓ first sync — agent registered' : '✓ presence updated')
 
-    const { system_prompt: systemPrompt, tools, soul, skills, tasks } = await client.listTasks()
+    const { system_prompt: systemPrompt, tools, skills, tasks } = await client.listTasks()
     consola.info(`Pulled ${tasks.length} task${tasks.length === 1 ? '' : 's'}`)
     consola.info(`Tools enabled: ${tools.length === 0 ? '(none)' : tools.join(', ')}`)
     consola.info(`Skills: ${skills.length === 0 ? '(none)' : skills.map(s => s.name).join(', ')}`)
-    consola.info(`SOUL.md: ${soul.length > 0 ? `${soul.length} chars` : '(empty)'}`)
 
     // Sync runs as ROOT in production (the launchd plist sets
     // UserName=root so it can write /Library/LaunchDaemons/ and
@@ -152,13 +151,12 @@ export const syncAgentCommand = defineCommand({
       chownToAgent(path)
     }
 
-    // SOUL.md — always-on persona. Write empty string deliberately
-    // (don't delete the file) so the agent runtime sees the owner's
-    // explicit decision to clear rules rather than treating it as
-    // "not yet synced".
-    const soulPath = join(agentDir, 'SOUL.md')
-    writeFileSync(soulPath, soul.endsWith('\n') ? soul : `${soul}\n`, { mode: 0o600 })
-    chownToAgent(soulPath)
+    // SOUL.md retired — the per-agent persona is now part of
+    // `systemPrompt` (above) which the bridge composes into the
+    // system message on every turn. Any pre-existing
+    // `~/.openape/agent/SOUL.md` file on disk is left in place so a
+    // legacy bridge / agent runtime that still reads it keeps
+    // working until upgraded; nothing here writes or overwrites it.
 
     // Skills mirror — one-way sync from troop. Anything currently
     // on disk that's not in the response gets pruned, so disabling

--- a/packages/apes/src/lib/troop-client.ts
+++ b/packages/apes/src/lib/troop-client.ts
@@ -54,11 +54,6 @@ export interface AgentTasksResponse {
    */
   tools: string[]
   /**
-   * Always-on persona / hard rules — markdown body that lands at
-   * `~/.openape/agent/SOUL.md` after sync. Empty string when unset.
-   */
-  soul: string
-  /**
    * Lazy-load skill catalog — only enabled rows from agent_skills.
    * Each one lands at `~/.openape/agent/skills/<name>/SKILL.md`.
    */


### PR DESCRIPTION
## Summary

Patrick: \"stellt sich die Frage ob System prompt und SOUL.md nicht redundant sind\" → \"Nur system_prompt behalten, SOUL.md raus.\"

Drops the SOUL.md concept from troop + apes-cli + ape-agent. \`system_prompt\` absorbs the role: same field, now with a 32KB cap (was 8KB) and treated as free-form markdown.

## What changes

**Troop**
- DB: \`soul\` column removed from Drizzle schema (SQLite column itself stays as a tombstone — future migration drops it).
- PATCH /api/agents/[name]: stops accepting \`soul\`; bumps \`system_prompt\` cap 8KB → 32KB.
- GET /api/agents/me/tasks: stops returning \`soul\`.
- Agent-detail UI: SOUL.md card removed.

**apes-cli**
- \`apes agents sync\` no longer fetches/writes \`~/.openape/agent/SOUL.md\`.
- \`troop-client\` SyncResponse drops \`soul\` field.

**ape-agent (bridge)**
- \`composeSystemPrompt()\` still reads \`~/.openape/agent/SOUL.md\` if present for back-compat with already-deployed agents that carry persona content there. Nothing writes the file anymore, so over time these become empty / removed by the operator.

## Migration

Nothing to do for owners. \`system_prompt\` content is preserved; existing on-disk SOUL.md files persist until cleared manually.

## Test plan

- [x] Local turbo lint/typecheck/test green across @openape/troop, @openape/ape-agent, @openape/apes
- [ ] CI green
- [ ] After release: edit stephan's system_prompt in troop with a multi-paragraph markdown persona → bridge picks it up; no SOUL.md card on the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)