### PR TITLE
fix(cron-runner): keep both stdout+stderr in command task results

### DIFF
--- a/.changeset/cron-runner-capture-stderr.md
+++ b/.changeset/cron-runner-capture-stderr.md
@@ -1,0 +1,12 @@
+---
+"@openape/ape-agent": patch
+---
+
+fix(cron-runner): keep both stdout and stderr in a command task's result
+
+A deterministic command task recorded `stdout || stderr`, so a command
+that failed with its error only on stderr (a thrown CliError, a git
+failure) surfaced just the early stdout progress and hid the actual
+cause — runs showed `exited 1` with no reason. The result now includes
+both streams, tailed so the operative error (usually last) survives the
+size cap.

--- a/apps/openape-ape-agent/src/cron-runner.ts
+++ b/apps/openape-ape-agent/src/cron-runner.ts
@@ -120,6 +120,19 @@ function readTaskSpecs(): TaskSpec[] {
   return out
 }
 
+// Render a command task's result keeping BOTH streams (tailed, so the
+// operative error — usually last — survives the cap). `stdout || stderr`
+// alone hid failures whose only signal was on stderr.
+function composeTaskOutput(command: string, exitCode: number, stdout: string, stderr: string): string {
+  const tail = (s: string, n: number): string => (s.length > n ? `…${s.slice(-n)}` : s)
+  const parts = [`\`${command}\` exited ${exitCode}`]
+  const out = stdout.trim()
+  const err = stderr.trim()
+  if (out) parts.push(`stdout:\n${tail(out, 2500)}`)
+  if (err) parts.push(`stderr:\n${tail(err, 2500)}`)
+  return parts.join('\n\n')
+}
+
 function readSystemPrompt(): string {
   if (!existsSync(AGENT_CONFIG_PATH)) return ''
   try {
@@ -316,7 +329,11 @@ export class CronRunner {
         const turn = this.pending.get(sessionId)
         if (!turn) return
         turn.status = res.exit_code === 0 ? 'ok' : 'error'
-        turn.accumulated = `\`${spec.command}\` exited ${res.exit_code}\n\n${(res.stdout || res.stderr).slice(0, 4000)}`
+        // Keep BOTH streams: a command can fail with everything on stderr
+        // (e.g. a thrown CliError) while stdout holds only early progress —
+        // `stdout || stderr` would then hide the actual failure. Show the
+        // tail so the operative error (usually last) survives the cap.
+        turn.accumulated = composeTaskOutput(spec.command, res.exit_code, res.stdout, res.stderr)
         await this.finaliseRun(turn, 1)
         await this.postResult(sessionId, turn)
         this.pending.delete(sessionId)


### PR DESCRIPTION
## Summary
A deterministic command task (the coding-agent poll) recorded `stdout || stderr`. When a command failed with its error only on stderr (a thrown CliError, a git failure), the run surfaced just the early stdout progress (`Capabilities available: GH_TOKEN`) and hid the actual cause — every failure looked like `exited 1` with no reason. Now both streams are kept (tailed, so the operative error survives the cap).

## Test plan
- [x] ape-agent typecheck + lint clean
- [ ] CI → merge → publish → reload coder's bridge → next poll's run shows the real commit/push/PR error