### PR TITLE
fix(coding-agent): repeatable deploy flags + optional capabilities

### DIFF
--- a/.changeset/coding-agent-deploy-fix.md
+++ b/.changeset/coding-agent-deploy-fix.md
@@ -1,0 +1,12 @@
+---
+"@openape/apes": patch
+---
+
+fix(agent deploy): collect repeated `--param`/`--secret` flags from raw argv
+
+citty 0.2.2 coerces a repeated `type:'string'` flag to its last value only,
+so `apes agent deploy --param repo=… --param forge=…` silently dropped every
+param but the last and troop rejected the deploy with "missing required
+param". Deploy now parses all occurrences straight from `ctx.rawArgs`. Also
+bind supplied secrets even when no capability is strictly required, so
+optional capabilities passed via `--secret` are still sealed to the agent.

--- a/apps/openape-troop/server/utils/agent-recipe.ts
+++ b/apps/openape-troop/server/utils/agent-recipe.ts
@@ -24,6 +24,13 @@ const capabilitySchema = z.object({
   // broker and owns the lifecycle; `prefer` is a hint only.
   env: z.string().min(1).regex(/^[A-Z][A-Z0-9_]*$/, 'capability env must be UPPER_SNAKE_CASE'),
   prefer: z.enum(['proxy', 'local']).optional(),
+  // A recipe that supports several backends (e.g. a coding agent that can
+  // target different forges) declares a capability per backend but needs
+  // only the one matching the deploy. Optional capabilities are offered,
+  // never required: deploy binds them when supplied and skips them
+  // otherwise. The agent surfaces a clear runtime error if it later needs
+  // a credential that was never bound.
+  optional: z.boolean().default(false),
   description: z.string().optional(),
 })
 

--- a/apps/openape-troop/server/utils/recipe-deploy.ts
+++ b/apps/openape-troop/server/utils/recipe-deploy.ts
@@ -69,7 +69,7 @@ export function buildDeployPlan(recipe: AgentRecipe, mat: MaterializedRecipe, op
     systemPrompt: mat.intent,
     ...(opts.userAddendum ? { userAddendum: opts.userAddendum } : {}),
     schedules,
-    requiredCapabilities: recipe.capabilities.map(c => c.env),
+    requiredCapabilities: recipe.capabilities.filter(c => !c.optional).map(c => c.env),
   }
 }
 

--- a/apps/openape-troop/tests/recipe-deploy.test.ts
+++ b/apps/openape-troop/tests/recipe-deploy.test.ts
@@ -47,6 +47,34 @@ describe('buildDeployPlan', () => {
     expect(plan.schedules[1]!.userPrompt).toMatch(/Run your configured task/)
   })
 
+  it('excludes optional capabilities from requiredCapabilities (multi-forge recipe)', () => {
+    const manifest = `
+name: coding-agent
+kind: agent
+intent: Code on {{repo}}.
+capabilities:
+  - env: GH_TOKEN
+    optional: true
+  - env: AZ_PAT
+    optional: true
+  - env: LLM_API_KEY
+params:
+  - name: repo
+    type: string
+    required: true
+schedules:
+  - cron: "*/10 * * * *"
+`
+    const r = parseRecipe(manifest)
+    if (!r.ok) throw new Error(r.reason)
+    const mat = materializeRecipe(r.value, { repo: 'x/y' })
+    if (!mat.ok) throw new Error(mat.reason)
+    const plan = buildDeployPlan(r.value, mat.value)
+    // Only the non-optional capability is required at deploy time; the
+    // forge tokens are offered, not demanded.
+    expect(plan.requiredCapabilities).toEqual(['LLM_API_KEY'])
+  })
+
   it('honours an agent-name override + additive userAddendum (recipe is additive to a named spawn)', () => {
     const rec = recipe()
     const mat = materializeRecipe(rec, { topic: 'AI agents' })

--- a/examples/agent-recipes/coding-agent/ape-agent.yaml
+++ b/examples/agent-recipes/coding-agent/ape-agent.yaml
@@ -23,11 +23,17 @@ intent: |
   (auth, secrets, migrations, deploy/CI config, payments, data deletion),
   say so explicitly — it will require human approval.
 
+# A deployment targets exactly one forge (the `forge` param), so only the
+# matching token is needed — both are optional and the deploy binds
+# whichever you supply via --secret. GitHub → GH_TOKEN, Azure DevOps →
+# AZ_PAT. Other forges: add the capability your forge adapter reads.
 capabilities:
   - env: GH_TOKEN
     prefer: local
+    optional: true
   - env: AZ_PAT
     prefer: local
+    optional: true
 
 params:
   - name: repo

--- a/packages/apes/src/commands/agent/deploy.ts
+++ b/packages/apes/src/commands/agent/deploy.ts
@@ -26,10 +26,28 @@ export function missingCapabilities(required: string[], provided: Record<string,
   return required.filter(env => !(env in provided))
 }
 
-function asArray(v: unknown): string[] {
-  if (Array.isArray(v)) return v as string[]
-  if (typeof v === 'string' && v.length > 0) return [v]
-  return []
+// citty 0.2.2 coerces a repeated `type:'string'` flag to its LAST value
+// only (`--param a=1 --param b=2` → "b=2"), silently dropping earlier
+// occurrences. Collect every occurrence straight from the raw argv so
+// multiple --param / --secret flags all survive. Handles both
+// `--flag value` and `--flag=value` forms.
+export function collectFlag(rawArgs: string[], name: string): string[] {
+  const out: string[] = []
+  const long = `--${name}`
+  for (let i = 0; i < rawArgs.length; i++) {
+    const a = rawArgs[i]!
+    if (a === long) {
+      const v = rawArgs[i + 1]
+      if (v !== undefined && !v.startsWith('--')) {
+        out.push(v)
+        i++
+      }
+    }
+    else if (a.startsWith(`${long}=`)) {
+      out.push(a.slice(long.length + 1))
+    }
+  }
+  return out
 }
 
 interface DeployResponse {
@@ -63,11 +81,11 @@ export const deployAgentCommand = defineCommand({
     'host-id': { type: 'string', description: 'Target nest host_id (default: first connected)' },
     json: { type: 'boolean', description: 'Machine-readable output, no prompts' },
   },
-  async run({ args }) {
+  async run({ args, rawArgs }) {
     const repoRef = args.repo as string
     if (!repoRef) throw new CliError('usage: apes agent deploy <repo>@<ref> [--param k=v] [--secret ENV=val]')
-    const params = parseKeyValues(asArray(args.param))
-    const secrets = parseKeyValues(asArray(args.secret))
+    const params = parseKeyValues(collectFlag(rawArgs, 'param'))
+    const secrets = parseKeyValues(collectFlag(rawArgs, 'secret'))
     const json = !!args.json
 
     const token = (await ensureFreshIdpAuth()).access_token
@@ -103,8 +121,10 @@ export const deployAgentCommand = defineCommand({
 
     // Wait for the agent to come online (spawn-result), then bind the
     // sealed secrets. Binding 409s until the agent's first sync reports
-    // its X25519 pubkey, so we retry with backoff.
-    if (deploy.required_capabilities.length > 0) {
+    // its X25519 pubkey, so we retry with backoff. We bind whenever there
+    // are secrets to seal — including optional capabilities the caller
+    // supplied via --secret, which never appear in required_capabilities.
+    if (Object.keys(secrets).length > 0) {
       if (!json) consola.start('Waiting for the agent to come online…')
       let online = false
       for (let i = 0; i < 90 && !online; i++) {

--- a/packages/apes/test/agent-deploy.test.ts
+++ b/packages/apes/test/agent-deploy.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { missingCapabilities, parseKeyValues } from '../src/commands/agent/deploy'
+import { collectFlag, missingCapabilities, parseKeyValues } from '../src/commands/agent/deploy'
 
 describe('parseKeyValues', () => {
   it('parses KEY=value pairs (value may contain =)', () => {
@@ -19,6 +19,27 @@ describe('parseKeyValues', () => {
 
   it.each(['noequals', '=novalue'])('rejects malformed pair %s', (p) => {
     expect(() => parseKeyValues([p])).toThrow(/bad key=value pair/)
+  })
+})
+
+describe('collectFlag', () => {
+  it('collects every occurrence of a repeated flag (citty would keep only the last)', () => {
+    const raw = ['repo@v1', '--param', 'repo=https://x/y.git', '--param', 'forge=github']
+    expect(collectFlag(raw, 'param')).toEqual(['repo=https://x/y.git', 'forge=github'])
+  })
+
+  it('handles the --flag=value form', () => {
+    expect(collectFlag(['--param=repo=A', '--param=forge=B'], 'param')).toEqual(['repo=A', 'forge=B'])
+  })
+
+  it('keeps param and secret flags independent', () => {
+    const raw = ['--param', 'repo=A', '--secret', 'GH_TOKEN=ghp_x']
+    expect(collectFlag(raw, 'param')).toEqual(['repo=A'])
+    expect(collectFlag(raw, 'secret')).toEqual(['GH_TOKEN=ghp_x'])
+  })
+
+  it('returns [] when the flag is absent', () => {
+    expect(collectFlag(['--other', 'x'], 'param')).toEqual([])
   })
 })
 


### PR DESCRIPTION
## Summary
Two fixes that unblock `apes agent deploy` for the coding-agent recipe:

- **Repeatable deploy flags.** citty 0.2.2 coerces a repeated `type:'string'` flag to its *last* value only, so `apes agent deploy --param repo=… --param forge=…` silently dropped `repo` and troop rejected the deploy with `missing required param: repo`. Deploy now collects every `--param`/`--secret` occurrence straight from `ctx.rawArgs` (`collectFlag`).
- **Optional capabilities.** A recipe that supports several forges (coding-agent: GitHub *or* Azure) declared a capability per forge but a single deployment only needs the one matching its `forge` param. Capabilities now take an `optional` flag; `requiredCapabilities` excludes them, and deploy still binds any optional secret supplied via `--secret`. The coding-agent recipe marks both forge tokens optional.

## Why
Without these, the one-step recipe deploy can't be driven from the CLI at all for multi-param / multi-forge recipes.

## Test plan
- [x] `collectFlag` unit tests (repeated, `=` form, param/secret independence, absent)
- [x] `buildDeployPlan` excludes optional capabilities from `requiredCapabilities`
- [x] apes typecheck + troop typecheck clean
- [x] apes + troop recipe test suites green
- [ ] CI green, then merge → troop auto-deploys, apes auto-publishes