### PR TITLE
refactor(apes): destroy re-enters itself as root, no temp bash script

### DIFF
--- a/.changeset/apes-destroy-no-temp-script.md
+++ b/.changeset/apes-destroy-no-temp-script.md
@@ -1,0 +1,20 @@
+---
+"@openape/apes": minor
+---
+
+`apes agents destroy` Phase-G teardown no longer goes through a
+temp bash script. Instead the command re-invokes itself via
+`apes run --as root -- apes agents destroy <name> --force --root-stage`
+and runs the privileged ops (launchctl bootout, pkill, rm -rf home
++ ecosystem-config dirs) directly in Node when re-entered as root.
+
+DDISA grant request now reads
+`apes agents destroy <name> --force --root-stage` instead of
+`bash /var/folders/.../apes-destroy-<name>-XXXX/teardown.sh` —
+semantically meaningful AND matches the existing nest YOLO pattern
+`apes agents destroy *` for zero-prompt auto-approval. No new
+allow-pattern needed.
+
+`buildPhaseGTeardownScript` (the old bash builder) is kept as
+dead code for now — back-compat reference, not called by anything
+in-repo. Will drop in a follow-up once the new flow has bedded in.

--- a/packages/apes/src/commands/agents/destroy.ts
+++ b/packages/apes/src/commands/agents/destroy.ts
@@ -7,7 +7,7 @@ import consola from 'consola'
 import { getIdpUrl, loadAuth } from '../../config'
 import { CliError, CliExit } from '../../errors'
 import { apiFetch } from '../../http'
-import { AGENT_NAME_REGEX, buildDestroyTeardownScript, buildPhaseGTeardownScript } from '../../lib/agent-bootstrap'
+import { AGENT_NAME_REGEX, buildDestroyTeardownScript, runPhaseGTeardownInProcess } from '../../lib/agent-bootstrap'
 import { isDarwin, readMacOSUser, whichBinary } from '../../lib/macos-user'
 import { removeNestAgent } from '../../lib/nest-registry'
 import { readPasswordSilent } from '../../lib/silent-password'
@@ -42,6 +42,10 @@ export const destroyAgentCommand = defineCommand({
       type: 'boolean',
       description: 'Skip OS-side teardown. Useful for CI where the agent has no OS user.',
     },
+    'root-stage': {
+      type: 'boolean',
+      description: 'Internal — destroy.ts re-invokes itself via `apes run --as root --` with this flag set, then runs only the Phase-G teardown (rm home, launchctl bootout, kill processes). Skips IdP + auth + interactive prompts since those already ran in the outer pass.',
+    },
   },
   async run({ args }) {
     const name = args.name as string
@@ -49,6 +53,20 @@ export const destroyAgentCommand = defineCommand({
       throw new CliError(
         `Invalid agent name "${name}". Must match /^[a-z][a-z0-9-]{0,23}$/.`,
       )
+    }
+
+    // Inner re-entry: this process IS root (escapes-setuid'd via the
+    // outer `apes run --as root --`). Skip auth + IdP + prompts and
+    // just do the privileged ops. The outer pass already removed the
+    // IdP record and the nest-registry row by the time it called us.
+    if (args['root-stage']) {
+      if (process.geteuid?.() !== 0) {
+        throw new CliError('--root-stage was passed but this process is not running as root. Refusing to continue.')
+      }
+      const homeDir = readMacOSUser(name)?.homeDir ?? `/var/openape/homes/${name}`
+      consola.start(`Running teardown for ${name} (Phase-G, root-stage)…`)
+      runPhaseGTeardownInProcess({ name, homeDir })
+      return
     }
 
     const auth = loadAuth()
@@ -136,16 +154,28 @@ export const destroyAgentCommand = defineCommand({
         // longer exists. Operators can run `sudo sysadminctl
         // -deleteUser <name>` interactively later if they want full
         // cleanup.
-        const scratch = mkdtempSync(join(tmpdir(), `apes-destroy-${name}-`))
-        const scriptPath = join(scratch, 'teardown.sh')
-        try {
-          const script = buildPhaseGTeardownScript({ name, homeDir })
-          writeFileSync(scriptPath, script, { mode: 0o700 })
-          consola.start('Running teardown (Phase G — no admin password needed)…')
-          execFileSync('apes', ['run', '--as', 'root', '--wait', '--', 'bash', scriptPath], { stdio: 'inherit' })
+        //
+        // Re-enter ourselves as root via `apes run --as root --`
+        // instead of writing+executing a temp bash script. The
+        // resulting DDISA grant request reads
+        //   `apes agents destroy <name> --force --root-stage`
+        // which is semantic + matches the existing nest YOLO pattern
+        // `apes agents destroy *` for zero-prompt auto-approval.
+        // The inner re-entry detects --root-stage and runs just the
+        // Phase-G teardown ops via runPhaseGTeardownInProcess().
+        if (process.geteuid?.() === 0) {
+          // Already root (rare — `apes agents destroy` invoked from
+          // inside a setuid-root context like a CI runner with
+          // sudo). Do the teardown directly, no second escalation.
+          consola.start('Running teardown (Phase G — already root, no grant needed)…')
+          runPhaseGTeardownInProcess({ name, homeDir })
         }
-        finally {
-          rmSync(scratch, { recursive: true, force: true })
+        else {
+          consola.start('Running teardown (Phase G — no admin password needed)…')
+          execFileSync('apes', [
+            'run', '--as', 'root', '--wait', '--',
+            'apes', 'agents', 'destroy', name, '--force', '--root-stage',
+          ], { stdio: 'inherit' })
         }
         consola.info(`dscl record /Users/${name} kept as tombstone (hidden, no home). Run \`sudo sysadminctl -deleteUser ${name}\` to fully remove.`)
       }

--- a/packages/apes/src/lib/agent-bootstrap.ts
+++ b/packages/apes/src/lib/agent-bootstrap.ts
@@ -1,5 +1,7 @@
 import { Buffer } from 'node:buffer'
+import { execFileSync } from 'node:child_process'
 import { createPrivateKey, sign } from 'node:crypto'
+import { rmSync } from 'node:fs'
 import { exchangeWithDelegation } from '@openape/cli-auth'
 import { loadAuth } from '../config'
 import { apiFetch, getAgentAuthenticateEndpoint, getAgentChallengeEndpoint } from '../http'
@@ -437,6 +439,73 @@ export interface DestroyTeardownScriptInput {
  * Result: fully scriptable destroy without an interactive admin
  * password prompt.
  */
+/**
+ * Phase-G teardown — Node implementation. The shell variant
+ * (`buildPhaseGTeardownScript` below) is kept for back-compat but
+ * unused in the new flow: instead of `apes run --as root -- bash
+ * <tempScript>`, the destroy command does `apes run --as root --
+ * apes agents destroy <name> --force --root-stage`, then this
+ * function runs the same ops directly in-process when re-invoked
+ * as root. Net effect: the DDISA grant request reads
+ * "apes agents destroy <name> --force --root-stage" (matches the
+ * existing `apes agents destroy *` YOLO pattern) instead of an
+ * opaque `bash /var/folders/.../teardown.sh`.
+ *
+ * Caller invariant: process.geteuid() === 0. The shell script
+ * tolerated being called as non-root by no-op'ing on the privileged
+ * lines; this version trusts the caller to have already escalated
+ * via `apes run --as root`.
+ */
+export function runPhaseGTeardownInProcess(input: { name: string, homeDir: string }): void {
+  const { name, homeDir } = input
+
+  // Read agent's UID via dscl. Same approach as the shell version —
+  // dscl . -read /Users/<name> UniqueID emits "UniqueID: <n>".
+  let uid: string | null = null
+  try {
+    const out = execFileSync('/usr/bin/dscl', ['.', '-read', `/Users/${name}`, 'UniqueID'], { encoding: 'utf8' })
+    const m = out.match(/UniqueID:\s*(\d+)/)
+    if (m) uid = m[1]!
+  }
+  catch { /* dscl returns non-zero when the user doesn't exist — that's fine */ }
+
+  if (uid) {
+    // bootout the user-domain launchd + kill any live processes
+    // owned by the agent uid. Both allowed to fail (no live session
+    // is the common case after a clean spawn). We swallow failures
+    // identically to the shell script's `|| true`.
+    try { execFileSync('/bin/launchctl', ['bootout', `user/${uid}`], { stdio: 'ignore' }) }
+    catch { /* no live session — fine */ }
+    try { execFileSync('/usr/bin/pkill', ['-9', '-u', uid], { stdio: 'ignore' }) }
+    catch { /* no live procs — fine */ }
+  }
+
+  // Per-agent ecosystem files written by the Nest's pm2-supervisor.
+  const agentDir = `/var/openape/agents/${name}`
+  try { rmSync(agentDir, { recursive: true, force: true }) }
+  catch { /* nothing to remove */ }
+
+  // Home dir lives under /var/openape/homes/ — no FDA wall, root can
+  // rm directly. Same safety check as the shell script: refuse on
+  // empty / root-fs paths so a misconfigured agent.json can't nuke
+  // the filesystem.
+  if (homeDir && homeDir !== '/' && homeDir.startsWith('/var/openape/homes/')) {
+    try { rmSync(homeDir, { recursive: true, force: true }) }
+    catch { /* already gone */ }
+  }
+
+  // dscl record stays as a tombstone — opendirectoryd rejects the
+  // delete from escapes' setuid-root context without admin auth, so
+  // the user record sticks around hidden (IsHidden=1) with a stale
+  // NFSHomeDirectory. Operators run `sudo sysadminctl -deleteUser
+  // <name>` interactively later if they want full cleanup.
+  // eslint-disable-next-line no-console
+  console.log(`OK Phase-G teardown done for ${name} (dscl record kept as tombstone)`)
+}
+
+// Legacy: bash-script version of the same teardown. Kept as a
+// reference until we've verified the in-process variant covers all
+// the edge cases in production; no caller in this repo uses it.
 export function buildPhaseGTeardownScript(input: { name: string, homeDir: string }): string {
   const { name, homeDir } = input
   return `#!/bin/bash


### PR DESCRIPTION
## Summary

Patrick: \"Wenn ich einen agent in troop lösche bekomme ich eine grant Anfrage für ein teardown Script. Warum ist das keine Anfrage für \`apes agents destroy xyz\`?\"

The bash-script middleman is gone. Phase-G destroy now re-enters itself as root via \`apes run --as root -- apes agents destroy <name> --force --root-stage\` and runs the teardown ops directly in Node when re-entered. DDISA grant request reads the semantic command, matches the existing \`apes agents destroy *\` YOLO pattern, auto-approved zero-prompt.

## Mechanics

```
apes agents destroy <name> --force            (outer, runs as user)
  ├─ IdP DELETE  (auth from outer's auth.json)
  └─ apes run --as root -- apes agents destroy <name> --force --root-stage
     ↑ DDISA grant 'apes agents destroy <name> --force --root-stage' (auto)
     └─ inner (as root) → runPhaseGTeardownInProcess()
        ├─ dscl . -read UniqueID
        ├─ launchctl bootout user/<uid>
        ├─ pkill -9 -u <uid>
        ├─ rm -rf /var/openape/agents/<name>
        └─ rm -rf <homeDir>  (safety-clamped to /var/openape/homes/*)
```

## Test plan

- [x] Local turbo lint/typecheck/test green
- [ ] CI green
- [ ] After release on the mini: destroy from troop UI → no per-call grant prompt (already covered by existing YOLO pattern, no \`apes nest authorize\` re-run needed).

Closes #426 (the YOLO whitelist of \`bash *apes-destroy-*teardown.sh\` is unnecessary now that the inner-call uses a semantic command instead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)