### PR TITLE
fix(coding): non-interactive GitHub git auth + clarify agent persona

### DIFF
--- a/.changeset/coding-git-auth-persona.md
+++ b/.changeset/coding-git-auth-persona.md
@@ -1,0 +1,17 @@
+---
+"@openape/apes": patch
+---
+
+fix(coding): non-interactive GitHub git auth + clarify agent persona
+
+The agent's git defaulted to `credential.helper=osxkeychain`, which hangs
+headless (no GUI for the spawned agent user) — so when the LLM ran `git
+push` itself the whole run stalled. The clone now configures
+`credential.helper` to supply `x-access-token:$GH_TOKEN` (read from the
+gated shell's env at push time, never stored) for GitHub remotes, so any
+git operation authenticates without a prompt.
+
+Also clarifies the coding-agent recipe persona: the agent EDITS and
+VERIFIES only and leaves changes uncommitted; the orchestrator commits,
+pushes, and opens the PR (so the policy/merge gate is never bypassed).
+The old intent told the agent to "open a pull request" itself.

--- a/examples/agent-recipes/coding-agent/ape-agent.yaml
+++ b/examples/agent-recipes/coding-agent/ape-agent.yaml
@@ -3,20 +3,24 @@ kind: agent
 intent: |
   You are an autonomous coding agent for {{repo}} on {{forge}}.
 
-  Your job: pick up an assigned issue, implement it in an isolated git
-  worktree, make the verification command pass, and open a pull request.
-  You do NOT decide whether to merge — the orchestrator owns the merge
-  gate (risk classification + reviewer). Never run `gh pr merge` /
-  `az repos pr update` yourself.
+  Your job: pick up an assigned issue and IMPLEMENT it in the isolated git
+  worktree the orchestrator has already created for you. You edit and
+  verify — nothing else. The ORCHESTRATOR (not you) commits, pushes the
+  branch, opens the pull request, and runs the policy/merge gate. Do NOT
+  run `git commit`, `git push`, `gh pr create`, `gh pr merge`, or
+  `az repos pr ...` yourself — those are the orchestrator's job and doing
+  them yourself bypasses the safety gate.
 
   Workflow per task (the orchestrator sets up the worktree + branch and
   tells you the path):
-    1. Read the issue and the relevant code (file.read, bash for `git`/`rg`).
+    1. Read the issue and the relevant code (file.read, bash for `rg`).
     2. Make the change with file.edit (small, targeted edits) — not by
-       rewriting whole files.
+       rewriting whole files. Leave the changes UNCOMMITTED in the worktree.
     3. Run the repo's verification command with the `verify` tool. Do not
-       consider the task done until it passes. No PR on red.
-    4. Summarize what you changed and why.
+       consider the task done until it passes. The orchestrator will not
+       open a PR if your changes don't verify.
+    4. Summarize what you changed and why, then stop — the orchestrator
+       takes it from there.
 
   Read the repo's `.openape/coding.json` for the verify command, branch
   convention, and merge policy. If a change touches anything risky

--- a/packages/apes/src/lib/agent-tools/git-worktree.ts
+++ b/packages/apes/src/lib/agent-tools/git-worktree.ts
@@ -104,9 +104,19 @@ export function buildCreateCommand(repo: unknown, taskId: string, branch: string
     `git -C ${q(baseDir)} worktree prune 2>/dev/null || true`,
     `rm -rf ${q(wt)} 2>/dev/null || true`,
   ].join('; ')
+  // Non-interactive GitHub auth for the clone (shared by all its worktrees).
+  // A spawned agent's git defaults to credential.helper=osxkeychain, which
+  // hangs headless (no GUI) — so ANY `git push` the LLM runs itself would
+  // block. Point credential.helper at $GH_TOKEN (read from the gated shell's
+  // env at push time, never stored) so every git operation authenticates
+  // without a prompt. GitHub-only; other forges keep their default helper.
+  const ghAuth = /github\.com/i.test(source)
+    ? `git -C ${q(baseDir)} config credential.helper '!f() { echo username=x-access-token; echo "password=$GH_TOKEN"; }; f'`
+    : 'true'
   return [
     `mkdir -p ${q(reposRoot())} ${q(workRoot())}`,
     clone,
+    ghAuth,
     `git -C ${q(baseDir)} fetch --quiet || true`,
     `{ ${reset}; }`,
     `git -C ${q(baseDir)} worktree add -B ${q(br)} ${q(wt)}`,


### PR DESCRIPTION
## Summary
The 20-min stalled runs were the **LLM running `git push` itself** and hanging on `credential.helper=osxkeychain` (no GUI for the spawned agent user). Two fixes:

- **Non-interactive git auth.** The clone now sets `credential.helper` to supply `x-access-token:$GH_TOKEN` (read from the gated shell's env at push time, never stored) for GitHub remotes — so any git op authenticates without a prompt or hang.
- **Persona clarified.** The recipe intent told the agent to "open a pull request" — but the orchestrator does that (and the gate). It now says: edit + verify only, leave changes uncommitted, the orchestrator commits/pushes/opens the PR. Prevents the agent from bypassing the gate.

## Test plan
- [x] apes typecheck + agent-tools/coding-loop suites + lint clean
- [ ] CI → merge → publish → next poll: codex edits → orchestrator pushes (authed) → **PR opens**