### PR TITLE
fix(forge): pass repo to issueGet so the coding poll fetches issues pre-clone

### DIFF
--- a/.changeset/forge-issueget-repo.md
+++ b/.changeset/forge-issueget-repo.md
@@ -1,0 +1,13 @@
+---
+"@openape/apes": patch
+---
+
+fix(forge): pass repo to issueGet so the poll can fetch issues pre-clone
+
+The coding agent's poll calls `fetchIssue` BEFORE cloning the repo, but
+the GitHub forge adapter built `gh issue view <n> --json …` with no
+`--repo`, so `gh` tried to infer the repo from the (unrelated) CWD and
+failed with `fatal: not a git repository`. `issueGet` (and `buildIssueGet`
+/ `forge.issue.get`) now take the repo and emit `--repo <remote>`; the
+poll passes its `--repo`. Azure work-items are org/project-scoped so the
+arg is ignored there.

--- a/packages/apes/src/commands/agents/code.ts
+++ b/packages/apes/src/commands/agents/code.ts
@@ -61,9 +61,11 @@ function readPersona(file?: string): string {
   return DEFAULT_PERSONA
 }
 
-async function fetchIssue(forge: Forge, ref: string): Promise<IssueRef> {
-  const res = await runApeShell(buildIssueGet(forge, ref))
-  if (res.exit_code !== 0) throw new CliError(`could not fetch issue ${ref}: ${res.stderr.slice(0, 200)}`)
+async function fetchIssue(forge: Forge, ref: string, repo: string): Promise<IssueRef> {
+  // Pass repo explicitly: fetchIssue runs before the clone, so the CWD is
+  // not the target repo and `gh issue view` would otherwise fail.
+  const res = await runApeShell(buildIssueGet(forge, ref, repo))
+  if (res.exit_code !== 0) throw new CliError(`could not fetch issue ${ref}: ${(res.stderr || res.stdout).slice(0, 200)}`)
   const j = JSON.parse(res.stdout) as { number?: number, id?: number, title?: string, fields?: { 'System.Title'?: string }, body?: string }
   const number = j.number ?? j.id ?? Number(ref)
   const title = j.title ?? j.fields?.['System.Title'] ?? `issue ${ref}`
@@ -141,7 +143,7 @@ export const codeAgentCommand = defineCommand({
     }
 
     for (const ref of refs) {
-      const issue = await fetchIssue(forge, ref)
+      const issue = await fetchIssue(forge, ref, repo)
       consola.start(`coding issue #${issue.number}: ${issue.title}`)
       const result = await runCodingTask({ issue, repo, forge }, deps)
       consola.box(`#${issue.number} -> ${result.outcome}\nPR: ${result.prRef ?? '(none)'}\n${result.reason}`)

--- a/packages/apes/src/lib/agent-tools/forge.ts
+++ b/packages/apes/src/lib/agent-tools/forge.ts
@@ -83,7 +83,10 @@ export const forgeTools: ToolDefinition[] = [
     },
     execute: async (args: unknown) => {
       const a = args as { forge?: unknown, remote?: unknown, ref: string }
-      return await runApeShell(buildIssueGet(resolveForge(a), a.ref))
+      // Pass the remote so the lookup works even when the CWD isn't the
+      // target repo (e.g. before a clone).
+      const repo = typeof a.remote === 'string' ? a.remote : undefined
+      return await runApeShell(buildIssueGet(resolveForge(a), a.ref, repo))
     },
   },
 ]

--- a/packages/apes/src/lib/coding/forge.ts
+++ b/packages/apes/src/lib/coding/forge.ts
@@ -66,7 +66,11 @@ export interface ForgeAdapter {
   prCreate: (input: PrCreateInput) => string
   prMerge: (input: PrMergeInput) => string
   prStatus: (ref: string | number) => string
-  issueGet: (ref: string | number) => string
+  // `repo` is the target remote (URL or owner/name). Required for issue
+  // lookups that run BEFORE the repo is cloned (e.g. the poll's
+  // fetchIssue), where the CWD is not the repo — without it `gh issue
+  // view` errors "not a git repository" / resolves the wrong repo.
+  issueGet: (ref: string | number, repo?: string) => string
 }
 
 // --- Built-in adapters ---
@@ -94,7 +98,7 @@ const githubAdapter: ForgeAdapter = {
     const refTok = ID_RE.test(r) ? r : assertBranch(r)
     return `gh pr view ${shq(refTok)} --json state,mergeStateStatus,statusCheckRollup,reviewDecision`
   },
-  issueGet: ref => `gh issue view ${assertId(ref)} --json number,title,body,labels`,
+  issueGet: (ref, repo) => `gh issue view ${assertId(ref)}${repo ? ` --repo ${shq(repo)}` : ''} --json number,title,body,labels`,
 }
 
 const azureAdapter: ForgeAdapter = {
@@ -116,7 +120,10 @@ const azureAdapter: ForgeAdapter = {
     return parts.join(' ')
   },
   prStatus: ref => `az repos pr show --id ${assertId(ref)}`,
-  issueGet: ref => `az boards work-item show --id ${assertId(ref)}`,
+  // Azure work items are org/project-scoped, not repo-scoped, so `repo`
+  // doesn't apply here — the caller's `az` config (defaults.organization/
+  // project) resolves it.
+  issueGet: (ref, _repo) => `az boards work-item show --id ${assertId(ref)}`,
 }
 
 // --- Registry ---
@@ -173,8 +180,8 @@ export function buildPrStatus(forge: Forge, ref: string | number): string {
   return getForge(forge).prStatus(ref)
 }
 
-export function buildIssueGet(forge: Forge, ref: string | number): string {
-  return getForge(forge).issueGet(ref)
+export function buildIssueGet(forge: Forge, ref: string | number, repo?: string): string {
+  return getForge(forge).issueGet(ref, repo)
 }
 
 export const _internal = { shq, assertBranch, assertId, githubAdapter, azureAdapter, registry }

--- a/packages/apes/test/coding.test.ts
+++ b/packages/apes/test/coding.test.ts
@@ -84,6 +84,10 @@ describe('forge: command builders', () => {
     expect(buildPrStatus('azure', 7)).toContain('az repos pr show --id 7')
     expect(buildIssueGet('github', 7)).toContain('gh issue view 7 --json')
     expect(buildIssueGet('azure', 7)).toContain('az boards work-item show --id 7')
+    // With a repo (issue lookup before clone): --repo must be present so
+    // `gh` doesn't depend on the CWD being the target repo.
+    expect(buildIssueGet('github', 7, 'https://github.com/o/n.git'))
+      .toContain('gh issue view 7 --repo \'https://github.com/o/n.git\' --json')
   })
 
   it('rejects injection in branch', () => {


### PR DESCRIPTION
## Summary
The coding agent's poll runs `fetchIssue` **before** cloning the repo, but the GitHub forge adapter built `gh issue view <n> --json …` with **no `--repo`** — so `gh` inferred the repo from the (unrelated) working directory and failed with `fatal: not a git repository`. This was the agent's real last-mile failure (masked in the cron run because the runner keeps stdout over stderr).

## Fix
`issueGet` / `buildIssueGet` / the `forge.issue.get` tool now take the repo and emit `--repo <remote>`; the poll passes its `--repo`. Azure work-items are org/project-scoped, so the arg is ignored there.

## Test plan
- [x] apes typecheck + coding suite (41) + lint clean
- [x] new assertion: `buildIssueGet('github', 7, '<remote>')` includes `--repo`
- [ ] CI → merge → publish → next poll fetches #473 → clone → edit → verify → PR