### PR TITLE
fix(nest): YOLO whitelist destroy teardown.sh (mirror spawn pattern)

### DIFF
--- a/.changeset/nest-yolo-destroy-teardown.md
+++ b/.changeset/nest-yolo-destroy-teardown.md
@@ -1,0 +1,12 @@
+---
+"@openape/apes": patch
+---
+
+`apes nest authorize` now whitelists `bash *apes-destroy-*teardown.sh`
+in the nest's YOLO allow-list. The spawn-side equivalent was already
+there; destroy was missing, so every destroy-from-troop flow popped
+a per-call grant prompt even though the outer `apes agents destroy *`
+was already auto-approved. Operators who already ran
+`apes nest authorize` once need to re-run it to pick up the new
+pattern (or wait for the auto-renewal of the YOLO policy at next
+install).

--- a/packages/apes/src/commands/nest/authorize.ts
+++ b/packages/apes/src/commands/nest/authorize.ts
@@ -43,6 +43,12 @@ const DEFAULT_ALLOW_PATTERNS = [
   // glob below limits the auto-approval to that exact lifecycle path
   // — `bash *` would be unsafe.
   'bash *apes-spawn-*setup.sh',
+  // Sibling of the spawn one — `apes agents destroy` runs the same
+  // shape: `apes run --as root --wait -- bash <tempdir>/apes-destroy-
+  // <name>-XXXX/teardown.sh`. Without this the destroy-from-troop flow
+  // pops a per-call grant prompt even though the outer
+  // `apes agents destroy *` is already auto-approved.
+  'bash *apes-destroy-*teardown.sh',
   // Bridge invocation. The grant request escapes-helper sends to the
   // IdP contains the *inner* command only — `apes run --as <agent> --`
   // is the wrapper that gets unwrapped before grant creation. So the


### PR DESCRIPTION
## Summary

Patrick: \"Wenn ich einen agent in troop lösche dann bekomme ich eine grant Anfrage für ein teardown Script. Warum ist das keine Anfrage für \`apes agents destroy xyz\`?\"

Two layers of grants in the destroy chain:

1. **Outer**: nest → \`apes agents destroy <name>\`. Already auto-approved by the YOLO pattern \`apes agents destroy *\`.
2. **Inner**: \`apes agents destroy\` shells out to \`apes run --as root -- bash <tempdir>/apes-destroy-<name>-XXXX/teardown.sh\` for the Phase-G root teardown (dscl + rm + launchctl bootout).

The inner one was missing from the YOLO allow-list (the spawn-side equivalent \`bash *apes-spawn-*setup.sh\` was there). So Patrick saw a phone-grant prompt for the teardown.sh path on every troop-driven destroy.

Add the sibling pattern. Operators who already ran \`apes nest authorize\` once need to re-run it to pick up the new entry.

## Test plan

- [x] Local turbo lint/typecheck/test green
- [ ] CI green
- [ ] After release + re-run \`apes nest authorize\` on the mini: destroy from troop UI → no grant prompt on the phone, completes in ~1s like spawn does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)