### PR TITLE
fix(coding): disable credential helper on push so osxkeychain can't hang

### DIFF
--- a/.changeset/coding-disable-osxkeychain.md
+++ b/.changeset/coding-disable-osxkeychain.md
@@ -1,0 +1,14 @@
+---
+"@openape/apes": patch
+---
+
+fix(coding): disable credential helper on push so osxkeychain can't hang
+
+The token-URL push authenticated fine, but on success git invoked the
+inherited `credential.helper=osxkeychain` to *store* the credential,
+which hangs headless (no GUI for the spawned agent user) — stalling the
+run after the push. The push now runs with `-c credential.helper=`
+(no helper: the token URL already authenticates, and nothing is stored),
+and the clone resets the inherited helper before adding a $GH_TOKEN one
+for any direct git the agent might run. Fixes runs hanging at the push
+step (and the resulting pile-up of stuck git processes).

--- a/packages/apes/src/lib/agent-tools/git-worktree.ts
+++ b/packages/apes/src/lib/agent-tools/git-worktree.ts
@@ -110,8 +110,11 @@ export function buildCreateCommand(repo: unknown, taskId: string, branch: string
   // block. Point credential.helper at $GH_TOKEN (read from the gated shell's
   // env at push time, never stored) so every git operation authenticates
   // without a prompt. GitHub-only; other forges keep their default helper.
+  // First RESET the helper list (the empty value clears the inherited
+  // osxkeychain helper — otherwise git still calls it on `store` and hangs
+  // headless), then add ours that supplies $GH_TOKEN from the env.
   const ghAuth = /github\.com/i.test(source)
-    ? `git -C ${q(baseDir)} config credential.helper '!f() { echo username=x-access-token; echo "password=$GH_TOKEN"; }; f'`
+    ? `git -C ${q(baseDir)} config credential.helper '' && git -C ${q(baseDir)} config --add credential.helper '!f() { echo username=x-access-token; echo "password=$GH_TOKEN"; }; f'`
     : 'true'
   return [
     `mkdir -p ${q(reposRoot())} ${q(workRoot())}`,

--- a/packages/apes/src/lib/coding/coding-loop.ts
+++ b/packages/apes/src/lib/coding/coding-loop.ts
@@ -193,7 +193,13 @@ function shqMsg(issue: IssueRef): string {
 // auth via `origin`. GIT_TERMINAL_PROMPT=0 turns a missing credential into a
 // fast failure instead of a hang on a credential prompt.
 function buildPushCommand(forge: string, repo: string, worktree: string, branch: string): string {
-  const base = `GIT_TERMINAL_PROMPT=0 git -C '${worktree}'`
+  // `-c credential.helper=` disables ALL credential helpers for this push.
+  // The token URL already authenticates, so no helper is needed for `get`;
+  // critically it also stops git from calling the inherited osxkeychain
+  // helper on `store` after a successful push, which hangs headless (no GUI
+  // for the agent user). GIT_TERMINAL_PROMPT=0 makes a missing credential a
+  // fast failure rather than a prompt-hang.
+  const base = `GIT_TERMINAL_PROMPT=0 git -C '${worktree}' -c credential.helper=`
   if (forge === 'github') {
     const slug = repo.replace(/^[a-z]+:\/\/[^/]+\//i, '').replace(/\.git$/, '').replace(/['"\s]/g, '')
     return `${base} push "https://x-access-token:\${GH_TOKEN}@github.com/${slug}.git" '${branch}'`


### PR DESCRIPTION
## Summary
The token-URL push **authenticated fine**, but on success git invoked the inherited `credential.helper=osxkeychain` to *store* the credential — which hangs headless (no GUI for the spawned agent user). That stalled every run right after the push, and with the cron firing every 10 min the stuck git processes piled up (80+).

## Fix
- Orchestrator push runs with `-c credential.helper=` — no helper at all: the token URL authenticates, and nothing is stored, so osxkeychain is never called.
- The clone resets the inherited helper (`credential.helper ''`) before adding a `$GH_TOKEN`-based one, so any direct git the agent runs also avoids osxkeychain.

## Test plan
- [x] apes typecheck + agent-tools/coding-loop suites + lint clean
- [ ] CI → merge → publish → re-enable poll → run completes: edit → push → **PR**