### PR TITLE
feat(troop): capability-broker, sealed-at-rest agent secrets (M2c)

### DIFF
--- a/apps/openape-troop/server/api/agents/[name]/secrets/[env].delete.ts
+++ b/apps/openape-troop/server/api/agents/[name]/secrets/[env].delete.ts
@@ -1,0 +1,39 @@
+import { and, eq } from 'drizzle-orm'
+import { useDb } from '../../../../database/drizzle'
+import { agents, agentSecrets } from '../../../../database/schema'
+import { buildSecretRevokeFrame } from '../../../../utils/agent-secrets'
+import { requireOwner } from '../../../../utils/auth'
+import { broadcastToOwner } from '../../../../utils/nest-registry'
+
+// Revoke a bound secret. Soft tombstone: the sealed blob is cleared
+// and `revoked_at` set (binding history stays auditable), and a
+// secret-revoke frame is pushed so the agent drops its copy on the
+// next connect.
+export default defineEventHandler(async (event) => {
+  const owner = await requireOwner(event)
+  const name = getRouterParam(event, 'name')
+  const env = getRouterParam(event, 'env')
+  if (!name || !env) throw createError({ statusCode: 400, statusMessage: 'name and env are required' })
+
+  const db = useDb()
+  const agent = await db
+    .select({ email: agents.email })
+    .from(agents)
+    .where(and(eq(agents.ownerEmail, owner.toLowerCase()), eq(agents.agentName, name)))
+    .get()
+  if (!agent) throw createError({ statusCode: 404, statusMessage: 'agent not found' })
+
+  const now = Math.floor(Date.now() / 1000)
+  const updated = await db
+    .update(agentSecrets)
+    .set({ sealed: null, revokedAt: now, updatedAt: now })
+    .where(and(eq(agentSecrets.agentEmail, agent.email), eq(agentSecrets.env, env)))
+    .returning({ env: agentSecrets.env })
+
+  if (updated.length === 0) {
+    throw createError({ statusCode: 404, statusMessage: 'secret not found' })
+  }
+
+  broadcastToOwner(owner.toLowerCase(), buildSecretRevokeFrame(agent.email, env) as unknown as Record<string, unknown>)
+  return { ok: true, env }
+})

--- a/apps/openape-troop/server/api/agents/[name]/secrets/[env].put.ts
+++ b/apps/openape-troop/server/api/agents/[name]/secrets/[env].put.ts
@@ -1,0 +1,80 @@
+import { and, eq } from 'drizzle-orm'
+import { z } from 'zod'
+import { useDb } from '../../../../database/drizzle'
+import { agents, agentSecrets } from '../../../../database/schema'
+import { buildSecretUpdateFrame, sealSecret, serializeSealed, validateEnvName } from '../../../../utils/agent-secrets'
+import { requireOwner } from '../../../../utils/auth'
+import { broadcastToOwner } from '../../../../utils/nest-registry'
+
+// Bind or rotate a capability secret for an agent. The plaintext value
+// is sealed to the agent's X25519 pubkey immediately and only the
+// sealed blob is stored — troop never persists or logs the plaintext.
+// The sealed blob is pushed to the owner's nest over the WS so the
+// agent gets it without a re-deploy.
+const bodySchema = z.object({
+  value: z.string().min(1).max(8192),
+})
+
+export default defineEventHandler(async (event) => {
+  const owner = await requireOwner(event)
+  const name = getRouterParam(event, 'name')
+  const env = getRouterParam(event, 'env')
+  if (!name || !env) throw createError({ statusCode: 400, statusMessage: 'name and env are required' })
+
+  const envCheck = validateEnvName(env)
+  if (!envCheck.ok) throw createError({ statusCode: 400, statusMessage: envCheck.reason })
+
+  const parsed = bodySchema.safeParse(await readBody(event))
+  if (!parsed.success) {
+    throw createError({ statusCode: 400, statusMessage: parsed.error.issues[0]?.message ?? 'invalid body' })
+  }
+
+  const db = useDb()
+  const agent = await db
+    .select({ email: agents.email, pubkeyX25519: agents.pubkeyX25519 })
+    .from(agents)
+    .where(and(eq(agents.ownerEmail, owner.toLowerCase()), eq(agents.agentName, name)))
+    .get()
+  if (!agent) throw createError({ statusCode: 404, statusMessage: 'agent not found' })
+
+  let box
+  try {
+    box = sealSecret(agent.pubkeyX25519, parsed.data.value)
+  }
+  catch (e) {
+    throw createError({ statusCode: 409, statusMessage: (e as Error).message })
+  }
+  const sealed = serializeSealed(box)
+  const now = Math.floor(Date.now() / 1000)
+
+  const existing = await db
+    .select({ env: agentSecrets.env })
+    .from(agentSecrets)
+    .where(and(eq(agentSecrets.agentEmail, agent.email), eq(agentSecrets.env, env)))
+    .get()
+
+  if (existing) {
+    await db
+      .update(agentSecrets)
+      .set({ sealed, updatedAt: now, revokedAt: null })
+      .where(and(eq(agentSecrets.agentEmail, agent.email), eq(agentSecrets.env, env)))
+  }
+  else {
+    await db.insert(agentSecrets).values({
+      agentEmail: agent.email,
+      env,
+      sealed,
+      createdAt: now,
+      updatedAt: now,
+      revokedAt: null,
+    })
+  }
+
+  // Frame is a typed interface; broadcastToOwner takes the generic
+  // Record<string, unknown> wire shape — assert across the gap.
+  broadcastToOwner(owner.toLowerCase(), buildSecretUpdateFrame(agent.email, env, box) as unknown as Record<string, unknown>)
+
+  // Never cache a response on a secret-bearing request path.
+  setHeader(event, 'Cache-Control', 'no-store')
+  return { ok: true, env }
+})

--- a/apps/openape-troop/server/api/agents/[name]/secrets/index.get.ts
+++ b/apps/openape-troop/server/api/agents/[name]/secrets/index.get.ts
@@ -1,0 +1,41 @@
+import { and, eq } from 'drizzle-orm'
+import { useDb } from '../../../../database/drizzle'
+import { agents, agentSecrets } from '../../../../database/schema'
+import { requireOwner } from '../../../../utils/auth'
+
+// List the capability secrets bound to an agent. Returns env names +
+// status + timestamps only — never the sealed blob or any plaintext.
+export default defineEventHandler(async (event) => {
+  const owner = await requireOwner(event)
+  const name = getRouterParam(event, 'name')
+  if (!name) throw createError({ statusCode: 400, statusMessage: 'name is required' })
+
+  const db = useDb()
+  const agent = await db
+    .select({ email: agents.email })
+    .from(agents)
+    .where(and(eq(agents.ownerEmail, owner.toLowerCase()), eq(agents.agentName, name)))
+    .get()
+  if (!agent) throw createError({ statusCode: 404, statusMessage: 'agent not found' })
+
+  const rows = await db
+    .select({
+      env: agentSecrets.env,
+      createdAt: agentSecrets.createdAt,
+      updatedAt: agentSecrets.updatedAt,
+      revokedAt: agentSecrets.revokedAt,
+    })
+    .from(agentSecrets)
+    .where(eq(agentSecrets.agentEmail, agent.email))
+    .all()
+
+  return {
+    secrets: rows.map(r => ({
+      env: r.env,
+      status: r.revokedAt ? 'revoked' : 'active',
+      created_at: r.createdAt,
+      updated_at: r.updatedAt,
+      revoked_at: r.revokedAt,
+    })),
+  }
+})

--- a/apps/openape-troop/server/api/agents/me/sync.post.ts
+++ b/apps/openape-troop/server/api/agents/me/sync.post.ts
@@ -24,6 +24,10 @@ const bodySchema = z.object({
   // we cross-check the two below.
   owner_email: z.string().email(),
   pubkey_ssh: z.string().min(20).max(4000).optional(),
+  // Agent X25519 encryption pubkey (base64url DER, ~48 chars). troop
+  // seals capability secrets to it. Optional for back-compat with
+  // pre-M2b agents that don't have one yet.
+  pubkey_x25519: z.string().min(20).max(200).optional(),
 })
 
 // Agent self-introduction. Called on first sync (after spawn) and
@@ -85,6 +89,7 @@ export default defineEventHandler(async (event) => {
       hostname: body.data.hostname,
       ownerEmail: body.data.owner_email.toLowerCase(),
       pubkeySsh: body.data.pubkey_ssh ?? existing.pubkeySsh,
+      pubkeyX25519: body.data.pubkey_x25519 ?? existing.pubkeyX25519,
       tools: toolsBackfill,
       lastSeenAt: now,
     }).where(eq(agents.email, agentEmail))
@@ -98,6 +103,7 @@ export default defineEventHandler(async (event) => {
     hostId: body.data.host_id,
     hostname: body.data.hostname,
     pubkeySsh: body.data.pubkey_ssh ?? null,
+    pubkeyX25519: body.data.pubkey_x25519 ?? null,
     // Default-all-tools on first sync. Owner can later narrow via UI.
     tools: ALL_TOOL_NAMES,
     firstSeenAt: now,

--- a/apps/openape-troop/server/database/schema.ts
+++ b/apps/openape-troop/server/database/schema.ts
@@ -18,6 +18,11 @@ export const agents = sqliteTable('agents', {
   hostId: text('host_id'),
   hostname: text('hostname'),
   pubkeySsh: text('pubkey_ssh'),
+  // Agent X25519 encryption public key (base64url DER), reported on
+  // sync (M2b writes it on the host). troop seals capability secrets
+  // to this key; only the agent's private key can open them. Null
+  // until the agent has synced at least once post-spawn.
+  pubkeyX25519: text('pubkey_x25519'),
   // Persona / behaviour rules that apply to every interaction with this
   // agent — both cron-driven task runs and live chat-bridge messages
   // inherit it as the LLM `system` message. Per-task `userPrompt` is
@@ -106,4 +111,22 @@ export const runs = sqliteTable('runs', {
 }, table => [
   index('idx_runs_agent_task').on(table.agentEmail, table.taskId),
   index('idx_runs_started').on(table.startedAt),
+])
+
+// agent_secrets — capability secrets bound to an agent, sealed at rest.
+// `sealed` is the JSON of an @openape/core SealedBox encrypted to the
+// agent's X25519 public key the moment the owner submitted the value;
+// troop never stores or logs the plaintext. Revoke is a soft tombstone
+// (`revoked_at` set, `sealed` cleared) so the next push clears the
+// agent's copy and the binding history stays auditable. Composite PK
+// (agent_email, env) — one binding per env var per agent.
+export const agentSecrets = sqliteTable('agent_secrets', {
+  agentEmail: text('agent_email').notNull(),
+  env: text('env').notNull(),
+  sealed: text('sealed'),
+  createdAt: integer('created_at').notNull(),
+  updatedAt: integer('updated_at').notNull(),
+  revokedAt: integer('revoked_at'),
+}, table => [
+  primaryKey({ columns: [table.agentEmail, table.env] }),
 ])

--- a/apps/openape-troop/server/plugins/02.database.ts
+++ b/apps/openape-troop/server/plugins/02.database.ts
@@ -98,6 +98,23 @@ export default defineNitroPlugin(async () => {
     )`)
     await db.run(sql`CREATE INDEX IF NOT EXISTS idx_runs_agent_task ON runs(agent_email, task_id)`)
     await db.run(sql`CREATE INDEX IF NOT EXISTS idx_runs_started ON runs(started_at)`)
+
+    // Agent Recipe M2c: capability broker. pubkey_x25519 = agent's
+    // encryption pubkey (reported on sync); agent_secrets holds
+    // sealed-at-rest capability values (plaintext never stored).
+    try {
+      await db.run(sql`ALTER TABLE agents ADD COLUMN pubkey_x25519 TEXT`)
+    }
+    catch { /* column exists */ }
+    await db.run(sql`CREATE TABLE IF NOT EXISTS agent_secrets (
+      agent_email TEXT NOT NULL,
+      env TEXT NOT NULL,
+      sealed TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      revoked_at INTEGER,
+      PRIMARY KEY (agent_email, env)
+    )`)
   }
   catch (err) {
     console.error('[troop/database] table init failed:', err)

--- a/apps/openape-troop/server/utils/agent-secrets.ts
+++ b/apps/openape-troop/server/utils/agent-secrets.ts
@@ -1,0 +1,57 @@
+import type { SealedBox } from '@openape/core'
+import { seal } from '@openape/core'
+
+// Capability-broker core. troop never stores a secret in plaintext: a
+// bound secret is sealed to the agent's X25519 public key (M2a sealed-box)
+// the moment it is submitted, and only the sealed blob is persisted. The
+// agent opens it with its private key (M2b) — the agent is the only place
+// plaintext exists. Frame builders here produce the payloads M2d pushes
+// over the troop↔nest WS. See plans.openape.ai 01KRTAE8 (M2c).
+
+const ENV_RE = /^[A-Z][A-Z0-9_]*$/
+
+export function validateEnvName(env: string): { ok: true } | { ok: false, reason: string } {
+  if (!ENV_RE.test(env)) {
+    return { ok: false, reason: 'env name must be UPPER_SNAKE_CASE ([A-Z][A-Z0-9_]*)' }
+  }
+  return { ok: true }
+}
+
+/** Seal a secret value to the agent's X25519 public key (base64url DER). */
+export function sealSecret(pubkeyX25519: string | null | undefined, value: string): SealedBox {
+  if (!pubkeyX25519) {
+    throw new Error('agent has no X25519 public key yet — it must sync once after spawn before secrets can be bound')
+  }
+  return seal(value, pubkeyX25519)
+}
+
+/** Persisted form of a sealed box (single JSON string column). */
+export function serializeSealed(box: SealedBox): string {
+  return JSON.stringify(box)
+}
+
+export function deserializeSealed(s: string): SealedBox {
+  return JSON.parse(s) as SealedBox
+}
+
+export interface SecretUpdateFrame {
+  type: 'secret-update'
+  agent_email: string
+  env: string
+  /** Serialized SealedBox — nest relays this opaquely, never opens it. */
+  blob: string
+}
+
+export interface SecretRevokeFrame {
+  type: 'secret-revoke'
+  agent_email: string
+  env: string
+}
+
+export function buildSecretUpdateFrame(agentEmail: string, env: string, box: SealedBox): SecretUpdateFrame {
+  return { type: 'secret-update', agent_email: agentEmail, env, blob: serializeSealed(box) }
+}
+
+export function buildSecretRevokeFrame(agentEmail: string, env: string): SecretRevokeFrame {
+  return { type: 'secret-revoke', agent_email: agentEmail, env }
+}

--- a/apps/openape-troop/tests/agent-secrets.test.ts
+++ b/apps/openape-troop/tests/agent-secrets.test.ts
@@ -1,0 +1,59 @@
+import { generateX25519KeyPair, openString } from '@openape/core'
+import { describe, expect, it } from 'vitest'
+import {
+  buildSecretRevokeFrame,
+  buildSecretUpdateFrame,
+  deserializeSealed,
+  sealSecret,
+  serializeSealed,
+  validateEnvName,
+} from '../server/utils/agent-secrets'
+
+describe('validateEnvName', () => {
+  it.each(['BLUESKY_APP_PASSWORD', 'X', 'A1_B2'])('accepts %s', (e) => {
+    expect(validateEnvName(e).ok).toBe(true)
+  })
+  it.each(['lower', '1LEADING', 'HAS-DASH', 'HAS SPACE', ''])('rejects %s', (e) => {
+    const r = validateEnvName(e)
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.reason).toMatch(/UPPER_SNAKE/)
+  })
+})
+
+describe('sealSecret', () => {
+  it('seals to the agent pubkey so only the agent can open it', () => {
+    const kp = generateX25519KeyPair()
+    const box = sealSecret(kp.publicKey, 'hunter2')
+    expect(openString(box, kp.privateKey)).toBe('hunter2')
+  })
+
+  it.each([null, undefined, ''])('throws when the agent has no pubkey (%s)', (pk) => {
+    expect(() => sealSecret(pk as string | null, 'x')).toThrow(/no X25519 public key/)
+  })
+})
+
+describe('serialize/deserialize', () => {
+  it('round-trips a sealed box through storage form', () => {
+    const kp = generateX25519KeyPair()
+    const box = sealSecret(kp.publicKey, 'v')
+    const restored = deserializeSealed(serializeSealed(box))
+    expect(openString(restored, kp.privateKey)).toBe('v')
+  })
+})
+
+describe('frame builders', () => {
+  it('builds a secret-update frame carrying the serialized blob', () => {
+    const kp = generateX25519KeyPair()
+    const box = sealSecret(kp.publicKey, 's')
+    const f = buildSecretUpdateFrame('agent-a+p+h_eco@id.openape.ai', 'TOKEN', box)
+    expect(f.type).toBe('secret-update')
+    expect(f.agent_email).toBe('agent-a+p+h_eco@id.openape.ai')
+    expect(f.env).toBe('TOKEN')
+    expect(openString(deserializeSealed(f.blob), kp.privateKey)).toBe('s')
+  })
+
+  it('builds a secret-revoke frame', () => {
+    const f = buildSecretRevokeFrame('agent-a@id.openape.ai', 'TOKEN')
+    expect(f).toEqual({ type: 'secret-revoke', agent_email: 'agent-a@id.openape.ai', env: 'TOKEN' })
+  })
+})


### PR DESCRIPTION
M2c of **Agent Recipe** (plans.openape.ai `01KRTAE8`). troop becomes the
capability broker: it stores agent secrets **sealed at rest** and pushes
them to the agent over the existing nest WS.

## What
- `schema.ts`/`02.database.ts`: `agents.pubkey_x25519` column +
  `agent_secrets` table (`agent_email,env,sealed,created/updated/revoked_at`,
  idempotent migration matching the repo's CREATE-IF-NOT-EXISTS pattern).
- `agents/me/sync.post.ts`: accepts + persists `pubkey_x25519` (the
  agent's encryption pubkey from M2b), optional/back-compat.
- `server/utils/agent-secrets.ts`: `sealSecret` (→ @openape/core M2a),
  serialize, `validateEnvName`, `buildSecretUpdate/RevokeFrame`.
- Endpoints (owner-scoped, `requireOwner`, mirror the skills handlers):
  - `PUT  /api/agents/:name/secrets/:env` — seal-on-submit, upsert
    sealed blob, push `secret-update`. `Cache-Control: no-store`.
  - `DELETE …/:env` — soft tombstone + push `secret-revoke`.
  - `GET  …/secrets` — env names + status only, **never values**.

## Why
Plaintext exists in exactly one place — the agent (the accepted v1
model). troop's DB, logs and the WS only ever see ciphertext. Reuses
`broadcastToOwner` (no new channel); the nest side (relay → agent file)
is M2d, the agent watcher is M2e.

## Proof
`tests/agent-secrets.test.ts` — 15 tests: seal round-trips via a real
X25519 keypair, no-pubkey → 409-worthy throw, env-name validation,
storage serialize round-trip, frame builders carry an openable blob.
troop 96/96; lint ✓ typecheck ✓ build ✓ (4/4).

No DDISA protocol surface changed (additive sync field + troop-internal
tables/endpoints).