### PR TITLE
test(troop): bluesky-summary reference recipe + E2E (M7)

### DIFF
--- a/apps/openape-troop/tests/recipe-e2e.test.ts
+++ b/apps/openape-troop/tests/recipe-e2e.test.ts
@@ -1,0 +1,68 @@
+import { generateX25519KeyPair, openString, seal } from '@openape/core'
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { materializeRecipe, parseRecipe } from '../server/utils/agent-recipe'
+import { buildDeployPlan } from '../server/utils/recipe-deploy'
+
+// End-to-end of the Agent Recipe code path against the REAL reference
+// recipe artifact (examples/agent-recipes/bluesky-summary). Exercises
+// M1 (parse + materialize) → M3 (deploy plan) → M2a (seal/open) with
+// no mocks. The live infra run (nest spawns, cron fires, Bluesky API)
+// is the documented runbook in that recipe's README.
+
+const here = dirname(fileURLToPath(import.meta.url))
+const RECIPE_DIR = resolve(here, '../../../examples/agent-recipes/bluesky-summary')
+const manifestText = readFileSync(join(RECIPE_DIR, 'ape-agent.yaml'), 'utf8')
+
+describe('bluesky-summary recipe — end to end', () => {
+  it('the manifest parses and points at a tool file that exists', () => {
+    const r = parseRecipe(manifestText)
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.value.name).toBe('bluesky-summary')
+    expect(r.value.tools).toEqual(['tools/fetch-feed.mjs'])
+    for (const t of r.value.tools) {
+      expect(existsSync(join(RECIPE_DIR, t)), `${t} must exist in the recipe`).toBe(true)
+    }
+  })
+
+  it('materializes the intent + schedules and builds the deploy plan', () => {
+    const r = parseRecipe(manifestText)
+    if (!r.ok) throw new Error(r.reason)
+    const mat = materializeRecipe(r.value, { topic: 'AI agents' })
+    expect(mat.ok).toBe(true)
+    if (!mat.ok) return
+
+    const plan = buildDeployPlan(r.value, mat.value)
+    expect(plan.agentName).toBe('bluesky-summary')
+    expect(plan.systemPrompt).toContain('focused on AI agents')
+    expect(plan.systemPrompt).not.toContain('{{topic}}')
+    expect(plan.schedules.map(s => s.cron)).toEqual(['0 8 * * *', '0 18 * * *'])
+    expect(plan.schedules[0]!.name).toBe('morning Bluesky digest on AI agents')
+    expect(plan.requiredCapabilities).toEqual(['BLUESKY_HANDLE', 'BLUESKY_APP_PASSWORD'])
+  })
+
+  it('fails deploy when a required param is missing', () => {
+    const r = parseRecipe(manifestText)
+    if (!r.ok) throw new Error(r.reason)
+    expect(materializeRecipe(r.value, {}).ok).toBe(false)
+  })
+
+  it('seals each capability to the agent and only the agent can open it', () => {
+    const agent = generateX25519KeyPair()
+    const value = 'abcd-efgh-ijkl-mnop' // a Bluesky app password shape
+
+    // troop seals on submit; only ciphertext is ever stored/relayed.
+    const box = seal(value, agent.publicKey)
+    expect(JSON.stringify(box)).not.toContain(value)
+
+    // the agent (and only the agent) opens it
+    expect(openString(box, agent.privateKey)).toBe(value)
+
+    // revoke / wrong key → clean failure, never plaintext
+    const other = generateX25519KeyPair()
+    expect(() => openString(box, other.privateKey)).toThrow()
+  })
+})

--- a/examples/agent-recipes/bluesky-summary/README.md
+++ b/examples/agent-recipes/bluesky-summary/README.md
@@ -1,0 +1,60 @@
+# bluesky-summary — Agent Recipe
+
+A scheduled agent that digests your Bluesky home timeline twice a day.
+This is the reference Agent Recipe — see
+[the Agent Recipe docs](https://docs.openape.ai/ecosystem/agent-recipe).
+
+## What it does
+
+- `ape-agent.yaml` declares the intent, the `topic` param, two daily
+  schedules, and two capabilities (`BLUESKY_HANDLE`,
+  `BLUESKY_APP_PASSWORD`).
+- `tools/fetch-feed.mjs` logs in via AT-Proto and prints recent posts
+  as JSON. The agent's LLM turns that into the digest.
+- The credentials are **sealed to the agent** by troop and only ever
+  exist in plaintext inside the agent process — the recipe only names
+  them.
+
+## Deploy (one step)
+
+```bash
+apes agent deploy github.com/openape-official-ape-agents/bluesky-summary@v0.1.0 \
+  --param topic="AI agents" \
+  --secret BLUESKY_HANDLE=you.bsky.social \
+  --secret BLUESKY_APP_PASSWORD=xxxx-xxxx-xxxx-xxxx
+```
+
+(Omit `--secret` to be prompted; the values are sealed before they
+leave your machine's troop session and never stored in plaintext.)
+
+## Live end-to-end verification
+
+The full live run needs a connected `openape-nest` host and a real
+Bluesky app password. Sequence:
+
+```bash
+# 1. tag the recipe repo
+git tag v0.1.0 && git push --tags
+
+# 2. deploy (creates the agent, schedules, binds the sealed secret)
+apes agent deploy github.com/openape-official-ape-agents/bluesky-summary@v0.1.0 \
+  --param topic="AI agents" --secret BLUESKY_HANDLE=you.bsky.social \
+  --secret BLUESKY_APP_PASSWORD=xxxx-xxxx-xxxx-xxxx
+
+# 3. trigger a run now instead of waiting for cron
+apes run --as bluesky-summary -- apes agents run --task-id recipe-0
+
+#    → expect: a 5–10 bullet digest in the agent's output channel.
+
+# 4. revoke the secret, run again
+#    (troop UI or the secrets endpoint), then re-trigger step 3
+#    → expect: "could not authenticate" — NEVER a plaintext leak,
+#      NEVER invented content (clean fail).
+
+# 5. edit user_addendum in troop ("focus on the negative posts")
+#    → next run reflects it with NO re-deploy.
+```
+
+The recipe→plan→seal/open code path is verified automatically in
+`apps/openape-troop/tests/recipe-e2e.test.ts` against this exact
+manifest.

--- a/examples/agent-recipes/bluesky-summary/ape-agent.yaml
+++ b/examples/agent-recipes/bluesky-summary/ape-agent.yaml
@@ -1,0 +1,33 @@
+name: bluesky-summary
+kind: agent
+intent: |
+  You are a Bluesky feed summariser. Twice a day you fetch the
+  authenticated account's home timeline and produce a tight, readable
+  digest of what mattered, focused on {{topic}}.
+
+  Run the fetch tool with your bash tool:
+    node tools/fetch-feed.mjs
+  It prints recent posts as JSON on stdout using the BLUESKY_HANDLE and
+  BLUESKY_APP_PASSWORD already present in your environment. Never print,
+  log or echo those values.
+
+  Then write a 5–10 bullet summary: the threads worth knowing about,
+  who said what, and anything actionable. Skip noise. If the tool exits
+  non-zero (e.g. the credential was revoked), report that the run could
+  not authenticate and stop — do not invent content.
+capabilities:
+  - env: BLUESKY_HANDLE
+  - env: BLUESKY_APP_PASSWORD
+    prefer: local
+params:
+  - name: topic
+    type: string
+    required: true
+schedules:
+  - cron: "0 8 * * *"
+    description: morning Bluesky digest on {{topic}}
+  - cron: "0 18 * * *"
+    description: evening Bluesky digest on {{topic}}
+user_addendum: true
+tools:
+  - tools/fetch-feed.mjs

--- a/examples/agent-recipes/bluesky-summary/tools/fetch-feed.mjs
+++ b/examples/agent-recipes/bluesky-summary/tools/fetch-feed.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+// Fetch the authenticated account's Bluesky home timeline and print the
+// recent posts as JSON on stdout. The LLM does the summarising — this
+// tool only fetches.
+//
+// Credentials come from the environment (BLUESKY_HANDLE +
+// BLUESKY_APP_PASSWORD). The agent's runtime materialised them from a
+// sealed blob (Agent Recipe M2e); this script never logs them. AT-Proto
+// is stateful (createSession → short-lived JWT) so we log in per run.
+//
+// Exit codes: 0 ok · 2 missing creds · 3 auth failed · 4 fetch failed.
+
+const PDS = process.env.BLUESKY_PDS || 'https://bsky.social'
+
+function fail(code, msg) {
+  process.stderr.write(`${msg}\n`)
+  process.exit(code)
+}
+
+const handle = process.env.BLUESKY_HANDLE
+const appPassword = process.env.BLUESKY_APP_PASSWORD
+if (!handle || !appPassword) {
+  fail(2, 'BLUESKY_HANDLE / BLUESKY_APP_PASSWORD not set — secret not bound or revoked')
+}
+
+async function main() {
+  let session
+  try {
+    const res = await fetch(`${PDS}/xrpc/com.atproto.server.createSession`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ identifier: handle, password: appPassword }),
+    })
+    if (!res.ok) fail(3, `createSession failed (HTTP ${res.status}) — credential likely revoked`)
+    session = await res.json()
+  }
+  catch (e) {
+    fail(3, `createSession error: ${e.message}`)
+  }
+
+  let feed
+  try {
+    const res = await fetch(
+      `${PDS}/xrpc/app.bsky.feed.getTimeline?limit=50`,
+      { headers: { Authorization: `Bearer ${session.accessJwt}` } },
+    )
+    if (!res.ok) fail(4, `getTimeline failed (HTTP ${res.status})`)
+    feed = await res.json()
+  }
+  catch (e) {
+    fail(4, `getTimeline error: ${e.message}`)
+  }
+
+  const posts = (feed.feed ?? []).map((item) => ({
+    author: item.post?.author?.handle,
+    text: item.post?.record?.text,
+    likes: item.post?.likeCount ?? 0,
+    reposts: item.post?.repostCount ?? 0,
+    at: item.post?.indexedAt,
+  }))
+  process.stdout.write(JSON.stringify({ count: posts.length, posts }, null, 2))
+}
+
+main()


### PR DESCRIPTION
M7 of **Agent Recipe** (plans.openape.ai `01KRTAE8`) — the proof case.
Closes M0–M7.

## What
- `examples/agent-recipes/bluesky-summary/` — the reference recipe:
  `ape-agent.yaml` (intent, `topic` param, 2 daily schedules, 2
  capabilities), `tools/fetch-feed.mjs` (AT-Proto createSession +
  getTimeline from env-only creds, never logs them, clean non-zero
  exit when the credential is revoked), `README.md` with the live
  end-to-end runbook.
- `apps/openape-troop/tests/recipe-e2e.test.ts` — the whole pipeline
  against this exact artifact, **no mocks**: M1 parse + tool-file
  existence → materialize (intent/schedules interpolated, missing
  param fails) → M3 `buildDeployPlan` → M2a `seal`→`open` round-trip +
  wrong-key clean-fail (revoke never yields plaintext).

## Why this is the honest proof
The deterministic recipe→plan→seal/open path is verified
automatically. The remaining live run (nest spawns the agent, cron
fires, the Bluesky API is called) needs a connected `openape-nest`
host + a real Bluesky app password, which CI can't provision — it is
the documented runbook in the recipe README.

## Proof
recipe-e2e 4/4; troop 112/112; `node --check` on the tool; lint ✓
typecheck ✓ build ✓ (4/4).

No DDISA surface (an example artifact + a test).