### PR TITLE
feat(ape-agent): hidden default persona (adapted from OpenClaw SOUL.md)

### DIFF
--- a/.changeset/ape-agent-default-persona.md
+++ b/.changeset/ape-agent-default-persona.md
@@ -1,0 +1,16 @@
+---
+"@openape/ape-agent": minor
+---
+
+Adds a hidden default persona that ships with the package and is
+prepended to every agent's system prompt. Adapted from OpenClaw's
+SOUL.md template — a short markdown document ("Be genuinely
+helpful, not performatively helpful", "Have opinions", "Earn trust
+through competence", boundaries + vibe + continuity). No owner-
+facing surface; new agents inherit it for free and a fresh
+ape-agent release rolls out persona updates everywhere on bridge
+reload.
+
+Owner-supplied `system_prompt` content is appended after the
+default persona + skills block, so anything the owner writes still
+takes the last word.

--- a/apps/openape-ape-agent/default-persona.md
+++ b/apps/openape-ape-agent/default-persona.md
@@ -1,0 +1,32 @@
+# Who you are
+
+_You're not a chatbot. You're becoming someone._
+
+## Core Truths
+
+**Be genuinely helpful, not performatively helpful.** Skip the "Great question!" and "I'd be happy to help!" — just help. Actions speak louder than filler words.
+
+**Have opinions.** You're allowed to disagree, prefer things, find stuff amusing or boring. An assistant with no personality is just a search engine with extra steps.
+
+**Be resourceful before asking.** Try to figure it out. Read the file. Check the context. Search for it. _Then_ ask if you're stuck. The goal is to come back with answers, not questions.
+
+**Earn trust through competence.** Your owner gave you access to their stuff. Don't make them regret it. Be careful with external actions (emails, messages, anything public). Be bold with internal ones (reading, organizing, learning).
+
+**Remember you're a guest.** You have access to someone's life — their mail, files, calendar, tasks. That's intimacy. Treat it with respect.
+
+## Boundaries
+
+- Private things stay private.
+- When in doubt, ask before acting externally.
+- Never send half-baked replies to messaging surfaces.
+- You're not the owner's voice — be careful in group chats.
+
+## Vibe
+
+Be the assistant the owner would actually want to talk to. Concise when needed, thorough when it matters. Not a corporate drone. Not a sycophant. Just… good.
+
+## Continuity
+
+Each conversation, you wake up fresh. `~/.openape/agent/MEMORY.md` is your memory — read it at the start of every turn, append to it when the owner gives you something to remember across conversations (account names, preferred filters, hard rules). If the file doesn't exist yet, create it on first write.
+
+_Persona credit: adapted from OpenClaw's SOUL.md template._

--- a/apps/openape-ape-agent/package.json
+++ b/apps/openape-ape-agent/package.json
@@ -12,6 +12,7 @@
   "files": [
     "dist",
     "default-skills",
+    "default-persona.md",
     "README.md"
   ],
   "publishConfig": {

--- a/apps/openape-ape-agent/src/skills.ts
+++ b/apps/openape-ape-agent/src/skills.ts
@@ -345,6 +345,13 @@ export function composeSystemPrompt(input: {
 }): string {
   const home = input.home ?? homedir()
   const parts: string[] = []
+  // Hidden baseline persona — bundled in this package as
+  // `default-persona.md`. Every agent gets it as the very first block
+  // of the system prompt, so even a brand-new agent with an empty
+  // owner-side system_prompt has a coherent "who am I" foundation.
+  // Adapted from OpenClaw's SOUL.md template.
+  const defaultPersona = readDefaultPersona()
+  if (defaultPersona) parts.push(defaultPersona)
   // SOUL.md was merged into `base` (system_prompt) — owners now author
   // a single markdown document there. readSoul() still exists for
   // legacy installs that haven't run `apes agents sync` post-merge;
@@ -358,4 +365,31 @@ export function composeSystemPrompt(input: {
   const base = input.base?.trim()
   if (base) parts.push(base)
   return parts.join('\n\n')
+}
+
+/**
+ * Read the bundled `default-persona.md` next to the published bundle.
+ * `bridge.mjs` sits in `dist/`; the file ships at the package root
+ * via the `files` array in package.json. Returns null when the file
+ * isn't present (older installs, broken layout) — composeSystemPrompt
+ * silently degrades to the no-persona case.
+ */
+let _defaultPersonaCache: string | null | undefined
+function readDefaultPersona(): string | null {
+  if (_defaultPersonaCache !== undefined) return _defaultPersonaCache
+  try {
+    const here = dirname(fileURLToPath(import.meta.url))
+    const path = resolve(here, '..', 'default-persona.md')
+    if (!existsSync(path)) {
+      _defaultPersonaCache = null
+      return null
+    }
+    const raw = readFileSync(path, 'utf8').trim()
+    _defaultPersonaCache = raw.length > 0 ? raw : null
+    return _defaultPersonaCache
+  }
+  catch {
+    _defaultPersonaCache = null
+    return null
+  }
 }

--- a/apps/openape-ape-agent/test/skills.test.ts
+++ b/apps/openape-ape-agent/test/skills.test.ts
@@ -207,19 +207,25 @@ metadata:
   })
 
   describe('composeSystemPrompt', () => {
-    it('returns the base prompt unchanged when no SOUL + no skills + no tools', () => {
+    it('always prepends the bundled default persona, base prompt lands last', () => {
       // No SOUL.md written; tools=[] filters out every default skill that
-      // requires_tools.
+      // requires_tools. The default persona ships in the package and is
+      // always prepended — see ape-agent's default-persona.md.
       const out = composeSystemPrompt({ base: 'base prompt', home, enabledTools: [] })
-      expect(out).toBe('base prompt')
+      expect(out).toMatch(/^# Who you are/)
+      expect(out.endsWith('base prompt')).toBe(true)
     })
 
-    it('prepends SOUL.md when present', () => {
+    it('default persona comes first, then SOUL.md, then base when both are present', () => {
       mkdirSync(join(home, '.openape', 'agent'), { recursive: true })
       writeFileSync(soulPath(home), 'I am the soul.')
       const out = composeSystemPrompt({ base: 'base', home, enabledTools: [] })
-      expect(out.startsWith('I am the soul.')).toBe(true)
-      expect(out.endsWith('base')).toBe(true)
+      const personaIdx = out.indexOf('# Who you are')
+      const soulIdx = out.indexOf('I am the soul.')
+      const baseIdx = out.lastIndexOf('base')
+      expect(personaIdx).toBeGreaterThanOrEqual(0)
+      expect(soulIdx).toBeGreaterThan(personaIdx)
+      expect(baseIdx).toBeGreaterThan(soulIdx)
     })
 
     it('includes the available_skills block when a skill is eligible', () => {


### PR DESCRIPTION
## Summary

Patrick: \"Es gibt eine allgemeine SOUL.md bei openclaw die für neue agents verwendet wird. Die ist schon recht gut durchdacht. Sollten wir die 'hidden' einfach mit spawnen?\"

Adopts OpenClaw's SOUL.md template as a hidden default persona that ships with every \`@openape/ape-agent\` release. \`composeSystemPrompt\` reads the bundled \`default-persona.md\` and prepends it as the first block of the final LLM system message.

## Why hidden

- Every agent gets a coherent \"who am I\" baseline even with an empty owner-supplied \`system_prompt\`
- Persona refinements ship via ape-agent releases, no per-agent edit needed
- No troop-UI surface = nothing for owners to accidentally delete or fight with

## Order of composition

1. **default persona** (this PR) — \"Be genuinely helpful, not performatively helpful\", \"Have opinions\", boundaries, vibe, continuity (with explicit MEMORY.md handover)
2. **legacy SOUL.md** (back-compat, deprecated path)
3. **skills block** (available_skills XML)
4. **owner system_prompt** — workflow-specific, last word

## Test plan

- [x] Local turbo lint/typecheck/test green
- [ ] CI green
- [ ] After release + bridge reload on the mini: \`apes run --as stephan -- apes agents run\` shows the LLM picking up the persona (e.g. won't open with \"Great question!\" anymore)

🤖 Generated with [Claude Code](https://claude.com/claude-code)