### PR TITLE
feat(apes): agent runtime materializes sealed secrets (M2e)

### DIFF
--- a/.changeset/agent-secrets-runtime.md
+++ b/.changeset/agent-secrets-runtime.md
@@ -1,0 +1,10 @@
+---
+"@openape/apes": minor
+---
+
+The agent runtime now materializes capability secrets: it opens the
+sealed blobs in `~/.config/openape/secrets.d/` with its X25519 private
+key and injects them into `process.env` so the agent's tools see them.
+`apes agents run` does this once per task; `apes agents serve` watches
+the dir so troop rotate/revoke takes effect live without a re-deploy.
+The agent is the only place the plaintext ever exists.

--- a/packages/apes/src/commands/agents/run.ts
+++ b/packages/apes/src/commands/agents/run.ts
@@ -7,6 +7,7 @@ import { CliError } from '../../errors'
 import { taskTools } from '../../lib/agent-tools'
 import { runLoop  } from '../../lib/agent-runtime'
 import type { RuntimeConfig } from '../../lib/agent-runtime'
+import { materializeSecrets } from '../../lib/agent-secrets-runtime'
 import { resolveTroopUrl, TroopClient  } from '../../lib/troop-client'
 import type { TaskSpec } from '../../lib/troop-client'
 
@@ -145,6 +146,9 @@ export const runAgentCommand = defineCommand({
   async run({ args }) {
     const taskId = args['task-id'] as string
     const auth = readAuth()
+    // Inject any capability secrets troop sealed to this agent before
+    // the task runs, so the agent's tools see them in process.env.
+    materializeSecrets({ log: l => consola.info(l) })
     const spec = readTaskSpec(taskId)
     const agentCfg = readAgentConfig()
     const config = readLitellmConfig(args.model as string | undefined)

--- a/packages/apes/src/commands/agents/serve.ts
+++ b/packages/apes/src/commands/agents/serve.ts
@@ -7,6 +7,7 @@ import { CliError } from '../../errors'
 import { taskTools } from '../../lib/agent-tools'
 import { runLoop, RpcSessionMap  } from '../../lib/agent-runtime'
 import type { RuntimeConfig } from '../../lib/agent-runtime'
+import { startSecretsWatcher } from '../../lib/agent-secrets-runtime'
 
 // `apes agents serve --rpc` — long-running stdio JSON server.
 // Replaces `pi --mode rpc` for chat-bridge's per-room subprocesses.
@@ -78,9 +79,14 @@ export const serveAgentCommand = defineCommand({
       catch { /* tolerate */ }
     }
 
+    // Materialize capability secrets and keep them live: troop can
+    // rotate/revoke while this long-running process is up (M2 v1
+    // live-hotswap). Log to stderr — stdout is the RPC channel.
+    const stopSecrets = startSecretsWatcher({ log: l => process.stderr.write(`${l}\n`) })
+
     const sessions = new RpcSessionMap()
     const evictTimer = setInterval(() => sessions.evictStale(), 5 * 60 * 1000)
-    process.on('exit', () => clearInterval(evictTimer))
+    process.on('exit', () => { clearInterval(evictTimer); stopSecrets() })
 
     const rl = createInterface({ input: process.stdin, terminal: false })
     rl.on('line', async (line) => {

--- a/packages/apes/src/lib/agent-secrets-runtime.ts
+++ b/packages/apes/src/lib/agent-secrets-runtime.ts
@@ -1,0 +1,119 @@
+import type { SealedBox } from '@openape/core'
+import { existsSync, readdirSync, readFileSync, watch } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { openString } from '@openape/core'
+
+// Agent-side of the capability broker. troop seals a secret to this
+// agent's X25519 pubkey (M2a/M2c); nest drops the opaque blob into
+// ~/.config/openape/secrets.d/<ENV>.blob (M2d). Here the agent — the
+// ONLY place plaintext exists — opens it with its private key and
+// injects it into process.env so its tools (bash etc.) see it. Revoke
+// = blob removed → the env var is dropped on the next materialize.
+// See plans.openape.ai 01KRTAE8 (M2e).
+
+const CONFIG_DIR = join(homedir(), '.config', 'openape')
+export const SECRETS_DIR = join(CONFIG_DIR, 'secrets.d')
+export const X25519_KEY_PATH = join(CONFIG_DIR, 'agent-x25519.key')
+
+function envNameFromFile(file: string): string | null {
+  if (!file.endsWith('.blob')) return null
+  const env = file.slice(0, -'.blob'.length)
+  return /^[A-Z][A-Z0-9_]*$/.test(env) ? env : null
+}
+
+export function readAgentEncryptionKey(keyPath = X25519_KEY_PATH): string | null {
+  if (!existsSync(keyPath)) return null
+  const k = readFileSync(keyPath, 'utf8').trim()
+  return k.length > 0 ? k : null
+}
+
+export interface MaterializeOptions {
+  dir?: string
+  keyPath?: string
+  /** Target env map (defaults to process.env). Injected in tests. */
+  env?: NodeJS.ProcessEnv
+  /** Env names applied by a previous materialize, to drop on revoke. */
+  previouslyApplied?: Iterable<string>
+  log?: (line: string) => void
+}
+
+export interface MaterializeResult {
+  applied: string[]
+  failed: string[]
+}
+
+/**
+ * Open every sealed blob in the secrets dir and set the corresponding
+ * env var. Any env that was applied before but whose blob is now gone
+ * (revoke) is deleted. Best-effort per blob — a corrupt/foreign blob
+ * is logged and skipped, never throws.
+ */
+export function materializeSecrets(opts: MaterializeOptions = {}): MaterializeResult {
+  const dir = opts.dir ?? SECRETS_DIR
+  const env = opts.env ?? process.env
+  const log = opts.log ?? (() => {})
+  const applied: string[] = []
+  const failed: string[] = []
+
+  const key = readAgentEncryptionKey(opts.keyPath)
+  const files = key && existsSync(dir) ? readdirSync(dir) : []
+
+  for (const file of files) {
+    const name = envNameFromFile(file)
+    if (!name) continue
+    try {
+      const box = JSON.parse(readFileSync(join(dir, file), 'utf8')) as SealedBox
+      env[name] = openString(box, key!)
+      applied.push(name)
+    }
+    catch (e) {
+      failed.push(file)
+      log(`secrets: failed to open ${file}: ${(e as Error).message}`)
+    }
+  }
+
+  // Revoke: env names we set last time but that have no blob now.
+  const live = new Set(applied)
+  for (const prev of opts.previouslyApplied ?? []) {
+    if (!live.has(prev)) {
+      delete env[prev]
+      log(`secrets: revoked ${prev}`)
+    }
+  }
+
+  return { applied, failed }
+}
+
+/**
+ * Materialize once, then fs.watch the secrets dir and re-materialize
+ * on any change (rotate/revoke take effect live — the user's M2 v1
+ * choice). Returns a stop function. Safe to call when the dir doesn't
+ * exist yet (watch attaches once it appears on the next agent start).
+ */
+export function startSecretsWatcher(opts: MaterializeOptions = {}): () => void {
+  const dir = opts.dir ?? SECRETS_DIR
+  const log = opts.log ?? (() => {})
+  let appliedNames = new Set<string>()
+
+  const run = () => {
+    const r = materializeSecrets({ ...opts, previouslyApplied: appliedNames })
+    appliedNames = new Set(r.applied)
+  }
+
+  run()
+  if (!existsSync(dir)) return () => {}
+
+  let timer: NodeJS.Timeout | null = null
+  const watcher = watch(dir, () => {
+    // Debounce — a single rotate is several fs events (create, write).
+    if (timer) clearTimeout(timer)
+    timer = setTimeout(run, 150)
+  })
+  watcher.on('error', err => log(`secrets: watcher error: ${err.message}`))
+
+  return () => {
+    if (timer) clearTimeout(timer)
+    watcher.close()
+  }
+}

--- a/packages/apes/test/agent-secrets-runtime.test.ts
+++ b/packages/apes/test/agent-secrets-runtime.test.ts
@@ -1,0 +1,71 @@
+import { generateX25519KeyPair, seal } from '@openape/core'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { materializeSecrets } from '../src/lib/agent-secrets-runtime'
+
+let dir: string
+let keyPath: string
+const kp = generateX25519KeyPair()
+
+function writeBlob(env: string, value: string): void {
+  writeFileSync(join(dir, `${env}.blob`), JSON.stringify(seal(value, kp.publicKey)))
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'apes-secrets-'))
+  keyPath = join(dir, 'agent-x25519.key')
+  writeFileSync(keyPath, kp.privateKey)
+})
+afterEach(() => rmSync(dir, { recursive: true, force: true }))
+
+describe('materializeSecrets', () => {
+  it('opens sealed blobs and injects them into the env map', () => {
+    writeBlob('BLUESKY_APP_PASSWORD', 'hunter2')
+    writeBlob('BLUESKY_HANDLE', 'me.bsky.social')
+    const env: NodeJS.ProcessEnv = {}
+    const r = materializeSecrets({ dir, keyPath, env })
+    expect(r.applied.toSorted()).toEqual(['BLUESKY_APP_PASSWORD', 'BLUESKY_HANDLE'])
+    expect(env.BLUESKY_APP_PASSWORD).toBe('hunter2')
+    expect(env.BLUESKY_HANDLE).toBe('me.bsky.social')
+  })
+
+  it('does nothing when the agent has no key', () => {
+    writeBlob('TOKEN', 'v')
+    const env: NodeJS.ProcessEnv = {}
+    const r = materializeSecrets({ dir, keyPath: join(dir, 'missing.key'), env })
+    expect(r.applied).toEqual([])
+    expect(env.TOKEN).toBeUndefined()
+  })
+
+  it('skips corrupt / foreign blobs without throwing', () => {
+    writeBlob('GOOD', 'ok')
+    writeFileSync(join(dir, 'BAD.blob'), 'not json')
+    const other = generateX25519KeyPair()
+    writeFileSync(join(dir, 'FOREIGN.blob'), JSON.stringify(seal('x', other.publicKey)))
+    const env: NodeJS.ProcessEnv = {}
+    const r = materializeSecrets({ dir, keyPath, env })
+    expect(r.applied).toEqual(['GOOD'])
+    expect(r.failed.toSorted()).toEqual(['BAD.blob', 'FOREIGN.blob'])
+    expect(env.GOOD).toBe('ok')
+  })
+
+  it('ignores non-blob and non-UPPER_SNAKE files', () => {
+    writeBlob('REAL', 'v')
+    writeFileSync(join(dir, 'readme.txt'), 'x')
+    writeFileSync(join(dir, 'lower.blob'), 'x')
+    const env: NodeJS.ProcessEnv = {}
+    const r = materializeSecrets({ dir, keyPath, env })
+    expect(r.applied).toEqual(['REAL'])
+  })
+
+  it('revokes: an env applied before but with no blob now is deleted', () => {
+    writeBlob('KEEP', 'k')
+    const env: NodeJS.ProcessEnv = { GONE: 'old', KEEP: 'old' }
+    const r = materializeSecrets({ dir, keyPath, env, previouslyApplied: ['GONE', 'KEEP'] })
+    expect(r.applied).toEqual(['KEEP'])
+    expect(env.KEEP).toBe('k')
+    expect(env.GONE).toBeUndefined()
+  })
+})


### PR DESCRIPTION
M2e of **Agent Recipe** (plans.openape.ai `01KRTAE8`) — closes the
capability-broker chain. The agent opens the sealed blob and is the only
place plaintext ever exists.

## What
`packages/apes/src/lib/agent-secrets-runtime.ts`:
- `materializeSecrets()` — read the X25519 priv key
  (`~/.config/openape/agent-x25519.key`, M2b), open every
  `secrets.d/<ENV>.blob` (M2a `openString`) into `process.env`. Corrupt/
  foreign/garbage blobs are logged + skipped, never throw. Revoke (blob
  gone vs. previously-applied) deletes the env var.
- `startSecretsWatcher()` — materialize + `fs.watch` (debounced) for
  live rotate/revoke.

Wiring: `agents/run.ts` materializes once per cron task;
`agents/serve.ts` (long-running bridge subprocess) starts the watcher
(logs to stderr — stdout is the RPC channel).

## Why
Full chain now closed: troop seals to the agent pubkey, stores
ciphertext, pushes over WS; nest relays blind; the agent opens with its
private key into its own env. Live-hotswap (the M2 v1 decision) works
for `serve`; cron picks up changes next run.

## Proof
`test/agent-secrets-runtime.test.ts` — 5 tests: open+inject, no-key
no-op, corrupt + foreign-key blob skipped, non-blob/non-UPPER ignored,
revoke deletes. apes 668 pass; lint ✓ typecheck ✓ build ✓ (7/7).
Changeset (`@openape/apes` minor).

No DDISA protocol surface touched (agent-local env materialization).