### PR TITLE
fix(run): keep apes diagnostics off a wrapped command's stdout for agents

### DIFF
--- a/.changeset/gated-shell-stdout-pollution.md
+++ b/.changeset/gated-shell-stdout-pollution.md
@@ -1,0 +1,17 @@
+---
+"@openape/apes": patch
+---
+
+fix(run): keep apes diagnostics off a wrapped command's stdout for agents
+
+When an agent runs a gated command (`ape-shell -c …` → `apes run -- …`),
+it captures the process's stdout as the command result. But apes emitted
+its own diagnostics (grant requests, adapter installs, "Fetching grant
+token") to stdout via consola/console.log, so a structured command like
+`gh issue list --jq '.[].number'` came back as
+`ℹ Requesting grant…\n473` — and the coding agent's poll parsed the
+banner line as an issue id ("id must be a number"). In agent mode, apes
+now routes its JS-level stdout to stderr for the duration of a wrapped
+run; the command's own output (fd 1, `stdio:'inherit'`) is untouched, and
+the grant-token branch still writes its token to real stdout. Human mode
+is unchanged.

--- a/packages/apes/src/commands/run.ts
+++ b/packages/apes/src/commands/run.ts
@@ -84,6 +84,28 @@ function getUserMode(): ApesUserMode {
   return 'agent'
 }
 
+// When apes runs a wrapped command for an agent (ape-shell / `apes run --
+// <cmd>`), the agent captures THIS process's stdout as the command's
+// result. The wrapped command's own output reaches fd 1 directly
+// (execFileSync stdio:'inherit'), but apes's own diagnostics — grant
+// requests, adapter installs, "Fetching grant token", etc., emitted via
+// consola and console.log — also write to the JS-level stdout stream and
+// would corrupt that result (e.g. `gh … --jq '.[].number'` returning
+// "ℹ Requesting grant…\n473"). Point JS-level stdout writes at stderr for
+// the duration so the captured result is exactly the wrapped command's
+// output. The wrapped command (fd 1) is unaffected; the grant-token
+// branch keeps its token on real stdout via writeRealStdout. Human mode
+// is untouched — diagnostics stay on stdout for interactive use.
+let writeRealStdout: (s: string) => void = (s) => { process.stdout.write(s) }
+
+function routeDiagnosticsToStderrForWrappedAgentRun(): void {
+  const original = process.stdout.write.bind(process.stdout)
+  writeRealStdout = (s) => { original(s) }
+  process.stdout.write = ((chunk: string | Uint8Array, ...rest: unknown[]) =>
+    (process.stderr.write as (c: string | Uint8Array, ...a: unknown[]) => boolean)(chunk, ...rest)
+  ) as typeof process.stdout.write
+}
+
 // Poll interval + max-minutes helpers live in `../grant-poll.ts` so they
 // are shared with the CLI-side wait loop in `commands/grants/run.ts --wait`.
 // See that module for the full rationale; in this file we only need the
@@ -246,6 +268,12 @@ export const runCommand = defineCommand({
   },
   async run({ rawArgs, args }) {
     const wrappedCommand = extractWrappedCommand(rawArgs ?? [])
+
+    // Agent capturing a wrapped command's stdout — keep apes diagnostics
+    // off it (see routeDiagnosticsToStderrForWrappedAgentRun).
+    if (wrappedCommand.length > 0 && getUserMode() === 'agent') {
+      routeDiagnosticsToStderrForWrappedAgentRun()
+    }
 
     if (args.shell && wrappedCommand.length > 0) {
       // Shell mode: ape-shell -c "command" → apes run --shell -- bash -c "command"
@@ -738,7 +766,9 @@ function executeWithGrantToken(opts: {
     }
   }
   else {
-    process.stdout.write(token)
+    // The token IS the intended result for non-escapes audiences, so it
+    // must reach real stdout even when diagnostics were routed to stderr.
+    writeRealStdout(token)
   }
 }
 


### PR DESCRIPTION
## Summary
Discovered dogfooding the coding agent: its `*/10` poll failed with `id must be a number`. Root cause — the gated shell wrapper pollutes the command's stdout.

`ape-shell -c "gh issue list … --jq '.[].number'"` returned:
```
ℹ Requesting grant for: List issues in openape-ai/openape
✔ Grant … created (pending approval)
473
```
The agent captures stdout as the command result, so the poll parsed `ℹ Requesting grant…` as an issue id. Direct `gh` returns a clean `473`.

apes emitted its own diagnostics (grant requests, adapter installs, "Fetching grant token", pending-grant info) to **stdout** via consola + `console.log`. Diagnostics belong on **stderr**.

## Fix
In agent mode, when running a wrapped command (`apes run [--shell] -- <cmd>`), route apes's JS-level stdout to stderr for the duration. The wrapped command's own output is unaffected because it reaches fd 1 directly (`execFileSync … stdio:'inherit'`). The non-escapes grant-token branch still writes its token to real stdout via `writeRealStdout`. Human mode is untouched (diagnostics stay on stdout for interactive use).

Verified: `APES_USER=agent apes run --shell -- bash -c "echo X" 2>/dev/null` now prints only the command output; all banners go to stderr.

## Test plan
- [x] apes typecheck + full suite (733 passed)
- [x] manual: stdout/stderr separation confirmed
- [ ] CI green → merge → publish apes → coding agent poll parses clean issue numbers → opens PR