### PR TITLE
feat(troop+chat): on-brand email sign-in (green CTA + fingerprint)

### DIFF
--- a/apps/openape-chat/app/pages/index.vue
+++ b/apps/openape-chat/app/pages/index.vue
@@ -14,11 +14,30 @@ interface ContactRow {
 // Driven by the SP module's composable. `user` becomes null on 401, so a
 // missing session bounces to /login (which the module renders via its own
 // OpenApeAuth component).
-const { user, fetchUser, logout: spLogout } = useOpenApeAuth()
+const { user, loading, fetchUser, login, logout: spLogout } = useOpenApeAuth()
 await fetchUser()
 // No redirect to a separate /login — an unauthenticated visitor gets
 // the email/login form inline on this page (see the v-if="!user"
 // block in the template). DDISA-SP login belongs on the start page.
+
+const loginEmail = ref('')
+const loginError = ref('')
+const loggingIn = ref(false)
+async function handleLogin() {
+  loginError.value = ''
+  if (!loginEmail.value || !loginEmail.value.includes('@')) {
+    loginError.value = 'Bitte eine gültige Email-Adresse eingeben.'
+    return
+  }
+  loggingIn.value = true
+  try {
+    await login(loginEmail.value.trim())
+  }
+  catch (e: any) {
+    loginError.value = e?.data?.statusMessage || e?.message || 'Login fehlgeschlagen.'
+    loggingIn.value = false
+  }
+}
 
 const { data: contacts, refresh: refreshContacts } = await useFetch<ContactRow[]>('/api/contacts', {
   default: () => [],
@@ -195,7 +214,32 @@ async function doDelete(): Promise<void> {
           Team rooms and DMs for humans and agents.
         </p>
       </div>
-      <OpenApeAuth />
+      <form class="space-y-3" @submit.prevent="handleLogin">
+        <UInput
+          v-model="loginEmail"
+          type="email"
+          placeholder="you@example.com"
+          size="xl"
+          autocomplete="email"
+          icon="i-lucide-mail"
+          :disabled="loggingIn || loading"
+          class="w-full"
+          :ui="{ base: 'w-full' }"
+        />
+        <p v-if="loginError" class="text-sm text-red-400">
+          {{ loginError }}
+        </p>
+        <UButton
+          type="submit"
+          color="primary"
+          block
+          size="xl"
+          icon="i-lucide-fingerprint"
+          :loading="loggingIn || loading"
+        >
+          Sign in with OpenApe
+        </UButton>
+      </form>
     </div>
   </div>
 

--- a/apps/openape-troop/app/pages/index.vue
+++ b/apps/openape-troop/app/pages/index.vue
@@ -1,11 +1,32 @@
 <script setup lang="ts">
+import { ref } from 'vue'
 import { useOpenApeAuth } from '#imports'
 
-const { user, fetchUser } = useOpenApeAuth()
+const { user, loading, fetchUser, login } = useOpenApeAuth()
 await fetchUser()
 
 if (user.value) {
   await navigateTo('/agents')
+}
+
+const email = ref('')
+const error = ref('')
+const submitting = ref(false)
+
+async function handleLogin() {
+  error.value = ''
+  if (!email.value || !email.value.includes('@')) {
+    error.value = 'Bitte eine gültige Email-Adresse eingeben.'
+    return
+  }
+  submitting.value = true
+  try {
+    await login(email.value.trim())
+  }
+  catch (e: any) {
+    error.value = e?.data?.statusMessage || e?.message || 'Login fehlgeschlagen.'
+    submitting.value = false
+  }
 }
 </script>
 
@@ -34,14 +55,32 @@ if (user.value) {
           Cron-scheduled, single-purpose, OpenApe-identity. Manage from anywhere.
         </p>
 
-        <UCard class="mt-10 w-full text-left">
-          <OpenApeAuth
-            title="Sign in to Troop"
-            subtitle="Enter your email to manage your agents"
-            button-text="Continue"
-            post-login-redirect="/agents"
+        <form class="mt-10 w-full space-y-3" @submit.prevent="handleLogin">
+          <UInput
+            v-model="email"
+            type="email"
+            placeholder="you@example.com"
+            size="xl"
+            autocomplete="email"
+            icon="i-lucide-mail"
+            :disabled="submitting || loading"
+            class="w-full"
+            :ui="{ base: 'w-full' }"
           />
-        </UCard>
+          <p v-if="error" class="text-sm text-red-400 text-left">
+            {{ error }}
+          </p>
+          <UButton
+            type="submit"
+            color="primary"
+            block
+            size="xl"
+            icon="i-lucide-fingerprint"
+            :loading="submitting || loading"
+          >
+            Sign in with OpenApe
+          </UButton>
+        </form>
 
         <p class="mt-10 italic text-sm text-zinc-500">
           "Hatched by you. Loyal to you. Lives on your computer."


### PR DESCRIPTION
Feedback: the inline login looked *"ganz grau"* — the old sign-in
button was *"schön grün mit fingerprint symbol"*. And: keep the email
(identity-by-email is part of DDISA) — **no** username-less login.

## What
troop & chat landing: replaced the gray default `<OpenApeAuth>` card
with a CI-matching Nuxt-UI form — email `UInput` (mail icon) + a
**primary green** block `UButton` with `i-lucide-fingerprint`, wired
to `useOpenApeAuth().login(email)` (the same pattern agent-proxy
already uses). Inline validation + error text.

Email remains required — DNS discovery / `login_hint` is intrinsic to
DDISA. **No backend / module change**: an earlier draft that made the
email optional for a username-less path was reverted on your call.
`<OpenApeAuth>` and the `/login` pages are untouched (still valid
alternate entry).

## Proof
Only `apps/openape-troop/app/pages/index.vue` +
`apps/openape-chat/app/pages/index.vue` changed. troop+chat lint ✓
typecheck ✓; troop test ✓; build ✓ (5/5). No changeset (private apps,
no published surface). No DDISA protocol change.