### PR TITLE
fix(nest): surface the real spawn/sync error (not the stack tail)

### DIFF
--- a/.changeset/nest-real-spawn-error.md
+++ b/.changeset/nest-real-spawn-error.md
@@ -1,0 +1,9 @@
+---
+"@openape/nest": patch
+---
+
+Surface the real spawn/sync failure instead of the JS stack tail. The
+nest used to forward only the last 3 stderr lines, which for a failed
+`apes` command are V8 stack frames (`at async runMain …`) — the actual
+error message was discarded. Now stack frames are dropped and the
+human-readable error lines are kept, so troop shows why a spawn failed.

--- a/apps/openape-nest/src/lib/troop-ws.ts
+++ b/apps/openape-nest/src/lib/troop-ws.ts
@@ -370,8 +370,19 @@ function runWithCapture(bin: string, args: string[]): Promise<{ stdout: string, 
           resolve({ stdout: stdout.toString(), stderr: stderr.toString() })
           return
         }
-        const msg = stderr.toString() || err.message
-        reject(new Error(msg.split('\n').filter(Boolean).slice(-3).join(' / ')))
+        // Surface the *actual* failure. `apes` prints the real
+        // message and then a V8 stack; a blind tail-slice used to
+        // keep only the stack frames ("at async runMain …"), which
+        // is useless for diagnosing a failed spawn. Drop pure stack
+        // frames, keep the human-readable error lines.
+        const raw = (stderr.toString().trim() || stdout.toString().trim() || err.message)
+        const meaningful = raw
+          .split('\n')
+          .map(l => l.replace(/\s+$/, ''))
+          .filter(l => l.trim() && !/^\s*at\s/.test(l))
+        const picked = (meaningful.length > 0 ? meaningful : raw.split('\n').filter(Boolean))
+        const msg = picked.slice(-15).join('\n').slice(-2500)
+        reject(new Error(msg || err.message))
         return
       }
       resolve({ stdout: stdout.toString(), stderr: stderr.toString() })


### PR DESCRIPTION
Spawning the bluesky-summary recipe failed with an unreadable blob
(`at async runMain … / ERROR Command failed: apes run --as root …
setup.sh`). Root cause of the *unreadability*: `runWithCapture` kept
only the **last 3 stderr lines**, which for a failed `apes` command
are V8 stack frames — the real `ERROR <message>` was discarded before
it was even logged.

## Fix
Drop pure stack-frame lines (`^\s*at\s`), keep the human-readable
error lines (last 15, ≤2500 chars, newlines preserved), fall back to
stdout / `err.message`. Spawn & sync failures are now diagnosable from
troop and the nest log.

Changeset: `@openape/nest` patch. nest lint ✓ typecheck ✓ test ✓
build ✓ (3/3). No DDISA surface (observability only).

NB: the *actual* `pepper` spawn failure is almost certainly a host
config issue (headless nest, no TTY for the escapes admin-password
prompt → needs `APES_ADMIN_PASSWORD` in the nest env / YOLO authorize)
— the nest log shows the identical `No TTY available for the silent
password prompt. Set APES_ADMIN_PASSWORD …` on an earlier destroy.
This PR makes that reason visible instead of hidden.