### PR TITLE
feat(coding-agent): deterministic headless cron poll via task command

### DIFF
--- a/.changeset/coding-agent-autonomous-poll.md
+++ b/.changeset/coding-agent-autonomous-poll.md
@@ -1,0 +1,14 @@
+---
+"@openape/ape-agent": patch
+"@openape/apes": patch
+---
+
+feat(coding-agent): deterministic, headless cron poll via task `command`
+
+Recipe schedules can now carry an explicit `command`. troop threads it
+through materialize → deploy plan → the `tasks.command` column → the
+agent's task sync, and the cron-runner executes it via the gated
+ape-shell path with no LLM round-trip. Crucially, a command task fires
+headless — it no longer requires an active owner chat room, so the
+coding-agent's `*/10` poll runs autonomously (clone → worktree → edit →
+verify → PR) without anyone accepting a contact in chat first.

--- a/.openape/coding.json
+++ b/.openape/coding.json
@@ -1,0 +1,10 @@
+{
+  "verify": "pnpm install --frozen-lockfile && pnpm turbo run typecheck test",
+  "branchConvention": "fix/issue-<number>-<slug> for bug fixes, feat/issue-<number>-<slug> for features",
+  "notes": "Autonomous coding agent config (openape coding-agent). The agent reads `verify` to know how to gate a change (no PR until it passes) and `mergePolicy` to know what it may merge. It never self-merges; the orchestrator owns the merge gate.",
+  "mergePolicy": {
+    "autoMergeEnabled": false,
+    "autoPaths": [],
+    "riskPaths": []
+  }
+}

--- a/apps/openape-ape-agent/src/cron-runner.ts
+++ b/apps/openape-ape-agent/src/cron-runner.ts
@@ -164,7 +164,9 @@ export class CronRunner {
     taskId: string
     taskName: string
     accumulated: string
-    roomId: string
+    // Undefined for headless command tasks that fire with no owner room —
+    // they still run and record a troop run, they just skip the DM.
+    roomId?: string
     status: 'ok' | 'error' | 'pending'
     runId?: string
   }>()
@@ -254,7 +256,11 @@ export class CronRunner {
     const contacts = await this.deps.chat.listContacts().catch(() => [])
     const ownerLower = this.deps.ownerEmail.toLowerCase()
     const room = contacts.find(c => c.peerEmail.toLowerCase() === ownerLower && c.connected && c.roomId)
-    if (!room?.roomId) {
+    // A deterministic command task runs headless — it drives its own work
+    // (e.g. opening a PR) and doesn't need an owner room to exist. Only
+    // LLM/chat tasks require a room to DM their result into. When a room
+    // IS present we still post the command's summary there as a courtesy.
+    if (!spec.command && !room?.roomId) {
       this.deps.log(`task ${spec.taskId} fired but no active owner room — skipping DM (accept the contact in chat)`)
       return
     }
@@ -289,7 +295,7 @@ export class CronRunner {
       this.deps.log(`troop startRun ${spec.taskId} error: ${err instanceof Error ? err.message : String(err)}`)
     }
 
-    this.pending.set(sessionId, { taskId: spec.taskId, taskName: spec.name, accumulated: '', roomId: room.roomId, status: 'pending', runId })
+    this.pending.set(sessionId, { taskId: spec.taskId, taskName: spec.name, accumulated: '', roomId: room?.roomId ?? undefined, status: 'pending', runId })
     this.deps.log(`task ${spec.taskId} fired (session=${sessionId}, run=${runId ?? 'no-troop'})`)
 
     // Run the agent loop in-process. No subprocess, no RPC.
@@ -380,7 +386,15 @@ export class CronRunner {
     }
   }
 
-  private async postResult(sid: string, turn: { taskId: string, taskName: string, accumulated: string, roomId: string, status: 'ok' | 'error' | 'pending' }): Promise<void> {
+  private async postResult(sid: string, turn: { taskId: string, taskName: string, accumulated: string, roomId?: string, status: 'ok' | 'error' | 'pending' }): Promise<void> {
+    // Headless command task with no owner room — nothing to DM into. The
+    // run is already recorded in troop; the work reports through its own
+    // channel (e.g. a PR), so just log and move on.
+    if (!turn.roomId) {
+      this.deps.log(`task ${turn.taskId} ran headless (no owner room) — DM skipped`)
+      return
+    }
+    const roomId = turn.roomId
     const prefix = turn.status === 'error' ? '❌' : '✅'
     const text = turn.accumulated.trim() || (turn.status === 'error' ? '(crashed)' : '(no output)')
     const body = `${prefix} *${turn.taskName}*\n\n${text}`.slice(0, 9000)
@@ -391,7 +405,7 @@ export class CronRunner {
     // thread, fanning out everything into one stream).
     if (!threadId) {
       try {
-        const created = await this.deps.chat.createThread(turn.roomId, turn.taskName || turn.taskId)
+        const created = await this.deps.chat.createThread(roomId, turn.taskName || turn.taskId)
         threadId = created.id
         this.taskThreads.set(turn.taskId, threadId)
         this.persistTaskThreads()
@@ -402,7 +416,7 @@ export class CronRunner {
       }
     }
     try {
-      const posted = await this.deps.chat.postMessage(turn.roomId, body, threadId ? { threadId } : {})
+      const posted = await this.deps.chat.postMessage(roomId, body, threadId ? { threadId } : {})
       this.deps.log(`task DM posted (session=${sid}, ${turn.accumulated.length} chars, thread=${posted.threadId})`)
     }
     catch (err) {

--- a/apps/openape-troop/server/api/agents/[name]/tasks/index.post.ts
+++ b/apps/openape-troop/server/api/agents/[name]/tasks/index.post.ts
@@ -14,6 +14,10 @@ const bodySchema = z.object({
   // (set on the agent itself) provides persona/style; the task-level
   // userPrompt provides the concrete job.
   user_prompt: z.string().min(1).max(8000),
+  // Optional deterministic shell command. When set, the cron-runner runs
+  // it via the gated ape-shell path instead of an LLM turn; user_prompt is
+  // then just the human-readable fallback.
+  command: z.string().min(1).max(8000).optional(),
   tools: z.array(z.string()),
   max_steps: z.number().int().min(1).max(50).default(10),
   enabled: z.boolean().default(true),
@@ -54,6 +58,7 @@ export default defineEventHandler(async (event) => {
     name: body.data.name,
     cron: body.data.cron,
     userPrompt: body.data.user_prompt,
+    command: body.data.command ?? null,
     tools: t.tools,
     maxSteps: body.data.max_steps,
     enabled: body.data.enabled,
@@ -65,6 +70,7 @@ export default defineEventHandler(async (event) => {
       name: body.data.name,
       cron: body.data.cron,
       userPrompt: body.data.user_prompt,
+      command: body.data.command ?? null,
       tools: t.tools,
       maxSteps: body.data.max_steps,
       enabled: body.data.enabled,

--- a/apps/openape-troop/server/database/schema.ts
+++ b/apps/openape-troop/server/database/schema.ts
@@ -69,6 +69,11 @@ export const tasks = sqliteTable('tasks', {
   name: text('name').notNull(),
   cron: text('cron').notNull(),
   userPrompt: text('user_prompt').notNull(),
+  // Optional deterministic shell command. When set, the cron-runner
+  // executes it via the gated ape-shell path (no LLM round-trip, no chat
+  // room needed) and `userPrompt` is only the human-readable fallback.
+  // Used by the coding-agent recipe's poll schedule.
+  command: text('command'),
   tools: text('tools', { mode: 'json' }).notNull().$type<string[]>(),
   maxSteps: integer('max_steps').notNull().default(10),
   enabled: integer('enabled', { mode: 'boolean' }).notNull().default(true),

--- a/apps/openape-troop/server/plugins/02.database.ts
+++ b/apps/openape-troop/server/plugins/02.database.ts
@@ -90,6 +90,13 @@ export default defineNitroPlugin(async () => {
       await db.run(sql`ALTER TABLE tasks ADD COLUMN user_prompt TEXT NOT NULL DEFAULT ''`)
     }
     catch { /* column exists (either via fresh create or from rename above) */ }
+    // Deterministic command tasks: the cron-runner runs `command` via the
+    // gated ape-shell path instead of an LLM turn. Nullable — chat-style
+    // tasks leave it unset and fall back to user_prompt.
+    try {
+      await db.run(sql`ALTER TABLE tasks ADD COLUMN command TEXT`)
+    }
+    catch { /* column exists */ }
 
     await db.run(sql`CREATE TABLE IF NOT EXISTS runs (
       id TEXT PRIMARY KEY,

--- a/apps/openape-troop/server/routes/api/nest-ws.ts
+++ b/apps/openape-troop/server/routes/api/nest-ws.ts
@@ -234,6 +234,7 @@ export default defineWebSocketHandler({
                     name: s.name,
                     cron: s.cron,
                     userPrompt: s.userPrompt,
+                    command: s.command ?? null,
                     tools: s.tools,
                     maxSteps: 10,
                     enabled: true,
@@ -241,7 +242,7 @@ export default defineWebSocketHandler({
                     updatedAt: now,
                   }).onConflictDoUpdate({
                     target: [tasks.agentEmail, tasks.taskId],
-                    set: { name: s.name, cron: s.cron, userPrompt: s.userPrompt, tools: s.tools, updatedAt: now },
+                    set: { name: s.name, cron: s.cron, userPrompt: s.userPrompt, command: s.command ?? null, tools: s.tools, updatedAt: now },
                   })
                 }
               })(),

--- a/apps/openape-troop/server/utils/agent-recipe.ts
+++ b/apps/openape-troop/server/utils/agent-recipe.ts
@@ -37,6 +37,11 @@ const capabilitySchema = z.object({
 const scheduleSchema = z.object({
   cron: z.string().min(1),
   description: z.string().optional(),
+  // An explicit shell command for deterministic, LLM-free polling. When
+  // set, the agent's cron-runner executes it via the gated ape-shell path
+  // (no chat room / no model call) and `description` is the human-readable
+  // fallback. `{{param}}` placeholders are interpolated like everything else.
+  command: z.string().optional(),
 })
 
 const recipeSchema = z.object({
@@ -223,7 +228,13 @@ export function materializeRecipe(
   for (const s of recipe.schedules) {
     const desc = s.description ? interpolate(s.description, params) : null
     if (desc && !desc.ok) return desc
-    schedules.push({ cron: s.cron, ...(desc ? { description: desc.value } : {}) })
+    const cmd = s.command ? interpolate(s.command, params) : null
+    if (cmd && !cmd.ok) return cmd
+    schedules.push({
+      cron: s.cron,
+      ...(desc ? { description: desc.value } : {}),
+      ...(cmd ? { command: cmd.value } : {}),
+    })
   }
 
   return { ok: true, value: { recipe, params, intent: intent.value, schedules, tools } }

--- a/apps/openape-troop/server/utils/recipe-deploy.ts
+++ b/apps/openape-troop/server/utils/recipe-deploy.ts
@@ -18,6 +18,8 @@ export interface DeploySchedule {
   name: string
   cron: string
   userPrompt: string
+  /** Deterministic shell command (gated ape-shell, no LLM). Optional. */
+  command?: string
   tools: string[]
 }
 
@@ -59,9 +61,10 @@ export interface DeployPlanOptions {
 export function buildDeployPlan(recipe: AgentRecipe, mat: MaterializedRecipe, opts: DeployPlanOptions = {}): DeployPlan {
   const schedules: DeploySchedule[] = mat.schedules.map((s, i) => ({
     taskId: `recipe-${i}`,
-    name: s.description ?? `${recipe.name} #${i + 1}`,
+    name: s.description ?? s.command ?? `${recipe.name} #${i + 1}`,
     cron: s.cron,
     userPrompt: s.description ?? 'Run your configured task as described in your instructions.',
+    ...(s.command ? { command: s.command } : {}),
     tools: [...RECIPE_AGENT_TOOLS],
   }))
   return {

--- a/apps/openape-troop/tests/recipe-deploy.test.ts
+++ b/apps/openape-troop/tests/recipe-deploy.test.ts
@@ -75,6 +75,37 @@ schedules:
     expect(plan.requiredCapabilities).toEqual(['LLM_API_KEY'])
   })
 
+  it('threads an interpolated schedule command onto the deploy plan', () => {
+    const manifest = `
+name: coding-agent
+kind: agent
+intent: Code on {{repo}}.
+params:
+  - name: repo
+    type: string
+    required: true
+schedules:
+  - cron: "*/10 * * * *"
+    command: apes agents code --poll-label agent --repo {{repo}}
+    description: Poll {{repo}} for issues.
+`
+    const r = parseRecipe(manifest)
+    if (!r.ok) throw new Error(r.reason)
+    const mat = materializeRecipe(r.value, { repo: 'x/y' })
+    if (!mat.ok) throw new Error(mat.reason)
+    // materialize interpolates the command's {{repo}} placeholder
+    expect(mat.value.schedules[0]!.command).toBe('apes agents code --poll-label agent --repo x/y')
+    const plan = buildDeployPlan(r.value, mat.value)
+    expect(plan.schedules[0]!.command).toBe('apes agents code --poll-label agent --repo x/y')
+  })
+
+  it('leaves command undefined for chat-style schedules', () => {
+    const rec = recipe()
+    const mat = materializeRecipe(rec, { topic: 'x' })
+    if (!mat.ok) throw new Error(mat.reason)
+    expect(buildDeployPlan(rec, mat.value).schedules[0]!.command).toBeUndefined()
+  })
+
   it('honours an agent-name override + additive userAddendum (recipe is additive to a named spawn)', () => {
     const rec = recipe()
     const mat = materializeRecipe(rec, { topic: 'AI agents' })

--- a/examples/agent-recipes/coding-agent/ape-agent.yaml
+++ b/examples/agent-recipes/coding-agent/ape-agent.yaml
@@ -43,18 +43,17 @@ params:
     type: string
     required: true
 
-# Poll for assigned issues every 10 minutes. The schedule description is
-# the task the agent runs: an explicit, deterministic command. Run it via
-# your bash tool exactly as written and report the outcome — do not
-# improvise. (When the cron task carries a `command` field the runner
-# executes it directly without this LLM round-trip; the wording here is
-# the portable fallback.)
+# Poll for assigned issues every 10 minutes. `command` makes this
+# deterministic: the agent's cron-runner executes it via the gated
+# ape-shell path — no chat room, no LLM round-trip, no contact-acceptance
+# needed. `description` is the human-readable fallback (and what an older
+# runner without command-support would hand to the LLM verbatim).
 schedules:
   - cron: "*/10 * * * *"
+    command: apes agents code --poll-label agent --repo {{repo}} --forge {{forge}}
     description: |
-      Run exactly this shell command via your bash tool and report the result,
-      nothing else:
-        apes agents code --poll-label agent --repo {{repo}} --forge {{forge}}
+      Poll {{repo}} for open issues labelled `agent` and, for each, run the
+      coding pipeline (worktree → edit → verify → PR). Never self-merge.
 
 user_addendum: true
 

--- a/packages/apes/src/lib/troop-client.ts
+++ b/packages/apes/src/lib/troop-client.ts
@@ -21,6 +21,13 @@ export interface TaskSpec {
    * and served separately at sync time (see `AgentTasksResponse`).
    */
   userPrompt: string
+  /**
+   * Optional deterministic shell command. When present, the cron-runner
+   * executes it via the gated ape-shell path (no LLM turn, no chat room)
+   * and `userPrompt` is just the human-readable fallback. Carried through
+   * `apes agents sync` into the per-task cache the cron-runner reads.
+   */
+  command?: string | null
   tools: string[]
   maxSteps: number
   enabled: boolean


### PR DESCRIPTION
## Summary
Makes the coding-agent poll run **autonomously** — no chat round-trip, no contact acceptance needed.

- **Threads an explicit `command`** from a recipe schedule through the whole pipeline: recipe schema → `materializeRecipe` (interpolates `{{params}}`) → `buildDeployPlan` → new nullable `tasks.command` column → `apes agents sync` → the cron-runner's per-task cache. The cron-runner already executes `command` via the gated ape-shell path (no LLM turn).
- **Headless command tasks.** Previously `fire()` returned early when there was no active owner chat room — so even a deterministic command task was blocked on "accept the contact in chat". Now command tasks run regardless of room; they record a troop run and skip only the DM when no room exists. This is what lets the `*/10` poll run on its own.
- **Recipe** (`examples/agent-recipes/coding-agent`) uses the explicit `command:` form; `description` is the human-readable fallback.
- **`.openape/coding.json`** for this repo: `verify` command + `mergePolicy.autoMergeEnabled=false` (PR-only first; risk paths auto-derived from the deploy workflows' `paths:` filters + CODEOWNERS — nothing hardcoded).
- Manual `POST /agents/:name/tasks` also accepts `command` so a task can be made deterministic from the UI.

## Test plan
- [x] apes + ape-agent typecheck clean
- [x] troop suite 117 passed; ape-agent suite 35 passed
- [x] recipe-deploy: command interpolation + plan passthrough + chat-style stays undefined
- [ ] CI green → merge → troop auto-deploy + apes/ape-agent publish
- [ ] Dogfood: issue labelled `agent` → poll opens a PR autonomously