### PR TITLE
fix: auth + chat hardening sweep (#283)

### DIFF
--- a/apps/openape-chat-cli/src/commands/watch.ts
+++ b/apps/openape-chat-cli/src/commands/watch.ts
@@ -69,11 +69,18 @@ async function connectAndPump(
   filterRoomId: string | undefined,
   json: boolean,
 ): Promise<void> {
+  // Mint a short-lived HS256 ws-token (#283 item 4) instead of putting
+  // the full IdP JWT in the URL. The IdP token has hours of lifetime
+  // and full scope; the ws-token expires in 5min and is only valid
+  // for the WS upgrade. Without this, the JWT lands in nginx/Vercel
+  // access logs, proxy buffers, and error traces.
   const bearer = await getChatBearer()
-  // Mint a fresh token per connect so we ride out long-running streams
-  // across IdP-token refreshes (the token sits in the URL — chat.openape.ai
-  // verifies it once at upgrade-time and reuses the resulting Caller).
-  const token = bearer.replace(/^Bearer\s+/i, '')
+  const wsTokenUrl = wsUrl.replace(/\/api\/ws$/, '/api/ws-token').replace(/^ws/, 'http')
+  const wsTokenResp = await fetch(wsTokenUrl, { headers: { Authorization: bearer } })
+  if (!wsTokenResp.ok) {
+    throw new Error(`Failed to mint ws-token: ${wsTokenResp.status} ${wsTokenResp.statusText}`)
+  }
+  const { token } = (await wsTokenResp.json()) as { token: string }
   const url = `${wsUrl}?token=${encodeURIComponent(token)}`
   const ws = new WebSocket(url)
 

--- a/apps/openape-chat/server/plugins/02.database.ts
+++ b/apps/openape-chat/server/plugins/02.database.ts
@@ -68,6 +68,13 @@ export default defineNitroPlugin(async () => {
       archived_at INTEGER
     )`)
     await db.run(sql`CREATE INDEX IF NOT EXISTS idx_threads_room ON threads(room_id, created_at)`)
+    // Partial unique index — prevents duplicate ACTIVE main threads in a
+    // single room (#283 item 5). Without it, two concurrent first-message
+    // sends can race the existence check in ensureMainThread, both INSERT
+    // a 'main' thread, then bridge spawns two pi sessions for the same
+    // conversation. Archived threads are allowed to coexist with the new
+    // active one.
+    await db.run(sql`CREATE UNIQUE INDEX IF NOT EXISTS idx_threads_room_active_name ON threads(room_id, name) WHERE archived_at IS NULL`)
 
     await db.run(sql`CREATE TABLE IF NOT EXISTS reactions (
       message_id TEXT NOT NULL,

--- a/apps/openape-chat/server/utils/threads.ts
+++ b/apps/openape-chat/server/utils/threads.ts
@@ -32,6 +32,10 @@ export async function findThreadById(id: string): Promise<Thread | null> {
  * existing one if already there. Used both by contact-accept (eager
  * creation) and by GET /api/rooms/{id}/threads (lazy backfill for legacy
  * rooms that pre-date the threads table).
+ *
+ * Race-safe via the partial unique index `idx_threads_room_active_name`
+ * (#283 item 5): if a parallel call wins the INSERT, ours throws on the
+ * unique constraint and we re-select the winning row.
  */
 export async function ensureMainThread(opts: { roomId: string, createdByEmail: string }): Promise<Thread> {
   const db = useDb()
@@ -43,13 +47,27 @@ export async function ensureMainThread(opts: { roomId: string, createdByEmail: s
   if (existing) return existing
   const id = randomUUID()
   const now = Math.floor(Date.now() / 1000)
-  await db.insert(threads).values({
-    id,
-    roomId: opts.roomId,
-    name: MAIN_THREAD_NAME,
-    createdByEmail: opts.createdByEmail,
-    createdAt: now,
-  })
+  try {
+    await db.insert(threads).values({
+      id,
+      roomId: opts.roomId,
+      name: MAIN_THREAD_NAME,
+      createdByEmail: opts.createdByEmail,
+      createdAt: now,
+    })
+  }
+  catch (err: unknown) {
+    // Conflict on the partial unique index — a concurrent call won the
+    // race. Re-select the active main thread; if it's still missing
+    // something else is wrong and we re-throw.
+    const winner = await db
+      .select()
+      .from(threads)
+      .where(and(eq(threads.roomId, opts.roomId), eq(threads.name, MAIN_THREAD_NAME), isNull(threads.archivedAt)))
+      .get()
+    if (winner) return winner
+    throw err
+  }
   // Also backfill: any existing room messages without a thread_id get
   // attributed to this main thread. Safe one-time op since main is the
   // only thread that could absorb them at this point.

--- a/modules/nuxt-auth-idp/src/runtime/server/plugins/init-signing-key.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/plugins/init-signing-key.ts
@@ -1,7 +1,24 @@
 import type { NitroApp } from 'nitropack'
+import { useRuntimeConfig } from 'nitropack/runtime'
 import { useIdpStores } from '../utils/stores'
 
+const DEFAULT_SESSION_SECRET = 'change-me-to-a-real-secret-at-least-32-chars'
+
 export default async (_nitroApp: NitroApp) => {
+  // Refuse to boot with the literal default sessionSecret (#283 item 1).
+  // The default is public source — leaving it in place lets anyone reading
+  // the repo forge any session cookie. Test runs skip the check.
+  if (process.env.NODE_ENV !== 'test' && process.env.VITEST !== 'true') {
+    const config = useRuntimeConfig() as { openapeIdp?: { sessionSecret?: string } }
+    const secret = config.openapeIdp?.sessionSecret ?? ''
+    if (!secret || secret === DEFAULT_SESSION_SECRET) {
+      throw new Error(
+        '[openape-idp] NUXT_OPENAPE_SESSION_SECRET is unset or still the public default. '
+        + 'Set a unique secret (>= 32 chars) before deploying — session cookies are forgeable otherwise.',
+      )
+    }
+  }
+
   // Ensure a signing key exists on startup so JWKS is never empty
   try {
     const { keyStore } = useIdpStores()

--- a/modules/nuxt-auth-idp/src/runtime/server/utils/agent-auth.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/utils/agent-auth.ts
@@ -1,12 +1,17 @@
 import type { H3Event } from 'h3'
 import { getHeader } from 'h3'
 import type { AgentTokenPayload, AuthTokenPayload } from './agent-token'
-import { verifyAgentToken, verifyAuthToken } from './agent-token'
+import { DEFAULT_CLI_AUDIENCE, verifyAgentToken, verifyAuthToken } from './agent-token'
 import { getIdpIssuer, useIdpStores } from './stores'
 import { createProblemError } from './problem'
 
 // --- Generalized bearer auth (accepts both agent and human tokens) ---
 
+// Enforces `aud='apes-cli'` (#283 item 2). Without an audience check,
+// any IdP-issued token (id_tokens, delegation tokens, future client-
+// credentials) verified against the same signing key would be accepted,
+// removing a defence-in-depth layer that downstream service providers
+// already enforce on /api/cli/exchange.
 export async function tryBearerAuth(event: H3Event): Promise<AuthTokenPayload | null> {
   const authHeader = getHeader(event, 'authorization')
   if (!authHeader?.startsWith('Bearer '))
@@ -17,7 +22,7 @@ export async function tryBearerAuth(event: H3Event): Promise<AuthTokenPayload | 
   const signingKey = await keyStore.getSigningKey()
 
   try {
-    return await verifyAuthToken(token, getIdpIssuer(), signingKey.publicKey)
+    return await verifyAuthToken(token, getIdpIssuer(), signingKey.publicKey, DEFAULT_CLI_AUDIENCE)
   }
   catch (err) {
     console.warn('[openape-idp] Bearer token verification failed:', err instanceof Error ? err.message : String(err))

--- a/packages/cli-auth/src/exchange.ts
+++ b/packages/cli-auth/src/exchange.ts
@@ -64,8 +64,12 @@ export async function exchangeForSpToken(
     throw new AuthError(0, `Exchange response from ${url} missing access_token`)
   }
 
+  // Short fallback when an SP omits both claims (#283 item 3). The old
+  // 30-day default cached misbehaving SPs effectively forever; an hour
+  // is short enough that revocation upstream catches up while still
+  // covering the common case where a server forgets to set the field.
   const expiresAt = response.expires_at
-    ?? (response.expires_in ? now + response.expires_in : now + 3600 * 24 * 30)
+    ?? (response.expires_in ? now + response.expires_in : now + 3600)
 
   const token: SpToken = {
     endpoint: request.endpoint,


### PR DESCRIPTION
Closes #283.

Bundle of the 5 medium-severity items from the 2026-05-04 audit.

| # | File | Fix |
|---|---|---|
| 1 | `modules/nuxt-auth-idp/src/runtime/server/plugins/init-signing-key.ts` | Refuse boot if `sessionSecret` is empty or matches the literal default. Skips in test mode. |
| 2 | `modules/nuxt-auth-idp/src/runtime/server/utils/agent-auth.ts` | `tryBearerAuth` now enforces `aud='apes-cli'` via `DEFAULT_CLI_AUDIENCE`. Tokens minted for other audiences (id_tokens, delegation, future client-credentials) no longer pass at endpoints that use this helper. |
| 3 | `packages/cli-auth/src/exchange.ts` | SP token-exchange fallback shortened from 30d to 1h when both `expires_at` and `expires_in` are missing. Stops a misbehaving SP from being cached effectively forever. |
| 4 | `apps/openape-chat-cli/src/commands/watch.ts` | CLI `watch` now calls `/api/ws-token` first and puts the short-lived (5min) HS256 token in the URL — not the full-lifetime IdP JWT. Keeps full-scope tokens out of nginx/Vercel access logs and proxy buffers. |
| 5 | `apps/openape-chat/server/plugins/02.database.ts` + `server/utils/threads.ts` | Partial unique index on `(room_id, name)` where `archived_at IS NULL`. `ensureMainThread` catches the conflict + re-selects the winning row. No more duplicate `main` threads (and no more duplicate pi sessions) on concurrent first-message races. |

## Test plan

- [x] `pnpm --filter @openape/nuxt-auth-idp typecheck` ✓
- [x] `pnpm --filter @openape/nuxt-auth-idp test` — 134/134 pass
- [x] `pnpm --filter @openape/cli-auth typecheck` ✓
- [x] `pnpm --filter @openape/cli-auth test` — 23/23 pass
- [x] `pnpm --filter @openape/chat typecheck` ✓
- [x] `pnpm --filter @openape/ape-chat typecheck` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)