### PR TITLE
feat(apes): coding-agent integration — orchestrator + LLM review/risk + recipe (INT-1/2/3)

### DIFF
--- a/.changeset/coding-agent-integration.md
+++ b/.changeset/coding-agent-integration.md
@@ -1,0 +1,5 @@
+---
+"@openape/apes": minor
+---
+
+Coding-agent integration layer (INT-1/INT-2): `coding/coding-loop.ts` orchestrator ties M1–M7 into one run (issue → worktree → LLM coding loop → verify → PR → policy-gated merge). The LLM does the coding (file.edit/bash/verify, NOT pr.merge); the orchestrator owns branch/worktree/PR/merge-gate and arms `--auto` (merge-when-green) only after the risk + reviewer gates pass. `coding/llm-review.ts` provides LLM-backed `RiskAssessorFn` + `ReviewerFn` (fail-safe: unsure → risky/blocked). All I/O injected → unit-tested without a live LLM or git. Plus a `coding-agent` example recipe (`examples/agent-recipes/coding-agent/`).

--- a/examples/agent-recipes/coding-agent/README.md
+++ b/examples/agent-recipes/coding-agent/README.md
@@ -1,0 +1,54 @@
+# coding-agent recipe
+
+An autonomous coding agent: assigned issue → isolated worktree → edit →
+verify → PR → policy-gated merge. Built on the `@openape/apes` coding
+library (M1–M7) + orchestrator (`coding/coding-loop.ts`).
+
+## Deploy
+
+```bash
+apes agent deploy <this-repo>@main \
+  --param repo=https://github.com/openape-ai/openape.git \
+  --param forge=github \
+  --secret GH_TOKEN=ghp_xxx
+```
+
+For Azure DevOps use `--param forge=azure --secret AZ_PAT=xxx`.
+
+## Division of responsibility
+
+- **The LLM does the coding** — `file.edit`, `bash`, `verify`. It is NOT
+  given `forge.pr.merge`; even a `gh pr merge` via `bash` needs a grant
+  the agent doesn't hold, so it cannot self-merge.
+- **The orchestrator owns policy** — branch + worktree, opening the PR,
+  classifying the diff, the risk assessor + reviewer gate, and arming
+  `--auto` (merge-when-green). Branch protection is the server-side CI gate.
+
+## Per-repo config: `.openape/coding.json`
+
+Policy lives in the **target repo**, not in this recipe or the library:
+
+```json
+{
+  "verifyCommand": "pnpm test",
+  "branch": { "template": "fix/issue-{number}-{slug}", "defaultType": "fix" },
+  "mergePolicy": {
+    "autoMergeEnabled": true,
+    "autoPaths": ["**/*.md", ".changeset/**"],
+    "riskPaths": ["infra/**"]
+  }
+}
+```
+
+- `autoMergeEnabled` is **false** by default — auto-merge is opt-in.
+- `riskPaths` is augmented automatically from the repo's deploy-workflow
+  `paths:` filters + CODEOWNERS (you don't maintain a parallel list).
+- The agent additionally judges risk semantically; either source escalates
+  a change to "human approval required".
+
+## Updating a deployed agent
+
+Intent, tools, and schedules hot-update via the agent's normal `apes
+agents sync` cycle (~5 min) — no destroy/respawn. To roll out a new
+recipe version (or new capabilities), re-deploy at the new ref; deploy is
+an upsert (see plan INT-4).

--- a/examples/agent-recipes/coding-agent/ape-agent.yaml
+++ b/examples/agent-recipes/coding-agent/ape-agent.yaml
@@ -1,0 +1,58 @@
+name: coding-agent
+kind: agent
+intent: |
+  You are an autonomous coding agent for {{repo}} on {{forge}}.
+
+  Your job: pick up an assigned issue, implement it in an isolated git
+  worktree, make the verification command pass, and open a pull request.
+  You do NOT decide whether to merge — the orchestrator owns the merge
+  gate (risk classification + reviewer). Never run `gh pr merge` /
+  `az repos pr update` yourself.
+
+  Workflow per task (the orchestrator sets up the worktree + branch and
+  tells you the path):
+    1. Read the issue and the relevant code (file.read, bash for `git`/`rg`).
+    2. Make the change with file.edit (small, targeted edits) — not by
+       rewriting whole files.
+    3. Run the repo's verification command with the `verify` tool. Do not
+       consider the task done until it passes. No PR on red.
+    4. Summarize what you changed and why.
+
+  Read the repo's `.openape/coding.json` for the verify command, branch
+  convention, and merge policy. If a change touches anything risky
+  (auth, secrets, migrations, deploy/CI config, payments, data deletion),
+  say so explicitly — it will require human approval.
+
+capabilities:
+  - env: GH_TOKEN
+    prefer: local
+  - env: AZ_PAT
+    prefer: local
+
+params:
+  - name: repo
+    type: string
+    required: true
+  - name: forge
+    type: string
+    required: true
+
+# Poll for assigned issues. The cron-driven trigger fetches issues
+# labelled for the agent and runs one coding task each.
+schedules:
+  - cron: "*/10 * * * *"
+    description: poll {{repo}} for assigned issues and work them
+
+user_addendum: true
+
+# Built-in apes tools the agent may use (the LLM toolset). forge.pr.merge
+# is intentionally absent — merge is the orchestrator's job, gated.
+tools:
+  - file.read
+  - file.write
+  - file.edit
+  - bash
+  - git.worktree
+  - verify
+  - forge.issue.get
+  - forge.pr.status

--- a/packages/apes/src/lib/coding/coding-loop.ts
+++ b/packages/apes/src/lib/coding/coding-loop.ts
@@ -1,0 +1,154 @@
+// Coding-task orchestrator (INT-1). Ties the M1–M7 pieces into one run:
+// issue → worktree → LLM coding loop → verify → PR → merge gate.
+//
+// Division of responsibility (deliberate):
+//   - The LLM does the CODING (edit files, run the verify command). It
+//     gets file.* / bash / verify tools — NOT forge.pr.merge. Even if it
+//     shells `gh pr merge`, that's a high-risk grant the agent doesn't
+//     hold a YOLO scope for, so it can't self-merge.
+//   - The ORCHESTRATOR owns everything policy-critical: branch + worktree
+//     lifecycle, opening the PR, classifying the diff, running the risk
+//     assessor + reviewer gate, and arming the merge. The LLM never
+//     decides whether to merge.
+//
+// All I/O (shell, runLoop, reviewer, riskAssessor) is injected so the
+// orchestration is unit-testable without a live LLM or git.
+
+import type { ToolDefinition } from '../agent-tools'
+import type { RunOptions, RunResult, RuntimeConfig } from '../agent-runtime'
+import { runLoop } from '../agent-runtime'
+import { runApeShell } from '../agent-tools/ape-shell-exec'
+import { buildCreateCommand, worktreePathFor } from '../agent-tools/git-worktree'
+import { buildPrCreate, buildPrMerge  } from './forge'
+import type { Forge } from './forge'
+import type { IssueRef, BranchNaming  } from './issue-task'
+import { buildBranchName, buildTaskPrompt } from './issue-task'
+import { decideMerge } from './merge-policy'
+import type { MergeDecision, MergePolicy, RiskAssessorFn } from './merge-policy'
+import { gateMerge } from './review-gate'
+import type { ReviewerFn } from './review-gate'
+
+const DIFF_CAP = 60 * 1024
+
+export interface ShellResult { stdout: string, stderr: string, exit_code: number }
+export type ShellFn = (cmd: string, timeoutMs?: number) => Promise<ShellResult>
+
+export interface CodingTaskInput {
+  issue: IssueRef
+  repo: string // URL or $HOME path
+  forge: Forge
+}
+
+export interface CodingTaskDeps {
+  runtimeConfig: RuntimeConfig
+  // Coding tools given to the LLM (file.*, bash, verify, …) — must NOT
+  // include forge.pr.merge.
+  tools: ToolDefinition[]
+  persona: string
+  maxSteps: number
+  policy: MergePolicy
+  reviewer: ReviewerFn
+  riskAssessor: RiskAssessorFn
+  branchNaming?: BranchNaming
+  // Merge strategy + auto behaviour for the PR the orchestrator opens.
+  squash?: boolean
+  // Injected I/O (defaults wired to production impls).
+  shell?: ShellFn
+  runLoopImpl?: (opts: RunOptions) => Promise<RunResult>
+  log?: (line: string) => void
+}
+
+export type MergeOutcome = 'auto-armed' | 'awaiting-human' | 'reviewer-blocked' | 'run-failed'
+
+export interface CodingTaskResult {
+  branch: string
+  worktree: string
+  runStatus: 'ok' | 'error'
+  changedFiles: string[]
+  decision?: MergeDecision
+  outcome: MergeOutcome
+  prRef?: string
+  reason: string
+}
+
+function taskIdFromIssue(issue: IssueRef): string {
+  const num = String(issue.number).replace(/\D/g, '')
+  return `issue-${num || 'x'}`
+}
+
+export async function runCodingTask(input: CodingTaskInput, deps: CodingTaskDeps): Promise<CodingTaskResult> {
+  const shell = deps.shell ?? (async (cmd, t) => {
+    const r = await runApeShell(cmd, t)
+    return { stdout: r.stdout, stderr: r.stderr, exit_code: r.exit_code }
+  })
+  const loop = deps.runLoopImpl ?? runLoop
+  const log = deps.log ?? (() => {})
+
+  const branch = buildBranchName(input.issue, deps.branchNaming)
+  const taskId = taskIdFromIssue(input.issue)
+  const worktree = worktreePathFor(taskId)
+
+  // 1. Orchestrator creates the isolated worktree (deterministic path).
+  log(`[coding] creating worktree ${worktree} on ${branch}`)
+  const wt = await shell(buildCreateCommand(input.repo, taskId, branch))
+  if (wt.exit_code !== 0) {
+    return { branch, worktree, runStatus: 'error', changedFiles: [], outcome: 'run-failed', reason: `worktree create failed: ${wt.stderr.slice(0, 300)}` }
+  }
+
+  // 2. LLM does the coding (it has file.*/bash/verify; NOT pr.merge).
+  const prompt = buildTaskPrompt(input.issue, { persona: deps.persona })
+  const run = await loop({
+    config: deps.runtimeConfig,
+    systemPrompt: deps.persona,
+    userMessage: `${prompt}\n\nWorktree: ${worktree}`,
+    tools: deps.tools,
+    maxSteps: deps.maxSteps,
+  })
+  if (run.status !== 'ok') {
+    return { branch, worktree, runStatus: 'error', changedFiles: [], outcome: 'run-failed', reason: `coding loop errored after ${run.stepCount} steps` }
+  }
+
+  // 3. Determine the actual diff (orchestrator, not the LLM's word).
+  const namesRes = await shell(`git -C '${worktree}' add -A && git -C '${worktree}' diff --cached --name-only`)
+  const changedFiles = namesRes.stdout.split('\n').map(s => s.trim()).filter(Boolean)
+  if (changedFiles.length === 0) {
+    return { branch, worktree, runStatus: 'ok', changedFiles: [], outcome: 'run-failed', reason: 'no changes produced — nothing to PR' }
+  }
+  const diffRes = await shell(`git -C '${worktree}' diff --cached`)
+  const diff = diffRes.stdout.slice(0, DIFF_CAP)
+
+  // 4. Risk + merge decision (agent judgment ∪ config/derived).
+  const agentRisk = await deps.riskAssessor({ paths: changedFiles, diff })
+  const decision = decideMerge(changedFiles, deps.policy, agentRisk)
+  log(`[coding] decision=${decision.classification} (${decision.reason})`)
+
+  // 5. Commit + push + open the PR (orchestrator owns this).
+  await shell(`git -C '${worktree}' commit -m ${shqMsg(input.issue)} && git -C '${worktree}' push -u origin '${branch}'`)
+  const prCmd = buildPrCreate({ forge: input.forge, title: prTitle(input.issue), body: prBody(input.issue), head: branch })
+  const prRes = await shell(`cd '${worktree}' && ${prCmd}`)
+  const prRef = (prRes.stdout.match(/\/pull\/(\d+)|!(\d+)|\bpr\/(\d+)/i)?.slice(1).find(Boolean)) ?? branch
+
+  // 6. Merge gate. Human/risk → stop. Code → reviewer. Chore → arm.
+  if (decision.needsHuman) {
+    return { branch, worktree, runStatus: 'ok', changedFiles, decision, outcome: 'awaiting-human', prRef, reason: decision.reason }
+  }
+  const gate = await gateMerge(decision, { prRef, diff }, deps.reviewer)
+  if (!gate.armMerge) {
+    return { branch, worktree, runStatus: 'ok', changedFiles, decision, outcome: 'reviewer-blocked', prRef, reason: gate.reason }
+  }
+  // Arm merge-when-green (never bypasses required checks — branch protection).
+  const mergeCmd = buildPrMerge({ forge: input.forge, ref: prRef, auto: true, squash: deps.squash, deleteBranch: true })
+  await shell(`cd '${worktree}' && ${mergeCmd}`)
+  return { branch, worktree, runStatus: 'ok', changedFiles, decision, outcome: 'auto-armed', prRef, reason: gate.reason }
+}
+
+// Local helpers (kept here so the file is self-contained).
+function prTitle(issue: IssueRef): string {
+  return `${issue.type ?? 'fix'}: ${issue.title} (#${String(issue.number).replace(/\D/g, '')})`
+}
+function prBody(issue: IssueRef): string {
+  return `Resolves #${String(issue.number).replace(/\D/g, '')}.\n\nAutomated by the OpenApe coding agent.`
+}
+function shqMsg(issue: IssueRef): string {
+  return `'${prTitle(issue).replace(/'/g, '\'\\\'\'')}'`
+}

--- a/packages/apes/src/lib/coding/llm-review.ts
+++ b/packages/apes/src/lib/coding/llm-review.ts
@@ -1,0 +1,80 @@
+// LLM-backed risk assessor + reviewer (INT-2). These satisfy the
+// injected `RiskAssessorFn` / `ReviewerFn` interfaces with real model
+// calls, so the coding loop's "is this risky?" and "approve this diff?"
+// decisions are semantic, not glob-only.
+//
+// Fail-safe: if the model errors or returns unparseable output, the
+// assessor treats the change as RISKY and the reviewer BLOCKS — unsure
+// always degrades toward human/no-merge, never toward silent auto-merge.
+
+import type { RuntimeConfig } from '../agent-runtime'
+import type { AgentRiskAssessment, RiskAssessorFn } from './merge-policy'
+import type { ReviewerFn, ReviewVerdict } from './review-gate'
+
+const DIFF_CAP = 48 * 1024
+
+async function jsonCompletion(
+  config: RuntimeConfig,
+  system: string,
+  user: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<Record<string, unknown> | null> {
+  try {
+    const res = await fetchImpl(`${config.apiBase}/chat/completions`, {
+      method: 'POST',
+      headers: { 'authorization': `Bearer ${config.apiKey}`, 'content-type': 'application/json' },
+      body: JSON.stringify({
+        model: config.model,
+        messages: [{ role: 'system', content: system }, { role: 'user', content: user }],
+        response_format: { type: 'json_object' },
+      }),
+    })
+    if (!res.ok) return null
+    const data = await res.json() as { choices?: { message?: { content?: string } }[] }
+    const content = data.choices?.[0]?.message?.content
+    if (!content) return null
+    return JSON.parse(content) as Record<string, unknown>
+  }
+  catch {
+    return null
+  }
+}
+
+const RISK_SYSTEM = [
+  'You are a security/risk classifier for an autonomous coding agent.',
+  'Given a diff + changed file paths, decide whether merging it WITHOUT a human is risky.',
+  'Risky = touches authentication, authorization, secrets/credentials, payment, data migrations,',
+  'deploy/release/CI config, cryptography, deletion of data, or anything whose failure is hard to',
+  'reverse in production. Routine code/tests/docs/refactors are NOT risky.',
+  'Respond ONLY as JSON: {"risky": boolean, "reason": string}.',
+].join(' ')
+
+export function createLlmRiskAssessor(config: RuntimeConfig, fetchImpl?: typeof fetch): RiskAssessorFn {
+  return async ({ paths, diff }): Promise<AgentRiskAssessment> => {
+    const user = `Changed files:\n${paths.join('\n')}\n\nDiff (truncated):\n${diff.slice(0, DIFF_CAP)}`
+    const out = await jsonCompletion(config, RISK_SYSTEM, user, fetchImpl)
+    if (!out || typeof out.risky !== 'boolean') {
+      return { risky: true, reason: 'risk classifier unavailable/unparseable — treating as risky (fail-safe)' }
+    }
+    return { risky: out.risky, reason: typeof out.reason === 'string' ? out.reason : undefined }
+  }
+}
+
+const REVIEW_SYSTEM = [
+  'You are a code reviewer for an autonomous coding agent.',
+  'Given a PR diff, decide whether it is correct, safe, and complete enough to auto-merge.',
+  'Approve only if you would be comfortable shipping it without further human review.',
+  'Block if you see bugs, missing tests, security issues, or incomplete work.',
+  'Respond ONLY as JSON: {"approved": boolean, "reason": string}.',
+].join(' ')
+
+export function createLlmReviewer(config: RuntimeConfig, fetchImpl?: typeof fetch): ReviewerFn {
+  return async ({ prRef, diff }): Promise<ReviewVerdict> => {
+    const user = `PR ${String(prRef)} diff (truncated):\n${diff.slice(0, DIFF_CAP)}`
+    const out = await jsonCompletion(config, REVIEW_SYSTEM, user, fetchImpl)
+    if (!out || typeof out.approved !== 'boolean') {
+      return { approved: false, reason: 'reviewer unavailable/unparseable — blocking (fail-safe)' }
+    }
+    return { approved: out.approved, reason: typeof out.reason === 'string' ? out.reason : undefined }
+  }
+}

--- a/packages/apes/test/coding-loop.test.ts
+++ b/packages/apes/test/coding-loop.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from 'vitest'
+import { runCodingTask } from '../src/lib/coding/coding-loop'
+import type { CodingTaskDeps, ShellResult } from '../src/lib/coding/coding-loop'
+import type { MergePolicy } from '../src/lib/coding/merge-policy'
+import { createLlmReviewer, createLlmRiskAssessor } from '../src/lib/coding/llm-review'
+
+const runtimeConfig = { apiBase: 'http://x/v1', apiKey: 'k', model: 'm' }
+const POLICY: MergePolicy = { autoMergeEnabled: true, autoPaths: ['**/*.md'], riskPaths: ['infra/**'] }
+
+// Mock shell: pattern-match the command, return canned results. Records
+// every command for assertions.
+function mockShell(opts: { changed: string[], createExit?: number }) {
+  const calls: string[] = []
+  const fn = vi.fn(async (cmd: string): Promise<ShellResult> => {
+    calls.push(cmd)
+    if (cmd.includes('worktree add')) return { stdout: '', stderr: '', exit_code: opts.createExit ?? 0 }
+    if (cmd.includes('diff --cached --name-only')) return { stdout: opts.changed.join('\n'), stderr: '', exit_code: 0 }
+    if (cmd.includes('diff --cached')) return { stdout: 'some diff', stderr: '', exit_code: 0 }
+    if (cmd.includes('pr create') || cmd.includes('repos pr create')) return { stdout: 'https://github.com/o/r/pull/77', stderr: '', exit_code: 0 }
+    return { stdout: '', stderr: '', exit_code: 0 }
+  })
+  return { fn, calls }
+}
+
+function baseDeps(over: Partial<CodingTaskDeps> = {}): CodingTaskDeps {
+  return {
+    runtimeConfig,
+    tools: [],
+    persona: 'You are a coding agent.',
+    maxSteps: 5,
+    policy: POLICY,
+    reviewer: async () => ({ approved: true }),
+    riskAssessor: async () => ({ risky: false }),
+    runLoopImpl: async () => ({ status: 'ok', finalMessage: 'done', stepCount: 1, trace: [] }),
+    ...over,
+  }
+}
+
+const input = { issue: { number: 42, title: 'Fix login', type: 'fix' }, repo: 'https://github.com/o/r.git', forge: 'github' as const }
+
+describe('runCodingTask orchestrator', () => {
+  it('chore change → auto-armed without reviewer', async () => {
+    const { fn, calls } = mockShell({ changed: ['docs/readme.md'] })
+    const reviewer = vi.fn(async () => ({ approved: true }))
+    const r = await runCodingTask(input, baseDeps({ shell: fn, reviewer }))
+    expect(r.outcome).toBe('auto-armed')
+    expect(r.decision?.classification).toBe('chore')
+    expect(reviewer).not.toHaveBeenCalled()
+    expect(calls.some(c => c.includes('pr merge') || c.includes('auto-complete') || c.includes('--auto'))).toBe(true)
+  })
+
+  it('code change → reviewer approves → auto-armed', async () => {
+    const { fn } = mockShell({ changed: ['src/login.ts'] })
+    const r = await runCodingTask(input, baseDeps({ shell: fn, reviewer: async () => ({ approved: true, reason: 'ok' }) }))
+    expect(r.decision?.classification).toBe('code')
+    expect(r.outcome).toBe('auto-armed')
+  })
+
+  it('code change → reviewer blocks → reviewer-blocked, no merge', async () => {
+    const { fn, calls } = mockShell({ changed: ['src/login.ts'] })
+    const r = await runCodingTask(input, baseDeps({ shell: fn, reviewer: async () => ({ approved: false, reason: 'bug' }) }))
+    expect(r.outcome).toBe('reviewer-blocked')
+    expect(calls.some(c => c.includes('--auto'))).toBe(false)
+  })
+
+  it('agent-judged risk → awaiting-human, never merges', async () => {
+    const { fn, calls } = mockShell({ changed: ['src/login.ts'] })
+    const r = await runCodingTask(input, baseDeps({ shell: fn, riskAssessor: async () => ({ risky: true, reason: 'auth' }) }))
+    expect(r.outcome).toBe('awaiting-human')
+    expect(r.decision?.classification).toBe('risk')
+    expect(calls.some(c => c.includes('--auto'))).toBe(false)
+  })
+
+  it('config/derived risk path → awaiting-human', async () => {
+    const { fn } = mockShell({ changed: ['infra/prod.tf'] })
+    const r = await runCodingTask(input, baseDeps({ shell: fn }))
+    expect(r.outcome).toBe('awaiting-human')
+  })
+
+  it('no changes → run-failed (no empty PR)', async () => {
+    const { fn } = mockShell({ changed: [] })
+    const r = await runCodingTask(input, baseDeps({ shell: fn }))
+    expect(r.outcome).toBe('run-failed')
+    expect(r.reason).toMatch(/no changes/)
+  })
+
+  it('worktree create failure → run-failed', async () => {
+    const { fn } = mockShell({ changed: ['x'], createExit: 1 })
+    const r = await runCodingTask(input, baseDeps({ shell: fn }))
+    expect(r.outcome).toBe('run-failed')
+    expect(r.reason).toMatch(/worktree create failed/)
+  })
+
+  it('coding loop error → run-failed', async () => {
+    const { fn } = mockShell({ changed: ['x'] })
+    const r = await runCodingTask(input, baseDeps({ shell: fn, runLoopImpl: async () => ({ status: 'error', finalMessage: null, stepCount: 2, trace: [] }) }))
+    expect(r.outcome).toBe('run-failed')
+  })
+})
+
+describe('llm-review (fail-safe)', () => {
+  function fetchReturning(json: unknown): typeof fetch {
+    return (async () => ({ ok: true, json: async () => ({ choices: [{ message: { content: JSON.stringify(json) } }] }) })) as unknown as typeof fetch
+  }
+  const fetchErroring = (async () => ({ ok: false, json: async () => ({}) })) as unknown as typeof fetch
+
+  it('risk assessor parses model verdict', async () => {
+    const a = createLlmRiskAssessor(runtimeConfig, fetchReturning({ risky: true, reason: 'auth change' }))
+    expect(await a({ paths: ['x'], diff: 'd' })).toMatchObject({ risky: true, reason: 'auth change' })
+  })
+
+  it('risk assessor fails safe to risky on error', async () => {
+    const a = createLlmRiskAssessor(runtimeConfig, fetchErroring)
+    expect((await a({ paths: ['x'], diff: 'd' })).risky).toBe(true)
+  })
+
+  it('reviewer parses + fails safe to blocked', async () => {
+    const ok = createLlmReviewer(runtimeConfig, fetchReturning({ approved: true, reason: 'lgtm' }))
+    expect((await ok({ prRef: 1, diff: 'd', classification: 'code' })).approved).toBe(true)
+    const bad = createLlmReviewer(runtimeConfig, fetchErroring)
+    expect((await bad({ prRef: 1, diff: 'd', classification: 'code' })).approved).toBe(false)
+  })
+})


### PR DESCRIPTION
Integration layer on top of the merged M1–M7 library (#464, #465). Makes "a coding agent" real: issue → worktree → LLM coding → verify → PR → policy-gated merge.

## What

- **`coding/coding-loop.ts`** (INT-1) — `runCodingTask(input, deps)` orchestrator. Division of responsibility:
  - **LLM does the coding**: `file.edit` / `bash` / `verify` (NOT `forge.pr.merge` — a `gh pr merge` via bash needs a grant the agent doesn't hold, so it can't self-merge).
  - **Orchestrator owns policy**: branch + worktree lifecycle, opens the PR, computes the real diff, runs risk-assessor + reviewer gate, arms `--auto` (merge-when-green) only when the gate passes. Branch protection is the server-side CI gate.
- **`coding/llm-review.ts`** (INT-2) — LLM-backed `RiskAssessorFn` + `ReviewerFn`. **Fail-safe**: model error/unparseable → risk assessor returns risky, reviewer blocks. Never degrades toward silent auto-merge.
- **`examples/agent-recipes/coding-agent/`** (INT-3) — deployable recipe (`ape-agent.yaml` + README). Per-repo policy lives in the target repo's `.openape/coding.json` (verify command, branch template, merge policy) — not in the recipe or library.

## Safety invariants (carried from the library)
- Risk = agent judgment ∪ repo config ∪ derived signals; **zero hardcoded** risk paths.
- Auto-merge opt-in per repo (`autoMergeEnabled` false by default).
- Merge never bypasses required checks (branch protection).
- All shell via the gated `runApeShell`.

## Test plan
- [x] `pnpm --filter @openape/apes typecheck` ✓
- [x] `pnpm --filter @openape/apes test` — 728 passed / 3 skipped (11 new: orchestrator chore/code/risk/reviewer-block/no-changes/worktree-fail/loop-error outcomes; llm-review parse + fail-safe)
- [x] `pnpm --filter @openape/apes lint` — 0 errors
- [ ] **Dogfood** after deploy: real agent picks up an issue → PR.

## Remaining (next)
- **INT-4 recipe update** (you flagged it): intent/tools/schedules already hot-update via `apes agents sync`; remaining gap is making `apes agent deploy` an idempotent upsert + new-capability binding. Specced in the plan.
- **REL** publish apes · **deploy** spawn the agent with a GH token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)