### PR TITLE
feat(troop): agent-recipe manifest schema + parser (M1)

### DIFF
--- a/apps/openape-troop/package.json
+++ b/apps/openape-troop/package.json
@@ -27,6 +27,7 @@
     "drizzle-orm": "^0.44.7",
     "nuxt": "^4.3.1",
     "tailwindcss": "^4.2.1",
+    "yaml": "^2.9.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/apps/openape-troop/server/utils/agent-recipe.ts
+++ b/apps/openape-troop/server/utils/agent-recipe.ts
@@ -1,0 +1,223 @@
+import { parse as parseYaml } from 'yaml'
+import { z } from 'zod'
+import { validateCron } from './task-validation'
+
+// Agent Recipe manifest (`ape-agent.yaml`). A recipe is a declarative
+// description (this manifest) plus a `tools/` code part in a pinned repo.
+// troop parses + validates it, binds capabilities, interpolates deploy-time
+// params, schedules the runs. See plans.openape.ai 01KRTAE8 (M1).
+
+export type Result<T>
+  = | { ok: true, value: T }
+    | { ok: false, reason: string }
+
+const paramSchema = z.object({
+  name: z.string().min(1).regex(/^\w+$/, 'param name must be [A-Za-z0-9_]'),
+  type: z.enum(['string', 'number', 'boolean']),
+  required: z.boolean().default(false),
+  default: z.union([z.string(), z.number(), z.boolean()]).optional(),
+  description: z.string().optional(),
+})
+
+const capabilitySchema = z.object({
+  // Placeholder env name the recipe needs (never the value). troop is the
+  // broker and owns the lifecycle; `prefer` is a hint only.
+  env: z.string().min(1).regex(/^[A-Z][A-Z0-9_]*$/, 'capability env must be UPPER_SNAKE_CASE'),
+  prefer: z.enum(['proxy', 'local']).optional(),
+  description: z.string().optional(),
+})
+
+const scheduleSchema = z.object({
+  cron: z.string().min(1),
+  description: z.string().optional(),
+})
+
+const recipeSchema = z.object({
+  name: z.string().min(1).regex(/^[a-z][a-z0-9-]*$/, 'name must be kebab-case'),
+  // v1: only `kind: agent` (YAGNI — `kind: script` is a future additive
+  // extension, see Decision Log).
+  kind: z.literal('agent'),
+  intent: z.string().min(1),
+  capabilities: z.array(capabilitySchema).default([]),
+  params: z.array(paramSchema).default([]),
+  schedules: z.array(scheduleSchema).min(1),
+  user_addendum: z.boolean().default(false),
+  tools: z.array(z.string().min(1)).default([]),
+})
+
+export type RecipeParam = z.infer<typeof paramSchema>
+export type RecipeCapability = z.infer<typeof capabilitySchema>
+export type RecipeSchedule = z.infer<typeof scheduleSchema>
+export type AgentRecipe = z.infer<typeof recipeSchema>
+
+export type ParamValue = string | number | boolean
+
+function zodReason(err: z.ZodError): string {
+  return err.issues
+    .map(i => `${i.path.join('.') || '(root)'}: ${i.message}`)
+    .join('; ')
+}
+
+export function parseRecipe(yamlText: string): Result<AgentRecipe> {
+  let raw: unknown
+  try {
+    raw = parseYaml(yamlText)
+  }
+  catch (e) {
+    return { ok: false, reason: `invalid YAML: ${(e as Error).message}` }
+  }
+  if (raw === null || typeof raw !== 'object') {
+    return { ok: false, reason: 'recipe must be a YAML mapping' }
+  }
+
+  const parsed = recipeSchema.safeParse(raw)
+  if (!parsed.success) {
+    return { ok: false, reason: zodReason(parsed.error) }
+  }
+  const recipe = parsed.data
+
+  for (const s of recipe.schedules) {
+    const c = validateCron(s.cron)
+    if (!c.ok) return { ok: false, reason: `invalid schedule cron "${s.cron}": ${c.reason}` }
+  }
+
+  const seenParam = new Set<string>()
+  for (const p of recipe.params) {
+    if (seenParam.has(p.name)) return { ok: false, reason: `duplicate param: ${p.name}` }
+    seenParam.add(p.name)
+  }
+  const seenCap = new Set<string>()
+  for (const cap of recipe.capabilities) {
+    if (seenCap.has(cap.env)) return { ok: false, reason: `duplicate capability: ${cap.env}` }
+    seenCap.add(cap.env)
+  }
+
+  return { ok: true, value: recipe }
+}
+
+// A pinned ref is a commit SHA (7–40 hex) or a version tag (`v1.2.3` /
+// `1.2.3`). Floating refs (main, master, HEAD, branch names, latest) are
+// rejected — recipe integrity requires a fixed point. (Plan: Ref-Pin Pflicht.)
+const SHA_RE = /^[0-9a-f]{7,40}$/i
+const VERSION_TAG_RE = /^v?\d+\.\d+\.\d+(?:[-+.]\w[\w.-]*)?$/
+
+export function parseRepoRef(spec: string): Result<{ repo: string, ref: string }> {
+  const at = spec.lastIndexOf('@')
+  // lastIndexOf('@') > 0 so a leading scope-less spec without ref fails the
+  // ref-required branch below rather than splitting on a non-existent '@'.
+  if (at <= 0) {
+    return { ok: false, reason: `missing pinned ref — use <repo>@<tag|commit>, got "${spec}"` }
+  }
+  const repo = spec.slice(0, at).trim()
+  const ref = spec.slice(at + 1).trim()
+  if (!repo) return { ok: false, reason: 'repo is empty' }
+  if (!ref) return { ok: false, reason: 'ref is empty — pin to a tag or commit' }
+  if (!SHA_RE.test(ref) && !VERSION_TAG_RE.test(ref)) {
+    return {
+      ok: false,
+      reason: `floating ref "${ref}" not allowed — pin to a version tag (v1.2.3) or commit SHA`,
+    }
+  }
+  return { ok: true, value: { repo, ref } }
+}
+
+function coerce(value: unknown, type: RecipeParam['type']): Result<ParamValue> {
+  if (type === 'string') return { ok: true, value: String(value) }
+  if (type === 'number') {
+    const n = typeof value === 'number' ? value : Number(value)
+    if (!Number.isFinite(n)) return { ok: false, reason: `expected a number, got "${String(value)}"` }
+    return { ok: true, value: n }
+  }
+  // boolean
+  if (typeof value === 'boolean') return { ok: true, value }
+  if (value === 'true') return { ok: true, value: true }
+  if (value === 'false') return { ok: true, value: false }
+  return { ok: false, reason: `expected true/false, got "${String(value)}"` }
+}
+
+// Validate deploy-time params against the recipe's param defs: apply
+// defaults, type-coerce, reject missing-required and unknown keys.
+export function resolveParams(
+  recipe: AgentRecipe,
+  supplied: Record<string, unknown>,
+): Result<Record<string, ParamValue>> {
+  const defs = new Map(recipe.params.map(p => [p.name, p]))
+  for (const key of Object.keys(supplied)) {
+    if (!defs.has(key)) return { ok: false, reason: `unknown param: ${key}` }
+  }
+  const out: Record<string, ParamValue> = {}
+  for (const p of recipe.params) {
+    if (Object.hasOwn(supplied, p.name)) {
+      const c = coerce(supplied[p.name], p.type)
+      if (!c.ok) return { ok: false, reason: `param "${p.name}": ${c.reason}` }
+      out[p.name] = c.value
+      continue
+    }
+    if (p.default !== undefined) {
+      out[p.name] = p.default
+      continue
+    }
+    if (p.required) return { ok: false, reason: `missing required param: ${p.name}` }
+  }
+  return { ok: true, value: out }
+}
+
+const PLACEHOLDER_RE = /\{\{\s*(\w+)\s*\}\}/g
+
+// Replace `{{name}}` with resolved param values. Any placeholder without a
+// value is an error — we never deploy a half-interpolated intent.
+export function interpolate(
+  template: string,
+  values: Record<string, ParamValue>,
+): Result<string> {
+  const missing = new Set<string>()
+  const out = template.replace(PLACEHOLDER_RE, (_m, name: string) => {
+    if (!(name in values)) {
+      missing.add(name)
+      return ''
+    }
+    return String(values[name])
+  })
+  if (missing.size > 0) {
+    return { ok: false, reason: `unresolved placeholder(s): ${[...missing].join(', ')}` }
+  }
+  return { ok: true, value: out }
+}
+
+export interface MaterializedRecipe {
+  recipe: AgentRecipe
+  params: Record<string, ParamValue>
+  intent: string
+  schedules: RecipeSchedule[]
+  tools: string[]
+}
+
+// Full deploy-time materialization: resolve params, then interpolate the
+// intent, schedule descriptions and tool entrypoints.
+export function materializeRecipe(
+  recipe: AgentRecipe,
+  supplied: Record<string, unknown>,
+): Result<MaterializedRecipe> {
+  const p = resolveParams(recipe, supplied)
+  if (!p.ok) return p
+  const params = p.value
+
+  const intent = interpolate(recipe.intent, params)
+  if (!intent.ok) return intent
+
+  const tools: string[] = []
+  for (const t of recipe.tools) {
+    const r = interpolate(t, params)
+    if (!r.ok) return r
+    tools.push(r.value)
+  }
+
+  const schedules: RecipeSchedule[] = []
+  for (const s of recipe.schedules) {
+    const desc = s.description ? interpolate(s.description, params) : null
+    if (desc && !desc.ok) return desc
+    schedules.push({ cron: s.cron, ...(desc ? { description: desc.value } : {}) })
+  }
+
+  return { ok: true, value: { recipe, params, intent: intent.value, schedules, tools } }
+}

--- a/apps/openape-troop/tests/agent-recipe.test.ts
+++ b/apps/openape-troop/tests/agent-recipe.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from 'vitest'
+import {
+  interpolate,
+  materializeRecipe,
+  parseRecipe,
+  parseRepoRef,
+  resolveParams,
+} from '../server/utils/agent-recipe'
+
+const VALID = `
+name: bluesky-summary
+kind: agent
+intent: |
+  Summarize the Bluesky feed about {{topic}}.
+capabilities:
+  - env: BLUESKY_HANDLE
+  - env: BLUESKY_APP_PASSWORD
+    prefer: local
+params:
+  - name: topic
+    type: string
+    required: true
+schedules:
+  - cron: "0 8 * * *"
+  - cron: "0 18 * * *"
+    description: evening run for {{topic}}
+user_addendum: true
+tools:
+  - tools/summarize.mjs
+`
+
+describe('parseRecipe', () => {
+  it('parses a valid manifest', () => {
+    const r = parseRecipe(VALID)
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.value.name).toBe('bluesky-summary')
+    expect(r.value.kind).toBe('agent')
+    expect(r.value.capabilities).toHaveLength(2)
+    expect(r.value.user_addendum).toBe(true)
+    expect(r.value.schedules).toHaveLength(2)
+  })
+
+  it('defaults optional collections', () => {
+    const r = parseRecipe('name: x\nkind: agent\nintent: hi\nschedules:\n  - cron: "* * * * *"\n')
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.value.capabilities).toEqual([])
+    expect(r.value.params).toEqual([])
+    expect(r.value.user_addendum).toBe(false)
+  })
+
+  it.each([
+    ['rejects non-mapping', 'just a string', /must be a YAML mapping/],
+    ['rejects kind:script (v1 agent only)', 'name: x\nkind: script\nintent: hi\nschedules:\n  - cron: "* * * * *"\n', /kind/],
+    ['rejects missing intent', 'name: x\nkind: agent\nschedules:\n  - cron: "* * * * *"\n', /intent/],
+    ['rejects no schedules', 'name: x\nkind: agent\nintent: hi\nschedules: []\n', /schedules/],
+    ['rejects invalid cron', 'name: x\nkind: agent\nintent: hi\nschedules:\n  - cron: "@hourly"\n', /invalid schedule cron/],
+    ['rejects non-kebab name', 'name: BadName\nkind: agent\nintent: hi\nschedules:\n  - cron: "* * * * *"\n', /kebab/],
+  ])('%s', (_label, yaml, re) => {
+    const r = parseRecipe(yaml)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(r.reason).toMatch(re)
+  })
+
+  it('rejects duplicate capability', () => {
+    const r = parseRecipe('name: x\nkind: agent\nintent: hi\ncapabilities:\n  - env: A\n  - env: A\nschedules:\n  - cron: "* * * * *"\n')
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(r.reason).toMatch(/duplicate capability: A/)
+  })
+})
+
+describe('parseRepoRef — ref-pin enforcement', () => {
+  it.each([
+    'github.com/openape-official-ape-agents/bluesky-summary@v0.1.0',
+    'github.com/o/r@1.2.3',
+    'github.com/o/r@1.2.3-rc.1',
+    'github.com/o/r@9f1c2ab',
+    'github.com/o/r@9f1c2ab3d4e5f60718293a4b5c6d7e8f90123456',
+  ])('accepts pinned ref %s', (spec) => {
+    expect(parseRepoRef(spec).ok).toBe(true)
+  })
+
+  it.each([
+    ['github.com/o/r@main', /floating ref "main"/],
+    ['github.com/o/r@master', /floating ref/],
+    ['github.com/o/r@HEAD', /floating ref/],
+    ['github.com/o/r@feature/foo', /floating ref/],
+    ['github.com/o/r@latest', /floating ref/],
+    ['github.com/o/r', /missing pinned ref/],
+    ['github.com/o/r@', /ref is empty/],
+  ])('rejects %s', (spec, re) => {
+    const r = parseRepoRef(spec)
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(r.reason).toMatch(re)
+  })
+})
+
+describe('resolveParams', () => {
+  const recipe = parseRecipe(VALID)
+  if (!recipe.ok) throw new Error('fixture invalid')
+
+  it('errors on missing required param', () => {
+    const r = resolveParams(recipe.value, {})
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(r.reason).toMatch(/missing required param: topic/)
+  })
+
+  it('passes the supplied required param through', () => {
+    const r = resolveParams(recipe.value, { topic: 'AI agents' })
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.value.topic).toBe('AI agents')
+  })
+
+  it('rejects unknown param', () => {
+    const r = resolveParams(recipe.value, { topic: 'x', nope: 1 })
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(r.reason).toMatch(/unknown param: nope/)
+  })
+
+  it('applies default and coerces types', () => {
+    const rc = parseRecipe('name: x\nkind: agent\nintent: hi\nschedules:\n  - cron: "* * * * *"\nparams:\n  - name: n\n    type: number\n    default: 5\n  - name: flag\n    type: boolean\n')
+    expect(rc.ok).toBe(true)
+    if (!rc.ok) return
+    const r = resolveParams(rc.value, { flag: 'true' })
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.value.n).toBe(5)
+    expect(r.value.flag).toBe(true)
+  })
+
+  it('errors when a number param gets a non-number', () => {
+    const rc = parseRecipe('name: x\nkind: agent\nintent: hi\nschedules:\n  - cron: "* * * * *"\nparams:\n  - name: n\n    type: number\n    required: true\n')
+    if (!rc.ok) throw new Error('fixture')
+    const r = resolveParams(rc.value, { n: 'abc' })
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(r.reason).toMatch(/param "n": expected a number/)
+  })
+})
+
+describe('interpolate', () => {
+  it('replaces {{topic}} in the intent', () => {
+    const r = interpolate('Summarize {{topic}} now', { topic: 'AI agents' })
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.value).toBe('Summarize AI agents now')
+  })
+
+  it('tolerates inner whitespace', () => {
+    const r = interpolate('x={{  topic  }}', { topic: 'y' })
+    expect(r.ok && r.value).toBe('x=y')
+  })
+
+  it('errors on unresolved placeholder', () => {
+    const r = interpolate('hi {{missing}}', {})
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(r.reason).toMatch(/unresolved placeholder\(s\): missing/)
+  })
+})
+
+describe('materializeRecipe — end to end', () => {
+  it('resolves params and interpolates intent + schedule descriptions', () => {
+    const recipe = parseRecipe(VALID)
+    if (!recipe.ok) throw new Error('fixture')
+    const r = materializeRecipe(recipe.value, { topic: 'AI agents' })
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.value.intent).toContain('Summarize the Bluesky feed about AI agents.')
+    const evening = r.value.schedules.find(s => s.cron === '0 18 * * *')
+    expect(evening?.description).toBe('evening run for AI agents')
+    expect(r.value.tools).toEqual(['tools/summarize.mjs'])
+  })
+
+  it('fails fast if a required param is missing', () => {
+    const recipe = parseRecipe(VALID)
+    if (!recipe.ok) throw new Error('fixture')
+    const r = materializeRecipe(recipe.value, {})
+    expect(r.ok).toBe(false)
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -500,6 +500,9 @@ importers:
       tailwindcss:
         specifier: ^4.2.1
         version: 4.3.0
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
       zod:
         specifier: ^4.3.6
         version: 4.4.3


### PR DESCRIPTION
First milestone of **Agent Recipe** (plans.openape.ai `01KRTAE8`) — a
declarative `ape-agent.yaml` that makes scheduled capability-agents
one-step deployable via troop.

## What
`apps/openape-troop/server/utils/agent-recipe.ts`:
- `parseRecipe(yaml)` — zod schema. `kind: agent` only (v1; `script` is a
  future additive extension). Schedules validated via the existing
  `validateCron` (no duplication). Rejects dup caps/params, non-kebab name.
- `parseRepoRef(spec)` — **ref-pin enforcement**: floating refs
  (`@main`, branch names, `latest`, missing) rejected; version tags
  (`v1.2.3`) and commit SHAs accepted. Recipe integrity needs a fixed point.
- `resolveParams` / `interpolate` / `materializeRecipe` — typed deploy-time
  param validation (missing-required → error, defaults, type-coerce,
  reject-unknown) + `{{param}}` interpolation into intent/schedules/tools;
  unresolved placeholder is a hard error (never deploy half-interpolated).

## Why this shape
Mirrors `task-validation.ts` Result-type style (`{ok}|{ok:false,reason}`),
no throw. `yaml` declared as an **explicit** troop dependency — not relying
on workspace hoisting (direct lesson from the #435 phantom-dep fix).

## Proof
- `apps/openape-troop/tests/agent-recipe.test.ts` — 31 tests covering all
  M1 acceptance criteria (valid parses; `@main` rejected; missing required
  param errors; `{{topic}}` interpolated) + edge cases.
- troop: test 81/81 ✓, lint ✓, typecheck ✓, build ✓.

No protocol/DDISA surface touched — troop-internal util only.