### PR TITLE
fix(troop): roomier Spawn modal + pinned footer (iOS safe-area)

### DIFF
--- a/apps/openape-troop/app/components/SpawnAgentDialog.vue
+++ b/apps/openape-troop/app/components/SpawnAgentDialog.vue
@@ -331,10 +331,10 @@ function close() {
 <template>
   <UModal
     v-model:open="open"
-    :ui="{ content: 'sm:max-w-md max-h-[90vh] flex flex-col' }"
+    :ui="{ content: 'sm:max-w-md max-h-[92dvh] flex flex-col' }"
   >
     <template #content>
-      <div class="p-5 space-y-4 overflow-y-auto">
+      <div class="flex-1 overflow-y-auto p-5 sm:p-6 space-y-5">
         <div class="flex items-start justify-between gap-3">
           <div>
             <h3 class="text-lg font-semibold">
@@ -558,20 +558,23 @@ function close() {
         <UAlert v-if="result?.ok && result.error" color="warning" title="Spawned with a note" :description="result.error" />
         <UAlert v-if="result && !result.ok" color="error" title="Failed" :description="result.error" />
 
-        <div class="flex justify-end gap-2">
-          <UButton variant="ghost" :disabled="submitting" @click="close">
-            {{ result?.ok ? 'Close' : 'Cancel' }}
-          </UButton>
-          <UButton
-            v-if="!result?.ok"
-            color="primary"
-            :loading="submitting"
-            :disabled="!canSubmit"
-            @click="submit"
-          >
-            Spawn
-          </UButton>
-        </div>
+      </div>
+
+      <!-- Pinned footer: never scrolls out of reach and clears the
+           iOS home-indicator / browser chrome via the safe-area inset. -->
+      <div class="shrink-0 flex justify-end gap-2 border-t border-default bg-default px-5 sm:px-6 pt-3 pb-[max(0.875rem,env(safe-area-inset-bottom))]">
+        <UButton variant="ghost" :disabled="submitting" @click="close">
+          {{ result?.ok ? 'Close' : 'Cancel' }}
+        </UButton>
+        <UButton
+          v-if="!result?.ok"
+          color="primary"
+          :loading="submitting"
+          :disabled="!canSubmit"
+          @click="submit"
+        >
+          Spawn
+        </UButton>
       </div>
     </template>
   </UModal>


### PR DESCRIPTION
Reported on mobile (troop.openape.ai): the Spawn modal is cramped and
the **Cancel / Spawn** buttons get clipped at the bottom under the
browser chrome / iOS home-indicator.

## Fix
Split the one scrolling `<div>` into a scrollable body + a pinned
footer inside the flex-col modal content:
- `max-h-[90vh]` → `max-h-[92dvh]` — dynamic viewport unit, so the
  modal sizes to the *visible* area on mobile instead of hiding behind
  the browser UI.
- Body: `flex-1 overflow-y-auto`, padding `p-5 → p-5 sm:p-6`, spacing
  `space-y-4 → space-y-5` (more air).
- Footer: `shrink-0`, `border-t`/`bg` so it never scrolls away, and
  `pb-[max(0.875rem,env(safe-area-inset-bottom))]` so the buttons
  always clear the iOS home-bar.

Single file: `SpawnAgentDialog.vue`. troop lint ✓ typecheck ✓ test ✓
build ✓ (4/4). No DDISA surface.