### PR TITLE
fix(agents sync): report X25519 pubkey so sealed secrets can bind

### DIFF
--- a/.changeset/sync-report-x25519-pubkey.md
+++ b/.changeset/sync-report-x25519-pubkey.md
@@ -1,0 +1,13 @@
+---
+"@openape/apes": patch
+---
+
+fix(agents sync): report the agent's X25519 public key to troop
+
+The capability broker seals secrets to an agent's X25519 public key, but
+`apes agents sync` only ever sent `pubkey_ssh` — so `pubkey_x25519` stayed
+null for every agent and every sealed-secret bind failed with HTTP 409
+("agent has no X25519 public key yet"). Sync now reads
+`~/.config/openape/agent-x25519.key.pub` (written at spawn) and includes
+it in the sync payload, which troop already accepts. Sealed capability
+secrets (e.g. a coding agent's GH_TOKEN) can finally be bound.

--- a/packages/apes/src/commands/agents/sync.ts
+++ b/packages/apes/src/commands/agents/sync.ts
@@ -3,6 +3,7 @@ import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { defineCommand } from 'citty'
 import consola from 'consola'
+import { readAgentEncryptionPublicKey } from '../../lib/agent-secrets-runtime'
 import { CliError } from '../../errors'
 import { getHostId, getHostname } from '../../lib/macos-host'
 import { resolveTroopUrl, TroopClient } from '../../lib/troop-client'
@@ -90,12 +91,19 @@ export const syncAgentCommand = defineCommand({
 
     consola.start(`Syncing ${agentName} (${host}, hostId ${hostId.slice(0, 8)}…) with ${troopUrl}`)
 
+    // Report the agent's X25519 public key so troop's capability broker
+    // can seal secrets to it. Without this every sealed bind 409s with
+    // "no X25519 public key yet". The keypair is written at spawn; we read
+    // the public half from ~/.config/openape/agent-x25519.key.pub.
+    const pubkeyX25519 = readAgentEncryptionPublicKey() ?? undefined
     const sync = await client.sync({
       hostname: host,
       hostId,
       ownerEmail: auth.owner_email,
+      ...(pubkeyX25519 ? { pubkeyX25519 } : {}),
     })
     consola.info(sync.first_sync ? '✓ first sync — agent registered' : '✓ presence updated')
+    if (!pubkeyX25519) consola.warn('No X25519 public key found on disk — sealed capability secrets cannot be bound until the agent is re-spawned.')
 
     const { system_prompt: systemPrompt, tools, skills, tasks } = await client.listTasks()
     consola.info(`Pulled ${tasks.length} task${tasks.length === 1 ? '' : 's'}`)

--- a/packages/apes/src/lib/agent-secrets-runtime.ts
+++ b/packages/apes/src/lib/agent-secrets-runtime.ts
@@ -15,6 +15,9 @@ import { openString } from '@openape/core'
 const CONFIG_DIR = join(homedir(), '.config', 'openape')
 export const SECRETS_DIR = join(CONFIG_DIR, 'secrets.d')
 export const X25519_KEY_PATH = join(CONFIG_DIR, 'agent-x25519.key')
+// Public half written alongside the private key at spawn (agent-bootstrap).
+// Reported to troop on sync so the capability broker can seal secrets to it.
+export const X25519_PUBKEY_PATH = `${X25519_KEY_PATH}.pub`
 
 function envNameFromFile(file: string): string | null {
   if (!file.endsWith('.blob')) return null
@@ -25,6 +28,12 @@ function envNameFromFile(file: string): string | null {
 export function readAgentEncryptionKey(keyPath = X25519_KEY_PATH): string | null {
   if (!existsSync(keyPath)) return null
   const k = readFileSync(keyPath, 'utf8').trim()
+  return k.length > 0 ? k : null
+}
+
+export function readAgentEncryptionPublicKey(pubPath = X25519_PUBKEY_PATH): string | null {
+  if (!existsSync(pubPath)) return null
+  const k = readFileSync(pubPath, 'utf8').trim()
   return k.length > 0 ? k : null
 }
 

--- a/packages/apes/src/lib/troop-client.ts
+++ b/packages/apes/src/lib/troop-client.ts
@@ -110,7 +110,7 @@ export class TroopClient {
     return await res.json() as T
   }
 
-  sync(input: { hostname: string, hostId: string, ownerEmail: string, pubkeySsh?: string }): Promise<SyncResponse> {
+  sync(input: { hostname: string, hostId: string, ownerEmail: string, pubkeySsh?: string, pubkeyX25519?: string }): Promise<SyncResponse> {
     return this.request('/api/agents/me/sync', {
       method: 'POST',
       body: JSON.stringify({
@@ -118,6 +118,11 @@ export class TroopClient {
         host_id: input.hostId,
         owner_email: input.ownerEmail,
         ...(input.pubkeySsh ? { pubkey_ssh: input.pubkeySsh } : {}),
+        // Without this the agent's encryption pubkey never reaches troop,
+        // so every sealed-capability bind 409s ("no X25519 public key
+        // yet"). The keypair is written at spawn (agent-bootstrap); we
+        // just have to report the public half here.
+        ...(input.pubkeyX25519 ? { pubkey_x25519: input.pubkeyX25519 } : {}),
       }),
     })
   }

--- a/packages/apes/test/troop-client.test.ts
+++ b/packages/apes/test/troop-client.test.ts
@@ -69,6 +69,7 @@ describe('TroopClient', () => {
       hostId: 'AAAA-BBBB',
       ownerEmail: 'patrick@example.com',
       pubkeySsh: 'ssh-ed25519 …',
+      pubkeyX25519: 'x25519-pub-key',
     })
     const [url, init] = fetchMock.mock.calls[0]!
     expect(url).toBe('http://localhost:3010/api/agents/me/sync')
@@ -79,7 +80,18 @@ describe('TroopClient', () => {
       host_id: 'AAAA-BBBB',
       owner_email: 'patrick@example.com',
       pubkey_ssh: 'ssh-ed25519 …',
+      // Without this the capability broker can never seal secrets to the
+      // agent — every bind 409s. Regression guard.
+      pubkey_x25519: 'x25519-pub-key',
     })
+  })
+
+  it('omits pubkey_x25519 when not provided', async () => {
+    fetchMock.mockResolvedValue(new Response(JSON.stringify({ first_sync: false }), { status: 200 }))
+    const client = new TroopClient('http://localhost:3010', 'jwt')
+    await client.sync({ hostname: 'm', hostId: 'h', ownerEmail: 'o@e.com' })
+    const body = JSON.parse(fetchMock.mock.calls[0]![1].body as string)
+    expect(body).not.toHaveProperty('pubkey_x25519')
   })
 
   it('startRun maps task_id, finaliseRun PATCHes the run id', async () => {


### PR DESCRIPTION
## Summary
Discovered while deploying the coding-agent: binding **any** sealed capability secret (e.g. `GH_TOKEN`) fails with `HTTP 409: agent has no X25519 public key yet`. Root cause — the agent never reports its X25519 public key.

- The X25519 keypair **is** generated at spawn (`agent-bootstrap` writes `~/.config/openape/agent-x25519.key{,.pub}`).
- troop's `/api/agents/me/sync` **already accepts** `pubkey_x25519`.
- But `apes agents sync` only ever sent `pubkey_ssh` — so `pubkeyX25519` stayed `null` for every agent and the capability broker had nothing to seal to.

Fix: `apes agents sync` reads the public half (`agent-x25519.key.pub`) and includes it in the sync payload (new `readAgentEncryptionPublicKey()` helper). Adds a warning when the key is absent.

## Test plan
- [x] apes typecheck clean
- [x] troop-client suite (10) — asserts `pubkey_x25519` is sent when provided and omitted otherwise
- [ ] CI green → merge → `pnpm release:local` (publish apes) → update global apes on the nest → next sync reports the key → `GH_TOKEN` binds