### PR TITLE
feat(troop): user_addendum runtime layer (M5)

### DIFF
--- a/apps/openape-troop/server/api/agents/[name].patch.ts
+++ b/apps/openape-troop/server/api/agents/[name].patch.ts
@@ -20,6 +20,11 @@ const bodySchema = z.object({
   // guides here. The bridge reads it on every turn (cheap — small
   // file read, no LLM round-trip).
   system_prompt: z.string().max(32_000).optional(),
+  // Owner-editable free-text behaviour layer (Agent Recipe M5).
+  // Appended to system_prompt at sync — changing it takes effect on
+  // the next run, no re-deploy. For recipe agents this is the only
+  // prompt field the owner should touch (system_prompt = the intent).
+  user_addendum: z.string().max(32_000).optional(),
   tools: z.array(z.string()).optional().refine(
     arr => arr === undefined || arr.every(t => KNOWN_TOOL_NAMES.has(t)),
     { message: 'tools list contains unknown tool names — see /api/tool-catalog' },
@@ -44,6 +49,7 @@ export default defineEventHandler(async (event) => {
   const db = useDb()
   const updates: Record<string, unknown> = {}
   if (body.data.system_prompt !== undefined) updates.systemPrompt = body.data.system_prompt
+  if (body.data.user_addendum !== undefined) updates.userAddendum = body.data.user_addendum
   if (body.data.tools !== undefined) updates.tools = body.data.tools
 
   const result = await db

--- a/apps/openape-troop/server/api/agents/me/tasks.get.ts
+++ b/apps/openape-troop/server/api/agents/me/tasks.get.ts
@@ -2,6 +2,7 @@ import { and, eq } from 'drizzle-orm'
 import { useDb } from '../../../database/drizzle'
 import { agents, agentSkills, tasks } from '../../../database/schema'
 import { requireAgent } from '../../../utils/auth'
+import { composeSystemPrompt } from '../../../utils/system-prompt'
 
 // Agent reads its own task list + agent-level config. No owner gate —
 // the JWT's sub is the agent email and we filter rows on it.
@@ -17,6 +18,7 @@ export default defineEventHandler(async (event) => {
   const agent = await db
     .select({
       systemPrompt: agents.systemPrompt,
+      userAddendum: agents.userAddendum,
       tools: agents.tools,
     })
     .from(agents)
@@ -38,7 +40,7 @@ export default defineEventHandler(async (event) => {
     .from(agentSkills)
     .where(and(eq(agentSkills.agentEmail, agentEmail), eq(agentSkills.enabled, true)))
   return {
-    system_prompt: agent?.systemPrompt ?? '',
+    system_prompt: composeSystemPrompt(agent?.systemPrompt ?? '', agent?.userAddendum),
     // tools[] = whitelist for chat-bridge runtime + cron task fallback.
     tools: agent?.tools ?? [],
     skills: skillRows,

--- a/apps/openape-troop/server/database/schema.ts
+++ b/apps/openape-troop/server/database/schema.ts
@@ -35,6 +35,11 @@ export const agents = sqliteTable('agents', {
   // `/api/agents/:email/tools`). The chat-bridge reads this list
   // from `~/.openape/agent/agent.json` after each sync.
   tools: text('tools', { mode: 'json' }).notNull().$type<string[]>().default([]),
+  // Free-text behaviour layer the owner can edit any time without a
+  // re-deploy; appended to systemPrompt at sync (see system-prompt.ts).
+  // For recipe agents systemPrompt is the (immutable) intent and this
+  // is the mutable augmentation. (Agent Recipe M5.)
+  userAddendum: text('user_addendum').notNull().default(''),
   // (legacy) `soul` text column still exists in the DB for back-compat
   // with rows written before the SOUL.md + system_prompt merge. New code
   // doesn't read or write it — the system_prompt above absorbed its role.

--- a/apps/openape-troop/server/plugins/02.database.ts
+++ b/apps/openape-troop/server/plugins/02.database.ts
@@ -66,6 +66,12 @@ export default defineNitroPlugin(async () => {
       await db.run(sql`ALTER TABLE agents ADD COLUMN soul TEXT NOT NULL DEFAULT ''`)
     }
     catch { /* column exists */ }
+    // Agent Recipe M5: owner-editable behaviour layer appended to the
+    // system prompt at sync (no re-deploy).
+    try {
+      await db.run(sql`ALTER TABLE agents ADD COLUMN user_addendum TEXT NOT NULL DEFAULT ''`)
+    }
+    catch { /* column exists */ }
     await db.run(sql`CREATE TABLE IF NOT EXISTS agent_skills (
       agent_email TEXT NOT NULL,
       name TEXT NOT NULL,

--- a/apps/openape-troop/server/utils/system-prompt.ts
+++ b/apps/openape-troop/server/utils/system-prompt.ts
@@ -1,0 +1,14 @@
+// The agent's effective system prompt = the recipe intent (or the
+// owner-set base systemPrompt) plus an optional free-text
+// `user_addendum` the owner can edit any time. It is appended at sync
+// time, so changing it takes effect on the next run with no re-deploy
+// (Agent Recipe M5). Kept tiny + pure so it is unit-testable and the
+// /api/agents/me/tasks handler stays declarative.
+
+export function composeSystemPrompt(base: string, addendum: string | null | undefined): string {
+  const b = (base ?? '').trim()
+  const a = (addendum ?? '').trim()
+  if (!a) return b
+  if (!b) return a
+  return `${b}\n\n${a}`
+}

--- a/apps/openape-troop/tests/system-prompt.test.ts
+++ b/apps/openape-troop/tests/system-prompt.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { composeSystemPrompt } from '../server/utils/system-prompt'
+
+describe('composeSystemPrompt', () => {
+  it('appends the addendum after a blank-line separator', () => {
+    expect(composeSystemPrompt('You are a Bluesky summariser.', 'Focus on the negative posts.'))
+      .toBe('You are a Bluesky summariser.\n\nFocus on the negative posts.')
+  })
+
+  it('returns just the base when there is no addendum', () => {
+    expect(composeSystemPrompt('base', '')).toBe('base')
+    expect(composeSystemPrompt('base', null)).toBe('base')
+    expect(composeSystemPrompt('base', undefined)).toBe('base')
+    expect(composeSystemPrompt('base', '   ')).toBe('base')
+  })
+
+  it('returns just the addendum when the base is empty', () => {
+    expect(composeSystemPrompt('', 'only addendum')).toBe('only addendum')
+  })
+
+  it('trims both sides', () => {
+    expect(composeSystemPrompt('  base  ', '  add  ')).toBe('base\n\nadd')
+  })
+
+  it('is empty when both are empty', () => {
+    expect(composeSystemPrompt('', '')).toBe('')
+  })
+})


### PR DESCRIPTION
M5 of **Agent Recipe** (plans.openape.ai `01KRTAE8`). A free-text
behaviour layer the owner can change any time — no re-deploy.

## What
- `agents.user_addendum` column + idempotent ALTER (repo pattern).
- `server/utils/system-prompt.ts` `composeSystemPrompt(base, addendum)`
  — base + addendum joined by a blank line; trims; handles empties.
- `/api/agents/me/tasks` returns `composeSystemPrompt(systemPrompt,
  userAddendum)` as `system_prompt`. **Agent runtime unchanged** — it
  already consumes `system_prompt`, so a changed addendum is picked up
  on the next sync/run with zero re-deploy.
- `PATCH /api/agents/:name` accepts `user_addendum` (reuses the
  existing owner-scoped handler + its config-update fan-out).

## Why
For recipe agents `systemPrompt` is the immutable intent (set by M3
deploy); `user_addendum` is the owner's mutable augmentation
("focus on the negative posts"). Composing at read-time keeps the two
concerns separate and the agent dumb.

## Proof
`tests/system-prompt.test.ts` — 5 tests (append w/ separator, empty
addendum → base only incl. null/undefined/whitespace, empty base →
addendum, trim, both-empty). troop 108/108; lint ✓ typecheck ✓
build ✓ (4/4).

No DDISA protocol surface touched (troop-internal field + read-time
composition).