### PR TITLE
feat(nest): blind relay for capability secrets (M2d)

### DIFF
--- a/.changeset/nest-secret-relay.md
+++ b/.changeset/nest-secret-relay.md
@@ -1,0 +1,9 @@
+---
+"@openape/nest": minor
+---
+
+nest now relays capability secrets: it handles `secret-update` /
+`secret-revoke` frames from troop by writing/removing an opaque sealed
+blob in the agent's `~/.config/openape/secrets.d/<env>.blob` as the agent
+user (blob piped via stdin, never argv). nest never opens the blob — it
+is a blind relay; only the agent can decrypt it.

--- a/apps/openape-nest/src/lib/secret-relay.ts
+++ b/apps/openape-nest/src/lib/secret-relay.ts
@@ -1,0 +1,49 @@
+// nest is a blind relay for capability secrets. troop pushes a
+// `secret-update` frame carrying an opaque sealed blob (M2c); nest
+// drops it verbatim into the agent's own home as the agent user and
+// never opens it. `secret-revoke` removes it. The agent runtime (M2e)
+// watches the dir, opens the blob with its X25519 private key, and
+// writes its .env. See plans.openape.ai 01KRTAE8 (M2d).
+
+export const SECRETS_REL_DIR = '.config/openape/secrets.d'
+
+// troop already enforces this (validateEnvName); re-checked here so a
+// malformed env can never reach the shell script below.
+const ENV_RE = /^[A-Z][A-Z0-9_]*$/
+
+/**
+ * Derive the local agent slug from a DDISA agent email
+ * (`<name>-<hash>+<owner-local>+<owner-domain>@<idp>`). Same convention
+ * the config-update path uses.
+ */
+export function agentNameFromEmail(email: string): string | null {
+  const local = email.split('+')[0]
+  if (!local) return null
+  const dash = local.lastIndexOf('-')
+  return dash > 0 ? local.slice(0, dash) : local
+}
+
+export type RelayPlan
+  = | { ok: true, script: string }
+    | { ok: false, reason: string }
+
+/**
+ * Shell script (run via `apes run --as <agent> -- sh -c <script>`) that
+ * writes the blob from stdin into the agent's secrets dir with mode 600.
+ * The env name is strictly validated so it is safe to interpolate into
+ * the path; the blob never touches argv (stdin only — not in the
+ * process list, and nest never parses it).
+ */
+export function planSecretWrite(env: string): RelayPlan {
+  if (!ENV_RE.test(env)) return { ok: false, reason: `invalid env name: ${env}` }
+  const path = `"$HOME/${SECRETS_REL_DIR}/${env}.blob"`
+  return {
+    ok: true,
+    script: `mkdir -p "$HOME/${SECRETS_REL_DIR}" && chmod 700 "$HOME/${SECRETS_REL_DIR}" && umask 077 && cat > ${path}`,
+  }
+}
+
+export function planSecretRevoke(env: string): RelayPlan {
+  if (!ENV_RE.test(env)) return { ok: false, reason: `invalid env name: ${env}` }
+  return { ok: true, script: `rm -f "$HOME/${SECRETS_REL_DIR}/${env}.blob"` }
+}

--- a/apps/openape-nest/src/lib/troop-ws.ts
+++ b/apps/openape-nest/src/lib/troop-ws.ts
@@ -16,17 +16,25 @@
 //   reload-bridge { name }          → pm2 reload openape-bridge-<name>,
 //                                     no sync (used after manual
 //                                     agent.json edits in rare cases).
+//   secret-update { agent_email, env, blob }
+//                                   → write the opaque sealed blob into
+//                                     the agent's ~/.config/openape/
+//                                     secrets.d/<env>.blob as the agent
+//                                     user (blind relay; M2d).
+//   secret-revoke { agent_email, env }
+//                                   → rm that blob.
 //
 // The 5-min `troop-sync.ts` polling loop stays running in parallel as
 // a cold-path fallback for whenever the WS connection is down (Mac
 // sleeping, troop deploying, flaky network).
 
-import { execFile, execFileSync } from 'node:child_process'
+import { execFile, execFileSync, spawn } from 'node:child_process'
 import { createHash } from 'node:crypto'
 import { readFileSync } from 'node:fs'
 import { hostname, networkInterfaces } from 'node:os'
 import { ensureFreshIdpAuth, NotLoggedInError } from '@openape/cli-auth'
 import WebSocket from 'ws'
+import { agentNameFromEmail, planSecretRevoke, planSecretWrite } from './secret-relay'
 
 const HEARTBEAT_INTERVAL_MS = 30_000
 const RECONNECT_BASE_MS = 1_000
@@ -57,7 +65,23 @@ interface ReloadBridgeFrame {
   name: string
 }
 
-type InboundFrame = SpawnIntentFrame | DestroyIntentFrame | ConfigUpdateFrame | ReloadBridgeFrame | { type: string }
+interface SecretUpdateFrame {
+  type: 'secret-update'
+  agent_email: string
+  env: string
+  /** Serialized sealed blob — relayed verbatim, nest never opens it. */
+  blob: string
+}
+
+interface SecretRevokeFrame {
+  type: 'secret-revoke'
+  agent_email: string
+  env: string
+}
+
+type InboundFrame
+  = | SpawnIntentFrame | DestroyIntentFrame | ConfigUpdateFrame | ReloadBridgeFrame
+    | SecretUpdateFrame | SecretRevokeFrame | { type: string }
 
 export interface TroopWsOptions {
   /** Default: `wss://troop.openape.ai`. Override via env `OPENAPE_TROOP_WS_URL`. */
@@ -206,20 +230,56 @@ export class TroopWs {
     }
     if (frame.type === 'reload-bridge') {
       await this.handleReloadBridge(frame as ReloadBridgeFrame)
+      return
+    }
+    if (frame.type === 'secret-update') {
+      await this.handleSecretUpdate(frame as SecretUpdateFrame)
+      return
+    }
+    if (frame.type === 'secret-revoke') {
+      await this.handleSecretRevoke(frame as SecretRevokeFrame)
     }
     // Unknown frame types: ignore. Forward-compat for future troop
     // versions that send frames an older nest doesn't recognize.
   }
 
   private async handleConfigUpdate(frame: ConfigUpdateFrame): Promise<void> {
-    // Map agent_email → local agent slug (the part before '+'/'-'-hash).
-    // We use the same convention agents/sync.ts has: `<name>-<hash>+<owner-local>+<owner-domain>@<idp>`.
-    const local = frame.agent_email.split('+')[0]
-    if (!local) return
-    const dash = local.lastIndexOf('-')
-    const name = dash > 0 ? local.slice(0, dash) : local
+    const name = agentNameFromEmail(frame.agent_email)
+    if (!name) return
     this.opts.log(`troop-ws: config-update for ${name} — running sync`)
     await this.runApes(['run', '--as', name, '--wait', '--', 'apes', 'agents', 'sync'], `config-update sync ${name}`)
+  }
+
+  private async handleSecretUpdate(frame: SecretUpdateFrame): Promise<void> {
+    const name = agentNameFromEmail(frame.agent_email)
+    if (!name) return
+    const plan = planSecretWrite(frame.env)
+    if (!plan.ok) {
+      this.opts.log(`troop-ws: secret-update ${frame.agent_email}/${frame.env} rejected: ${plan.reason}`)
+      return
+    }
+    // Blob goes via stdin, never argv — it stays out of the process
+    // list and nest never parses it (blind relay). Runs as the agent
+    // user so it lands in the agent's own home with mode 600.
+    this.opts.log(`troop-ws: secret-update ${name}/${frame.env}`)
+    try {
+      await runWithInput(this.opts.apesBin, ['run', '--as', name, '--wait', '--', 'sh', '-c', plan.script], frame.blob)
+    }
+    catch (err) {
+      this.opts.log(`troop-ws: secret-update ${name}/${frame.env} failed: ${err instanceof Error ? err.message : String(err)}`)
+    }
+  }
+
+  private async handleSecretRevoke(frame: SecretRevokeFrame): Promise<void> {
+    const name = agentNameFromEmail(frame.agent_email)
+    if (!name) return
+    const plan = planSecretRevoke(frame.env)
+    if (!plan.ok) {
+      this.opts.log(`troop-ws: secret-revoke ${frame.agent_email}/${frame.env} rejected: ${plan.reason}`)
+      return
+    }
+    this.opts.log(`troop-ws: secret-revoke ${name}/${frame.env}`)
+    await this.runApes(['run', '--as', name, '--wait', '--', 'sh', '-c', plan.script], `secret-revoke ${name}/${frame.env}`)
   }
 
   private async handleSpawnIntent(frame: SpawnIntentFrame): Promise<void> {
@@ -316,6 +376,27 @@ function runWithCapture(bin: string, args: string[]): Promise<{ stdout: string, 
       }
       resolve({ stdout: stdout.toString(), stderr: stderr.toString() })
     })
+  })
+}
+
+/**
+ * Run `bin args` and feed `input` to its stdin (closing the stream so
+ * a `cat >file` script terminates). Used for the blind secret relay:
+ * the sealed blob is piped, never placed on argv. 30s cap — this is a
+ * tiny write, not a spawn/install.
+ */
+function runWithInput(bin: string, args: string[], input: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(bin, args, { stdio: ['pipe', 'ignore', 'pipe'], timeout: 30_000 })
+    let stderr = ''
+    child.stderr?.on('data', (d: Buffer) => { stderr += d.toString() })
+    child.on('error', reject)
+    child.on('close', (code) => {
+      if (code === 0) resolve()
+      else reject(new Error(stderr.split('\n').filter(Boolean).slice(-3).join(' / ') || `exit ${code}`))
+    })
+    child.stdin?.on('error', () => { /* child may exit before we finish writing; close handler reports it */ })
+    child.stdin?.end(input)
   })
 }
 

--- a/apps/openape-nest/test/secret-relay.test.ts
+++ b/apps/openape-nest/test/secret-relay.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { agentNameFromEmail, planSecretRevoke, planSecretWrite, SECRETS_REL_DIR } from '../src/lib/secret-relay'
+
+describe('agentNameFromEmail', () => {
+  it.each([
+    // DDISA agent emails always carry the +owner-local+owner-domain
+    // suffix, so split('+')[0] isolates the `<name>-<hash>` slug. Same
+    // derivation the config-update path has always used.
+    ['agent-a-9f1c2ab+patrick+hofmann_eco@id.openape.ai', 'agent-a'],
+    ['bsky-deadbeef+p+h_eco@id.openape.ai', 'bsky'],
+    ['multi-word-name-cafe1234+p+h_eco@id.openape.ai', 'multi-word-name'],
+  ])('%s → %s', (email, name) => {
+    expect(agentNameFromEmail(email)).toBe(name)
+  })
+
+  it('returns null for an empty local part', () => {
+    expect(agentNameFromEmail('+x+y@id')).toBeNull()
+  })
+})
+
+describe('planSecretWrite', () => {
+  it('writes into the agent secrets dir via stdin with mode 600', () => {
+    const p = planSecretWrite('BLUESKY_APP_PASSWORD')
+    expect(p.ok).toBe(true)
+    if (!p.ok) return
+    expect(p.script).toContain(`"$HOME/${SECRETS_REL_DIR}/BLUESKY_APP_PASSWORD.blob"`)
+    expect(p.script).toContain('umask 077')
+    expect(p.script).toContain('cat > ')
+    // env strictly validated → no shell metacharacters can reach the path
+    expect(p.script).not.toMatch(/[;&|`$(]\(/)
+  })
+
+  it.each(['lower', 'HAS-DASH', 'HAS SPACE', 'X;rm -rf ~', '../escape', ''])('rejects unsafe env %s', (env) => {
+    const p = planSecretWrite(env)
+    expect(p.ok).toBe(false)
+    if (p.ok) return
+    expect(p.reason).toMatch(/invalid env name/)
+  })
+})
+
+describe('planSecretRevoke', () => {
+  it('removes exactly the env blob', () => {
+    const p = planSecretRevoke('TOKEN')
+    expect(p.ok).toBe(true)
+    if (!p.ok) return
+    expect(p.script).toBe(`rm -f "$HOME/${SECRETS_REL_DIR}/TOKEN.blob"`)
+  })
+
+  it('rejects an unsafe env', () => {
+    expect(planSecretRevoke('a b').ok).toBe(false)
+  })
+})


### PR DESCRIPTION
M2d of **Agent Recipe** (plans.openape.ai `01KRTAE8`). The wire between
the troop broker (M2c) and the agent: nest receives the sealed blob and
drops it into the agent's home **without ever opening it**.

## What
- `secret-relay.ts` (pure, unit-tested): `agentNameFromEmail`,
  `planSecretWrite`/`planSecretRevoke` → the `sh -c` script that writes
  (mode 600, via stdin) / removes `~/.config/openape/secrets.d/<env>.blob`.
  env names strictly re-validated (`^[A-Z][A-Z0-9_]*$`) so nothing unsafe
  reaches the shell.
- `troop-ws.ts`: new `secret-update` / `secret-revoke` frame types,
  dispatch + handlers; `runWithInput` (spawn + stdin) so the blob is
  piped, never on argv. `agentNameFromEmail` reused by config-update (DRY).

## Why
The blob is opaque to nest — it is sealed to the agent's X25519 key
(M2a/M2c). nest runs the write **as the agent user** (existing
`apes run --as` escapes path, no new privilege, no escapes-repo change)
so plaintext only ever exists inside the agent (M2e opens it). Revoke
removes the file → next agent read has nothing.

## Proof
`test/secret-relay.test.ts` — name derivation (incl. multi-word slugs),
write/revoke script shape, and rejection of unsafe envs including
`X;rm -rf ~` and `../escape`. nest 16/16; lint ✓ typecheck ✓ build ✓.
Changeset (`@openape/nest` minor).

No DDISA protocol surface touched (control-plane frame relay only).