### PR TITLE
fix(run --as): preserve argv for wrapped commands with shell metacharacters

### DIFF
--- a/.changeset/run-as-argv-preservation.md
+++ b/.changeset/run-as-argv-preservation.md
@@ -1,0 +1,17 @@
+---
+"@openape/apes": patch
+---
+
+fix(run --as): preserve argv for wrapped commands with metacharacters
+
+`apes run --as <user> -- <cmd>` flattened the wrapped command to a string
+(`command.join(' ')`) and `runAudienceMode` re-split it on spaces, which
+shattered any argument containing spaces or shell metacharacters. The
+nest's capability-secret relay runs
+`apes run --as <agent> -- sh -c "mkdir … && cat > …"`, so its script was
+mangled and escapes rejected the broken argv with exit 64 — meaning
+sealed secrets (e.g. GH_TOKEN) never reached the agent. The escapes path
+now carries the original argv through intact; the joined string is kept
+only for the human-readable grant display. (Latent until now: secret
+binding was impossible before agents reported their X25519 key, so this
+relay path had never actually run in production.)

--- a/packages/apes/src/commands/run.ts
+++ b/packages/apes/src/commands/run.ts
@@ -573,8 +573,12 @@ async function runAdapterMode(
 
   // If caller wants to run as another user (e.g. root), auto-switch to the escapes audience flow.
   // Adapter mode (Shapes) is user-level and cannot elevate privileges.
+  // Pass the argv array through so commands carrying shell metacharacters
+  // or spaces (e.g. `sh -c "mkdir … && cat > …"` from the nest secret
+  // relay) survive intact — joining to a string and re-splitting on spaces
+  // would shatter them and escapes would reject the mangled argv (exit 64).
   if (args.as) {
-    await runAudienceMode('escapes', command.join(' '), args)
+    await runAudienceMode('escapes', command.join(' '), args, command)
     return
   }
 
@@ -650,6 +654,11 @@ async function runAudienceMode(
   audience: string,
   action: string,
   args: Record<string, unknown>,
+  // When provided, the exact argv to authorize + execute. Avoids the
+  // lossy `action.split(' ')` round-trip for commands whose arguments
+  // contain spaces or shell metacharacters (the `--as` wrapped-command
+  // path). `action` is still used for the human-readable grant display.
+  commandArgv?: string[],
 ) {
   const auth = loadAuth()
   if (!auth) {
@@ -658,7 +667,7 @@ async function runAudienceMode(
 
   const idp = getIdpUrl(args.idp as string | undefined)!
   const grantsUrl = await getGrantsEndpoint(idp)
-  const command = action.split(' ')
+  const command = commandArgv ?? action.split(' ')
   const targetHost = (args.host as string) || hostname()
   const runAs = resolveRunAsTarget((args.as as string | undefined) ?? undefined)
 


### PR DESCRIPTION
## Summary
Final blocker for the autonomous coding agent's credentials. The nest's capability-secret relay was failing to deliver sealed secrets (e.g. `GH_TOKEN`) with **exit 64**.

Root cause: `apes run --as <user> -- <cmd>` did `command.join(' ')`, and `runAudienceMode` did `action.split(' ')` — a lossy round-trip that shatters any argument containing spaces or shell metacharacters. The relay runs `apes run --as <agent> -- sh -c "mkdir … && chmod … && cat > …"`, so the script was split into broken argv and escapes rejected it (EX_USAGE = 64). `config-update` (`apes run --as <agent> -- apes agents sync`) survived only because it has no metacharacters.

This path had never run in production before: secret binding was impossible until agents started reporting their X25519 key (#472), so the relay never actually executed a write.

## Fix
The `--as` escapes path now passes the original argv array through to `runAudienceMode`/`executeWithGrantToken` intact; the joined string is kept only for the human-readable grant display. `sh -c "<script>"` stays a single argument.

## Test plan
- [x] apes typecheck + full suite (733 passed) + lint clean
- [x] manual: `apes run --as coder -- sh -c '… && cat > …'` keeps the script as one arg
- [ ] CI → merge → publish apes → update nest's global apes → re-bind GH_TOKEN → nest delivers the blob → agent authenticates and opens a PR