### PR TITLE
feat(apes): apes agents code — coding-agent trigger entrypoint

### DIFF
--- a/.changeset/coding-agent-cli.md
+++ b/.changeset/coding-agent-cli.md
@@ -1,0 +1,5 @@
+---
+"@openape/apes": minor
+---
+
+`apes agents code` — the coding-agent trigger entrypoint. Runs one coding task (`--issue <ref> --repo <url> [--forge]`) or polls a label (`--poll-label`), wiring the orchestrator (`runCodingTask`) with the LLM reviewer + risk assessor, the coding toolset (file.*/bash/verify/forge-read — no pr.merge), and per-repo policy resolved from the cloned worktree (`.openape/coding.json` + derived signals). The recipe's cron schedule calls this in `--poll-label` mode. Also: `runCodingTask` now accepts `resolvePolicy(worktree)` to load policy lazily from the clone.

--- a/packages/apes/src/commands/agents/code.ts
+++ b/packages/apes/src/commands/agents/code.ts
@@ -1,0 +1,127 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import process from 'node:process'
+import { defineCommand } from 'citty'
+import { consola } from 'consola'
+import type { RuntimeConfig } from '../../lib/agent-runtime'
+import { taskTools } from '../../lib/agent-tools'
+import { runApeShell } from '../../lib/agent-tools/ape-shell-exec'
+import { runCodingTask } from '../../lib/coding/coding-loop'
+import { buildIssueGet, detectForge } from '../../lib/coding/forge'
+import type { Forge } from '../../lib/coding/forge'
+import type { IssueRef } from '../../lib/coding/issue-task'
+import { createLlmReviewer, createLlmRiskAssessor } from '../../lib/coding/llm-review'
+import { resolveMergePolicy } from '../../lib/coding/derive-policy'
+
+class CliError extends Error {}
+
+// The LLM toolset for coding — file.*/bash/verify + read-only forge.
+// Deliberately NO forge.pr.merge (the orchestrator owns merge).
+const CODING_TOOLS = ['file.read', 'file.write', 'file.edit', 'bash', 'git.worktree', 'verify', 'forge.issue.get', 'forge.pr.status']
+
+const DEFAULT_PERSONA = [
+  'You are an autonomous coding agent. You implement an assigned issue in',
+  'the provided git worktree: read the relevant code, make small targeted',
+  'edits with file.edit, and make the repo verification command pass via',
+  'the verify tool. Do not open or merge PRs — the orchestrator does that.',
+  'No change is done until verify is green.',
+].join(' ')
+
+function readLitellmConfig(model?: string): RuntimeConfig {
+  const env: Record<string, string> = {}
+  const envPath = join(homedir(), 'litellm', '.env')
+  if (existsSync(envPath)) {
+    for (const raw of readFileSync(envPath, 'utf8').split('\n')) {
+      const line = raw.trim()
+      const m = /^([A-Z_][A-Z0-9_]*)=(.*)$/.exec(line)
+      if (m) env[m[1]!] = m[2]!.trim().replace(/^["']|["']$/g, '')
+    }
+  }
+  for (const k of ['LITELLM_API_KEY', 'LITELLM_MASTER_KEY', 'LITELLM_BASE_URL']) {
+    if (process.env[k]) env[k] = process.env[k]!
+  }
+  const apiKey = env.LITELLM_API_KEY || env.LITELLM_MASTER_KEY
+  const apiBase = (env.LITELLM_BASE_URL || 'http://127.0.0.1:4000/v1').replace(/\/$/, '')
+  if (!apiKey) throw new CliError('No LITELLM_API_KEY / LITELLM_MASTER_KEY in ~/litellm/.env or env.')
+  return { apiBase, apiKey, model: model || process.env.APE_CHAT_BRIDGE_MODEL || 'claude-haiku-4-5' }
+}
+
+function readPersona(file?: string): string {
+  if (file && existsSync(file)) return readFileSync(file, 'utf8')
+  const agentJson = join(homedir(), '.openape', 'agent', 'agent.json')
+  if (existsSync(agentJson)) {
+    try {
+      const p = JSON.parse(readFileSync(agentJson, 'utf8')) as { systemPrompt?: string }
+      if (p.systemPrompt?.trim()) return p.systemPrompt
+    }
+    catch { /* fall through */ }
+  }
+  return DEFAULT_PERSONA
+}
+
+async function fetchIssue(forge: Forge, ref: string): Promise<IssueRef> {
+  const res = await runApeShell(buildIssueGet(forge, ref))
+  if (res.exit_code !== 0) throw new CliError(`could not fetch issue ${ref}: ${res.stderr.slice(0, 200)}`)
+  const j = JSON.parse(res.stdout) as { number?: number, id?: number, title?: string, fields?: { 'System.Title'?: string }, body?: string }
+  const number = j.number ?? j.id ?? Number(ref)
+  const title = j.title ?? j.fields?.['System.Title'] ?? `issue ${ref}`
+  return { number, title, body: j.body }
+}
+
+export const codeAgentCommand = defineCommand({
+  meta: {
+    name: 'code',
+    description: 'Run a coding task: issue to worktree to edit to verify to PR (policy-gated merge). The agent never self-merges.',
+  },
+  args: {
+    'issue': { type: 'string', description: 'Issue / work-item ref to work on.' },
+    'repo': { type: 'string', description: 'Git remote URL of the target repo.', required: true },
+    'forge': { type: 'string', description: 'github | azure | registered forge. Auto-detected from --repo if omitted.' },
+    'model': { type: 'string', description: 'Override LLM model.' },
+    'max-steps': { type: 'string', description: 'Max tool-call rounds (default 40).' },
+    'persona-file': { type: 'string', description: 'File with the agent persona/system prompt.' },
+    'poll-label': { type: 'string', description: 'Poll mode: work all open issues with this label.' },
+  },
+  async run({ args }) {
+    const repo = args.repo as string
+    const forge: Forge = (args.forge as string) || detectForge(repo)
+    const config = readLitellmConfig(args.model as string | undefined)
+    const persona = readPersona(args['persona-file'] as string | undefined)
+    const maxSteps = Number(args['max-steps']) > 0 ? Number(args['max-steps']) : 40
+    const tools = taskTools(CODING_TOOLS)
+
+    const deps = {
+      runtimeConfig: config,
+      tools,
+      persona,
+      maxSteps,
+      resolvePolicy: (worktree: string) => resolveMergePolicy(worktree),
+      reviewer: createLlmReviewer(config),
+      riskAssessor: createLlmRiskAssessor(config),
+      log: (l: string) => consola.info(l),
+    }
+
+    // Determine the issue list (single or poll).
+    const refs: string[] = []
+    if (args['poll-label']) {
+      const slug = repo.replace(/^https:\/\/github\.com\//, '').replace(/\.git$/, '')
+      const list = await runApeShell(`gh issue list --repo ${slug} --label '${args['poll-label']}' --state open --json number --jq '.[].number'`)
+      refs.push(...list.stdout.split('\n').map(s => s.trim()).filter(Boolean))
+      if (refs.length === 0) { consola.info('no open issues with that label'); return }
+    }
+    else if (args.issue) {
+      refs.push(args.issue as string)
+    }
+    else {
+      throw new CliError('provide --issue <ref> or --poll-label <label>')
+    }
+
+    for (const ref of refs) {
+      const issue = await fetchIssue(forge, ref)
+      consola.start(`coding issue #${issue.number}: ${issue.title}`)
+      const result = await runCodingTask({ issue, repo, forge }, deps)
+      consola.box(`#${issue.number} -> ${result.outcome}\nPR: ${result.prRef ?? '(none)'}\n${result.reason}`)
+    }
+  },
+})

--- a/packages/apes/src/commands/agents/index.ts
+++ b/packages/apes/src/commands/agents/index.ts
@@ -1,6 +1,7 @@
 import { defineCommand } from 'citty'
 import { allowAgentCommand } from './allow'
 import { cleanupOrphansCommand } from './cleanup-orphans'
+import { codeAgentCommand } from './code'
 import { destroyAgentCommand } from './destroy'
 import { listAgentsCommand } from './list'
 import { registerAgentCommand } from './register'
@@ -12,7 +13,7 @@ import { syncAgentCommand } from './sync'
 export const agentsCommand = defineCommand({
   meta: {
     name: 'agents',
-    description: 'Manage owned agents (register, spawn, list, destroy, allow, sync, run, serve, cleanup-orphans)',
+    description: 'Manage owned agents (register, spawn, list, destroy, allow, sync, run, serve, code, cleanup-orphans)',
   },
   subCommands: {
     register: registerAgentCommand,
@@ -23,6 +24,7 @@ export const agentsCommand = defineCommand({
     sync: syncAgentCommand,
     run: runAgentCommand,
     serve: serveAgentCommand,
+    code: codeAgentCommand,
     'cleanup-orphans': cleanupOrphansCommand,
   },
 })

--- a/packages/apes/src/lib/coding/coding-loop.ts
+++ b/packages/apes/src/lib/coding/coding-loop.ts
@@ -23,7 +23,7 @@ import { buildPrCreate, buildPrMerge  } from './forge'
 import type { Forge } from './forge'
 import type { IssueRef, BranchNaming  } from './issue-task'
 import { buildBranchName, buildTaskPrompt } from './issue-task'
-import { decideMerge } from './merge-policy'
+import { decideMerge, SECURE_DEFAULT_POLICY } from './merge-policy'
 import type { MergeDecision, MergePolicy, RiskAssessorFn } from './merge-policy'
 import { gateMerge } from './review-gate'
 import type { ReviewerFn } from './review-gate'
@@ -46,7 +46,11 @@ export interface CodingTaskDeps {
   tools: ToolDefinition[]
   persona: string
   maxSteps: number
-  policy: MergePolicy
+  // Static policy, OR resolvePolicy to load it from the cloned worktree
+  // (e.g. the repo's .openape/coding.json + derived signals). When both
+  // are absent the secure default applies (auto-merge off).
+  policy?: MergePolicy
+  resolvePolicy?: (worktree: string) => Promise<MergePolicy>
   reviewer: ReviewerFn
   riskAssessor: RiskAssessorFn
   branchNaming?: BranchNaming
@@ -95,6 +99,12 @@ export async function runCodingTask(input: CodingTaskInput, deps: CodingTaskDeps
     return { branch, worktree, runStatus: 'error', changedFiles: [], outcome: 'run-failed', reason: `worktree create failed: ${wt.stderr.slice(0, 300)}` }
   }
 
+  // Resolve the merge policy from the cloned repo (config + derived
+  // signals), or use the static one, or the secure default.
+  const policy = deps.resolvePolicy
+    ? await deps.resolvePolicy(worktree)
+    : (deps.policy ?? SECURE_DEFAULT_POLICY)
+
   // 2. LLM does the coding (it has file.*/bash/verify; NOT pr.merge).
   const prompt = buildTaskPrompt(input.issue, { persona: deps.persona })
   const run = await loop({
@@ -119,7 +129,7 @@ export async function runCodingTask(input: CodingTaskInput, deps: CodingTaskDeps
 
   // 4. Risk + merge decision (agent judgment ∪ config/derived).
   const agentRisk = await deps.riskAssessor({ paths: changedFiles, diff })
-  const decision = decideMerge(changedFiles, deps.policy, agentRisk)
+  const decision = decideMerge(changedFiles, policy, agentRisk)
   log(`[coding] decision=${decision.classification} (${decision.reason})`)
 
   // 5. Commit + push + open the PR (orchestrator owns this).


### PR DESCRIPTION
The entrypoint that makes the coding agent runnable end-to-end.

`apes agents code`:
- `--issue <ref> --repo <url> [--forge github|azure]` — run one coding task.
- `--poll-label <label>` — work all open issues with that label (the recipe's cron uses this).

Wires `runCodingTask` (orchestrator) + LLM `reviewer`/`riskAssessor` (fail-safe) + the coding toolset (file.*/bash/verify/forge-read — **no pr.merge**) + per-repo policy resolved from the cloned worktree (`.openape/coding.json` + derived deploy-filter/CODEOWNERS signals). LLM/runtime config from `~/litellm/.env`.

Also: `runCodingTask` now accepts `resolvePolicy(worktree)` so policy loads lazily from the clone (the orchestrator can't know it before cloning).

## Test plan
- [x] typecheck + 728 tests + lint clean
- [x] `apes agents code --help` registered + documented
- [ ] Dogfood: `apes agents code --issue <n> --repo <url>` → PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)