### PR TITLE
fix(agents code): materialize capability secrets so forge CLIs authenticate

### DIFF
--- a/.changeset/coding-agent-materialize-secrets.md
+++ b/.changeset/coding-agent-materialize-secrets.md
@@ -1,0 +1,16 @@
+---
+"@openape/apes": patch
+---
+
+fix(agents code): materialize sealed capability secrets before forge calls
+
+`apes agents code` shells out to `gh`/`az`, which need their token in the
+environment. The capability broker seals e.g. GH_TOKEN and the nest drops
+the blob in `~/.config/openape/secrets.d/`, but nothing opened it for the
+coding command — so `gh` ran unauthenticated and `gh issue list` returned
+an empty result that the poll silently read as "no open issues". The
+command now calls `materializeSecrets()` at startup (it runs as the agent
+user, so the blobs + X25519 key are readable) to inject the tokens into
+its env, which propagates to the gated forge CLIs. The poll also now
+checks gh's exit code and detects the unauthenticated case explicitly
+instead of treating an empty list as "nothing to do".

--- a/packages/apes/src/commands/agents/code.ts
+++ b/packages/apes/src/commands/agents/code.ts
@@ -7,6 +7,7 @@ import { consola } from 'consola'
 import type { RuntimeConfig } from '../../lib/agent-runtime'
 import { taskTools } from '../../lib/agent-tools'
 import { runApeShell } from '../../lib/agent-tools/ape-shell-exec'
+import { materializeSecrets } from '../../lib/agent-secrets-runtime'
 import { runCodingTask } from '../../lib/coding/coding-loop'
 import { buildIssueGet, detectForge } from '../../lib/coding/forge'
 import type { Forge } from '../../lib/coding/forge'
@@ -86,6 +87,18 @@ export const codeAgentCommand = defineCommand({
   async run({ args }) {
     const repo = args.repo as string
     const forge: Forge = (args.forge as string) || detectForge(repo)
+
+    // Inject sealed capability secrets (e.g. GH_TOKEN / AZ_PAT) into this
+    // process's env so the forge CLIs we shell out to are authenticated.
+    // The cron-runner invokes us as the agent user, so the blobs + the
+    // X25519 key in ~/.config/openape are readable. Best-effort: no key /
+    // no blobs just means nothing to inject. Without this, `gh` runs
+    // unauthenticated and silently returns an empty issue list.
+    try {
+      const { applied } = materializeSecrets()
+      if (applied.length > 0) consola.info(`Capabilities available: ${applied.join(', ')}`)
+    }
+    catch { /* no secrets to materialize */ }
     const config = readLitellmConfig(args.model as string | undefined)
     const persona = readPersona(args['persona-file'] as string | undefined)
     const maxSteps = Number(args['max-steps']) > 0 ? Number(args['max-steps']) : 40
@@ -107,7 +120,17 @@ export const codeAgentCommand = defineCommand({
     if (args['poll-label']) {
       const slug = repo.replace(/^https:\/\/github\.com\//, '').replace(/\.git$/, '')
       const list = await runApeShell(`gh issue list --repo ${slug} --label '${args['poll-label']}' --state open --json number --jq '.[].number'`)
-      refs.push(...list.stdout.split('\n').map(s => s.trim()).filter(Boolean))
+      if (list.exit_code !== 0) {
+        throw new CliError(`gh issue list failed (exit ${list.exit_code}): ${(list.stderr || list.stdout).slice(0, 300)}`)
+      }
+      // `gh` exits 0 with empty stdout when it is unauthenticated, which
+      // would otherwise look identical to "no matching issues". Detect that
+      // explicitly so a missing GH_TOKEN is a loud error, not a silent no-op.
+      if (list.stdout.trim() === '' && /gh auth login|GH_TOKEN/i.test(list.stderr)) {
+        throw new CliError('gh is not authenticated (no GH_TOKEN). The agent\'s GH_TOKEN capability is not materialized — bind it via the deploy/secrets flow.')
+      }
+      // Keep only numeric issue ids — defensive against any stray line.
+      refs.push(...list.stdout.split('\n').map(s => s.trim()).filter(s => /^\d+$/.test(s)))
       if (refs.length === 0) { consola.info('no open issues with that label'); return }
     }
     else if (args.issue) {


### PR DESCRIPTION
## Summary
Final link for the autonomous coding agent. Its `*/10` poll ran cleanly but reported "no open issues" even with a labelled issue present.

Root cause: `apes agents code` shells out to `gh` (and `az`), which read their token from the environment. The capability broker seals `GH_TOKEN` and the nest delivers the blob to `~/.config/openape/secrets.d/`, but **nothing opened that blob for the coding command** — `materializeSecrets()` was only called in `serve`/`run`/`sync`, not here nor in the bridge. So `gh` ran unauthenticated, and an unauthenticated `gh issue list` exits 0 with empty stdout — which the poll silently read as "no open issues".

## Fix
- `apes agents code` calls `materializeSecrets()` at startup (it runs as the agent user via the cron-runner, so `secrets.d/*.blob` + the X25519 key are readable). The opened tokens land in `process.env` and propagate to the gated forge CLIs (which inherit env).
- Poll hardening: check `gh`'s exit code and detect the unauthenticated case (empty stdout + auth hint on stderr) explicitly, so a missing token is a loud error rather than a silent "nothing to do". Issue ids are also filtered to numeric.

## Test plan
- [x] apes typecheck + lint clean
- [ ] CI green → merge → publish apes → update nest's global apes → next poll authenticates, finds the issue, opens a PR