### PR TITLE
feat(apes): agent X25519 encryption keypair on spawn (M2b)

### DIFF
--- a/.changeset/agent-x25519-bootstrap.md
+++ b/.changeset/agent-x25519-bootstrap.md
@@ -1,0 +1,9 @@
+---
+"@openape/apes": minor
+---
+
+`apes agents spawn` now also generates an X25519 encryption keypair for the
+agent (separate from the ed25519 auth key). The private key is written to
+`~/.config/openape/agent-x25519.key` (0600) and the public key alongside
+(`.pub`, 0644), so troop can seal capability secrets to the agent's public
+key and only the agent can open them.

--- a/packages/apes/src/commands/agents/spawn.ts
+++ b/packages/apes/src/commands/agents/spawn.ts
@@ -164,7 +164,7 @@ export const spawnAgentCommand = defineCommand({
 
     try {
       consola.start(`Generating keypair for ${name}…`)
-      const { privatePem, publicSshLine } = generateKeyPairInMemory()
+      const { privatePem, publicSshLine, x25519PrivateKey, x25519PublicKey } = generateKeyPairInMemory()
 
       consola.start(`Registering agent at ${idp}…`)
       const registration = await registerAgentAtIdp({ name, publicKey: publicSshLine, idp })
@@ -250,6 +250,8 @@ export const spawnAgentCommand = defineCommand({
         shellPath: loginShell,
         privateKeyPem: privatePem,
         publicKeySshLine: publicSshLine,
+        x25519PrivateKey,
+        x25519PublicKey,
         authJson,
         claudeSettingsJson: includeClaudeHook ? CLAUDE_SETTINGS_JSON : null,
         hookScriptSource: includeClaudeHook ? BASH_VIA_APE_SHELL_HOOK_SOURCE : null,

--- a/packages/apes/src/lib/agent-bootstrap.ts
+++ b/packages/apes/src/lib/agent-bootstrap.ts
@@ -212,6 +212,15 @@ export interface SpawnSetupScriptInput {
   shellPath: string
   privateKeyPem: string
   publicKeySshLine: string
+  /**
+   * Agent X25519 keypair (base64url DER) for sealed capability secrets.
+   * The private key is written to `~/.config/openape/agent-x25519.key`
+   * (0600) so the agent runtime can open secrets troop sealed to its
+   * public key. The public key is written alongside (`.pub`, 0644) so
+   * the agent can report it to troop on sync.
+   */
+  x25519PrivateKey: string
+  x25519PublicKey: string
   authJson: string
   claudeSettingsJson: string | null
   hookScriptSource: string | null
@@ -383,13 +392,19 @@ mkdir -p "$HOME_DIR/.ssh" "$HOME_DIR/.config/apes"
 cat > "$HOME_DIR/.ssh/id_ed25519" ${shHeredoc(privatePemForHeredoc.trimEnd())}
 cat > "$HOME_DIR/.ssh/id_ed25519.pub" ${shHeredoc(`${input.publicKeySshLine}`)}
 cat > "$HOME_DIR/.config/apes/auth.json" ${shHeredoc(input.authJson)}
+mkdir -p "$HOME_DIR/.config/openape"
+cat > "$HOME_DIR/.config/openape/agent-x25519.key" ${shHeredoc(input.x25519PrivateKey)}
+cat > "$HOME_DIR/.config/openape/agent-x25519.key.pub" ${shHeredoc(input.x25519PublicKey)}
 ${claudeBlock}${claudeTokenBlock}${buildBridgeBlock(input.bridge)}${buildTroopBlock(input.troop)}
 chown -R "$MACOS_USER:staff" "$HOME_DIR"
 chmod 700 "$HOME_DIR/.ssh"
 chmod 700 "$HOME_DIR/.config"
+chmod 700 "$HOME_DIR/.config/openape"
 chmod 600 "$HOME_DIR/.ssh/id_ed25519"
 chmod 644 "$HOME_DIR/.ssh/id_ed25519.pub"
 chmod 600 "$HOME_DIR/.config/apes/auth.json"
+chmod 600 "$HOME_DIR/.config/openape/agent-x25519.key"
+chmod 644 "$HOME_DIR/.config/openape/agent-x25519.key.pub"
 if [ -f "$HOME_DIR/.config/openape/claude-token.env" ]; then
   chmod 700 "$HOME_DIR/.config/openape"
   chmod 600 "$HOME_DIR/.config/openape/claude-token.env"

--- a/packages/apes/src/lib/keygen.ts
+++ b/packages/apes/src/lib/keygen.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { generateKeyPairSync } from 'node:crypto'
 import { homedir } from 'node:os'
 import { dirname, resolve } from 'node:path'
+import { generateX25519KeyPair } from '@openape/core'
 import { loadEd25519PrivateKey } from '../ssh-key'
 
 export function resolveKeyPath(p: string): string {
@@ -57,6 +58,14 @@ export function generateAndSaveKey(keyPath: string): string {
 export interface GeneratedKeyPair {
   privatePem: string
   publicSshLine: string
+  /**
+   * Agent encryption keypair (X25519, base64url DER). Separate from the
+   * ed25519 auth key on purpose — auth signs, this one decrypts. troop
+   * seals capability secrets to `x25519PublicKey`; the agent opens them
+   * with `x25519PrivateKey`. See @openape/core sealed-box.
+   */
+  x25519PrivateKey: string
+  x25519PublicKey: string
 }
 
 export function generateKeyPairInMemory(): GeneratedKeyPair {
@@ -64,8 +73,11 @@ export function generateKeyPairInMemory(): GeneratedKeyPair {
   const privatePem = privateKey.export({ type: 'pkcs8', format: 'pem' }) as string
   const jwk = publicKey.export({ format: 'jwk' }) as { x: string }
   const pubBytes = Buffer.from(jwk.x, 'base64url')
+  const enc = generateX25519KeyPair()
   return {
     privatePem,
     publicSshLine: buildSshEd25519Line(pubBytes),
+    x25519PrivateKey: enc.privateKey,
+    x25519PublicKey: enc.publicKey,
   }
 }

--- a/packages/apes/test/agents-bootstrap.test.ts
+++ b/packages/apes/test/agents-bootstrap.test.ts
@@ -100,8 +100,26 @@ describe('buildSpawnSetupScript', () => {
     shellPath: '/usr/local/bin/ape-shell',
     privateKeyPem: '-----BEGIN PRIVATE KEY-----\nDEADBEEF\n-----END PRIVATE KEY-----\n',
     publicKeySshLine: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBz1WSDX',
+    x25519PrivateKey: 'TUVfWDI1NTE5X1BSSVZBVEVfREVSX0ZBS0U',
+    x25519PublicKey: 'TUVfWDI1NTE5X1BVQkxJQ19ERVJfRkFLRQ',
     authJson: '{"idp":"https://id.openape.ai"}\n',
   }
+
+  it('writes the agent X25519 keypair with private key chmod 600', () => {
+    const script = buildSpawnSetupScript({
+      ...baseInput,
+      claudeSettingsJson: null,
+      hookScriptSource: null,
+      claudeOauthToken: null,
+    })
+    expect(script).toContain('mkdir -p "$HOME_DIR/.config/openape"')
+    expect(script).toContain('cat > "$HOME_DIR/.config/openape/agent-x25519.key"')
+    expect(script).toContain('cat > "$HOME_DIR/.config/openape/agent-x25519.key.pub"')
+    expect(script).toContain('chmod 600 "$HOME_DIR/.config/openape/agent-x25519.key"')
+    expect(script).toContain('chmod 644 "$HOME_DIR/.config/openape/agent-x25519.key.pub"')
+    // private key never world-readable
+    expect(script).not.toContain('chmod 644 "$HOME_DIR/.config/openape/agent-x25519.key"')
+  })
 
   it('with claude hook: includes settings.json + hook script blocks', () => {
     const script = buildSpawnSetupScript({

--- a/packages/apes/test/agents-spawn.test.ts
+++ b/packages/apes/test/agents-spawn.test.ts
@@ -28,6 +28,8 @@ vi.mock('../src/lib/keygen.js', async () => {
     generateKeyPairInMemory: vi.fn(() => ({
       privatePem: '-----BEGIN PRIVATE KEY-----\nFAKE\n-----END PRIVATE KEY-----\n',
       publicSshLine: 'ssh-ed25519 AAAAFAKE',
+      x25519PrivateKey: 'WDI1NTE5X1BSSVZfRkFLRQ',
+      x25519PublicKey: 'WDI1NTE5X1BVQl9GQUtF',
     })),
   }
 })
@@ -162,6 +164,8 @@ describe('apes agents spawn', () => {
     const buildArgs = bootstrapMock.buildSpawnSetupScript.mock.calls[0]![0] as any
     expect(buildArgs.claudeSettingsJson).toBe('{}') // hook included by default
     expect(buildArgs.shellPath).toBe('/bin/zsh')
+    expect(buildArgs.x25519PrivateKey).toBe('WDI1NTE5X1BSSVZfRkFLRQ')
+    expect(buildArgs.x25519PublicKey).toBe('WDI1NTE5X1BVQl9GQUtF')
 
     expect(writeFileSync).toHaveBeenCalledWith(
       '/tmp/apes-spawn-test/setup.sh',

--- a/packages/apes/test/keygen.test.ts
+++ b/packages/apes/test/keygen.test.ts
@@ -1,0 +1,27 @@
+import { openString, seal } from '@openape/core'
+import { describe, expect, it } from 'vitest'
+import { generateKeyPairInMemory } from '../src/lib/keygen'
+
+describe('generateKeyPairInMemory', () => {
+  it('produces an ed25519 auth key and an X25519 encryption key', () => {
+    const kp = generateKeyPairInMemory()
+    expect(kp.privatePem).toContain('BEGIN PRIVATE KEY')
+    expect(kp.publicSshLine).toMatch(/^ssh-ed25519 /)
+    expect(kp.x25519PrivateKey).toMatch(/^[\w-]+$/)
+    expect(kp.x25519PublicKey).toMatch(/^[\w-]+$/)
+    expect(kp.x25519PrivateKey).not.toBe(kp.x25519PublicKey)
+  })
+
+  it('X25519 keypair round-trips a sealed secret (troop seals, agent opens)', () => {
+    const kp = generateKeyPairInMemory()
+    const box = seal('BLUESKY_APP_PASSWORD=hunter2', kp.x25519PublicKey)
+    expect(openString(box, kp.x25519PrivateKey)).toBe('BLUESKY_APP_PASSWORD=hunter2')
+  })
+
+  it('a different agent cannot open another agent\'s sealed secret', () => {
+    const a = generateKeyPairInMemory()
+    const b = generateKeyPairInMemory()
+    const box = seal('secret', a.x25519PublicKey)
+    expect(() => openString(box, b.x25519PrivateKey)).toThrow()
+  })
+})


### PR DESCRIPTION
M2b of **Agent Recipe** (plans.openape.ai `01KRTAE8`). The agent side of
the capability broker: every spawned agent now has an X25519 encryption
keypair so troop can seal secrets to it (M2a sealed-box) and only the
agent can decrypt.

## What
- `keygen.ts`: `generateKeyPairInMemory()` additionally returns
  `x25519PrivateKey` / `x25519PublicKey` (base64url DER, via
  `@openape/core` `generateX25519KeyPair`). Separate from the ed25519
  auth key on purpose — auth signs, this one decrypts.
- `agent-bootstrap.ts`: `SpawnSetupScriptInput` gains the two fields; the
  spawn setup script writes `~/.config/openape/agent-x25519.key` (chmod
  600) + `.pub` (644), dir 700.
- `spawn.ts`: threads the keypair through.

## Why
The agent generates and keeps its own private key (never leaves the host);
the public key is persisted so the agent can report it to troop on sync
(M2c). Continues the zero-new-dependency line — pure `@openape/core`.

## Proof
`test/keygen.test.ts`: the X25519 pair round-trips a sealed secret
(`seal`→`openString`) and a different agent's key cannot open it.
`test/agents-bootstrap.test.ts`: setup script writes the key with chmod
600 and never 644 for the private key. `test/agents-spawn.test.ts`:
orchestration passes the keypair through. apes 663 pass, coverage
thresholds met; lint ✓ typecheck ✓ build ✓. Changeset (`@openape/apes`
minor).

No DDISA protocol surface touched (spawn-local key material only).