### PR TITLE
docs(ecosystem): Agent Recipe convention page (M6)

### DIFF
--- a/apps/docs/content/2.ecosystem/8.agent-recipe.md
+++ b/apps/docs/content/2.ecosystem/8.agent-recipe.md
@@ -1,0 +1,139 @@
+---
+title: Agent Recipe
+description: One-step deployable, scheduled, capability-using agents from a pinned repo.
+---
+
+# Agent Recipe
+
+An **Agent Recipe** turns a scheduled, capability-using agent into a
+single declarative artifact you can deploy in one step. Instead of
+hand-wiring a script, a password "somewhere", a cron entry and a system
+prompt, you point troop at a pinned repo and it provisions everything.
+
+Agent Recipe is a **troop feature and a repo convention** — not a
+protocol. There is nothing in the DDISA spec about it.
+
+## The shape of a recipe
+
+A recipe repo has two parts:
+
+- **`ape-agent.yaml`** — the manifest (all the declarative data).
+- **`tools/`** — the code part: the actual scripts the agent runs.
+- `README.md` — for humans.
+
+```
+my-recipe/
+├── ape-agent.yaml
+├── tools/
+│   └── summarize.mjs
+└── README.md
+```
+
+## `ape-agent.yaml`
+
+```yaml
+name: bluesky-summary           # kebab-case; becomes the agent slug
+kind: agent                     # v1: only `agent`
+intent: |                       # the prepared system prompt
+  You summarise the Bluesky feed about {{topic}} twice a day.
+  Be concise. Use the tools in tools/ via your bash tool.
+capabilities:                   # declared placeholder env names only
+  - env: BLUESKY_HANDLE
+  - env: BLUESKY_APP_PASSWORD
+    prefer: local               # optional hint: proxy | local
+params:                         # typed, validated at deploy time
+  - name: topic
+    type: string                # string | number | boolean
+    required: true
+schedules:                      # one agent run per tick
+  - cron: "0 8 * * *"
+    description: morning digest for {{topic}}
+  - cron: "0 18 * * *"
+user_addendum: true             # allow a free runtime behaviour layer
+tools:                          # entrypoints under tools/
+  - tools/summarize.mjs
+```
+
+| Field | Meaning |
+|---|---|
+| `name` | kebab-case; the deployed agent's name (capped at 24 chars). |
+| `kind` | `agent` only in v1. `script` is a future additive extension. |
+| `intent` | The prepared system prompt. `{{param}}` placeholders are interpolated at deploy. |
+| `capabilities[]` | The **names** of the secrets the recipe needs — never values. `prefer` is a hint only; troop owns the lifecycle. |
+| `params[]` | Typed deploy-time inputs (`name`, `type`, `required`, optional `default`). Interpolated into `intent`, `schedules`, `tools`. |
+| `schedules[]` | Cron list (the 5-field subset troop supports). Each tick is one agent run with the intent. |
+| `user_addendum` | If `true`, the owner gets a free-text behaviour layer editable at runtime (see below). |
+| `tools[]` | Entrypoints under `tools/` the agent invokes. |
+
+## Sourcing & trust
+
+Deploy with a **pinned ref** — a version tag (`v1.0.0`) or a commit
+SHA. A floating ref (`@main`, a branch) is **rejected before any
+fetch**. Integrity comes from the pin.
+
+```bash
+apes agent deploy github.com/openape-official-ape-agents/bluesky-summary@v0.1.0 \
+  --param topic="AI agents"
+```
+
+`@openape-official-ape-agents/*` is only a **curated discovery index**.
+It carries **no special trust** — capabilities are always consented
+explicitly, once, regardless of where the recipe comes from. A
+first-class recipe and your own repo are technically identical.
+
+## Capabilities & secrets — the agent never sees them as a stranger
+
+A recipe only declares **placeholder env names**. troop is the broker
+and owns the whole lifecycle:
+
+1. At deploy you supply the values (prompted, or `--secret ENV=val`).
+2. troop **seals each value to the agent's X25519 public key the
+   moment you submit it** and stores only the sealed blob. troop's DB,
+   logs and the control-plane WS only ever see ciphertext.
+3. The blob is relayed **blind** through the nest to the agent host.
+4. The agent — the **only** place plaintext exists — opens it with its
+   private key and puts it in its own environment.
+
+Revoke clears the agent's copy on the next connect. Rotate takes effect
+live, no re-deploy.
+
+This follows the published principle *"the infrastructure carries the
+knowledge, the agent operates blind"* —
+[Was der Agent nicht weiß](https://www.delta-mind.at/de/blog/was-der-agent-nicht-weiss).
+The proxy-injection path (where the agent never even decrypts) is the
+North-Star; see the [`proxy-secrets` runbook](https://github.com/openape-ai/openape/blob/main/docs/proxy-secrets.md).
+
+## Params vs. user_addendum
+
+- **`params`** are typed and validated at deploy time, then
+  interpolated into the intent/schedules/tools. They are fixed for the
+  life of the deploy.
+- **`user_addendum`** is free text the owner can edit any time in
+  troop. It is appended to the intent on every run — **no re-deploy**.
+  Use it for "focus on the negative posts" style tweaks.
+
+## Deploying
+
+CLI and troop UI are equivalent. The CLI:
+
+```bash
+# pinned ref is mandatory
+apes agent deploy github.com/<owner>/<name>@v1.2.0 \
+  --param topic="AI agents" \
+  --secret BLUESKY_HANDLE=me.bsky.social \
+  --secret BLUESKY_APP_PASSWORD=xxxx-xxxx-xxxx-xxxx
+
+# omit --secret to be prompted interactively
+# add --json for non-interactive / scripted use
+```
+
+What happens: troop fetches and validates the manifest, validates your
+params, spawns the agent, sets its system prompt to the interpolated
+intent, creates the schedules, and binds the sealed secrets. Within
+seconds the agent is running on its schedule.
+
+## Next Steps
+
+- [Capabilities & Grants](/guides/capabilities) — the consent model
+- [escapes](/ecosystem/escapes) — the privilege boundary the relay uses
+- [Quick Start: Agent](/getting-started/quickstart-agent) — your first agent


### PR DESCRIPTION
M6 of **Agent Recipe** (plans.openape.ai `01KRTAE8`). The convention,
documented where it belongs — the ecosystem docs site, **not** the
DDISA protocol repo (Agent Recipe is a troop feature + repo
convention).

## What
`apps/docs/content/2.ecosystem/8.agent-recipe.md`:
- the two-part recipe repo shape (`ape-agent.yaml` + `tools/`)
- full manifest field reference + a complete example
- `<repo>@<ref>` pin convention (floating ref rejected pre-fetch)
- first-class index = curated discovery only, **identical trust**
- the sealed capability/secret model end to end (seal-at-submit →
  ciphertext-at-rest → blind relay → agent-only plaintext; revoke/
  rotate live)
- `params` (deploy-time, typed) vs. `user_addendum` (runtime, no
  re-deploy)
- CLI + UI deploy
- links the *Was der Agent nicht weiß* blog + the `proxy-secrets`
  runbook (the North-Star)

## Proof
docs `lint` ✓ and `build` ✓ — 88 routes prerendered including the new
`/ecosystem/agent-recipe`.

No code, no DDISA surface — documentation only.