### PR TITLE
feat(grants): inline delegation scopes in AuthZ-JWT

### DIFF
--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -249,6 +249,12 @@ export interface OpenApeAuthZClaims {
   permissions?: string[]
   /** Structured authorization details */
   authorization_details?: OpenApeAuthorizationDetail[]
+  /** Delegation scopes — present for delegation grants so a relying party
+   * can enforce them offline (protocol sp-data-access.md §5). */
+  scope?: string[]
+  /** Delegate identity (delegation grants only) — the actor acting on
+   * behalf of `sub`, per delegation.md. Provenance for the relying party. */
+  delegate?: string
   /** Command hash */
   cmd_hash?: string
   /** Plaintext command array (for apes grant-token mode) */

--- a/packages/grants/src/authz-jwt.ts
+++ b/packages/grants/src/authz-jwt.ts
@@ -57,6 +57,12 @@ export async function issueAuthzJWT(
     approval: grantType,
     ...(grant.request.permissions ? { permissions: grant.request.permissions } : {}),
     ...(grant.request.authorization_details ? { authorization_details: grant.request.authorization_details } : {}),
+    // Delegation grants: surface scopes + delegate inline so a relying party
+    // can enforce offline (protocol sp-data-access.md §5). Additive — only
+    // present for delegations; non-delegation grants (incl. the apes-cli
+    // login token, which is NOT issued via this function) are unchanged.
+    ...(grant.request.scopes ? { scope: grant.request.scopes } : {}),
+    ...(grant.request.delegate ? { delegate: grant.request.delegate } : {}),
     ...(grant.request.cmd_hash ? { cmd_hash: grant.request.cmd_hash } : {}),
     ...(grant.request.command ? { command: grant.request.command } : {}),
     ...(grant.request.execution_context ? { execution_context: grant.request.execution_context } : {}),


### PR DESCRIPTION
issueAuthzJWT spreadete permissions/authorization_details aus grant.request, aber nicht scopes/delegate. Delegationen (createDelegation speichert request.scopes/delegate) trugen daher keine Scopes im JWT → Provider konnte nicht offline enforcen. Fix additiv: scope+delegate nur wenn vorhanden (=Delegationen). apes-cli-Login-Token läuft NICHT durch issueAuthzJWT → strukturell unberührt. lint+typecheck+free-idp build grün. Protocol-konform: sp-data-access.md §5, OpenApeAuthZClaims erweitert.