### PR TITLE
fix(apes): spawn picks lowest free UID, not max+1 (real spawn-failure root cause)

### DIFF
--- a/.changeset/spawn-uid-lowest-free.md
+++ b/.changeset/spawn-uid-lowest-free.md
@@ -1,0 +1,10 @@
+---
+"@openape/apes": patch
+---
+
+Fix agent spawn UID allocation. The setup script picked
+`max(existing UID in [200,500)) + 1`, so once any agent landed on UID
+499 every subsequent `apes agents spawn` failed with "No free UID in
+[200, 500) — refusing to clobber a real user" even with 100+ UIDs
+free. Now it scans for the lowest actually-unused UID in the range
+(skipping agent users and macOS system accounts) and reuses gaps.

--- a/packages/apes/src/lib/agent-bootstrap.ts
+++ b/packages/apes/src/lib/agent-bootstrap.ts
@@ -357,19 +357,23 @@ mkdir -p /var/openape/homes
 chmod 755 /var/openape/homes
 
 if [ "$TOMBSTONE_REUSE" = "0" ]; then
-  # Pick the next free UID in the [200, 500) hidden service-account range.
-  # Starts the running max at 199 so an empty range yields 200 after the
-  # floor check; otherwise NEXT_UID = max(existing in-range UIDs) + 1.
-  NEXT_UID=199
-  for uid in $(dscl . -list /Users UniqueID | awk '$2 >= 200 && $2 < 500 {print $2}'); do
-    if [ "$uid" -ge "$NEXT_UID" ]; then
-      NEXT_UID=$((uid + 1))
+  # Pick the LOWEST free UID in the [200, 500) hidden service-account
+  # range. We must skip every occupied UID — agent users AND the many
+  # macOS system _* accounts — and reuse gaps. The old code took
+  # max(existing)+1, so a single agent landing on 499 wedged every
+  # future spawn ("No free UID") even with 100+ UIDs free. Now we scan
+  # for the first actually-unused UID.
+  OCCUPIED_UIDS=$(dscl . -list /Users UniqueID | awk '$2 >= 200 && $2 < 500 {print $2}' | sort -n -u)
+  NEXT_UID=""
+  candidate=200
+  while [ "$candidate" -lt 500 ]; do
+    if ! printf '%s\n' "$OCCUPIED_UIDS" | grep -qx "$candidate"; then
+      NEXT_UID=$candidate
+      break
     fi
+    candidate=$((candidate + 1))
   done
-  if [ "$NEXT_UID" -lt 200 ]; then
-    NEXT_UID=200
-  fi
-  if [ "$NEXT_UID" -ge 500 ]; then
+  if [ -z "$NEXT_UID" ]; then
     echo "No free UID in [200, 500) — refusing to clobber a real user." >&2
     exit 1
   fi

--- a/packages/apes/test/agents-bootstrap.test.ts
+++ b/packages/apes/test/agents-bootstrap.test.ts
@@ -121,6 +121,24 @@ describe('buildSpawnSetupScript', () => {
     expect(script).not.toContain('chmod 644 "$HOME_DIR/.config/openape/agent-x25519.key"')
   })
 
+  it('allocates the lowest free UID, not max+1 (so a high UID does not wedge spawns)', () => {
+    const script = buildSpawnSetupScript({
+      ...baseInput,
+      claudeSettingsJson: null,
+      hookScriptSource: null,
+      claudeOauthToken: null,
+    })
+    // Scans for the first actually-unused UID in [200,500)…
+    expect(script).toContain('OCCUPIED_UIDS=')
+    expect(script).toMatch(/while \[ "\$candidate" -lt 500 \]/)
+    expect(script).toContain('grep -qx "$candidate"')
+    // …and must NOT be the old max(existing)+1 logic.
+    expect(script).not.toContain('NEXT_UID=199')
+    expect(script).not.toContain('NEXT_UID=$((uid + 1))')
+    // The genuine "range full" guard is still present.
+    expect(script).toContain('No free UID in [200, 500)')
+  })
+
   it('with claude hook: includes settings.json + hook script blocks', () => {
     const script = buildSpawnSetupScript({
       ...baseInput,


### PR DESCRIPTION
## Root cause (diagnosed live on the host)
Every `apes agents spawn` was failing. The nest forwarded only a JS
stack tail (fixed in #455); reproducing a spawn directly surfaced the
real error from `setup.sh`:

`No free UID in [200, 500) — refusing to clobber a real user.`

…with only **124/300** UIDs used in the range and a **132-wide
contiguous free gap**. So the range was *not* exhausted — the
allocator was buggy: it computed `NEXT_UID = max(existing UID in
[200,500)) + 1`. macOS parks ~100 system `_*` accounts there, plus the
agent users; once any agent landed on UID **499** (a normal spawn —
that was the last one that ever succeeded), `max+1 = 500 ≥ 500` →
permanent failure for **all** future spawns regardless of free UIDs.
Deleting agents would only "fix" it by accidentally lowering the max.

## Fix
`agent-bootstrap.ts`: the setup script now scans for the **lowest
actually-unused UID** in `[200,500)` (skipping agent users *and* macOS
system accounts) and reuses gaps. The genuine range-full guard +
message are kept.

## Proof
`agents-bootstrap.test.ts` +1: asserts the new lowest-free scan is
emitted and the old `NEXT_UID=199` / `max+1` logic is gone, range-full
guard retained. apes 677 tests, lint ✓ typecheck ✓ build ✓.
Changeset: `@openape/apes` patch.

NB: takes effect on the host once the global `@openape/apes`/nest is
updated to the released version.