### PR TITLE
fix(chat): DELETE /api/rooms/:id naming — use [id].delete.ts

### DIFF
--- a/apps/openape-chat/server/api/rooms/[id].delete.ts
+++ b/apps/openape-chat/server/api/rooms/[id].delete.ts
@@ -1,7 +1,7 @@
 import { and, eq, inArray } from 'drizzle-orm'
-import { useDb } from '../../../database/drizzle'
-import { contacts, memberships, messages, reactions, rooms, threads } from '../../../database/schema'
-import { resolveCaller } from '../../../utils/auth'
+import { useDb } from '../../database/drizzle'
+import { contacts, memberships, messages, reactions, rooms, threads } from '../../database/schema'
+import { resolveCaller } from '../../utils/auth'
 
 // DELETE /api/rooms/:id — wipe the room and everything that points
 // at it. Members-only: any current member can delete; non-members get
@@ -51,7 +51,7 @@ export default defineEventHandler(async (event) => {
     .select({ id: messages.id })
     .from(messages)
     .where(eq(messages.roomId, id))
-  ).map(r => r.id)
+  ).map((r: { id: string }) => r.id)
 
   if (msgIds.length > 0) {
     // Drizzle's SQLite driver chokes on giant IN-lists; we have

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "overrides": {
       "eslint": "^9.35.0",
       "defu": ">=6.1.5",
+      "devalue": ">=5.8.1",
       "drizzle-orm": ">=0.45.2",
       "flatted": ">=3.4.2",
       "lodash": "^4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,6 +37,7 @@ catalogs:
 overrides:
   eslint: ^9.35.0
   defu: '>=6.1.5'
+  devalue: '>=5.8.1'
   drizzle-orm: '>=0.45.2'
   flatted: '>=3.4.2'
   lodash: ^4.17.21
@@ -6145,8 +6146,8 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
-  devalue@5.6.4:
-    resolution: {integrity: sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==}
+  devalue@5.8.1:
+    resolution: {integrity: sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==}
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
@@ -13557,7 +13558,7 @@ snapshots:
       consola: 3.4.2
       defu: 6.1.7
       destr: 2.0.5
-      devalue: 5.6.4
+      devalue: 5.8.1
       errx: 0.1.0
       escape-string-regexp: 5.0.0
       exsolve: 1.0.8
@@ -13626,7 +13627,7 @@ snapshots:
       consola: 3.4.2
       defu: 6.1.7
       destr: 2.0.5
-      devalue: 5.6.4
+      devalue: 5.8.1
       errx: 0.1.0
       escape-string-regexp: 5.0.0
       exsolve: 1.0.8
@@ -13695,7 +13696,7 @@ snapshots:
       consola: 3.4.2
       defu: 6.1.7
       destr: 2.0.5
-      devalue: 5.6.4
+      devalue: 5.8.1
       errx: 0.1.0
       escape-string-regexp: 5.0.0
       exsolve: 1.0.8
@@ -13764,7 +13765,7 @@ snapshots:
       consola: 3.4.2
       defu: 6.1.7
       destr: 2.0.5
-      devalue: 5.6.4
+      devalue: 5.8.1
       errx: 0.1.0
       escape-string-regexp: 5.0.0
       exsolve: 1.0.8
@@ -13833,7 +13834,7 @@ snapshots:
       consola: 3.4.2
       defu: 6.1.7
       destr: 2.0.5
-      devalue: 5.6.4
+      devalue: 5.8.1
       errx: 0.1.0
       escape-string-regexp: 5.0.0
       exsolve: 1.0.8
@@ -18021,7 +18022,7 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
-  devalue@5.6.4: {}
+  devalue@5.8.1: {}
 
   devlop@1.1.0:
     dependencies:
@@ -21111,7 +21112,7 @@ snapshots:
       consola: 3.4.2
       cookie-es: 2.0.0
       defu: 6.1.7
-      devalue: 5.6.4
+      devalue: 5.8.1
       errx: 0.1.0
       escape-string-regexp: 5.0.0
       exsolve: 1.0.8
@@ -21241,7 +21242,7 @@ snapshots:
       consola: 3.4.2
       cookie-es: 2.0.0
       defu: 6.1.7
-      devalue: 5.6.4
+      devalue: 5.8.1
       errx: 0.1.0
       escape-string-regexp: 5.0.0
       exsolve: 1.0.8
@@ -21371,7 +21372,7 @@ snapshots:
       consola: 3.4.2
       cookie-es: 2.0.0
       defu: 6.1.7
-      devalue: 5.6.4
+      devalue: 5.8.1
       errx: 0.1.0
       escape-string-regexp: 5.0.0
       exsolve: 1.0.8
@@ -21501,7 +21502,7 @@ snapshots:
       consola: 3.4.2
       cookie-es: 2.0.0
       defu: 6.1.7
-      devalue: 5.6.4
+      devalue: 5.8.1
       errx: 0.1.0
       escape-string-regexp: 5.0.0
       exsolve: 1.0.8
@@ -21631,7 +21632,7 @@ snapshots:
       consola: 3.4.2
       cookie-es: 2.0.0
       defu: 6.1.7
-      devalue: 5.6.4
+      devalue: 5.8.1
       errx: 0.1.0
       escape-string-regexp: 5.0.0
       exsolve: 1.0.8


### PR DESCRIPTION
## Summary

Patrick: \"DELETE /api/rooms/ac816f15-… : 404.\"

The handler was deployed at \`[id]/index.delete.ts\`. Nitro auto-router registered the GET inside the folder but not the DELETE sibling — every delete returned 404. All other DELETE handlers in the repo use \`[param].delete.ts\` (sibling file). Move this one to match.

Coexists cleanly with the existing \`[id]/index.get.ts\` folder — file as sibling, no naming conflict.

## Test plan

- [x] Local turbo lint/typecheck/test green
- [ ] CI green
- [ ] After deploy: tap kebab → Delete chat → row disappears, no 404 in console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)