### PR TITLE
feat(core): X25519 sealed-box for agent secrets (M2a)

### DIFF
--- a/.changeset/sealed-box.md
+++ b/.changeset/sealed-box.md
@@ -1,0 +1,9 @@
+---
+"@openape/core": minor
+---
+
+Add anonymous X25519 sealed-box (`seal`, `open`, `openString`,
+`generateX25519KeyPair`). Pure `node:crypto` (X25519 ECDH → HKDF-SHA256 →
+AES-256-GCM), no external dependency. Used to encrypt agent secrets to a
+recipient's public key so only the holder of the matching private key can
+decrypt them.

--- a/packages/core/src/__tests__/sealed-box.test.ts
+++ b/packages/core/src/__tests__/sealed-box.test.ts
@@ -1,0 +1,98 @@
+import type { SealedBox } from '../crypto/sealed-box.js'
+import { describe, expect, it } from 'vitest'
+import {
+  generateX25519KeyPair,
+  open,
+  openString,
+  seal,
+} from '../crypto/sealed-box.js'
+
+describe('sealed-box', () => {
+  it('round-trips a UTF-8 string', () => {
+    const kp = generateX25519KeyPair()
+    const box = seal('hunter2-🔐', kp.publicKey)
+    expect(box.v).toBe(1)
+    expect(openString(box, kp.privateKey)).toBe('hunter2-🔐')
+  })
+
+  it('round-trips binary data', () => {
+    const kp = generateX25519KeyPair()
+    const bytes = new Uint8Array([0, 1, 2, 255, 128, 42])
+    const out = open(seal(bytes, kp.publicKey), kp.privateKey)
+    expect(Buffer.from(out)).toEqual(Buffer.from(bytes))
+  })
+
+  it('round-trips an empty payload', () => {
+    const kp = generateX25519KeyPair()
+    expect(openString(seal('', kp.publicKey), kp.privateKey)).toBe('')
+  })
+
+  it('produces different ciphertext each time (ephemeral key + IV)', () => {
+    const kp = generateX25519KeyPair()
+    const a = seal('same', kp.publicKey)
+    const b = seal('same', kp.publicKey)
+    expect(a.ct).not.toBe(b.ct)
+    expect(a.epk).not.toBe(b.epk)
+    expect(a.iv).not.toBe(b.iv)
+    expect(openString(a, kp.privateKey)).toBe('same')
+    expect(openString(b, kp.privateKey)).toBe('same')
+  })
+
+  it('cannot be opened with a different key', () => {
+    const a = generateX25519KeyPair()
+    const b = generateX25519KeyPair()
+    const box = seal('secret', a.publicKey)
+    expect(() => open(box, b.privateKey)).toThrow()
+  })
+
+  it('rejects a tampered ciphertext', () => {
+    const kp = generateX25519KeyPair()
+    const box = seal('secret', kp.publicKey)
+    const ct = Buffer.from(box.ct, 'base64url')
+    ct[0] = (ct[0] ?? 0) ^ 0xFF
+    const tampered: SealedBox = { ...box, ct: ct.toString('base64url') }
+    expect(() => open(tampered, kp.privateKey)).toThrow()
+  })
+
+  it('rejects a tampered auth tag', () => {
+    const kp = generateX25519KeyPair()
+    const box = seal('secret', kp.publicKey)
+    const tag = Buffer.from(box.tag, 'base64url')
+    tag[0] = (tag[0] ?? 0) ^ 0xFF
+    expect(() => open({ ...box, tag: tag.toString('base64url') }, kp.privateKey)).toThrow()
+  })
+
+  it('rejects an unsupported version', () => {
+    const kp = generateX25519KeyPair()
+    const box = seal('x', kp.publicKey)
+    expect(() => open({ ...box, v: 2 as 1 }, kp.privateKey)).toThrow(/unsupported sealed-box version: 2/)
+  })
+
+  it('rejects a wrong-length ephemeral public key', () => {
+    const kp = generateX25519KeyPair()
+    const box = seal('x', kp.publicKey)
+    expect(() => open({ ...box, epk: Buffer.alloc(31).toString('base64url') }, kp.privateKey))
+      .toThrow(/invalid ephemeral public key length/)
+  })
+
+  it('rejects a wrong-length IV', () => {
+    const kp = generateX25519KeyPair()
+    const box = seal('x', kp.publicKey)
+    expect(() => open({ ...box, iv: Buffer.alloc(8).toString('base64url') }, kp.privateKey))
+      .toThrow(/invalid IV length/)
+  })
+
+  it('rejects a wrong-length auth tag', () => {
+    const kp = generateX25519KeyPair()
+    const box = seal('x', kp.publicKey)
+    expect(() => open({ ...box, tag: Buffer.alloc(15).toString('base64url') }, kp.privateKey))
+      .toThrow(/invalid auth tag length/)
+  })
+
+  it('generates self-contained DER-encoded base64url keys', () => {
+    const kp = generateX25519KeyPair()
+    expect(kp.publicKey).toMatch(/^[\w-]+$/)
+    expect(kp.privateKey).toMatch(/^[\w-]+$/)
+    expect(kp.publicKey).not.toBe(kp.privateKey)
+  })
+})

--- a/packages/core/src/crypto/index.ts
+++ b/packages/core/src/crypto/index.ts
@@ -13,3 +13,12 @@ export {
   generateNonce,
   generateState,
 } from './pkce.js'
+
+export {
+  generateX25519KeyPair,
+  open,
+  openString,
+  seal,
+  type SealedBox,
+  type X25519KeyPair,
+} from './sealed-box.js'

--- a/packages/core/src/crypto/sealed-box.ts
+++ b/packages/core/src/crypto/sealed-box.ts
@@ -1,0 +1,120 @@
+import type { KeyObject } from 'node:crypto'
+import {
+  createCipheriv,
+  createDecipheriv,
+  createPrivateKey,
+  createPublicKey,
+  diffieHellman,
+  generateKeyPairSync,
+  hkdfSync,
+  randomBytes,
+} from 'node:crypto'
+
+// Anonymous sealed box: encrypt a secret to a recipient's long-term X25519
+// public key so only the holder of the matching private key can open it.
+// Pure node:crypto (X25519 ECDH → HKDF-SHA256 → AES-256-GCM); no external
+// dependency. Used by troop to seal agent secrets at rest / in transit and
+// by the agent runtime to open them. The agent is the only place plaintext
+// exists. See plans.openape.ai 01KRTAE8 (M2a).
+
+const HKDF_INFO = new TextEncoder().encode('openape-sealed-box-v1')
+const IV_LEN = 12
+const TAG_LEN = 16
+const RAW_KEY_LEN = 32
+
+export interface SealedBox {
+  v: 1
+  /** Ephemeral X25519 public key, raw 32 bytes, base64url. */
+  epk: string
+  /** AES-GCM IV, base64url. */
+  iv: string
+  /** Ciphertext, base64url. */
+  ct: string
+  /** AES-GCM auth tag, base64url. */
+  tag: string
+}
+
+export interface X25519KeyPair {
+  /** SPKI DER, base64url — self-contained, safe to publish. */
+  publicKey: string
+  /** PKCS8 DER, base64url — self-contained, keep secret. */
+  privateKey: string
+}
+
+function b64u(data: Uint8Array): string {
+  return Buffer.from(data).toString('base64url')
+}
+
+function unb64u(s: string): Buffer {
+  return Buffer.from(s, 'base64url')
+}
+
+/** Raw 32-byte X25519 public key of a public-or-private KeyObject. */
+function rawPub(key: KeyObject): Buffer {
+  const pub = key.type === 'private' ? createPublicKey(key) : key
+  const jwk = pub.export({ format: 'jwk' }) as { x: string }
+  return unb64u(jwk.x)
+}
+
+function ephPublicFromRaw(raw: Buffer): KeyObject {
+  return createPublicKey({
+    key: { kty: 'OKP', crv: 'X25519', x: b64u(raw) },
+    format: 'jwk',
+  })
+}
+
+function deriveKey(shared: Buffer, ephPubRaw: Buffer, recipPubRaw: Buffer): Buffer {
+  const salt = Buffer.concat([ephPubRaw, recipPubRaw])
+  return Buffer.from(hkdfSync('sha256', shared, salt, HKDF_INFO, 32))
+}
+
+/** Generate a fresh long-term X25519 key pair for a recipient (the agent). */
+export function generateX25519KeyPair(): X25519KeyPair {
+  const { publicKey, privateKey } = generateKeyPairSync('x25519')
+  return {
+    publicKey: b64u(publicKey.export({ type: 'spki', format: 'der' })),
+    privateKey: b64u(privateKey.export({ type: 'pkcs8', format: 'der' })),
+  }
+}
+
+/** Seal a message to the recipient's public key (SPKI DER, base64url). */
+export function seal(plaintext: string | Uint8Array, recipientPublicKey: string): SealedBox {
+  const recipPub = createPublicKey({ key: unb64u(recipientPublicKey), format: 'der', type: 'spki' })
+  const eph = generateKeyPairSync('x25519')
+  const ephPubRaw = rawPub(eph.publicKey)
+  const shared = diffieHellman({ privateKey: eph.privateKey, publicKey: recipPub })
+  const key = deriveKey(shared, ephPubRaw, rawPub(recipPub))
+
+  const iv = randomBytes(IV_LEN)
+  const cipher = createCipheriv('aes-256-gcm', key, iv)
+  const data = typeof plaintext === 'string' ? Buffer.from(plaintext, 'utf8') : Buffer.from(plaintext)
+  const ct = Buffer.concat([cipher.update(data), cipher.final()])
+  const tag = cipher.getAuthTag()
+
+  return { v: 1, epk: b64u(ephPubRaw), iv: b64u(iv), ct: b64u(ct), tag: b64u(tag) }
+}
+
+/** Open a sealed box with the recipient's private key (PKCS8 DER, base64url). Throws if tampered or wrong key. */
+export function open(box: SealedBox, recipientPrivateKey: string): Uint8Array {
+  if (box.v !== 1) throw new Error(`unsupported sealed-box version: ${box.v}`)
+  const epkRaw = unb64u(box.epk)
+  if (epkRaw.length !== RAW_KEY_LEN) throw new Error('invalid ephemeral public key length')
+  const iv = unb64u(box.iv)
+  if (iv.length !== IV_LEN) throw new Error('invalid IV length')
+  const tag = unb64u(box.tag)
+  if (tag.length !== TAG_LEN) throw new Error('invalid auth tag length')
+
+  const recipPriv = createPrivateKey({ key: unb64u(recipientPrivateKey), format: 'der', type: 'pkcs8' })
+  const ephPub = ephPublicFromRaw(epkRaw)
+  const shared = diffieHellman({ privateKey: recipPriv, publicKey: ephPub })
+  const key = deriveKey(shared, epkRaw, rawPub(recipPriv))
+
+  const decipher = createDecipheriv('aes-256-gcm', key, iv)
+  decipher.setAuthTag(tag)
+  return Buffer.concat([decipher.update(unb64u(box.ct)), decipher.final()])
+}
+
+/** Open a sealed box and decode the plaintext as UTF-8. */
+export function openString(box: SealedBox, recipientPrivateKey: string): string {
+  return Buffer.from(open(box, recipientPrivateKey)).toString('utf8')
+}


### PR DESCRIPTION
M2a of **Agent Recipe** (plans.openape.ai `01KRTAE8`). The cryptographic
core for the capability broker: a secret is sealed to the agent's public
key so only the agent (with its private key) can open it — the agent is
the only place plaintext ever exists.

## What
`packages/core/src/crypto/sealed-box.ts` (exported from `@openape/core`):
- `generateX25519KeyPair()` — self-contained DER (base64url) keypair.
- `seal(plaintext, recipientPublicKey)` → `{ v, epk, iv, ct, tag }`.
- `open(box, recipientPrivateKey)` / `openString(...)` — throws on tamper
  or wrong key.

Construction: ephemeral X25519 → ECDH → HKDF-SHA256 (salt = ephPub‖recipPub,
info `openape-sealed-box-v1`) → AES-256-GCM. **Pure `node:crypto`, zero new
dependencies** (continues the dependency-hygiene line of #435/#437). A
separate encryption keypair — auth stays ed25519; key separation as `age`
does it, avoids an ed25519→x25519 birational-map + `@noble`/libsodium dep.

## Why this shape
troop will store secrets sealed-at-rest and push ciphertext over the
troop↔nest WS; nest relays blindly; the agent opens with its key. This util
is the shared seam — `@openape/core` is consumed by both troop and the apes
agent runtime, so one implementation, both sides.

## Proof
`packages/core/src/__tests__/sealed-box.test.ts` — 13 tests: round-trip
(utf8 / binary / empty), distinct ciphertext per seal, wrong-key rejected,
tampered ct + tampered tag rejected, unsupported version + epk/iv/tag
length guards. `sealed-box.ts` 100% stmt/branch/func/line. core 93/93;
lint ✓ typecheck ✓ build ✓. Changeset added (`@openape/core` minor).

No DDISA protocol surface touched (additive crypto util).