### PR TITLE
feat: coding-agent auto-trigger (INT-1b) + recipe set/update from troop (INT-4)

### DIFF
--- a/.changeset/coding-agent-cron-trigger.md
+++ b/.changeset/coding-agent-cron-trigger.md
@@ -1,0 +1,6 @@
+---
+"@openape/apes": minor
+"@openape/ape-agent": minor
+---
+
+Coding-agent auto-trigger (INT-1b). The cron-runner now supports deterministic `command` tasks: when a task spec carries a `command`, the runner executes it via the gated ape-shell path instead of an LLM runLoop — no model round-trip just to fire a fixed command. `runApeShell` is now exported from `@openape/apes`. The coding-agent recipe's schedule runs `apes agents code --poll-label …` so a deployed agent polls for assigned issues and works them. (Until the recipe→task `command` field is threaded through troop, the recipe schedule expresses the poll as an explicit bash command — the portable fallback.)

--- a/apps/openape-ape-agent/src/cron-runner.ts
+++ b/apps/openape-ape-agent/src/cron-runner.ts
@@ -20,7 +20,7 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import type { RuntimeConfig } from '@openape/apes'
-import { runLoop, taskTools } from '@openape/apes'
+import { runApeShell, runLoop, taskTools } from '@openape/apes'
 import type { ChatApi } from './chat-api'
 
 const TASK_CACHE_DIR = join(homedir(), '.openape', 'agent', 'tasks')
@@ -39,6 +39,12 @@ interface TaskSpec {
   tools: string[]
   maxSteps: number
   enabled: boolean
+  // Deterministic tasks (e.g. the coding-agent's issue poll): when set,
+  // the runner executes this command via the gated ape-shell path
+  // instead of an LLM runLoop — no model round-trip just to fire a fixed
+  // command. Used by the coding-agent recipe's schedule to run
+  // `apes agents code --poll-label …`.
+  command?: string
 }
 
 interface CronExpr {
@@ -293,8 +299,33 @@ export class CronRunner {
   private async runTask(
     sessionId: string,
     systemPrompt: string,
-    spec: { tools: string[], maxSteps: number, userPrompt: string },
+    spec: { tools: string[], maxSteps: number, userPrompt: string, command?: string },
   ): Promise<void> {
+    // Deterministic command task (e.g. coding-agent poll) — run it via
+    // the gated ape-shell path, no LLM round-trip. The command itself
+    // (apes agents code …) drives the LLM coding loop internally.
+    if (spec.command) {
+      try {
+        const res = await runApeShell(spec.command, 30 * 60 * 1000)
+        const turn = this.pending.get(sessionId)
+        if (!turn) return
+        turn.status = res.exit_code === 0 ? 'ok' : 'error'
+        turn.accumulated = `\`${spec.command}\` exited ${res.exit_code}\n\n${(res.stdout || res.stderr).slice(0, 4000)}`
+        await this.finaliseRun(turn, 1)
+        await this.postResult(sessionId, turn)
+        this.pending.delete(sessionId)
+      }
+      catch (err) {
+        const turn = this.pending.get(sessionId)
+        if (!turn) return
+        turn.status = 'error'
+        turn.accumulated = `(command error: ${err instanceof Error ? err.message : String(err)})`
+        await this.finaliseRun(turn, 0)
+        await this.postResult(sessionId, turn)
+        this.pending.delete(sessionId)
+      }
+      return
+    }
     try {
       const result = await runLoop({
         config: this.deps.runtimeConfig,

--- a/apps/openape-troop/app/pages/agents/[name].vue
+++ b/apps/openape-troop/app/pages/agents/[name].vue
@@ -135,6 +135,38 @@ async function saveSystemPrompt() {
   }
 }
 
+// Set / update the recipe on this existing agent (INT-4). Re-materializes
+// <repo>@<ref> and applies its intent + toolset live (no respawn).
+const recipeRef = ref('')
+const recipeParams = ref('{}')
+const recipeSaving = ref(false)
+const recipeError = ref('')
+const recipeResult = ref<{ ref: string, required_capabilities: string[] } | null>(null)
+
+async function applyRecipe() {
+  if (!recipeRef.value.trim()) return
+  recipeSaving.value = true
+  recipeError.value = ''
+  recipeResult.value = null
+  try {
+    let params: Record<string, unknown> = {}
+    if (recipeParams.value.trim()) params = JSON.parse(recipeParams.value)
+    const res = await ($fetch as any)(`/api/agents/${agentName.value}/recipe`, {
+      method: 'POST',
+      body: { repo_ref: recipeRef.value.trim(), params },
+    })
+    recipeResult.value = { ref: res.ref, required_capabilities: res.required_capabilities ?? [] }
+    // Refresh the system prompt the editor shows.
+    if (detail.value) detail.value.agent.systemPrompt = (await ($fetch as any)(`/api/agents/${agentName.value}`)).agent.systemPrompt
+  }
+  catch (err: any) {
+    recipeError.value = err?.data?.statusMessage || err?.message || 'apply failed'
+  }
+  finally {
+    recipeSaving.value = false
+  }
+}
+
 // Agent-level tool whitelist editor — saved on toggle via PATCH
 // /api/agents/[name] with `tools: string[]`. The bridge re-reads the
 // list from agent.json on every new chat thread, so changes
@@ -607,6 +639,41 @@ onBeforeUnmount(() => { if (destroyPollTimer) clearTimeout(destroyPollTimer) })
               <div v-if="systemPromptDirty" class="flex justify-end mt-3">
                 <UButton size="sm" color="primary" :loading="systemPromptSaving" @click="saveSystemPrompt">
                   Save
+                </UButton>
+              </div>
+            </div>
+          </details>
+        </UCard>
+
+        <!-- Set / update the recipe on this existing agent (INT-4).
+             Re-materializes <repo>@<ref> and applies its intent + tools
+             live; the nest re-syncs within ~1s. -->
+        <UCard :ui="{ body: 'p-0' }">
+          <details class="group">
+            <summary class="cursor-pointer list-none px-4 py-3 flex items-center justify-between gap-2">
+              <div class="flex items-center gap-2 text-sm">
+                <UIcon name="i-lucide-package" class="text-muted size-4" />
+                <span class="font-medium">Recipe</span>
+              </div>
+              <UIcon name="i-lucide-chevron-down" class="size-4 text-muted transition-transform group-open:rotate-180" />
+            </summary>
+            <div class="px-4 pb-4 pt-3 border-t border-(--ui-border) space-y-3">
+              <UFormField label="Recipe ref" description="owner/repo@ref (pinned), e.g. openape-ai/coding-agent@main">
+                <UInput v-model="recipeRef" placeholder="openape-ai/coding-agent@main" class="w-full" :ui="{ base: 'w-full' }" />
+              </UFormField>
+              <UFormField label="Params (JSON)" description="e.g. {&quot;repo&quot;:&quot;https://github.com/openape-ai/openape.git&quot;,&quot;forge&quot;:&quot;github&quot;}">
+                <UTextarea v-model="recipeParams" :rows="2" class="w-full" :ui="{ base: 'w-full' }" />
+              </UFormField>
+              <UAlert v-if="recipeError" color="error" :title="recipeError" />
+              <UAlert
+                v-if="recipeResult"
+                color="success"
+                :title="`Applied ${recipeResult.ref}`"
+                :description="recipeResult.required_capabilities.length ? `Bind secrets: ${recipeResult.required_capabilities.join(', ')}` : 'No new secrets required.'"
+              />
+              <div class="flex justify-end">
+                <UButton size="sm" color="primary" :loading="recipeSaving" :disabled="!recipeRef.trim()" @click="applyRecipe">
+                  Set / update recipe
                 </UButton>
               </div>
             </div>

--- a/apps/openape-troop/server/api/agents/[name]/recipe.post.ts
+++ b/apps/openape-troop/server/api/agents/[name]/recipe.post.ts
@@ -1,0 +1,70 @@
+import { and, eq } from 'drizzle-orm'
+import { z } from 'zod'
+import { useDb } from '../../../database/drizzle'
+import { agents } from '../../../database/schema'
+import { materializeRecipe } from '../../../utils/agent-recipe'
+import { requireOwner } from '../../../utils/auth'
+import { broadcastToOwner } from '../../../utils/nest-registry'
+import { buildDeployPlan, fetchRecipeManifest, RECIPE_AGENT_TOOLS } from '../../../utils/recipe-deploy'
+
+// POST /api/agents/:name/recipe — set / update the recipe on an EXISTING
+// agent (INT-4). Re-fetches <repo>@<ref>'s ape-agent.yaml, re-validates
+// + materializes it with the given params, and applies the resulting
+// intent + toolset to the live agent (no destroy/respawn). The nest
+// re-syncs within ~1s (config-update broadcast); the bridge picks up the
+// new system prompt on the next run. New capability secrets are returned
+// so the UI can prompt the owner to bind them (sealed) via
+// /api/agents/:name/secrets/:env.
+//
+// This is the "iterate on a deployed agent" path: change the recipe,
+// re-point the agent at the new ref, done.
+const bodySchema = z.object({
+  repo_ref: z.string().min(3).max(400),
+  params: z.record(z.string(), z.unknown()).default({}),
+})
+
+export default defineEventHandler(async (event) => {
+  const owner = await requireOwner(event)
+  const name = getRouterParam(event, 'name')
+  if (!name) {
+    throw createError({ statusCode: 400, statusMessage: 'name is required' })
+  }
+  const body = bodySchema.safeParse(await readBody(event))
+  if (!body.success) {
+    throw createError({ statusCode: 400, statusMessage: body.error.issues[0]?.message ?? 'invalid body' })
+  }
+
+  const manifest = await fetchRecipeManifest(body.data.repo_ref, async (url) => {
+    const r = await fetch(url)
+    return { ok: r.ok, status: r.status, text: await r.text() }
+  })
+  if (!manifest.ok) throw createError({ statusCode: 400, statusMessage: manifest.reason })
+
+  const mat = materializeRecipe(manifest.recipe, body.data.params)
+  if (!mat.ok) throw createError({ statusCode: 400, statusMessage: mat.reason })
+
+  const plan = buildDeployPlan(manifest.recipe, mat.value, { agentName: name })
+
+  const db = useDb()
+  const result = await db
+    .update(agents)
+    .set({ systemPrompt: plan.systemPrompt, tools: [...RECIPE_AGENT_TOOLS] })
+    .where(and(eq(agents.ownerEmail, owner.toLowerCase()), eq(agents.agentName, name)))
+    .returning()
+
+  if (result.length === 0) {
+    throw createError({ statusCode: 404, statusMessage: 'agent not found' })
+  }
+
+  const agent = result[0]!
+  // Re-sync the named agent on any connected nest (same path as the
+  // PATCH endpoint) so the new intent lands on disk within ~1s.
+  broadcastToOwner(agent.ownerEmail, { type: 'config-update', agent_email: agent.email })
+
+  return {
+    agent_name: agent.agentName,
+    ref: manifest.ref,
+    required_capabilities: plan.requiredCapabilities,
+    schedules: plan.schedules.map(s => ({ task_id: s.taskId, cron: s.cron, name: s.name })),
+  }
+})

--- a/examples/agent-recipes/coding-agent/ape-agent.yaml
+++ b/examples/agent-recipes/coding-agent/ape-agent.yaml
@@ -37,11 +37,18 @@ params:
     type: string
     required: true
 
-# Poll for assigned issues. The cron-driven trigger fetches issues
-# labelled for the agent and runs one coding task each.
+# Poll for assigned issues every 10 minutes. The schedule description is
+# the task the agent runs: an explicit, deterministic command. Run it via
+# your bash tool exactly as written and report the outcome — do not
+# improvise. (When the cron task carries a `command` field the runner
+# executes it directly without this LLM round-trip; the wording here is
+# the portable fallback.)
 schedules:
   - cron: "*/10 * * * *"
-    description: poll {{repo}} for assigned issues and work them
+    description: |
+      Run exactly this shell command via your bash tool and report the result,
+      nothing else:
+        apes agents code --poll-label agent --repo {{repo}} --forge {{forge}}
 
 user_addendum: true
 

--- a/packages/apes/src/index.ts
+++ b/packages/apes/src/index.ts
@@ -62,3 +62,5 @@ export type {
 } from './lib/agent-runtime'
 export { taskTools, TOOLS } from './lib/agent-tools'
 export type { ToolDefinition } from './lib/agent-tools'
+export { runApeShell } from './lib/agent-tools/ape-shell-exec'
+export type { ApeShellResult } from './lib/agent-tools/ape-shell-exec'


### PR DESCRIPTION
The last two integration pieces for a self-running, iterable coding agent.

## INT-1b — cron auto-trigger (`@openape/apes` + `@openape/ape-agent`)
- cron-runner gains deterministic **`command` tasks**: when a task carries a `command`, the runner executes it via the gated ape-shell path instead of an LLM runLoop — no model round-trip to fire a fixed command.
- `runApeShell` exported from `@openape/apes`.
- The `coding-agent` recipe schedule runs `apes agents code --poll-label agent --repo {{repo}} --forge {{forge}}` every 10 min → a deployed agent polls + works assigned issues. (Until the recipe→task `command` field is threaded through troop, the schedule expresses the poll as an explicit bash command — portable fallback that works today.)

## INT-4 — set/update recipe on an existing agent (`@openape/troop`)
- **`POST /api/agents/:name/recipe`** — re-fetches `<repo>@<ref>`, re-materializes with params, applies the intent + toolset to the **live** agent (no destroy/respawn), broadcasts `config-update` → nest re-syncs in ~1s. Returns required capabilities so the owner can bind new sealed secrets. Reuses the existing `fetchRecipeManifest`/`materializeRecipe`/`buildDeployPlan` + the same update+broadcast pattern as `[name].patch.ts`.
- **Agent detail UI**: a "Recipe" card (ref + params + apply) on `agents/[name].vue`.
- This is the "iterate on a deployed agent" path Patrick asked for: change the recipe, re-point at the new ref from troop, done.

**Why this works cleanly:** `apes agents sync` already reconciles `system_prompt`/`tools`/`schedules` from troop every cycle, so applying a re-materialized recipe to the agent record propagates to the host automatically.

## Test plan
- [x] apes typecheck + 728 tests + lint clean
- [x] ape-agent typecheck + 35 tests + lint clean
- [x] troop typecheck + lint clean (new endpoint + UI card)
- [ ] Dogfood after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)