### PR TITLE
fix(chat): DDISA subject-issuer resolution

### DIFF
--- a/apps/openape-chat/server/api/cli/exchange.post.ts
+++ b/apps/openape-chat/server/api/cli/exchange.post.ts
@@ -1,6 +1,7 @@
 import type { JWTPayload } from 'jose'
 import { createRemoteJWKSet, jwtVerify } from 'jose'
 import { signCliToken } from '../../utils/cli-token'
+import { resolveIssuerForToken } from '../../utils/ddisa-issuer'
 
 interface ExchangeBody {
   subject_token?: string
@@ -40,10 +41,19 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: 'subject_token required' })
   }
 
-  const idpUrl = useRuntimeConfig().public.idpUrl as string
-  if (!idpUrl) {
-    throw createError({ statusCode: 500, statusMessage: 'IdP URL not configured' })
+  // DDISA: resolve the authoritative issuer from the SUBJECT's domain
+  // (protocol sp-data-access.md §2.1) — never a hardcoded/configured single
+  // issuer, no allowlist. Behaviour-preserving: domains without a DDISA
+  // record (or pointing at id.openape.ai) resolve to id.openape.ai as before.
+  const resolved = await resolveIssuerForToken(body.subject_token)
+  if (!resolved) {
+    throw createError({
+      statusCode: 401,
+      statusMessage: 'subject_token has no usable subject claim',
+      data: { detail: 'Expected sub to be an email address.' },
+    })
   }
+  const idpUrl = resolved.issuer
 
   let claims: JWTPayload
   try {

--- a/apps/openape-chat/server/utils/ddisa-issuer.ts
+++ b/apps/openape-chat/server/utils/ddisa-issuer.ts
@@ -1,0 +1,49 @@
+import { extractDomain, resolveIdP } from '@openape/core'
+
+// DDISA trust doctrine (protocol sp-data-access.md §2.1): the authoritative
+// issuer for a subject is whatever the SUBJECT'S domain points to via
+// `_ddisa.<domain>`. The Provider MUST resolve it dynamically — no hardcoded
+// issuer, no allowlist on this path. Fallback to id.openape.ai only when a
+// domain publishes no DDISA record (behaviour-preserving for legacy
+// single-IdP users; e.g. id.openape.ai's own domain resolves to itself).
+const FALLBACK_ISSUER = 'https://id.openape.ai'
+
+/**
+ * Decode a JWT payload WITHOUT verifying the signature — used solely to read
+ * `sub` so we can discover the authoritative issuer via the subject's domain.
+ * The token is fully verified afterwards against THAT issuer's JWKS, so a
+ * forged/altered token cannot benefit from this peek.
+ */
+export function unsafeDecodeSub(token: string): string | null {
+  const parts = token.split('.')
+  if (parts.length !== 3) return null
+  try {
+    const payload = JSON.parse(Buffer.from(parts[1]!, 'base64url').toString('utf-8')) as { sub?: unknown }
+    return typeof payload.sub === 'string' && payload.sub.includes('@') ? payload.sub : null
+  }
+  catch {
+    return null
+  }
+}
+
+export interface ResolvedIssuer {
+  sub: string
+  issuer: string
+  jwksUri: string
+}
+
+/**
+ * Resolve the issuer to verify a subject_token against, from the subject's
+ * own domain via DDISA. Returns null if the token carries no usable email
+ * subject.
+ */
+export async function resolveIssuerForToken(token: string): Promise<ResolvedIssuer | null> {
+  const sub = unsafeDecodeSub(token)
+  if (!sub) return null
+  const domain = extractDomain(sub)
+  const idp = (await resolveIdP(domain).catch(() => null)) || FALLBACK_ISSUER
+  const issuer = idp.replace(/\/$/, '')
+  return { sub, issuer, jwksUri: `${issuer}/.well-known/jwks.json` }
+}
+
+export { FALLBACK_ISSUER }


### PR DESCRIPTION
DDISA-Compliance-Fix (protocol sp-data-access.md §2.1): chat exchange verifizierte gegen einen einzelnen konfigurierten idpUrl. Jetzt Issuer aus Subjekt-Domain via @openape/core resolveIdP. Behavior-preserving (hofmann.eco/kein _ddisa → id.openape.ai). lint+typecheck+build grün.