### PR TITLE
feat(troop+chat): DDISA login on the start page (no extra click)

### DIFF
--- a/apps/openape-chat/app/pages/index.vue
+++ b/apps/openape-chat/app/pages/index.vue
@@ -16,9 +16,9 @@ interface ContactRow {
 // OpenApeAuth component).
 const { user, fetchUser, logout: spLogout } = useOpenApeAuth()
 await fetchUser()
-if (!user.value && import.meta.client) {
-  navigateTo('/login')
-}
+// No redirect to a separate /login — an unauthenticated visitor gets
+// the email/login form inline on this page (see the v-if="!user"
+// block in the template). DDISA-SP login belongs on the start page.
 
 const { data: contacts, refresh: refreshContacts } = await useFetch<ContactRow[]>('/api/contacts', {
   default: () => [],
@@ -185,7 +185,21 @@ async function doDelete(): Promise<void> {
 </script>
 
 <template>
-  <div class="min-h-dvh flex flex-col">
+  <div v-if="!user" class="min-h-dvh flex items-center justify-center p-6">
+    <div class="w-full max-w-sm space-y-6">
+      <div class="text-center space-y-2">
+        <h1 class="text-2xl font-semibold">
+          OpenApe Chat
+        </h1>
+        <p class="text-zinc-400 text-sm">
+          Team rooms and DMs for humans and agents.
+        </p>
+      </div>
+      <OpenApeAuth />
+    </div>
+  </div>
+
+  <div v-else class="min-h-dvh flex flex-col">
     <header class="safe-pt sticky top-0 z-10 flex items-center gap-2 px-4 py-3 border-b border-zinc-800 bg-zinc-950">
       <div class="flex-1 min-w-0">
         <h1 class="font-semibold text-lg leading-tight">

--- a/apps/openape-troop/app/pages/index.vue
+++ b/apps/openape-troop/app/pages/index.vue
@@ -34,15 +34,14 @@ if (user.value) {
           Cron-scheduled, single-purpose, OpenApe-identity. Manage from anywhere.
         </p>
 
-        <UButton
-          to="/login"
-          color="primary"
-          size="xl"
-          class="mt-10"
-          icon="i-lucide-fingerprint"
-        >
-          Sign in with OpenApe
-        </UButton>
+        <UCard class="mt-10 w-full text-left">
+          <OpenApeAuth
+            title="Sign in to Troop"
+            subtitle="Enter your email to manage your agents"
+            button-text="Continue"
+            post-login-redirect="/agents"
+          />
+        </UCard>
 
         <p class="mt-10 italic text-sm text-zinc-500">
           "Hatched by you. Loyal to you. Lives on your computer."


### PR DESCRIPTION
Feedback: *"Die Email-Adresse sollte schon am/von troop einzugeben
sein. … Gilt übrigens für alle Apps die wir mit DDISA anmelden."*

The login email must be enterable on the **start page** — no extra
click/navigation to a separate `/login` route.

## What
- **troop** `pages/index.vue`: replaced the "Sign in with OpenApe"
  button (→ `/login`) with the inline `<OpenApeAuth>` card in the
  landing hero (post-login → `/agents`).
- **chat** `pages/index.vue`: stopped redirecting unauthenticated
  visitors to `/login`; `/` now renders `<OpenApeAuth>` inline as the
  `v-if="!user"` state and the chat app as `v-else`.
- Both keep their standalone `/login` as a still-valid alternate
  entry (OAuth-error redirects etc.).

## Scope (the rule, applied)
- **agent-proxy** — already had the email field on its index; no
  change.
- **free-idp / idp examples** — IdP-side passkey login, different
  semantics; intentionally out of scope.
- **Out-of-monorepo SP apps** (`openape-tasks`, `ape-plans` web) need
  the same treatment — flagged to the user (separate repos).

Saved as a durable preference so future DDISA-SP apps follow it.

## Proof
troop: lint ✓ typecheck ✓ test ✓ build ✓ (4/4).
chat: lint ✓ typecheck ✓ test ✓ build ✓ (4/4).

No DDISA protocol surface (SP landing UX only).