### PR TITLE
feat(chat): delete chat from the overview (swipe on mobile, hover on desktop)

### DIFF
--- a/apps/openape-chat/app/pages/index.vue
+++ b/apps/openape-chat/app/pages/index.vue
@@ -132,6 +132,127 @@ function shortEmail(email: string): string {
 function isAgent(email: string): boolean {
   return email.endsWith('@id.openape.ai')
 }
+
+// ── Room delete (swipe on mobile, hover-button on desktop) ──
+//
+// Per-row swipe state: how far the row has been dragged left, in
+// pixels. The contact-row inside Connected uses transform translateX
+// of -swipeOffset, revealing a red Delete action behind it. Threshold
+// past which the delete action becomes the dominant gesture (we keep
+// the row snapped open instead of letting it return) is
+// SWIPE_REVEAL_PX; past SWIPE_COMMIT_PX a release fires the delete
+// directly without a separate tap. Desktop ignores all of this — the
+// hover variant uses a plain button visible at sm: breakpoint.
+const SWIPE_REVEAL_PX = 80
+const SWIPE_COMMIT_PX = 180
+const swipeOffsets = ref<Record<string, number>>({})
+interface SwipeState {
+  roomId: string
+  startX: number
+  startY: number
+  // Once we've decided this drag is horizontal (i.e. a swipe, not a
+  // vertical scroll), `committed` flips true and we preventDefault on
+  // subsequent move events to keep iOS Safari from competing for the
+  // gesture. Until then, scrolling wins.
+  committed: boolean
+  // Initial offset at touchstart so a half-open row keeps dragging
+  // from where it sits instead of jumping back to 0.
+  startOffset: number
+}
+let activeSwipe: SwipeState | null = null
+
+function onRowPointerDown(roomId: string, ev: PointerEvent): void {
+  if (ev.pointerType !== 'touch') return
+  activeSwipe = {
+    roomId,
+    startX: ev.clientX,
+    startY: ev.clientY,
+    committed: false,
+    startOffset: swipeOffsets.value[roomId] ?? 0,
+  }
+}
+
+function onRowPointerMove(roomId: string, ev: PointerEvent): void {
+  if (!activeSwipe || activeSwipe.roomId !== roomId) return
+  const dx = ev.clientX - activeSwipe.startX
+  const dy = ev.clientY - activeSwipe.startY
+  // First-move heuristic: if vertical movement dominates, this is a
+  // scroll, abandon the swipe. Otherwise lock in as a swipe and don't
+  // give up until pointer-up.
+  if (!activeSwipe.committed) {
+    if (Math.abs(dy) > Math.abs(dx) && Math.abs(dy) > 8) {
+      activeSwipe = null
+      return
+    }
+    if (Math.abs(dx) > 8) {
+      activeSwipe.committed = true
+    }
+    else {
+      return
+    }
+  }
+  // Clamp 0..(SWIPE_COMMIT_PX + 60) so the row can't drag off-screen
+  // and gives a nice "rubber-band" feel past the threshold.
+  const next = Math.max(0, Math.min(SWIPE_COMMIT_PX + 60, activeSwipe.startOffset - dx))
+  swipeOffsets.value = { ...swipeOffsets.value, [roomId]: next }
+}
+
+function onRowPointerUp(roomId: string): void {
+  if (!activeSwipe || activeSwipe.roomId !== roomId) return
+  const offset = swipeOffsets.value[roomId] ?? 0
+  activeSwipe = null
+  if (offset >= SWIPE_COMMIT_PX) {
+    // Dragged far enough → commit the delete directly. The row snaps
+    // closed by the deletion (it disappears from the list).
+    swipeOffsets.value = { ...swipeOffsets.value, [roomId]: 0 }
+    void requestDeleteRoom(roomId)
+    return
+  }
+  // Past the reveal threshold: leave snapped open so the user can
+  // tap the Delete pill. Below: snap closed.
+  swipeOffsets.value = {
+    ...swipeOffsets.value,
+    [roomId]: offset >= SWIPE_REVEAL_PX ? SWIPE_REVEAL_PX : 0,
+  }
+}
+
+function closeSwipe(roomId: string): void {
+  swipeOffsets.value = { ...swipeOffsets.value, [roomId]: 0 }
+}
+
+// Delete-confirm modal state. We don't auto-delete on tap because a
+// chat can be irrecoverable (no undo, no soft-delete in v1) — confirm
+// guards against a wrong-row swipe-and-tap on a phone.
+const confirmDelete = ref<{ roomId: string, peerEmail: string } | null>(null)
+const confirmDeleteOpen = computed({
+  get: () => confirmDelete.value !== null,
+  set: (v) => { if (!v) confirmDelete.value = null },
+})
+const deleting = ref(false)
+const deleteError = ref<string | null>(null)
+
+function requestDeleteRoom(roomId: string): void {
+  const c = (contacts.value ?? []).find(x => x.roomId === roomId)
+  if (!c) return
+  confirmDelete.value = { roomId, peerEmail: c.peerEmail }
+}
+
+async function doDelete(): Promise<void> {
+  if (!confirmDelete.value || deleting.value) return
+  deleting.value = true
+  deleteError.value = null
+  try {
+    await $fetch(`/api/rooms/${encodeURIComponent(confirmDelete.value.roomId)}`, { method: 'DELETE' })
+    confirmDelete.value = null
+    await refreshContacts()
+  }
+  catch (err: unknown) {
+    deleteError.value = err instanceof Error ? err.message : 'Delete failed'
+  }
+  finally {
+    deleting.value = false
+  }
+}
 </script>
 
 <template>
@@ -226,27 +347,60 @@ function isAgent(email: string): boolean {
           Contacts · {{ connected.length }}
         </h2>
         <ul class="divide-y divide-zinc-800">
-          <li v-for="c of connected" :key="c.peerEmail">
-            <NuxtLink
+          <li
+            v-for="c of connected"
+            :key="c.peerEmail"
+            class="relative overflow-hidden group/row"
+          >
+            <!-- Delete action behind the row. On mobile this gets
+                 revealed by swiping left; on desktop it slides in on
+                 hover as a "ghost" hint (group-hover translates the
+                 content above by a few px so the trash peeks out). -->
+            <button
               v-if="c.roomId"
-              :to="`/rooms/${c.roomId}`"
-              class="block px-4 py-3 hover:bg-zinc-900 active:bg-zinc-800 transition-colors"
+              type="button"
+              class="absolute inset-y-0 right-0 px-5 bg-red-600 text-white text-sm font-medium flex items-center gap-2"
+              aria-label="Delete chat"
+              @click="requestDeleteRoom(c.roomId!)"
             >
-              <div class="flex items-center gap-3">
-                <UIcon
-                  :name="isAgent(c.peerEmail) ? 'i-lucide-bot' : 'i-lucide-user'"
-                  class="text-zinc-500 size-5 shrink-0"
-                />
-                <div class="flex-1 min-w-0">
-                  <div class="font-medium truncate">
-                    {{ shortEmail(c.peerEmail) }}
-                  </div>
-                  <div class="text-xs text-zinc-500 truncate">
-                    {{ c.peerEmail }}
+              <UIcon name="i-lucide-trash-2" class="size-4 shrink-0" />
+              <span class="hidden sm:inline">Delete</span>
+            </button>
+            <!-- The swipeable content. On pointer-down (touch only)
+                 we track the gesture, on move we offset, on up we
+                 commit or snap back. Desktop pointer-down is ignored
+                 — hover reveals the same Delete pill via a small
+                 translate on group-hover. -->
+            <div
+              class="relative bg-zinc-950 transition-transform duration-150 ease-out group-hover/row:-translate-x-12 motion-reduce:transition-none"
+              :style="(swipeOffsets[c.roomId ?? ''] ?? 0) > 0 ? { transform: `translateX(-${swipeOffsets[c.roomId ?? ''] ?? 0}px)`, transitionDuration: '0ms' } : undefined"
+              @pointerdown="c.roomId && onRowPointerDown(c.roomId, $event)"
+              @pointermove="c.roomId && onRowPointerMove(c.roomId, $event)"
+              @pointerup="c.roomId && onRowPointerUp(c.roomId)"
+              @pointercancel="c.roomId && onRowPointerUp(c.roomId)"
+            >
+              <NuxtLink
+                v-if="c.roomId"
+                :to="`/rooms/${c.roomId}`"
+                class="block px-4 py-3 hover:bg-zinc-900 active:bg-zinc-800 transition-colors"
+                @click="closeSwipe(c.roomId)"
+              >
+                <div class="flex items-center gap-3">
+                  <UIcon
+                    :name="isAgent(c.peerEmail) ? 'i-lucide-bot' : 'i-lucide-user'"
+                    class="text-zinc-500 size-5 shrink-0"
+                  />
+                  <div class="flex-1 min-w-0">
+                    <div class="font-medium truncate">
+                      {{ shortEmail(c.peerEmail) }}
+                    </div>
+                    <div class="text-xs text-zinc-500 truncate">
+                      {{ c.peerEmail }}
+                    </div>
                   </div>
                 </div>
-              </div>
-            </NuxtLink>
+              </NuxtLink>
+            </div>
           </li>
         </ul>
       </section>
@@ -314,6 +468,36 @@ function isAgent(email: string): boolean {
             </UButton>
           </div>
         </form>
+      </template>
+    </UModal>
+
+    <!-- Delete-confirm modal — no soft-delete, so we make the user
+         confirm. Both DM participants lose access on a single press
+         from either side; once gone, gone. -->
+    <UModal v-model:open="confirmDeleteOpen" :ui="{ content: 'sm:max-w-md' }">
+      <template #content>
+        <div class="p-6 space-y-4">
+          <h2 class="text-lg font-semibold">
+            Delete chat?
+          </h2>
+          <p class="text-sm text-zinc-400">
+            This deletes the entire conversation with
+            <span class="font-medium text-zinc-200">{{ confirmDelete?.peerEmail }}</span>
+            for both sides. Messages, threads, and reactions are gone — no undo.
+            You stay contacts; a new chat starts blank if either side sends a message later.
+          </p>
+          <p v-if="deleteError" class="text-sm text-red-400">
+            {{ deleteError }}
+          </p>
+          <div class="flex gap-2 justify-end">
+            <UButton color="neutral" variant="ghost" :disabled="deleting" @click="confirmDelete = null">
+              Cancel
+            </UButton>
+            <UButton color="error" :loading="deleting" @click="doDelete">
+              Delete forever
+            </UButton>
+          </div>
+        </div>
       </template>
     </UModal>
   </div>

--- a/apps/openape-chat/server/api/rooms/[id]/index.delete.ts
+++ b/apps/openape-chat/server/api/rooms/[id]/index.delete.ts
@@ -1,0 +1,69 @@
+import { and, eq, inArray } from 'drizzle-orm'
+import { useDb } from '../../../database/drizzle'
+import { memberships, messages, reactions, rooms, threads } from '../../../database/schema'
+import { resolveCaller } from '../../../utils/auth'
+
+// DELETE /api/rooms/:id — wipe the room and everything that points
+// at it. Members-only: any current member can delete; non-members get
+// the same 404 they'd see for "room doesn't exist". For DM rooms
+// (the only kind we create) that's the two participants — either
+// can nuke the conversation from their end.
+//
+// What gets deleted:
+//   - reactions where message_id ∈ this room's messages
+//   - messages (rows scoped by room_id)
+//   - threads (scoped by room_id)
+//   - memberships (both rows, scoped by room_id)
+//   - the room itself
+//
+// Contacts stay intact. The contact-row is what represents "I know
+// this person"; the room is just where chats happen. Deleting one
+// chat doesn't unfriend — the next time either side opens the
+// thread, `ensureDmRoomFor` will provision a fresh room. The history
+// stays gone, but the relationship survives.
+//
+// No soft-delete (yet): two-person DMs, deleting from one side wipes
+// for both. The semantic is "I'm done with this conversation, let
+// it disappear" not "archive". If we want personal-only deletes
+// later (each side has their own copy), this endpoint changes to
+// drop the caller's membership + leave the room intact for the
+// peer; that's a follow-up if anyone asks.
+export default defineEventHandler(async (event) => {
+  const caller = await resolveCaller(event)
+  const id = getRouterParam(event, 'id')
+  if (!id) throw createError({ statusCode: 400, statusMessage: 'Missing room id' })
+
+  const db = useDb()
+  const m = await db
+    .select()
+    .from(memberships)
+    .where(and(eq(memberships.roomId, id), eq(memberships.userEmail, caller.email)))
+    .get()
+  if (!m) {
+    // Same "indistinguishable from non-existent" pattern as GET — no
+    // information leak about other tenants' room ids.
+    throw createError({ statusCode: 404, statusMessage: 'Room not found' })
+  }
+
+  // Reactions reference message_id, not room_id directly — collect the
+  // ids first so we can filter the reactions delete by them.
+  const msgIds = (await db
+    .select({ id: messages.id })
+    .from(messages)
+    .where(eq(messages.roomId, id))
+  ).map(r => r.id)
+
+  if (msgIds.length > 0) {
+    // Drizzle's SQLite driver chokes on giant IN-lists; we have
+    // plenty of headroom here (room-sized message counts, rarely
+    // > a few thousand) so a single delete is fine. Chunk if it
+    // ever bites.
+    await db.delete(reactions).where(inArray(reactions.messageId, msgIds))
+  }
+  await db.delete(messages).where(eq(messages.roomId, id))
+  await db.delete(threads).where(eq(threads.roomId, id))
+  await db.delete(memberships).where(eq(memberships.roomId, id))
+  await db.delete(rooms).where(eq(rooms.id, id))
+
+  return { ok: true }
+})


### PR DESCRIPTION
## Summary

Patrick: \"Ich wollte gerade die alten Chats auf chat.openape.ai löschen. Das geht im UI aber nicht.\" Adds delete-from-overview.

## Pieces

**Server**
- \`DELETE /api/rooms/:id\` — members-only, 404 for non-members. Cascades through reactions → messages → threads → memberships → room. Contacts are NOT touched; a future message from either side provisions a fresh empty room.

**UI (\`pages/index.vue\`)**
- Each connected-contact row becomes swipeable via pointer events:
  - drag left past 80px → snap open to reveal red Delete pill
  - drag left past 180px → release fires the delete directly
  - vertical-dominant drag → abort, scroll wins
- Desktop equivalent: row-hover translates the content -12px to peek the Delete pill, then a click does the same thing.
- Two-step delete: confirm modal warns that the conversation is wiped for both sides, no undo.

## Test plan

- [x] Local turbo lint/typecheck/test green
- [ ] CI green
- [ ] Mobile: swipe a contact row left, snap-open feels native, tap pill → confirm → delete; both sides see empty list.
- [ ] Desktop: hover row, Delete peeks, click → confirm → delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)