### PR TITLE
feat(troop): one-step Agent Recipe deploy-flow (M3)

### DIFF
--- a/apps/openape-troop/server/api/agents/recipe-deploy.post.ts
+++ b/apps/openape-troop/server/api/agents/recipe-deploy.post.ts
@@ -1,0 +1,66 @@
+import { randomUUID } from 'node:crypto'
+import { z } from 'zod'
+import { materializeRecipe } from '../../utils/agent-recipe'
+import { requireOwner } from '../../utils/auth'
+import { listNestPeersForOwner } from '../../utils/nest-registry'
+import { buildDeployPlan, fetchRecipeManifest } from '../../utils/recipe-deploy'
+import { stashRecipeDeploy } from '../../utils/recipe-deploys'
+import { createSpawnIntent } from '../../utils/spawn-intents'
+
+// POST /api/agents/recipe-deploy — one-step deploy of an Agent Recipe.
+// Fetches <repo>@<ref>'s ape-agent.yaml (ref-pin enforced), validates
+// it + the supplied params (M1), spawns the agent (existing intent
+// flow), and stashes the deploy plan so spawn-result applies the
+// system prompt + schedules. Capability secrets are bound separately
+// by the owner via /api/agents/:name/secrets/:env (M2c) — the response
+// lists which envs are required.
+const bodySchema = z.object({
+  repo_ref: z.string().min(3).max(400),
+  params: z.record(z.string(), z.unknown()).default({}),
+  host_id: z.string().optional(),
+})
+
+export default defineEventHandler(async (event) => {
+  const owner = await requireOwner(event)
+  const parsed = bodySchema.safeParse(await readBody(event))
+  if (!parsed.success) {
+    throw createError({ statusCode: 400, statusMessage: parsed.error.issues[0]?.message ?? 'invalid body' })
+  }
+
+  const manifest = await fetchRecipeManifest(parsed.data.repo_ref, async (url) => {
+    const r = await fetch(url)
+    return { ok: r.ok, status: r.status, text: await r.text() }
+  })
+  if (!manifest.ok) throw createError({ statusCode: 400, statusMessage: manifest.reason })
+
+  const mat = materializeRecipe(manifest.recipe, parsed.data.params)
+  if (!mat.ok) throw createError({ statusCode: 400, statusMessage: mat.reason })
+
+  const plan = buildDeployPlan(manifest.recipe, mat.value)
+
+  const peers = listNestPeersForOwner(owner)
+  if (peers.length === 0) {
+    throw createError({ statusCode: 503, statusMessage: 'no connected nest — start the nest daemon on the target host' })
+  }
+  const target = parsed.data.host_id ? peers.find(p => p.hostId === parsed.data.host_id) : peers[0]
+  if (!target) {
+    throw createError({ statusCode: 404, statusMessage: `no nest found for host_id ${parsed.data.host_id}` })
+  }
+
+  const intentId = randomUUID()
+  createSpawnIntent(intentId)
+  stashRecipeDeploy(intentId, owner.toLowerCase(), plan)
+
+  const ok = target.send({ type: 'spawn-intent', intent_id: intentId, name: plan.agentName })
+  if (!ok) {
+    throw createError({ statusCode: 503, statusMessage: 'nest dropped before intent was delivered — retry shortly' })
+  }
+
+  return {
+    intent_id: intentId,
+    agent_name: plan.agentName,
+    ref: manifest.ref,
+    required_capabilities: plan.requiredCapabilities,
+    schedules: plan.schedules.map(s => ({ task_id: s.taskId, cron: s.cron, name: s.name })),
+  }
+})

--- a/apps/openape-troop/server/routes/api/nest-ws.ts
+++ b/apps/openape-troop/server/routes/api/nest-ws.ts
@@ -3,10 +3,11 @@ import { and, eq } from 'drizzle-orm'
 import { useRuntimeConfig } from 'nitropack/runtime'
 import toolCatalog from '../../tool-catalog.json'
 import { useDb } from '../../database/drizzle'
-import { agents } from '../../database/schema'
+import { agents, tasks } from '../../database/schema'
 import { parseAgentEmail } from '../../utils/agent-email'
 import { resolveDestroyIntent } from '../../utils/destroy-intents'
 import { registerNestPeer, touchNestPeer, unregisterNestPeerById } from '../../utils/nest-registry'
+import { takeRecipeDeploy } from '../../utils/recipe-deploys'
 import { resolveSpawnIntent } from '../../utils/spawn-intents'
 
 const ALL_TOOL_NAMES: string[] = (toolCatalog as { tools: Array<{ name: string }> }).tools.map(t => t.name)
@@ -210,6 +211,39 @@ export default defineWebSocketHandler({
               createdAt: now,
             }).onConflictDoNothing(),
           ).catch(() => { /* ignore — bridge sync will retry the upsert */ })
+
+          // Agent Recipe (M3): if this spawn came from a recipe-deploy,
+          // apply the stashed plan — set the agent's system prompt to
+          // the materialized intent and create the schedule task rows.
+          // Capability secrets are bound separately by the owner (M2c).
+          const deploy = takeRecipeDeploy(f.intent_id)
+          if (deploy) {
+            const plan = deploy.plan
+            void Promise.resolve(
+              (async () => {
+                await db.update(agents)
+                  .set({ systemPrompt: plan.systemPrompt })
+                  .where(eq(agents.email, agentEmail))
+                for (const s of plan.schedules) {
+                  await db.insert(tasks).values({
+                    agentEmail,
+                    taskId: s.taskId,
+                    name: s.name,
+                    cron: s.cron,
+                    userPrompt: s.userPrompt,
+                    tools: s.tools,
+                    maxSteps: 10,
+                    enabled: true,
+                    createdAt: now,
+                    updatedAt: now,
+                  }).onConflictDoUpdate({
+                    target: [tasks.agentEmail, tasks.taskId],
+                    set: { name: s.name, cron: s.cron, userPrompt: s.userPrompt, tools: s.tools, updatedAt: now },
+                  })
+                }
+              })(),
+            ).catch(() => { /* best-effort — owner can re-deploy */ })
+          }
         }
       }
       return

--- a/apps/openape-troop/server/utils/recipe-deploy.ts
+++ b/apps/openape-troop/server/utils/recipe-deploy.ts
@@ -1,0 +1,103 @@
+import type { AgentRecipe, MaterializedRecipe } from './agent-recipe'
+import { parseRecipe, parseRepoRef } from './agent-recipe'
+
+// Deploy-flow core: turn a validated + param-materialized recipe (M1)
+// into the concrete things troop applies to a freshly-spawned agent —
+// its system prompt (the intent), its scheduled task rows, and the
+// list of capability envs the owner still has to bind (M2c). Pure +
+// unit-tested; the endpoint wires it to spawn-intent + the DB. See
+// plans.openape.ai 01KRTAE8 (M3).
+
+// Recipe agents drive everything through the built-in toolset — the
+// repo's tools/ scripts are invoked via bash; http/file/time round it
+// out. Owners can narrow later in the troop UI.
+export const RECIPE_AGENT_TOOLS = ['bash', 'http', 'file', 'time'] as const
+
+export interface DeploySchedule {
+  taskId: string
+  name: string
+  cron: string
+  userPrompt: string
+  tools: string[]
+}
+
+export interface DeployPlan {
+  agentName: string
+  systemPrompt: string
+  schedules: DeploySchedule[]
+  requiredCapabilities: string[]
+}
+
+function agentNameFromRecipe(name: string): string {
+  // recipe.name is already kebab (M1); spawn-intent caps the slug at
+  // 24 chars ([a-z][a-z0-9-]{0,23}).
+  return name.slice(0, 24).replace(/-+$/, '')
+}
+
+/**
+ * Map a materialized recipe to its deploy plan. `mat.intent` is the
+ * fully-interpolated system prompt; each manifest schedule becomes a
+ * task whose user prompt is the (interpolated) schedule description or
+ * a sensible default.
+ */
+export function buildDeployPlan(recipe: AgentRecipe, mat: MaterializedRecipe): DeployPlan {
+  const schedules: DeploySchedule[] = mat.schedules.map((s, i) => ({
+    taskId: `recipe-${i}`,
+    name: s.description ?? `${recipe.name} #${i + 1}`,
+    cron: s.cron,
+    userPrompt: s.description ?? 'Run your configured task as described in your instructions.',
+    tools: [...RECIPE_AGENT_TOOLS],
+  }))
+  return {
+    agentName: agentNameFromRecipe(recipe.name),
+    systemPrompt: mat.intent,
+    schedules,
+    requiredCapabilities: recipe.capabilities.map(c => c.env),
+  }
+}
+
+export type FetchManifest = (rawUrl: string) => Promise<{ ok: boolean, status: number, text: string }>
+
+/**
+ * Resolve `<repo>@<ref>` to the GitHub raw URL of its `ape-agent.yaml`
+ * and fetch it. Ref-pin is enforced by parseRepoRef (M1): a floating
+ * ref is rejected before any network call. `repo` may be
+ * `github.com/owner/name` or `owner/name`.
+ */
+export async function fetchRecipeManifest(
+  spec: string,
+  fetchImpl: FetchManifest,
+): Promise<{ ok: true, recipe: AgentRecipe, ref: string } | { ok: false, reason: string }> {
+  const ref = parseRepoRef(spec)
+  if (!ref.ok) return { ok: false, reason: ref.reason }
+  let host = ref.value.repo.replace(/^https?:\/\//, '').replace(/\.git$/, '')
+  if (host.startsWith('github.com/')) {
+    host = host.slice('github.com/'.length)
+  }
+  else {
+    // A leading segment with a dot means a host other than github.com
+    // (gitlab.com/…, etc.) — not supported in v1.
+    const slash = host.indexOf('/')
+    if (slash > 0 && host.slice(0, slash).includes('.')) {
+      return { ok: false, reason: `unsupported repo "${ref.value.repo}" — expected github.com/<owner>/<name>` }
+    }
+  }
+  const slug = host
+  if (!/^[\w.-]+\/[\w.-]+$/.test(slug)) {
+    return { ok: false, reason: `unsupported repo "${ref.value.repo}" — expected github.com/<owner>/<name>` }
+  }
+  const rawUrl = `https://raw.githubusercontent.com/${slug}/${ref.value.ref}/ape-agent.yaml`
+  let res: Awaited<ReturnType<FetchManifest>>
+  try {
+    res = await fetchImpl(rawUrl)
+  }
+  catch (e) {
+    return { ok: false, reason: `fetch failed: ${(e as Error).message}` }
+  }
+  if (!res.ok) {
+    return { ok: false, reason: `manifest not found at ${slug}@${ref.value.ref} (HTTP ${res.status})` }
+  }
+  const parsed = parseRecipe(res.text)
+  if (!parsed.ok) return { ok: false, reason: `invalid ape-agent.yaml: ${parsed.reason}` }
+  return { ok: true, recipe: parsed.value, ref: ref.value.ref }
+}

--- a/apps/openape-troop/server/utils/recipe-deploys.ts
+++ b/apps/openape-troop/server/utils/recipe-deploys.ts
@@ -1,0 +1,40 @@
+import type { DeployPlan } from './recipe-deploy'
+
+// Pending recipe-deploys keyed by spawn intent_id. POST
+// /api/agents/recipe-deploy stashes the plan here, then emits a normal
+// spawn-intent. When the nest's `spawn-result` lands (nest-ws.ts), the
+// stored plan is applied to the new agent (system prompt + schedule
+// rows). Same prune policy as spawn-intents.
+
+interface PendingDeploy {
+  createdAt: number
+  ownerEmail: string
+  plan: DeployPlan
+}
+
+const deploys = new Map<string, PendingDeploy>()
+const PRUNE_AFTER_S = 30 * 60
+
+function prune(): void {
+  const now = Math.floor(Date.now() / 1000)
+  for (const [id, d] of deploys) {
+    if (now - d.createdAt > PRUNE_AFTER_S) deploys.delete(id)
+  }
+}
+
+export function stashRecipeDeploy(intentId: string, ownerEmail: string, plan: DeployPlan): void {
+  prune()
+  deploys.set(intentId, { createdAt: Math.floor(Date.now() / 1000), ownerEmail, plan })
+}
+
+export function takeRecipeDeploy(intentId: string): { ownerEmail: string, plan: DeployPlan } | undefined {
+  const d = deploys.get(intentId)
+  if (!d) return undefined
+  deploys.delete(intentId)
+  return { ownerEmail: d.ownerEmail, plan: d.plan }
+}
+
+// Test-only reset — unique name (Nuxt auto-import dedupe).
+export function __resetRecipeDeploysForTest(): void {
+  deploys.clear()
+}

--- a/apps/openape-troop/tests/recipe-deploy.test.ts
+++ b/apps/openape-troop/tests/recipe-deploy.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest'
+import { materializeRecipe, parseRecipe } from '../server/utils/agent-recipe'
+import { buildDeployPlan, fetchRecipeManifest, RECIPE_AGENT_TOOLS } from '../server/utils/recipe-deploy'
+
+const MANIFEST = `
+name: bluesky-summary
+kind: agent
+intent: Summarize the Bluesky feed about {{topic}}.
+capabilities:
+  - env: BLUESKY_HANDLE
+  - env: BLUESKY_APP_PASSWORD
+params:
+  - name: topic
+    type: string
+    required: true
+schedules:
+  - cron: "0 8 * * *"
+    description: morning digest for {{topic}}
+  - cron: "0 18 * * *"
+`
+
+function recipe() {
+  const r = parseRecipe(MANIFEST)
+  if (!r.ok) throw new Error(r.reason)
+  return r.value
+}
+
+describe('buildDeployPlan', () => {
+  it('maps a materialized recipe to system prompt + schedules + caps', () => {
+    const rec = recipe()
+    const mat = materializeRecipe(rec, { topic: 'AI agents' })
+    if (!mat.ok) throw new Error(mat.reason)
+    const plan = buildDeployPlan(rec, mat.value)
+
+    expect(plan.agentName).toBe('bluesky-summary')
+    expect(plan.systemPrompt).toBe('Summarize the Bluesky feed about AI agents.')
+    expect(plan.requiredCapabilities).toEqual(['BLUESKY_HANDLE', 'BLUESKY_APP_PASSWORD'])
+    expect(plan.schedules).toHaveLength(2)
+    expect(plan.schedules[0]).toMatchObject({
+      taskId: 'recipe-0',
+      cron: '0 8 * * *',
+      name: 'morning digest for AI agents',
+      userPrompt: 'morning digest for AI agents',
+      tools: [...RECIPE_AGENT_TOOLS],
+    })
+    // schedule without description gets a sensible default user prompt
+    expect(plan.schedules[1]!.userPrompt).toMatch(/Run your configured task/)
+  })
+
+  it('caps the agent name at the spawn-intent slug limit', () => {
+    const rec = { ...recipe(), name: 'a-very-long-recipe-name-way-over-limit' }
+    const mat = materializeRecipe(rec, { topic: 'x' })
+    if (!mat.ok) throw new Error(mat.reason)
+    expect(buildDeployPlan(rec, mat.value).agentName.length).toBeLessThanOrEqual(24)
+  })
+})
+
+describe('fetchRecipeManifest', () => {
+  const okFetch = async () => ({ ok: true, status: 200, text: MANIFEST })
+
+  it('fetches + parses a pinned manifest from a github raw URL', async () => {
+    let calledUrl = ''
+    const r = await fetchRecipeManifest('github.com/openape-official-ape-agents/bluesky-summary@v0.1.0', async (u) => {
+      calledUrl = u
+      return { ok: true, status: 200, text: MANIFEST }
+    })
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(calledUrl).toBe('https://raw.githubusercontent.com/openape-official-ape-agents/bluesky-summary/v0.1.0/ape-agent.yaml')
+    expect(r.recipe.name).toBe('bluesky-summary')
+    expect(r.ref).toBe('v0.1.0')
+  })
+
+  it('rejects a floating ref before any fetch (ref-pin)', async () => {
+    let fetched = false
+    const r = await fetchRecipeManifest('github.com/o/r@main', async () => { fetched = true; return { ok: true, status: 200, text: '' } })
+    expect(r.ok).toBe(false)
+    expect(fetched).toBe(false)
+    if (!r.ok) expect(r.reason).toMatch(/floating ref/)
+  })
+
+  it('rejects an unsupported repo shape', async () => {
+    const r = await fetchRecipeManifest('https://gitlab.com/o@v1.0.0', okFetch)
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.reason).toMatch(/unsupported repo|expected github/)
+  })
+
+  it('surfaces an HTTP error from the raw host', async () => {
+    const r = await fetchRecipeManifest('github.com/o/r@v1.0.0', async () => ({ ok: false, status: 404, text: '' }))
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.reason).toMatch(/HTTP 404/)
+  })
+
+  it('rejects an invalid manifest body', async () => {
+    const r = await fetchRecipeManifest('github.com/o/r@v1.0.0', async () => ({ ok: true, status: 200, text: 'kind: script\n' }))
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.reason).toMatch(/invalid ape-agent\.yaml/)
+  })
+})


### PR DESCRIPTION
M3 of **Agent Recipe** (plans.openape.ai `01KRTAE8`). Ties M1 (manifest)
+ M2 (secrets) + the existing spawn-intent + tasks machinery into one
endpoint: a pinned repo ref becomes a configured, scheduled agent.

## What
- `recipe-deploy.ts` (pure): `fetchRecipeManifest(<repo>@<ref>)` →
  GitHub-raw URL (ref-pin enforced by M1, github-host only), parse +
  validate; `buildDeployPlan` → { system prompt = interpolated intent,
  schedules → task rows, capabilities → required env list }.
- `recipe-deploys.ts`: pending-plan registry keyed by intent_id (same
  prune policy as spawn-intents).
- `POST /api/agents/recipe-deploy`: owner-scoped; fetch+validate+
  materialize (M1), pick nest peer, `createSpawnIntent`, stash plan,
  send spawn-intent. Returns intent_id + required_capabilities +
  schedules.
- `nest-ws.ts` `spawn-result`: when a stashed plan exists for the
  intent, set the agent's `system_prompt` and upsert the schedule
  `tasks` (best-effort, mirrors the existing stub-insert pattern).

## Why
Maximum reuse — no new spawn channel, no new scheduler: recipes ride
the existing spawn-intent + tasks + (M2c) secret-binding rails. Tool
delivery for the proof-case is via the agent's built-in toolset
(`bash`/`http`/`file`/`time`) running the repo scripts; richer tool
placement can extend `buildDeployPlan` later.

## Proof
`tests/recipe-deploy.test.ts` — 7 tests: plan mapping (intent→prompt,
schedules, caps, default user-prompt), name-slug cap, ref-pin rejected
before any fetch, non-github host rejected, HTTP 404, invalid manifest.
troop 103/103; lint ✓ typecheck ✓ build ✓ (4/4).

No DDISA protocol surface touched (troop-internal orchestration; reads
a public GitHub raw file).