### PR TITLE
feat(apes): coding-agent primitives — edit_file + git_worktree (M1)

### DIFF
--- a/.changeset/coding-agent-m1-primitives.md
+++ b/.changeset/coding-agent-m1-primitives.md
@@ -1,0 +1,5 @@
+---
+"@openape/apes": minor
+---
+
+Coding-agent primitives (M1): `edit_file` (structured substring replace, OS-confined to $HOME, no grant) and `git_worktree` (create/remove/list isolated worktrees under ~/work via the gated ape-shell path). Extracts the shared `runApeShell` gated-exec helper so every shell-touching tool routes through the same DDISA grant + shapes checkpoint. Both tools registered in the runtime registry + tool-catalog.json.

--- a/.changeset/coding-agent-m1-primitives.md
+++ b/.changeset/coding-agent-m1-primitives.md
@@ -2,4 +2,4 @@
 "@openape/apes": minor
 ---
 
-Coding-agent primitives (M1): `edit_file` (structured substring replace, OS-confined to $HOME, no grant) and `git_worktree` (create/remove/list isolated worktrees under ~/work via the gated ape-shell path). Extracts the shared `runApeShell` gated-exec helper so every shell-touching tool routes through the same DDISA grant + shapes checkpoint. Both tools registered in the runtime registry + tool-catalog.json.
+Coding-agent primitives (M1): `file.edit` (structured substring replace, OS-confined to $HOME, no grant) and `git.worktree` (create/remove/list isolated worktrees under ~/work via the gated ape-shell path). Extracts the shared `runApeShell` gated-exec helper so every shell-touching tool routes through the same DDISA grant + shapes checkpoint. Both tools registered in the runtime registry + tool-catalog.json.

--- a/apps/openape-troop/server/tool-catalog.json
+++ b/apps/openape-troop/server/tool-catalog.json
@@ -62,13 +62,13 @@
       "risk": "high"
     },
     {
-      "name": "edit_file",
+      "name": "file.edit",
       "description": "Replace an exact substring in a file under the agent's home directory. Touches only the changed region instead of rewriting the whole file. old_string must appear once unless replace_all is set. Path traversal blocked, OS-confined to $HOME (no grant).",
       "inputs": "{ path: string, old_string: string, new_string: string, replace_all?: boolean }",
       "risk": "low"
     },
     {
-      "name": "git_worktree",
+      "name": "git.worktree",
       "description": "Manage isolated git worktrees for coding tasks: create (clone-if-needed + worktree on a new branch under ~/work/<task_id>), remove, list. Git operations go through the DDISA grant cycle (git-shape).",
       "inputs": "{ action: 'create'|'remove'|'list', repo?: string, task_id?: string, branch?: string }",
       "risk": "high"

--- a/apps/openape-troop/server/tool-catalog.json
+++ b/apps/openape-troop/server/tool-catalog.json
@@ -60,6 +60,18 @@
       "description": "Run a shell command on the agent host via ape-shell. Every command goes through the DDISA grant cycle — auto-approved by a matching YOLO scope or owner push notification. Runs as the agent's macOS user; file/network access is limited to what that user can see. Returns stdout, stderr, exit code.",
       "inputs": "{ cmd: string, timeout_ms?: number }",
       "risk": "high"
+    },
+    {
+      "name": "edit_file",
+      "description": "Replace an exact substring in a file under the agent's home directory. Touches only the changed region instead of rewriting the whole file. old_string must appear once unless replace_all is set. Path traversal blocked, OS-confined to $HOME (no grant).",
+      "inputs": "{ path: string, old_string: string, new_string: string, replace_all?: boolean }",
+      "risk": "low"
+    },
+    {
+      "name": "git_worktree",
+      "description": "Manage isolated git worktrees for coding tasks: create (clone-if-needed + worktree on a new branch under ~/work/<task_id>), remove, list. Git operations go through the DDISA grant cycle (git-shape).",
+      "inputs": "{ action: 'create'|'remove'|'list', repo?: string, task_id?: string, branch?: string }",
+      "risk": "high"
     }
   ]
 }

--- a/packages/apes/src/lib/agent-tools/ape-shell-exec.ts
+++ b/packages/apes/src/lib/agent-tools/ape-shell-exec.ts
@@ -1,0 +1,81 @@
+import { spawn } from 'node:child_process'
+
+// Shared gated-exec path. Every shell command an agent tool runs goes
+// through `ape-shell -c <cmd>`, which rewrites to `apes run --shell --
+// bash -c …` — i.e. the DDISA grant cycle + shapes-adapter matching,
+// identical to what the human owner types interactively. APE_WAIT=1
+// forces the blocking path so the tool returns a result instead of
+// exiting 75 with grant-pending instructions.
+//
+// bash.ts and git-worktree.ts both build on this so the gating is
+// guaranteed in one place — no tool can shell out un-gated by reaching
+// for child_process directly.
+
+const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000
+const MAX_STDIO_BYTES = 64 * 1024
+const BIN = 'ape-shell'
+
+export interface ApeShellResult {
+  stdout: string
+  stderr: string
+  exit_code: number
+  timed_out?: boolean
+  error?: string
+  hint?: string
+}
+
+function capStdio(s: string): string {
+  const buf = Buffer.from(s, 'utf8')
+  if (buf.byteLength <= MAX_STDIO_BYTES) return s
+  return `${buf.subarray(0, MAX_STDIO_BYTES).toString('utf8')}\n[truncated to ${MAX_STDIO_BYTES} bytes]`
+}
+
+export function runApeShell(cmd: string, timeoutMs: number = DEFAULT_TIMEOUT_MS): Promise<ApeShellResult> {
+  return new Promise<ApeShellResult>((resolveResult) => {
+    const child = spawn(BIN, ['-c', cmd], {
+      env: { ...process.env, APE_WAIT: '1' },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    let stdout = ''
+    let stderr = ''
+    let timedOut = false
+    let spawnError: Error | null = null
+
+    child.stdout!.on('data', (chunk: Buffer) => { stdout += chunk.toString('utf8') })
+    child.stderr!.on('data', (chunk: Buffer) => { stderr += chunk.toString('utf8') })
+    child.on('error', (err) => { spawnError = err as Error })
+
+    const timer = setTimeout(() => {
+      timedOut = true
+      child.kill('SIGTERM')
+      // Force-kill if SIGTERM doesn't take in 5s — happens when the
+      // child is wedged waiting on an upstream grant approval.
+      setTimeout(() => {
+        try { child.kill('SIGKILL') }
+        catch { /* already dead */ }
+      }, 5000)
+    }, timeoutMs)
+
+    child.on('close', (code) => {
+      clearTimeout(timer)
+      if (spawnError) {
+        resolveResult({
+          stdout: '',
+          stderr: '',
+          exit_code: -1,
+          error: spawnError.message,
+          hint: `Could not exec '${BIN}'. The agent host needs @openape/apes installed globally so ape-shell is on PATH.`,
+        })
+        return
+      }
+      resolveResult({
+        stdout: capStdio(stdout),
+        stderr: capStdio(stderr),
+        exit_code: code ?? -1,
+        ...(timedOut ? { timed_out: true } : {}),
+      })
+    })
+  })
+}
+
+export const DEFAULTS = { DEFAULT_TIMEOUT_MS }

--- a/packages/apes/src/lib/agent-tools/bash.ts
+++ b/packages/apes/src/lib/agent-tools/bash.ts
@@ -1,23 +1,5 @@
-import { spawn } from 'node:child_process'
 import type { ToolDefinition } from './index'
-
-const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000
-const MAX_STDIO_BYTES = 64 * 1024
-
-// Spawning `ape-shell -c <cmd>` (instead of building the inner
-// `apes run --shell -- bash -c …` ourselves) keeps the tool aligned
-// with what the human owner types interactively. ape-shell rewrites
-// to the same `apes run --shell` flow, so the grant cycle and the
-// shapes-adapter detection are identical to a terminal invocation.
-// APE_WAIT=1 forces the blocking path — the tool must return a
-// result, not exit-75 with grant-pending instructions.
-const BIN = 'ape-shell'
-
-function capStdio(s: string): string {
-  const buf = Buffer.from(s, 'utf8')
-  if (buf.byteLength <= MAX_STDIO_BYTES) return s
-  return `${buf.subarray(0, MAX_STDIO_BYTES).toString('utf8')}\n[truncated to ${MAX_STDIO_BYTES} bytes]`
-}
+import { DEFAULTS, runApeShell } from './ape-shell-exec'
 
 export const bashTools: ToolDefinition[] = [
   {
@@ -45,50 +27,8 @@ export const bashTools: ToolDefinition[] = [
       }
       const timeout = typeof a.timeout_ms === 'number' && a.timeout_ms > 0
         ? a.timeout_ms
-        : DEFAULT_TIMEOUT_MS
-
-      return await new Promise<unknown>((resolveResult) => {
-        const child = spawn(BIN, ['-c', a.cmd as string], {
-          env: { ...process.env, APE_WAIT: '1' },
-          stdio: ['ignore', 'pipe', 'pipe'],
-        })
-        let stdout = ''
-        let stderr = ''
-        let timedOut = false
-        let spawnError: Error | null = null
-
-        child.stdout!.on('data', (chunk: Buffer) => { stdout += chunk.toString('utf8') })
-        child.stderr!.on('data', (chunk: Buffer) => { stderr += chunk.toString('utf8') })
-        child.on('error', (err) => { spawnError = err as Error })
-
-        const timer = setTimeout(() => {
-          timedOut = true
-          child.kill('SIGTERM')
-          // Force-kill if SIGTERM doesn't take in 5s — happens when the
-          // child is wedged waiting on an upstream grant approval.
-          setTimeout(() => {
-            try { child.kill('SIGKILL') }
-            catch { /* already dead */ }
-          }, 5000)
-        }, timeout)
-
-        child.on('close', (code) => {
-          clearTimeout(timer)
-          if (spawnError) {
-            resolveResult({
-              error: spawnError.message,
-              hint: `Could not exec '${BIN}'. The agent host needs @openape/apes installed globally so ape-shell is on PATH.`,
-            })
-            return
-          }
-          resolveResult({
-            stdout: capStdio(stdout),
-            stderr: capStdio(stderr),
-            exit_code: code ?? -1,
-            ...(timedOut ? { timed_out: true } : {}),
-          })
-        })
-      })
+        : DEFAULTS.DEFAULT_TIMEOUT_MS
+      return await runApeShell(a.cmd, timeout)
     },
   },
 ]

--- a/packages/apes/src/lib/agent-tools/file.ts
+++ b/packages/apes/src/lib/agent-tools/file.ts
@@ -69,6 +69,53 @@ export const fileTools: ToolDefinition[] = [
       return { path: p, bytes: Buffer.byteLength(a.content, 'utf8') }
     },
   },
+  {
+    name: 'edit_file',
+    description: 'Replace an exact substring in a file under the agent\'s home directory. Prefer this over file.write for edits — it touches only the changed region instead of rewriting the whole file. `old_string` must appear exactly once unless `replace_all` is true. Path traversal blocked, 1MB max.',
+    parameters: {
+      type: 'object',
+      properties: {
+        path: { type: 'string', description: 'Path relative to $HOME (or absolute under $HOME).' },
+        old_string: { type: 'string', description: 'Exact text to replace. Include enough surrounding context to be unique unless replace_all is set.' },
+        new_string: { type: 'string', description: 'Replacement text. Must differ from old_string.' },
+        replace_all: { type: 'boolean', description: 'Replace every occurrence instead of requiring a unique match. Default false.' },
+      },
+      required: ['path', 'old_string', 'new_string'],
+    },
+    execute: async (args: unknown) => {
+      const a = args as { path?: unknown, old_string?: unknown, new_string?: unknown, replace_all?: unknown }
+      if (typeof a.old_string !== 'string' || a.old_string === '') {
+        throw new Error('old_string must be a non-empty string')
+      }
+      if (typeof a.new_string !== 'string') {
+        throw new TypeError('new_string must be a string')
+      }
+      if (a.old_string === a.new_string) {
+        throw new Error('old_string and new_string are identical — nothing to change')
+      }
+      const replaceAll = a.replace_all === true
+      const p = jailPath(a.path)
+      const before = readFileSync(p, 'utf8')
+
+      const occurrences = before.split(a.old_string).length - 1
+      if (occurrences === 0) {
+        throw new Error('old_string not found in file')
+      }
+      if (occurrences > 1 && !replaceAll) {
+        throw new Error(`old_string occurs ${occurrences} times — pass replace_all:true or add surrounding context to make it unique`)
+      }
+
+      const after = replaceAll
+        ? before.split(a.old_string).join(a.new_string)
+        : before.replace(a.old_string, a.new_string)
+
+      if (Buffer.byteLength(after, 'utf8') > MAX_BYTES) {
+        throw new Error(`result exceeds ${MAX_BYTES} byte cap`)
+      }
+      writeFileSync(p, after, { encoding: 'utf8' })
+      return { path: p, replacements: replaceAll ? occurrences : 1 }
+    },
+  },
 ]
 
 export const _internal = { jailPath }

--- a/packages/apes/src/lib/agent-tools/file.ts
+++ b/packages/apes/src/lib/agent-tools/file.ts
@@ -70,7 +70,7 @@ export const fileTools: ToolDefinition[] = [
     },
   },
   {
-    name: 'edit_file',
+    name: 'file.edit',
     description: 'Replace an exact substring in a file under the agent\'s home directory. Prefer this over file.write for edits — it touches only the changed region instead of rewriting the whole file. `old_string` must appear exactly once unless `replace_all` is true. Path traversal blocked, 1MB max.',
     parameters: {
       type: 'object',

--- a/packages/apes/src/lib/agent-tools/git-worktree.ts
+++ b/packages/apes/src/lib/agent-tools/git-worktree.ts
@@ -95,7 +95,7 @@ export function buildListCommand(): string {
 
 export const gitWorktreeTools: ToolDefinition[] = [
   {
-    name: 'git_worktree',
+    name: 'git.worktree',
     description: 'Manage isolated git worktrees for coding tasks. action=create clones the repo (cached under ~/repos) and adds a fresh worktree under ~/work/<task_id> on a new branch. action=remove tears it down. action=list shows current task worktrees. Git operations go through the DDISA grant cycle (git-shape).',
     parameters: {
       type: 'object',

--- a/packages/apes/src/lib/agent-tools/git-worktree.ts
+++ b/packages/apes/src/lib/agent-tools/git-worktree.ts
@@ -1,0 +1,139 @@
+import { homedir } from 'node:os'
+import { resolve } from 'node:path'
+import type { ToolDefinition } from './index'
+import { runApeShell } from './ape-shell-exec'
+
+// Worktree lifecycle for the coding agent. All git invocations go
+// through the gated ape-shell path (runApeShell) — `git worktree add`
+// is a sandbox-leaving op, so it hits the DDISA grant / git-shape
+// matcher exactly like a terminal `apes run -- git …`.
+//
+// Layout (all under the agent's $HOME, OS-confined):
+//   ~/repos/<base>      cached bare-ish clone, one per repo
+//   ~/work/<task_id>    the per-task worktree the agent edits in
+//
+// Inputs are strictly validated + single-quoted before reaching the
+// shell. The charset rules reject quotes/metacharacters outright, so
+// the single-quoting can't be broken out of.
+
+const TASK_ID_RE = /^[\w.-]{1,64}$/
+const BRANCH_RE = /^[\w./-]{1,128}$/
+// Either an https/git remote URL, or a path (validated as jailed below).
+const URL_RE = /^(?:https:\/\/|git@)[\w@:/.-]{3,256}$/
+
+function assertTaskId(v: unknown): string {
+  if (typeof v !== 'string' || !TASK_ID_RE.test(v)) {
+    throw new Error('task_id must match ^[a-zA-Z0-9._-]{1,64}$')
+  }
+  return v
+}
+
+function assertBranch(v: unknown): string {
+  if (typeof v !== 'string' || !BRANCH_RE.test(v)) {
+    throw new Error('branch must match ^[A-Za-z0-9._/-]{1,128}$')
+  }
+  return v
+}
+
+// Resolve a repo reference to a base-clone dir + a clonable source.
+// URL → clone into ~/repos/<derived>. Local path → must be a git repo
+// already inside $HOME (jailed); used in place.
+export function resolveRepo(repo: unknown): { source: string; baseDir: string; isUrl: boolean } {
+  if (typeof repo !== 'string' || repo === '') {
+    throw new Error('repo must be a non-empty string (URL or path under $HOME)')
+  }
+  const home = homedir()
+  if (URL_RE.test(repo)) {
+    const tail = repo.replace(/\.git$/, '').replace(/[/:]+$/, '')
+    const parts = tail.split(/[/:]/).filter(Boolean).slice(-2)
+    const base = parts.join('-').replace(/[^\w.-]/g, '')
+    if (!base) throw new Error('could not derive a clone name from repo URL')
+    return { source: repo, baseDir: resolve(home, 'repos', base), isUrl: true }
+  }
+  // Local path — jail under $HOME.
+  const candidate = repo.startsWith('~/') ? resolve(home, repo.slice(2)) : resolve(home, repo)
+  if (candidate !== home && !candidate.startsWith(`${home}/`)) {
+    throw new Error(`repo path "${repo}" resolves outside the agent's home`)
+  }
+  return { source: candidate, baseDir: candidate, isUrl: false }
+}
+
+export function worktreePathFor(taskId: string): string {
+  return resolve(homedir(), 'work', assertTaskId(taskId))
+}
+
+const q = (s: string): string => `'${s}'` // safe: callers validate charset first
+
+export function buildCreateCommand(repo: unknown, taskId: string, branch: string): string {
+  const id = assertTaskId(taskId)
+  const br = assertBranch(branch)
+  const { source, baseDir, isUrl } = resolveRepo(repo)
+  const wt = worktreePathFor(id)
+  const clone = isUrl
+    ? `if [ ! -d ${q(baseDir)}/.git ]; then git clone ${q(source)} ${q(baseDir)}; fi`
+    : `test -d ${q(baseDir)}/.git`
+  return [
+    `mkdir -p ${q(resolve(homedir(), 'repos'))} ${q(resolve(homedir(), 'work'))}`,
+    clone,
+    `git -C ${q(baseDir)} fetch --quiet || true`,
+    `git -C ${q(baseDir)} worktree add -b ${q(br)} ${q(wt)}`,
+    `echo ${q(wt)}`,
+  ].join(' && ')
+}
+
+export function buildRemoveCommand(repo: unknown, taskId: string): string {
+  const id = assertTaskId(taskId)
+  const { baseDir } = resolveRepo(repo)
+  const wt = worktreePathFor(id)
+  return `git -C ${q(baseDir)} worktree remove --force ${q(wt)} && git -C ${q(baseDir)} worktree prune`
+}
+
+export function buildListCommand(): string {
+  const work = resolve(homedir(), 'work')
+  return `ls -1 ${q(work)} 2>/dev/null || true`
+}
+
+export const gitWorktreeTools: ToolDefinition[] = [
+  {
+    name: 'git_worktree',
+    description: 'Manage isolated git worktrees for coding tasks. action=create clones the repo (cached under ~/repos) and adds a fresh worktree under ~/work/<task_id> on a new branch. action=remove tears it down. action=list shows current task worktrees. Git operations go through the DDISA grant cycle (git-shape).',
+    parameters: {
+      type: 'object',
+      properties: {
+        action: { type: 'string', enum: ['create', 'remove', 'list'], description: 'create | remove | list' },
+        repo: { type: 'string', description: 'For create/remove: git remote URL (https/git@) or a path under $HOME to an existing clone.' },
+        task_id: { type: 'string', description: 'For create/remove: identifier for the worktree, ^[a-zA-Z0-9._-]{1,64}$. The worktree lands at ~/work/<task_id>.' },
+        branch: { type: 'string', description: 'For create: new branch name, ^[A-Za-z0-9._/-]{1,128}$.' },
+      },
+      required: ['action'],
+    },
+    execute: async (args: unknown) => {
+      const a = args as { action?: unknown, repo?: unknown, task_id?: unknown, branch?: unknown }
+      let cmd: string
+      if (a.action === 'create') {
+        if (typeof a.branch !== 'string') throw new Error('branch is required for action=create')
+        cmd = buildCreateCommand(a.repo, assertTaskId(a.task_id), a.branch)
+      }
+      else if (a.action === 'remove') {
+        cmd = buildRemoveCommand(a.repo, assertTaskId(a.task_id))
+      }
+      else if (a.action === 'list') {
+        cmd = buildListCommand()
+      }
+      else {
+        throw new Error('action must be one of: create, remove, list')
+      }
+      const res = await runApeShell(cmd)
+      return {
+        action: a.action,
+        ...(a.action !== 'list' ? { worktree: worktreePathFor(assertTaskId(a.task_id)) } : {}),
+        stdout: res.stdout,
+        stderr: res.stderr,
+        exit_code: res.exit_code,
+        ...(res.error ? { error: res.error, hint: res.hint } : {}),
+      }
+    },
+  },
+]
+
+export const _internal = { resolveRepo, worktreePathFor, buildCreateCommand, buildRemoveCommand, buildListCommand, assertTaskId, assertBranch }

--- a/packages/apes/src/lib/agent-tools/index.ts
+++ b/packages/apes/src/lib/agent-tools/index.ts
@@ -13,6 +13,7 @@
 
 import { bashTools } from './bash'
 import { fileTools } from './file'
+import { gitWorktreeTools } from './git-worktree'
 import { httpTools } from './http'
 import { mailTools } from './mail'
 import { tasksTools } from './tasks'
@@ -34,6 +35,7 @@ const ALL_TOOLS: ToolDefinition[] = [
   ...tasksTools,
   ...mailTools,
   ...bashTools,
+  ...gitWorktreeTools,
 ]
 
 export const TOOLS: Record<string, ToolDefinition> = Object.fromEntries(

--- a/packages/apes/test/agent-tools.test.ts
+++ b/packages/apes/test/agent-tools.test.ts
@@ -8,7 +8,7 @@ import { _internal as wtInternal } from '../src/lib/agent-tools/git-worktree'
 
 describe('tool registry', () => {
   it('TOOLS has the expected keys', () => {
-    for (const name of ['time.now', 'http.get', 'http.post', 'file.read', 'file.write', 'edit_file', 'tasks.list', 'tasks.create', 'mail.list', 'mail.search', 'bash', 'git_worktree']) {
+    for (const name of ['time.now', 'http.get', 'http.post', 'file.read', 'file.write', 'file.edit', 'tasks.list', 'tasks.create', 'mail.list', 'mail.search', 'bash', 'git.worktree']) {
       expect(TOOLS[name]).toBeDefined()
     }
   })
@@ -92,7 +92,7 @@ describe('edit_file', () => {
 
   it('replaces a unique substring', async () => {
     await withTempFile('hello world\n', async (rel, abs) => {
-      const r = await TOOLS.edit_file!.execute({ path: rel, old_string: 'world', new_string: 'there' }) as Record<string, unknown>
+      const r = await TOOLS['file.edit']!.execute({ path: rel, old_string: 'world', new_string: 'there' }) as Record<string, unknown>
       expect(r.replacements).toBe(1)
       expect(readFileSync(abs, 'utf8')).toBe('hello there\n')
     })
@@ -100,22 +100,22 @@ describe('edit_file', () => {
 
   it('errors when old_string is absent', async () => {
     await withTempFile('abc', async (rel) => {
-      await expect(TOOLS.edit_file!.execute({ path: rel, old_string: 'xyz', new_string: 'q' })).rejects.toThrow(/not found/)
+      await expect(TOOLS['file.edit']!.execute({ path: rel, old_string: 'xyz', new_string: 'q' })).rejects.toThrow(/not found/)
     })
   })
 
   it('errors on ambiguous match unless replace_all', async () => {
     await withTempFile('a a a', async (rel, abs) => {
-      await expect(TOOLS.edit_file!.execute({ path: rel, old_string: 'a', new_string: 'b' })).rejects.toThrow(/occurs 3 times/)
-      const r = await TOOLS.edit_file!.execute({ path: rel, old_string: 'a', new_string: 'b', replace_all: true }) as Record<string, unknown>
+      await expect(TOOLS['file.edit']!.execute({ path: rel, old_string: 'a', new_string: 'b' })).rejects.toThrow(/occurs 3 times/)
+      const r = await TOOLS['file.edit']!.execute({ path: rel, old_string: 'a', new_string: 'b', replace_all: true }) as Record<string, unknown>
       expect(r.replacements).toBe(3)
       expect(readFileSync(abs, 'utf8')).toBe('b b b')
     })
   })
 
   it('rejects identical old/new and out-of-home paths', async () => {
-    await expect(TOOLS.edit_file!.execute({ path: 'x', old_string: 's', new_string: 's' })).rejects.toThrow(/identical/)
-    await expect(TOOLS.edit_file!.execute({ path: '/etc/hosts', old_string: 'a', new_string: 'b' })).rejects.toThrow(/outside the agent's home/)
+    await expect(TOOLS['file.edit']!.execute({ path: 'x', old_string: 's', new_string: 's' })).rejects.toThrow(/identical/)
+    await expect(TOOLS['file.edit']!.execute({ path: '/etc/hosts', old_string: 'a', new_string: 'b' })).rejects.toThrow(/outside the agent's home/)
   })
 })
 

--- a/packages/apes/test/agent-tools.test.ts
+++ b/packages/apes/test/agent-tools.test.ts
@@ -1,11 +1,14 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { asOpenAiTools, taskTools, TOOLS } from '../src/lib/agent-tools'
 import { _internal as fileInternal } from '../src/lib/agent-tools/file'
-import { homedir } from 'node:os'
+import { _internal as wtInternal } from '../src/lib/agent-tools/git-worktree'
 
 describe('tool registry', () => {
   it('TOOLS has the expected keys', () => {
-    for (const name of ['time.now', 'http.get', 'http.post', 'file.read', 'file.write', 'tasks.list', 'tasks.create', 'mail.list', 'mail.search', 'bash']) {
+    for (const name of ['time.now', 'http.get', 'http.post', 'file.read', 'file.write', 'edit_file', 'tasks.list', 'tasks.create', 'mail.list', 'mail.search', 'bash', 'git_worktree']) {
       expect(TOOLS[name]).toBeDefined()
     }
   })
@@ -75,5 +78,84 @@ describe('file tool jail', () => {
   it('rejects empty + non-string paths', () => {
     expect(() => fileInternal.jailPath('')).toThrow()
     expect(() => fileInternal.jailPath(123 as unknown as string)).toThrow()
+  })
+})
+
+describe('edit_file', () => {
+  function withTempFile(body: string, fn: (rel: string, abs: string) => Promise<void> | void) {
+    const dir = mkdtempSync(join(homedir(), '.apes-edit-test-'))
+    const abs = join(dir, 'f.txt')
+    writeFileSync(abs, body, 'utf8')
+    const rel = abs.slice(homedir().length + 1) // path relative to $HOME
+    return Promise.resolve(fn(rel, abs)).finally(() => rmSync(dir, { recursive: true, force: true }))
+  }
+
+  it('replaces a unique substring', async () => {
+    await withTempFile('hello world\n', async (rel, abs) => {
+      const r = await TOOLS.edit_file!.execute({ path: rel, old_string: 'world', new_string: 'there' }) as Record<string, unknown>
+      expect(r.replacements).toBe(1)
+      expect(readFileSync(abs, 'utf8')).toBe('hello there\n')
+    })
+  })
+
+  it('errors when old_string is absent', async () => {
+    await withTempFile('abc', async (rel) => {
+      await expect(TOOLS.edit_file!.execute({ path: rel, old_string: 'xyz', new_string: 'q' })).rejects.toThrow(/not found/)
+    })
+  })
+
+  it('errors on ambiguous match unless replace_all', async () => {
+    await withTempFile('a a a', async (rel, abs) => {
+      await expect(TOOLS.edit_file!.execute({ path: rel, old_string: 'a', new_string: 'b' })).rejects.toThrow(/occurs 3 times/)
+      const r = await TOOLS.edit_file!.execute({ path: rel, old_string: 'a', new_string: 'b', replace_all: true }) as Record<string, unknown>
+      expect(r.replacements).toBe(3)
+      expect(readFileSync(abs, 'utf8')).toBe('b b b')
+    })
+  })
+
+  it('rejects identical old/new and out-of-home paths', async () => {
+    await expect(TOOLS.edit_file!.execute({ path: 'x', old_string: 's', new_string: 's' })).rejects.toThrow(/identical/)
+    await expect(TOOLS.edit_file!.execute({ path: '/etc/hosts', old_string: 'a', new_string: 'b' })).rejects.toThrow(/outside the agent's home/)
+  })
+})
+
+describe('git_worktree command builders', () => {
+  const home = homedir()
+
+  it('derives a clone dir + worktree path from a URL', () => {
+    const r = wtInternal.resolveRepo('https://github.com/openape-ai/openape.git')
+    expect(r.isUrl).toBe(true)
+    expect(r.baseDir).toBe(`${home}/repos/openape-ai-openape`)
+    expect(wtInternal.worktreePathFor('issue-42')).toBe(`${home}/work/issue-42`)
+  })
+
+  it('jails local repo paths under $HOME', () => {
+    expect(() => wtInternal.resolveRepo('/etc')).toThrow(/outside the agent's home/)
+    const r = wtInternal.resolveRepo('repos/myclone')
+    expect(r.isUrl).toBe(false)
+    expect(r.baseDir).toBe(`${home}/repos/myclone`)
+  })
+
+  it('validates task_id and branch charsets', () => {
+    expect(() => wtInternal.assertTaskId('bad id!')).toThrow(/task_id must match/)
+    expect(() => wtInternal.assertBranch('bad branch;rm')).toThrow(/branch must match/)
+    expect(wtInternal.assertTaskId('issue-42')).toBe('issue-42')
+    expect(wtInternal.assertBranch('feat/x-1')).toBe('feat/x-1')
+  })
+
+  it('builds a create command that clones-if-needed and adds the worktree', () => {
+    const cmd = wtInternal.buildCreateCommand('https://github.com/openape-ai/openape.git', 'issue-42', 'fix/issue-42')
+    expect(cmd).toContain('git clone')
+    expect(cmd).toContain(`worktree add -b 'fix/issue-42' '${home}/work/issue-42'`)
+  })
+
+  it('builds remove + list commands', () => {
+    expect(wtInternal.buildRemoveCommand('repos/myclone', 'issue-42')).toContain('worktree remove --force')
+    expect(wtInternal.buildListCommand()).toContain(`${home}/work`)
+  })
+
+  it('rejects injection attempts in inputs', () => {
+    expect(() => wtInternal.buildCreateCommand('https://github.com/x/y.git', 'a\'; rm -rf ~', 'b')).toThrow(/task_id must match/)
+    expect(() => wtInternal.buildCreateCommand('https://github.com/x/y.git', 'ok', 'b\'; rm -rf ~')).toThrow(/branch must match/)
   })
 })


### PR DESCRIPTION
Milestone M1 des 24/7-Coding-Agent-Plans (plans.openape.ai/p/01KS9SSJ1BJMH54F6MYTHQ5941).

## Was

Erste Coding-Primitives im `@openape/apes` Tool-Registry, nach dem Zwei-Tier-Gating-Modell:

- **`edit_file`** (`agent-tools/file.ts`) — strukturiertes substring-Replace mit Uniqueness-Check (`old_string` muss eindeutig sein, sonst `replace_all`). **OS-confined auf `$HOME`** (reuse `jailPath`, `..` blockiert), **kein Grant** — Tier-1. Token-effizienter + weniger destruktiv als `file.write` für Edits.
- **`git_worktree`** (`agent-tools/git-worktree.ts`) — `create`/`remove`/`list` isolierter Worktrees unter `~/work/<task_id>`, Clone gecached unter `~/repos/<base>`. Alle git-Ops über den **gegateten ape-shell-Pfad** (DDISA-Grant + git-shape) — Tier-2. Inputs strikt validiert (`task_id`/`branch`-Charset, repo URL/jailed-path) + single-quoted → injektionssicher.
- **`ape-shell-exec.ts`** — extrahierter `runApeShell`-Helper. `bash.ts` refactored um ihn zu nutzen → jedes shell-anfassende Tool geht durch *denselben* Gate-Checkpoint (keine ungegatete `child_process`-Abkürzung möglich).

Beide in `agent-tools/index.ts` registriert + in `apps/openape-troop/server/tool-catalog.json` (SP-Allowlist).

## Gating-Modell (verifiziert)

| Tool | Tier | Gate |
|---|---|---|
| `edit_file`, `file.read/write` | 1 | OS-confined auf Agent-`$HOME`, kein Grant |
| `git_worktree`, `bash` | 2 | ape-shell → `apes run --shell` → DDISA-Grant + shapes |

## Test plan

- [x] `pnpm --filter @openape/apes typecheck` ✓
- [x] `pnpm --filter @openape/apes build` ✓
- [x] `pnpm --filter @openape/apes test` — 687 passed / 3 skipped; Coverage-Schwelle (50%) gehalten
- [x] `pnpm --filter @openape/apes lint` — 0 errors
- Neue Tests: `edit_file` (replace unique/ambiguous/replace_all, not-found, identical-reject, out-of-home-reject), `git_worktree` command-builder (URL→clone-dir, path-jailing, charset-validierung, injection-reject)
- [ ] **Dogfood** (nächste Session, nach Merge): echter Agent mit `tools:["bash","edit_file","git_worktree"]` legt worktree an + editiert — `git -C <worktree> diff` zeigt Änderung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)