### PR TITLE
fix(coding): idempotent worktree creation for the polling agent

### DIFF
--- a/.changeset/idempotent-worktree.md
+++ b/.changeset/idempotent-worktree.md
@@ -1,0 +1,13 @@
+---
+"@openape/apes": patch
+---
+
+fix(coding): make worktree creation idempotent for the polling agent
+
+The coding agent polls the same issue every tick, mapping it to the same
+task id → same branch + worktree path. `git worktree add -b` then failed
+on the second attempt with "a branch named '…' already exists", so a
+re-poll could never make progress once a prior run left a worktree
+behind. Creation now tears down any leftover worktree (remove --force +
+prune + rm) and uses `-B` to create-or-reset the branch, so repeat
+attempts start clean.

--- a/packages/apes/src/lib/agent-tools/git-worktree.ts
+++ b/packages/apes/src/lib/agent-tools/git-worktree.ts
@@ -95,11 +95,21 @@ export function buildCreateCommand(repo: unknown, taskId: string, branch: string
   const clone = isUrl
     ? `if [ ! -d ${q(baseDir)}/.git ]; then git clone ${q(source)} ${q(baseDir)}; fi`
     : `test -d ${q(baseDir)}/.git`
+  // A polling agent re-attempts the same issue (same task id → same branch
+  // + worktree path) on every tick, so creation must be idempotent: tear
+  // down any leftover worktree from a prior run, then add fresh with `-B`
+  // (create-or-reset the branch). The cleanup group never fails the chain.
+  const reset = [
+    `git -C ${q(baseDir)} worktree remove --force ${q(wt)} 2>/dev/null || true`,
+    `git -C ${q(baseDir)} worktree prune 2>/dev/null || true`,
+    `rm -rf ${q(wt)} 2>/dev/null || true`,
+  ].join('; ')
   return [
     `mkdir -p ${q(reposRoot())} ${q(workRoot())}`,
     clone,
     `git -C ${q(baseDir)} fetch --quiet || true`,
-    `git -C ${q(baseDir)} worktree add -b ${q(br)} ${q(wt)}`,
+    `{ ${reset}; }`,
+    `git -C ${q(baseDir)} worktree add -B ${q(br)} ${q(wt)}`,
     `echo ${q(wt)}`,
   ].join(' && ')
 }

--- a/packages/apes/test/agent-tools.test.ts
+++ b/packages/apes/test/agent-tools.test.ts
@@ -143,10 +143,13 @@ describe('git_worktree command builders', () => {
     expect(wtInternal.assertBranch('feat/x-1')).toBe('feat/x-1')
   })
 
-  it('builds a create command that clones-if-needed and adds the worktree', () => {
+  it('builds a create command that clones-if-needed and adds the worktree (idempotent)', () => {
     const cmd = wtInternal.buildCreateCommand('https://github.com/openape-ai/openape.git', 'issue-42', 'fix/issue-42')
     expect(cmd).toContain('git clone')
-    expect(cmd).toContain(`worktree add -b 'fix/issue-42' '${home}/work/issue-42'`)
+    // -B (create-or-reset) + a teardown of any leftover worktree, so a
+    // polling agent's repeat attempts on the same issue don't collide.
+    expect(cmd).toContain(`worktree add -B 'fix/issue-42' '${home}/work/issue-42'`)
+    expect(cmd).toContain(`worktree remove --force '${home}/work/issue-42'`)
   })
 
   it('builds remove + list commands', () => {


### PR DESCRIPTION
## Summary
The coding agent polls the same issue every tick → same task id → same branch + worktree path. `git worktree add -b` failed on the second attempt (`a branch named '…' already exists`), so once a run left a worktree behind, every subsequent poll for that issue failed at setup (before the LLM even ran).

## Fix
`buildCreateCommand` now tears down any leftover worktree (`worktree remove --force` + `prune` + `rm -rf`) and uses `git worktree add -B` (create-or-reset the branch). Repeat attempts start clean.

## Test plan
- [x] apes typecheck + agent-tools/coding-loop suites + lint clean
- [x] assertion: create command contains `worktree add -B` + `worktree remove --force`
- [ ] CI → merge → publish → next poll reuses cleanly, runs the codex coding session → PR