### PR TITLE
feat(troop): group agents by nest on /agents overview

### DIFF
--- a/.changeset/troop-group-by-nest.md
+++ b/.changeset/troop-group-by-nest.md
@@ -1,0 +1,5 @@
+---
+'@openape/troop': patch
+---
+
+troop: group agents by nest (host) on the `/agents` overview. Each nest gets a hostname header with agent count; agents within a nest stay createdAt-desc, and nests sort by most-recent activity. Freshly-spawned agents whose first sync hasn't filled in the host identity yet live under a "Pending first sync" group at the bottom.

--- a/apps/openape-troop/app/pages/agents/index.vue
+++ b/apps/openape-troop/app/pages/agents/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, ref, watch } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { useOpenApeAuth } from '#imports'
 
 useSeoMeta({ title: 'My Agents' })
@@ -20,6 +20,20 @@ interface AgentRow {
   lastRunStatus: 'running' | 'ok' | 'error' | null
   lastRunAt: number | null
 }
+
+interface NestGroup {
+  /** Stable key — hostId when known, sentinel `__pending__` for agents
+   *  whose first sync hasn't filled in the nest identity yet. */
+  key: string
+  /** Display label — hostname when known, friendly fallback otherwise. */
+  label: string
+  /** Most-recent lastSeenAt across agents in this group; drives group
+   *  ordering (active nests first). null when no agent has ever synced. */
+  maxLastSeenAt: number | null
+  agents: AgentRow[]
+}
+
+const PENDING_SYNC_KEY = '__pending__'
 
 const agents = ref<AgentRow[]>([])
 const loading = ref(true)
@@ -68,6 +82,54 @@ const statusColor: Record<NonNullable<AgentRow['lastRunStatus']>, string> = {
   ok: 'success',
   error: 'error',
 }
+
+// Group agents by nest (hostId). Agents that haven't completed their
+// first /api/agents/me/sync yet have null hostId/hostname — bucket
+// them under a sentinel "Pending sync" group at the bottom so the
+// freshly-spawned ones don't disappear from the list during the
+// few-second window before the bridge connects. Within each group:
+// keep createdAt-desc (newest first); across groups: most-recently-
+// seen nest first, pending last.
+const nestGroups = computed<NestGroup[]>(() => {
+  const buckets = new Map<string, NestGroup>()
+  for (const a of agents.value) {
+    const key = a.hostId ?? PENDING_SYNC_KEY
+    const label = a.hostId ? (a.hostname || a.hostId) : 'Pending first sync'
+    const existing = buckets.get(key)
+    if (existing) {
+      existing.agents.push(a)
+      if (a.lastSeenAt && (!existing.maxLastSeenAt || a.lastSeenAt > existing.maxLastSeenAt)) {
+        existing.maxLastSeenAt = a.lastSeenAt
+      }
+      // Prefer the freshest hostname (operators may have renamed
+      // their Mac since this row was first written).
+      if (a.hostId && a.hostname && a.lastSeenAt === existing.maxLastSeenAt) {
+        existing.label = a.hostname
+      }
+    }
+    else {
+      buckets.set(key, {
+        key,
+        label,
+        maxLastSeenAt: a.lastSeenAt,
+        agents: [a],
+      })
+    }
+  }
+  const groups = Array.from(buckets.values())
+  for (const g of groups) {
+    g.agents.sort((x, y) => y.createdAt - x.createdAt)
+  }
+  groups.sort((x, y) => {
+    if (x.key === PENDING_SYNC_KEY) return 1
+    if (y.key === PENDING_SYNC_KEY) return -1
+    const xs = x.maxLastSeenAt ?? 0
+    const ys = y.maxLastSeenAt ?? 0
+    if (xs !== ys) return ys - xs
+    return x.label.localeCompare(y.label)
+  })
+  return groups
+})
 </script>
 
 <template>
@@ -129,65 +191,79 @@ const statusColor: Record<NonNullable<AgentRow['lastRunStatus']>, string> = {
         </div>
       </UCard>
 
-      <!-- Mobile-first card list. The table layout was unreadable on
-           a phone (5 narrow columns + email truncation). One tap-target
-           per agent → links to the detail page; everything secondary
-           goes underneath as small badges/labels. -->
-      <ul v-else class="space-y-3">
-        <li v-for="a in agents" :key="a.email">
-          <NuxtLink
-            :to="`/agents/${a.agentName}`"
-            class="block rounded-lg border border-(--ui-border) bg-(--ui-bg-elevated) px-4 py-4 active:bg-zinc-900 transition-colors"
-          >
-            <div class="flex items-start justify-between gap-3">
-              <div class="flex-1 min-w-0">
-                <div class="flex items-center gap-2 flex-wrap">
-                  <h3 class="text-lg font-semibold font-mono truncate">
-                    {{ a.agentName }}
-                  </h3>
-                  <UBadge
-                    v-if="a.lastRunStatus"
-                    :color="(statusColor[a.lastRunStatus] as any)"
-                    variant="subtle"
-                    size="xs"
-                  >
-                    {{ a.lastRunStatus }}
-                  </UBadge>
+      <!-- Mobile-first card list, grouped by nest. The hostname header
+           separates agents from different Macs so a multi-nest setup
+           doesn't blur together. One tap-target per agent → detail
+           page; secondary metadata sits underneath as small badges. -->
+      <div v-else class="space-y-6">
+        <section v-for="g in nestGroups" :key="g.key">
+          <header class="flex items-center gap-2 mb-2 px-1">
+            <UIcon
+              :name="g.key === PENDING_SYNC_KEY ? 'i-lucide-loader-2' : 'i-lucide-server'"
+              class="text-muted size-4 shrink-0"
+              :class="{ 'animate-spin': g.key === PENDING_SYNC_KEY }"
+            />
+            <h3 class="text-sm font-semibold text-zinc-300 truncate">
+              {{ g.label }}
+            </h3>
+            <span class="text-xs text-muted shrink-0">
+              ({{ g.agents.length }})
+            </span>
+          </header>
+          <ul class="space-y-3">
+            <li v-for="a in g.agents" :key="a.email">
+              <NuxtLink
+                :to="`/agents/${a.agentName}`"
+                class="block rounded-lg border border-(--ui-border) bg-(--ui-bg-elevated) px-4 py-4 active:bg-zinc-900 transition-colors"
+              >
+                <div class="flex items-start justify-between gap-3">
+                  <div class="flex-1 min-w-0">
+                    <div class="flex items-center gap-2 flex-wrap">
+                      <h4 class="text-lg font-semibold font-mono truncate">
+                        {{ a.agentName }}
+                      </h4>
+                      <UBadge
+                        v-if="a.lastRunStatus"
+                        :color="(statusColor[a.lastRunStatus] as any)"
+                        variant="subtle"
+                        size="xs"
+                      >
+                        {{ a.lastRunStatus }}
+                      </UBadge>
+                    </div>
+                  </div>
+                  <UIcon name="i-lucide-chevron-right" class="text-muted shrink-0 size-5 mt-1" />
                 </div>
-                <p class="text-xs text-muted mt-0.5 truncate">
-                  {{ a.hostname || '—' }}
-                </p>
-              </div>
-              <UIcon name="i-lucide-chevron-right" class="text-muted shrink-0 size-5 mt-1" />
-            </div>
 
-            <dl class="mt-3 grid grid-cols-2 gap-x-4 gap-y-2 text-xs">
-              <div>
-                <dt class="text-muted">
-                  Tasks
-                </dt>
-                <dd class="font-medium">
-                  {{ a.taskCount }}
-                </dd>
-              </div>
-              <div>
-                <dt class="text-muted">
-                  Last sync
-                </dt>
-                <dd class="truncate">
-                  {{ fmtRelative(a.lastSeenAt) }}
-                </dd>
-              </div>
-              <div v-if="a.lastRunAt" class="col-span-2">
-                <dt class="text-muted">
-                  Last run
-                </dt>
-                <dd>{{ fmtDate(a.lastRunAt) }}</dd>
-              </div>
-            </dl>
-          </NuxtLink>
-        </li>
-      </ul>
+                <dl class="mt-3 grid grid-cols-2 gap-x-4 gap-y-2 text-xs">
+                  <div>
+                    <dt class="text-muted">
+                      Tasks
+                    </dt>
+                    <dd class="font-medium">
+                      {{ a.taskCount }}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt class="text-muted">
+                      Last sync
+                    </dt>
+                    <dd class="truncate">
+                      {{ fmtRelative(a.lastSeenAt) }}
+                    </dd>
+                  </div>
+                  <div v-if="a.lastRunAt" class="col-span-2">
+                    <dt class="text-muted">
+                      Last run
+                    </dt>
+                    <dd>{{ fmtDate(a.lastRunAt) }}</dd>
+                  </div>
+                </dl>
+              </NuxtLink>
+            </li>
+          </ul>
+        </section>
+      </div>
     </main>
   </div>
 </template>


### PR DESCRIPTION
## Summary

On the troop `/agents` overview, agents are now grouped by the nest (host) they live on. Each group gets a hostname header with the agent count; within a group the order stays createdAt-desc (existing behaviour), and groups themselves sort by most-recent activity (active nests first).

Freshly-spawned agents whose first \`/api/agents/me/sync\` hasn't completed yet have \`host_id = null\` for a few seconds. They land under a "Pending first sync" section at the bottom so the post-spawn UI refresh doesn't briefly hide them.

The per-card hostname line is removed — the section header already conveys the nest, so the card body stays focused on agent-specific state (tasks, last sync, last run).

## Test plan

- [x] \`pnpm turbo run typecheck --filter=@openape/troop\` clean
- [x] \`pnpm turbo run lint --filter=@openape/troop\` clean
- [x] \`pnpm turbo run build --filter=@openape/troop\` succeeds
- [ ] Local: spin up troop dev, view \`/agents\` with multi-nest setup → verify section headers + ordering
- [ ] Local: spawn a new agent → it appears under "Pending first sync" briefly, then re-groups under its real nest within ~5 s