### PR TITLE
fix(coding): git identity + push auth + exit-code checks for the PR step

### DIFF
--- a/.changeset/coding-commit-push-auth.md
+++ b/.changeset/coding-commit-push-auth.md
@@ -1,0 +1,14 @@
+---
+"@openape/apes": patch
+---
+
+fix(coding): set git identity + push auth, and check commit/push/PR exit codes
+
+A freshly-spawned agent has no git identity, and `git push` over HTTPS
+needs the forge token — so the coding loop's commit/push silently failed
+and, because it didn't check exit codes, still reported `awaiting-human`
+with no PR ever created. The loop now: commits with a default author
+identity (overridable via `GIT_AUTHOR_NAME`/`GIT_AUTHOR_EMAIL`), pushes
+through the `gh` credential helper (which reads the materialized
+GH_TOKEN), and returns `run-failed` with the real error if commit, push,
+or `pr create` fails — never a phantom PR.

--- a/packages/apes/src/lib/coding/coding-loop.ts
+++ b/packages/apes/src/lib/coding/coding-loop.ts
@@ -132,10 +132,28 @@ export async function runCodingTask(input: CodingTaskInput, deps: CodingTaskDeps
   const decision = decideMerge(changedFiles, policy, agentRisk)
   log(`[coding] decision=${decision.classification} (${decision.reason})`)
 
-  // 5. Commit + push + open the PR (orchestrator owns this).
-  await shell(`git -C '${worktree}' commit -m ${shqMsg(input.issue)} && git -C '${worktree}' push -u origin '${branch}'`)
+  // 5. Commit + push + open the PR (orchestrator owns this). Each step is
+  //    checked: a freshly-spawned agent has no git identity and `git push`
+  //    over HTTPS needs the forge token, so a silent failure here must NOT
+  //    masquerade as a successful PR. Identity is a commit-author default
+  //    (overridable via GIT_AUTHOR_*); push auth rides the gh credential
+  //    helper, which reads the materialized GH_TOKEN from the env.
+  const authorEmail = process.env.GIT_AUTHOR_EMAIL || 'coding-agent@openape.ai'
+  const authorName = process.env.GIT_AUTHOR_NAME || 'OpenApe Coding Agent'
+  const ident = `-c user.email='${authorEmail.replace(/'/g, '')}' -c user.name='${authorName.replace(/'/g, '')}'`
+  const commitRes = await shell(`git -C '${worktree}' ${ident} commit -m ${shqMsg(input.issue)}`)
+  if (commitRes.exit_code !== 0) {
+    return { branch, worktree, runStatus: 'ok', changedFiles, decision, outcome: 'run-failed', prRef: branch, reason: `commit failed: ${(commitRes.stderr || commitRes.stdout).slice(0, 300)}` }
+  }
+  const pushRes = await shell(`git -C '${worktree}' -c credential.helper='!gh auth git-credential' push -u origin '${branch}'`)
+  if (pushRes.exit_code !== 0) {
+    return { branch, worktree, runStatus: 'ok', changedFiles, decision, outcome: 'run-failed', prRef: branch, reason: `push failed: ${(pushRes.stderr || pushRes.stdout).slice(0, 300)}` }
+  }
   const prCmd = buildPrCreate({ forge: input.forge, title: prTitle(input.issue), body: prBody(input.issue), head: branch })
   const prRes = await shell(`cd '${worktree}' && ${prCmd}`)
+  if (prRes.exit_code !== 0) {
+    return { branch, worktree, runStatus: 'ok', changedFiles, decision, outcome: 'run-failed', prRef: branch, reason: `pr create failed: ${(prRes.stderr || prRes.stdout).slice(0, 300)}` }
+  }
   const prRef = (prRes.stdout.match(/\/pull\/(\d+)|!(\d+)|\bpr\/(\d+)/i)?.slice(1).find(Boolean)) ?? branch
 
   // 6. Merge gate. Human/risk → stop. Code → reviewer. Chore → arm.

--- a/packages/apes/test/coding-loop.test.ts
+++ b/packages/apes/test/coding-loop.test.ts
@@ -77,6 +77,19 @@ describe('runCodingTask orchestrator', () => {
     expect(r.outcome).toBe('awaiting-human')
   })
 
+  it('push failure → run-failed, never reports a PR', async () => {
+    const { fn } = mockShell({ changed: ['docs/readme.md'] })
+    // Make the push step fail (e.g. missing auth) — must not masquerade
+    // as a successful PR / awaiting-human.
+    const shell = vi.fn(async (cmd: string) => {
+      if (cmd.includes('push')) return { stdout: '', stderr: 'fatal: could not read Username', exit_code: 128 }
+      return fn(cmd)
+    })
+    const r = await runCodingTask(input, baseDeps({ shell }))
+    expect(r.outcome).toBe('run-failed')
+    expect(r.reason).toMatch(/push failed/)
+  })
+
   it('no changes → run-failed (no empty PR)', async () => {
     const { fn } = mockShell({ changed: [] })
     const r = await runCodingTask(input, baseDeps({ shell: fn }))


### PR DESCRIPTION
## Summary
The codex run **made the edit** (`decision=code`) but no PR appeared — the branch was never pushed. A freshly-spawned agent has no git identity (commit fails) and `git push` over HTTPS needs the forge token; the loop checked neither exit code, so it reported `awaiting-human` with a phantom PR.

## Fix
- Commit with a default author identity (`OpenApe Coding Agent <coding-agent@openape.ai>`, overridable via `GIT_AUTHOR_NAME`/`GIT_AUTHOR_EMAIL`).
- Push via the `gh` credential helper (`-c credential.helper='!gh auth git-credential'`), which reads the materialized `GH_TOKEN`.
- Check commit / push / `pr create` exit codes — return `run-failed` with the real error instead of a phantom `awaiting-human`.

## Test plan
- [x] apes typecheck + coding-loop suite (12, incl. new push-failure case) + lint clean
- [ ] CI → merge → publish → next codex poll edits → commits → pushes → opens the PR for #473 (awaiting-human)