### PR TITLE
fix(coding): loopback LiteLLM needs no key; push via inline token URL

### DIFF
--- a/.changeset/coding-litellm-loopback-push.md
+++ b/.changeset/coding-litellm-loopback-push.md
@@ -1,0 +1,19 @@
+---
+"@openape/apes": patch
+---
+
+fix(coding): loopback LiteLLM needs no key; push via inline token URL
+
+Two changes that let the coding agent run hands-free:
+
+- `apes agents code` no longer requires `LITELLM_API_KEY` when
+  `LITELLM_BASE_URL` is loopback (127.0.0.1/localhost/[::1]). A LiteLLM
+  proxy bound to loopback can run keyless, so an agent needs no litellm
+  config at all (the default base is loopback). A remote base still needs
+  a key.
+- The coding loop pushes GitHub branches with an inline token URL
+  (`https://x-access-token:$GH_TOKEN@github.com/<owner/name>.git`,
+  expanded by the gated shell so the token never enters argv) plus
+  `GIT_TERMINAL_PROMPT=0` — so the push authenticates non-interactively
+  and fails fast instead of hanging on a credential prompt. Non-GitHub
+  forges keep their CLI's own auth via `origin`.

--- a/packages/apes/src/commands/agents/code.ts
+++ b/packages/apes/src/commands/agents/code.ts
@@ -42,9 +42,15 @@ function readLitellmConfig(model?: string): RuntimeConfig {
   for (const k of ['LITELLM_API_KEY', 'LITELLM_MASTER_KEY', 'LITELLM_BASE_URL']) {
     if (process.env[k]) env[k] = process.env[k]!
   }
-  const apiKey = env.LITELLM_API_KEY || env.LITELLM_MASTER_KEY
   const apiBase = (env.LITELLM_BASE_URL || 'http://127.0.0.1:4000/v1').replace(/\/$/, '')
-  if (!apiKey) throw new CliError('No LITELLM_API_KEY / LITELLM_MASTER_KEY in ~/litellm/.env or env.')
+  // A LiteLLM proxy bound to loopback can run keyless (any local process
+  // already has host access), so a localhost base URL needs no token — the
+  // proxy ignores the Authorization header. This lets an agent run with no
+  // litellm config at all (the default base is loopback). A remote base
+  // URL still requires a key.
+  const isLoopback = /^https?:\/\/(?:127\.0\.0\.1|localhost|\[::1\])(?::\d+)?(?:\/|$)/.test(apiBase)
+  const apiKey = env.LITELLM_API_KEY || env.LITELLM_MASTER_KEY || (isLoopback ? 'sk-loopback-noauth' : '')
+  if (!apiKey) throw new CliError('No LITELLM_API_KEY / LITELLM_MASTER_KEY for non-loopback LITELLM_BASE_URL.')
   return { apiBase, apiKey, model: model || process.env.APE_CHAT_BRIDGE_MODEL || 'claude-haiku-4-5' }
 }
 

--- a/packages/apes/src/lib/coding/coding-loop.ts
+++ b/packages/apes/src/lib/coding/coding-loop.ts
@@ -145,7 +145,13 @@ export async function runCodingTask(input: CodingTaskInput, deps: CodingTaskDeps
   if (commitRes.exit_code !== 0) {
     return { branch, worktree, runStatus: 'ok', changedFiles, decision, outcome: 'run-failed', prRef: branch, reason: `commit failed: ${(commitRes.stderr || commitRes.stdout).slice(0, 300)}` }
   }
-  const pushRes = await shell(`git -C '${worktree}' -c credential.helper='!gh auth git-credential' push -u origin '${branch}'`)
+  // Push with the capability token inline so it authenticates without an
+  // interactive credential prompt (the gh credential helper doesn't reach
+  // through the gated shell reliably). GIT_TERMINAL_PROMPT=0 makes a missing
+  // credential fail fast instead of hanging. `$GH_TOKEN` is expanded by the
+  // gated shell, where the materialized token lives — it never appears in
+  // this process's argv. Non-GitHub forges keep their own CLI auth (origin).
+  const pushRes = await shell(buildPushCommand(input.forge, input.repo, worktree, branch))
   if (pushRes.exit_code !== 0) {
     return { branch, worktree, runStatus: 'ok', changedFiles, decision, outcome: 'run-failed', prRef: branch, reason: `push failed: ${(pushRes.stderr || pushRes.stdout).slice(0, 300)}` }
   }
@@ -179,4 +185,18 @@ function prBody(issue: IssueRef): string {
 }
 function shqMsg(issue: IssueRef): string {
   return `'${prTitle(issue).replace(/'/g, '\'\\\'\'')}'`
+}
+
+// Non-interactive authenticated push. GitHub: inline the capability token
+// (double-quoted so the gated shell — not this process — expands $GH_TOKEN;
+// it never lands in argv or .git/config). Other forges keep their CLI's own
+// auth via `origin`. GIT_TERMINAL_PROMPT=0 turns a missing credential into a
+// fast failure instead of a hang on a credential prompt.
+function buildPushCommand(forge: string, repo: string, worktree: string, branch: string): string {
+  const base = `GIT_TERMINAL_PROMPT=0 git -C '${worktree}'`
+  if (forge === 'github') {
+    const slug = repo.replace(/^[a-z]+:\/\/[^/]+\//i, '').replace(/\.git$/, '').replace(/['"\s]/g, '')
+    return `${base} push "https://x-access-token:\${GH_TOKEN}@github.com/${slug}.git" '${branch}'`
+  }
+  return `${base} push -u origin '${branch}'`
 }

--- a/packages/apes/test/coding-loop.test.ts
+++ b/packages/apes/test/coding-loop.test.ts
@@ -47,6 +47,8 @@ describe('runCodingTask orchestrator', () => {
     expect(r.decision?.classification).toBe('chore')
     expect(reviewer).not.toHaveBeenCalled()
     expect(calls.some(c => c.includes('pr merge') || c.includes('auto-complete') || c.includes('--auto'))).toBe(true)
+    // github push authenticates non-interactively via the inline token URL
+    expect(calls.some(c => c.includes('push') && c.includes('x-access-token:') && c.includes('@github.com/') && c.includes('GIT_TERMINAL_PROMPT=0'))).toBe(true)
   })
 
   it('code change → reviewer approves → auto-armed', async () => {


### PR DESCRIPTION
## Summary
Two changes toward a hands-free coding agent:

- **Loopback LiteLLM needs no key.** `apes agents code` no longer requires `LITELLM_API_KEY` when `LITELLM_BASE_URL` is loopback (the proxy can run keyless on 127.0.0.1). With the default base being loopback, an agent needs no litellm config at all — removes the per-agent litellm provisioning. Remote base URLs still require a key.
- **Authenticated, non-interactive push.** The coding loop was hanging on `git push` (the gh credential helper didn't reach through the gated shell). It now pushes GitHub branches via an inline token URL (`https://x-access-token:$GH_TOKEN@github.com/<owner/name>.git`, expanded by the gated shell so the token never enters this process's argv) with `GIT_TERMINAL_PROMPT=0` (fail fast, no hang). Non-GitHub forges keep their CLI auth via `origin`.

## Test plan
- [x] apes typecheck + full suite (734) + lint clean
- [x] coding-loop asserts the github push uses the token URL + GIT_TERMINAL_PROMPT=0
- [ ] CI → merge → publish → next poll: edit → commit → push → **PR opens**