### PR TITLE
refactor(apes): HostPlatform interface for OS abstraction

### DIFF
--- a/packages/apes/src/commands/agents/allow.ts
+++ b/packages/apes/src/commands/agents/allow.ts
@@ -3,7 +3,8 @@ import { defineCommand } from 'citty'
 import consola from 'consola'
 import { CliError } from '../../errors'
 import { AGENT_NAME_REGEX } from '../../lib/agent-bootstrap'
-import { isDarwin, lookupMacOSUserForAgent, whichBinary } from '../../lib/macos-user'
+import { whichBinary } from '../../lib/macos-user'
+import { getHostPlatform, isDarwin } from '../../lib/host-platform'
 
 export const allowAgentCommand = defineCommand({
   meta: {
@@ -35,7 +36,7 @@ export const allowAgentCommand = defineCommand({
     if (!isDarwin()) {
       throw new CliError('`apes agents allow` is currently macOS-only.')
     }
-    if (!lookupMacOSUserForAgent(agent)) {
+    if (!getHostPlatform().lookupAgentUser(agent)) {
       throw new CliError(`No macOS user for agent "${agent}" — has it been spawned?`)
     }
     const apes = whichBinary('apes')

--- a/packages/apes/src/commands/agents/cleanup-orphans.ts
+++ b/packages/apes/src/commands/agents/cleanup-orphans.ts
@@ -2,7 +2,7 @@ import { execFileSync } from 'node:child_process'
 import { defineCommand } from 'citty'
 import consola from 'consola'
 import { CliError } from '../../errors'
-import { isDarwin, listOrphanedAgentRecords } from '../../lib/macos-user'
+import { getHostPlatform, isDarwin } from '../../lib/host-platform'
 
 /**
  * Sweep accumulated agent-user tombstones left behind by
@@ -42,7 +42,7 @@ export const cleanupOrphansCommand = defineCommand({
       throw new CliError(`\`apes agents cleanup-orphans\` is macOS-only. Detected platform: ${process.platform}.`)
     }
 
-    const orphans = listOrphanedAgentRecords()
+    const orphans = getHostPlatform().listOrphanAgentUsers()
     if (orphans.length === 0) {
       consola.success('No agent tombstones found — dscl is clean.')
       return

--- a/packages/apes/src/commands/agents/destroy.ts
+++ b/packages/apes/src/commands/agents/destroy.ts
@@ -8,7 +8,8 @@ import { getIdpUrl, loadAuth } from '../../config'
 import { CliError, CliExit } from '../../errors'
 import { apiFetch } from '../../http'
 import { AGENT_NAME_REGEX, buildDestroyTeardownScript, runPhaseGTeardownInProcess } from '../../lib/agent-bootstrap'
-import { isDarwin, lookupMacOSUserForAgent, macOSUsernameForAgent, whichBinary } from '../../lib/macos-user'
+import { whichBinary } from '../../lib/macos-user'
+import { getHostPlatform, isDarwin } from '../../lib/host-platform'
 import { removeNestAgent } from '../../lib/nest-registry'
 import { readPasswordSilent } from '../../lib/silent-password'
 
@@ -63,8 +64,9 @@ export const destroyAgentCommand = defineCommand({
       if (process.geteuid?.() !== 0) {
         throw new CliError('--root-stage was passed but this process is not running as root. Refusing to continue.')
       }
-      const resolved = lookupMacOSUserForAgent(name)
-      const macOSUsername = resolved?.name ?? macOSUsernameForAgent(name)
+      const platform = getHostPlatform()
+      const resolved = platform.lookupAgentUser(name)
+      const macOSUsername = resolved?.name ?? platform.agentUsername(name)
       const homeDir = resolved?.homeDir ?? `/var/openape/homes/${macOSUsername}`
       consola.start(`Running teardown for ${name} (Phase-G, root-stage)…`)
       runPhaseGTeardownInProcess({ name, homeDir, macOSUsername })
@@ -84,7 +86,7 @@ export const destroyAgentCommand = defineCommand({
     const idpAgent = owned.find(u => u.name === name)
     const idpExists = idpAgent !== undefined
 
-    const osUser = isDarwin() ? lookupMacOSUserForAgent(name) : null
+    const osUser = isDarwin() ? getHostPlatform().lookupAgentUser(name) : null
     const osUserExists = !args['keep-os-user'] && osUser !== null
 
     if (!idpExists && !osUserExists) {
@@ -141,7 +143,7 @@ export const destroyAgentCommand = defineCommand({
     }
 
     if (osUserExists) {
-      const macOSUsername = osUser?.name ?? macOSUsernameForAgent(name)
+      const macOSUsername = osUser?.name ?? getHostPlatform().agentUsername(name)
       // Fallback path depends on which dscl record we matched:
       // legacy bare-name records live under /Users/<name>, new
       // prefixed records under /var/openape/homes/<macOSUsername>.

--- a/packages/apes/src/commands/agents/list.ts
+++ b/packages/apes/src/commands/agents/list.ts
@@ -3,7 +3,7 @@ import consola from 'consola'
 import { getIdpUrl, loadAuth } from '../../config'
 import { CliError } from '../../errors'
 import { apiFetch } from '../../http'
-import { isDarwin, listMacOSUserNames, lookupMacOSUserForAgent, macOSUsernameForAgent } from '../../lib/macos-user'
+import { getHostPlatform, isDarwin } from '../../lib/host-platform'
 
 interface IdpUser {
   email: string
@@ -45,16 +45,17 @@ export const listAgentsCommand = defineCommand({
       ? all
       : all.filter(u => u.isActive !== false)
 
-    const osUsers = isDarwin() ? listMacOSUserNames() : new Set<string>()
-    // Resolve macOS state per agent, checking both the prefixed
-    // (`openape-agent-<name>`) and bare (`<name>`) dscl records so
-    // legacy pre-prefix agents keep showing up in the table.
+    const platform = getHostPlatform()
+    const osUsers = isDarwin() ? platform.listAgentUserNames() : new Set<string>()
+    // Resolve OS state per agent, checking both the prefixed
+    // (`openape-agent-<name>`) and bare (`<name>`) records so legacy
+    // pre-prefix agents keep showing up in the table.
     const osStateOf = (agentName: string): { osUser: boolean, home: string | null } => {
-      const u = lookupMacOSUserForAgent(agentName)
+      const u = platform.lookupAgentUser(agentName)
       if (u) return { osUser: true, home: u.homeDir }
-      // listMacOSUserNames covers ad-hoc records that dscl-read can't see
-      // (e.g. names with unusual characters) — keep it as a sentinel.
-      if (osUsers.has(macOSUsernameForAgent(agentName)) || osUsers.has(agentName)) {
+      // listAgentUserNames covers ad-hoc records that the read path can't
+      // see (e.g. names with unusual characters) — keep it as a sentinel.
+      if (osUsers.has(platform.agentUsername(agentName)) || osUsers.has(agentName)) {
         return { osUser: true, home: null }
       }
       return { osUser: false, home: null }

--- a/packages/apes/src/commands/agents/spawn.ts
+++ b/packages/apes/src/commands/agents/spawn.ts
@@ -26,12 +26,13 @@ import {
   captureHostBinDirs,
   resolveBridgeConfig,
 } from '../../lib/llm-bridge'
-import { isDarwin, isShellRegistered, macOSUsernameForAgent, readMacOSUser, whichBinary } from '../../lib/macos-user'
+import { isShellRegistered, whichBinary } from '../../lib/macos-user'
+import { getHostPlatform, isDarwin } from '../../lib/host-platform'
 import { upsertNestAgent } from '../../lib/nest-registry'
 
 function readMacOSUidOrNull(name: string): number | null {
   try {
-    const u = readMacOSUser(name)
+    const u = getHostPlatform().readAgentUser(name)
     return u?.uid ?? null
   }
   catch { return null }
@@ -141,8 +142,9 @@ export const spawnAgentCommand = defineCommand({
     // dir, `apes agents list`) stay on the bare `name`. Legacy agents
     // (pre-prefix) keep working via `lookupMacOSUserForAgent` which
     // falls through to the unprefixed lookup.
-    const macOSUsername = macOSUsernameForAgent(name)
-    const existing = readMacOSUser(macOSUsername) ?? readMacOSUser(name)
+    const platform = getHostPlatform()
+    const macOSUsername = platform.agentUsername(name)
+    const existing = platform.readAgentUser(macOSUsername) ?? platform.readAgentUser(name)
     if (existing) {
       throw new CliError(`macOS user "${existing.name}" already exists (uid=${existing.uid ?? '?'}). Refusing to overwrite.`)
     }

--- a/packages/apes/src/commands/agents/sync.ts
+++ b/packages/apes/src/commands/agents/sync.ts
@@ -5,7 +5,7 @@ import { defineCommand } from 'citty'
 import consola from 'consola'
 import { readAgentEncryptionPublicKey } from '../../lib/agent-secrets-runtime'
 import { CliError } from '../../errors'
-import { getHostId, getHostname } from '../../lib/macos-host'
+import { getHostPlatform } from '../../lib/host-platform'
 import { resolveTroopUrl, TroopClient } from '../../lib/troop-client'
 
 interface AuthJson {
@@ -80,8 +80,9 @@ export const syncAgentCommand = defineCommand({
     const troopUrl = resolveTroopUrl(args['troop-url'] as string | undefined)
     const client = new TroopClient(troopUrl, auth.access_token)
 
-    const hostId = getHostId()
-    const host = getHostname()
+    const platform = getHostPlatform()
+    const hostId = platform.getHostId()
+    const host = platform.getHostname()
     if (!hostId) {
       throw new CliError('Could not read IOPlatformUUID — is this macOS? Troop sync only works on macOS for v1.')
     }

--- a/packages/apes/src/commands/run.ts
+++ b/packages/apes/src/commands/run.ts
@@ -26,7 +26,7 @@ import { CliError, CliExit } from '../errors'
 import { notifyGrantPending } from '../notifications'
 import { checkSudoRejection, isApesSelfDispatch } from '../shell/apes-self-dispatch'
 import { AGENT_NAME_REGEX } from '../lib/agent-bootstrap'
-import { isDarwin, macOSUsernameForAgent, readMacOSUser } from '../lib/macos-user'
+import { getHostPlatform, isDarwin } from '../lib/host-platform'
 
 /**
  * Map an agent name (`igor`) to its macOS username (`openape-agent-igor`)
@@ -47,8 +47,9 @@ function resolveRunAsTarget(runAs: string | undefined): string | undefined {
   if (!AGENT_NAME_REGEX.test(runAs)) return runAs
   // Already prefixed (operator typed the full macOS username) — pass through.
   if (runAs.startsWith('openape-agent-')) return runAs
-  const prefixed = macOSUsernameForAgent(runAs)
-  if (readMacOSUser(prefixed)) return prefixed
+  const platform = getHostPlatform()
+  const prefixed = platform.agentUsername(runAs)
+  if (platform.readAgentUser(prefixed)) return prefixed
   return runAs
 }
 

--- a/packages/apes/src/lib/agent-bootstrap.ts
+++ b/packages/apes/src/lib/agent-bootstrap.ts
@@ -560,7 +560,7 @@ export function runPhaseGTeardownInProcess(input: { name: string, homeDir: strin
   // the user record sticks around hidden (IsHidden=1) with a stale
   // NFSHomeDirectory. Run `sudo apes agents cleanup-orphans` from a
   // shell later to sysadminctl-deleteUser the accumulated tombstones.
-  // eslint-disable-next-line no-console
+
   console.log(`OK Phase-G teardown done for ${name} (dscl record /Users/${macOSUser} kept as tombstone)`)
 }
 

--- a/packages/apes/src/lib/host-platform/darwin.ts
+++ b/packages/apes/src/lib/host-platform/darwin.ts
@@ -1,0 +1,61 @@
+// macOS HostPlatform impl. The read methods (identity, agent-user lookup,
+// orphan scan) delegate to the existing `lib/macos-host` + `lib/macos-user`
+// modules — those modules stay in place during the Milestone A migration
+// so call sites can move onto `getHostPlatform()` one at a time without
+// a flag-day rename. The lifecycle + supervisor methods will be wired
+// once `commands/agents/spawn` + `commands/agents/destroy` are refactored
+// to consume the interface (follow-up milestone within Milestone A).
+//
+// IMPORTANT: keep this module side-effect-free at top level. It is
+// imported on Linux too (the factory in ./index picks lazily); a
+// top-level `execFileSync('dscl', …)` would crash the Linux build. All
+// child_process / dscl invocations live inside the imported helpers.
+
+import { getHostId, getHostname } from '../macos-host'
+import {
+  listMacOSUserNames,
+  listOrphanedAgentRecords,
+  lookupMacOSUserForAgent,
+  macOSUsernameForAgent,
+  readMacOSUser,
+} from '../macos-user'
+import type {
+  AgentUserSummary,
+  BridgeSupervisorSpec,
+  CreateAgentUserSpec,
+  DestroyAgentUserSpec,
+  ExecResult,
+  HostPlatform,
+  NestSupervisorSpec,
+  OrphanRecord,
+  SyncSupervisorSpec,
+} from './index'
+
+function pending(method: string): never {
+  throw new Error(`darwinHostPlatform.${method} not wired yet (Milestone A follow-up)`)
+}
+
+export const darwinHostPlatform: HostPlatform = {
+  getHostId,
+  getHostname,
+
+  agentUsername: macOSUsernameForAgent,
+  lookupAgentUser: (agentName: string): AgentUserSummary | null => lookupMacOSUserForAgent(agentName),
+  readAgentUser: (osName: string): AgentUserSummary | null => readMacOSUser(osName),
+  listAgentUserNames: listMacOSUserNames,
+  listOrphanAgentUsers: (): OrphanRecord[] =>
+    listOrphanedAgentRecords().map(r => ({ name: r.name, uid: r.uid, homeDir: r.homeDir })),
+
+  createAgentUser: async (_s: CreateAgentUserSpec): Promise<AgentUserSummary> => pending('createAgentUser'),
+  destroyAgentUser: async (_s: DestroyAgentUserSpec): Promise<void> => pending('destroyAgentUser'),
+
+  installBridgeSupervisor: async (_s: BridgeSupervisorSpec): Promise<void> => pending('installBridgeSupervisor'),
+  removeBridgeSupervisor: async (_n: string): Promise<void> => pending('removeBridgeSupervisor'),
+  restartBridgeSupervisor: async (_n: string): Promise<void> => pending('restartBridgeSupervisor'),
+  installSyncSupervisor: async (_s: SyncSupervisorSpec): Promise<void> => pending('installSyncSupervisor'),
+  removeSyncSupervisor: async (_n: string): Promise<void> => pending('removeSyncSupervisor'),
+  installNestSupervisor: async (_s: NestSupervisorSpec): Promise<void> => pending('installNestSupervisor'),
+  uninstallNestSupervisor: async (_s: NestSupervisorSpec): Promise<void> => pending('uninstallNestSupervisor'),
+
+  runAsAgentUser: async (_n: string, _argv: string[]): Promise<ExecResult> => pending('runAsAgentUser'),
+}

--- a/packages/apes/src/lib/host-platform/index.ts
+++ b/packages/apes/src/lib/host-platform/index.ts
@@ -1,0 +1,146 @@
+// Platform abstraction for host-level ops (identity, agent users,
+// supervisor lifecycle, run-as). Currently macOS-only; the Linux impl
+// lands in Milestone B alongside `escapes-linux`. Every call site that
+// historically reached for `lib/macos-user`, `lib/macos-host`,
+// `lib/agent-bootstrap`, `lib/launchd-reconcile`, or `lib/troop-bootstrap`
+// should route through `getHostPlatform()` instead.
+//
+// Selection happens at first call via `process.platform`. Both impls are
+// eagerly imported so this module is platform-neutral at compile-time —
+// the impls themselves must NOT execute side effects at top level (no
+// dscl probes, no plist writes, no `which` calls) so importing the wrong
+// one on the wrong host is a no-op.
+
+import process from 'node:process'
+import { darwinHostPlatform } from './darwin'
+import { linuxHostPlatform } from './linux'
+
+// ---- Types ----------------------------------------------------------------
+
+export interface AgentUserSummary {
+  /** OS-level account name (e.g. `openape-agent-coder` on macOS). */
+  name: string
+  uid: number | null
+  shell: string | null
+  /** Resolved home directory (macOS NFSHomeDirectory / Linux passwd entry). */
+  homeDir: string | null
+}
+
+export interface OrphanRecord {
+  /** dscl record name / passwd entry. */
+  name: string
+  uid: number | null
+  /** Home directory the record points at — already verified missing. */
+  homeDir: string
+}
+
+export interface CreateAgentUserSpec {
+  agentName: string
+  /** Authorized SSH key (ed25519) for the agent's session. */
+  sshPublicKey: string
+  /** X25519 capability seal pubkey (base64). Optional pre-M2. */
+  encryptionPublicKey?: string
+  /** True when re-spawning over an existing account (idempotent path). */
+  respawn?: boolean
+}
+
+export interface DestroyAgentUserSpec {
+  agentName: string
+  /**
+   * Leave the user record as a tombstone instead of deleting it.
+   * macOS: forced true under the FDA-less audit-session — `cleanup-orphans`
+   * later sweeps from interactive sudo. Linux: ignored; `userdel` succeeds.
+   */
+  keepTombstone?: boolean
+}
+
+export interface BridgeSupervisorSpec {
+  agentName: string
+  agentUsername: string
+  homeDir: string
+  /** PATH + OPENAPE_* env vars passed to the ape-agent invocation. */
+  env: Record<string, string>
+}
+
+export interface SyncSupervisorSpec {
+  agentName: string
+  agentUsername: string
+  homeDir: string
+}
+
+export interface NestSupervisorSpec {
+  /** User the nest runs as (macOS: `_openape_nest`, Linux: `openape`). */
+  user: string
+  homeDir: string
+  /** UID for launchctl user-domain lookup (macOS only). */
+  uid?: number
+}
+
+export interface ExecResult {
+  stdout: string
+  stderr: string
+  exitCode: number
+}
+
+// ---- Interface ------------------------------------------------------------
+
+export interface HostPlatform {
+  // Identity
+  getHostId: () => string
+  getHostname: () => string
+
+  // Agent users — read
+  /** OS-level account name for an agent (with platform prefix on macOS). */
+  agentUsername: (agentName: string) => string
+  /** Resolve an agent's OS user record (tries prefixed + bare). Null when missing. */
+  lookupAgentUser: (agentName: string) => AgentUserSummary | null
+  /** Read by exact OS-level username (no prefix dance). */
+  readAgentUser: (osName: string) => AgentUserSummary | null
+  /** Raw set of all OS-level user-account names on the host. */
+  listAgentUserNames: () => Set<string>
+  /** Tombstone records. macOS only; Linux returns []. */
+  listOrphanAgentUsers: () => OrphanRecord[]
+
+  // Agent users — lifecycle (privileged)
+  createAgentUser: (spec: CreateAgentUserSpec) => Promise<AgentUserSummary>
+  destroyAgentUser: (spec: DestroyAgentUserSpec) => Promise<void>
+
+  // Supervisor — per-agent bridge
+  installBridgeSupervisor: (spec: BridgeSupervisorSpec) => Promise<void>
+  removeBridgeSupervisor: (agentName: string) => Promise<void>
+  restartBridgeSupervisor: (agentName: string) => Promise<void>
+
+  // Supervisor — per-agent troop-sync (Linux may collapse this into the bridge unit)
+  installSyncSupervisor: (spec: SyncSupervisorSpec) => Promise<void>
+  removeSyncSupervisor: (agentName: string) => Promise<void>
+
+  // Supervisor — the nest itself
+  installNestSupervisor: (spec: NestSupervisorSpec) => Promise<void>
+  uninstallNestSupervisor: (spec: NestSupervisorSpec) => Promise<void>
+
+  // Run-as (sandboxed exec inside an agent's account)
+  runAsAgentUser: (agentName: string, argv: string[]) => Promise<ExecResult>
+}
+
+// ---- Factory --------------------------------------------------------------
+
+export function isDarwin(): boolean {
+  return process.platform === 'darwin'
+}
+
+export function isLinux(): boolean {
+  return process.platform === 'linux'
+}
+
+let testOverride: HostPlatform | null = null
+
+export function getHostPlatform(): HostPlatform {
+  if (testOverride) return testOverride
+  if (isDarwin()) return darwinHostPlatform
+  if (isLinux()) return linuxHostPlatform
+  throw new Error(`unsupported host platform: ${process.platform}`)
+}
+
+export function __setHostPlatformForTesting(impl: HostPlatform | null): void {
+  testOverride = impl
+}

--- a/packages/apes/src/lib/host-platform/linux.ts
+++ b/packages/apes/src/lib/host-platform/linux.ts
@@ -1,0 +1,47 @@
+// Linux HostPlatform impl — placeholder. Filled in T12 (skeleton) and
+// expanded in Milestone B (functional, with escapes-linux + systemd).
+// All methods throw until then.
+//
+// IMPORTANT: keep this module side-effect-free at top level — it is
+// imported on macOS too (the factory in ./index picks lazily).
+
+import type {
+  AgentUserSummary,
+  BridgeSupervisorSpec,
+  CreateAgentUserSpec,
+  DestroyAgentUserSpec,
+  ExecResult,
+  HostPlatform,
+  NestSupervisorSpec,
+  OrphanRecord,
+  SyncSupervisorSpec,
+} from './index'
+
+function notImplemented(method: string): never {
+  throw new Error(`linuxHostPlatform.${method} not implemented (Milestone B)`)
+}
+
+export const linuxHostPlatform: HostPlatform = {
+  getHostId: () => notImplemented('getHostId'),
+  getHostname: () => notImplemented('getHostname'),
+
+  agentUsername: (_n: string) => notImplemented('agentUsername'),
+  lookupAgentUser: (_n: string): AgentUserSummary | null => notImplemented('lookupAgentUser'),
+  readAgentUser: (_n: string): AgentUserSummary | null => notImplemented('readAgentUser'),
+  listAgentUserNames: (): Set<string> => notImplemented('listAgentUserNames'),
+  // No tombstone concept on Linux — userdel + groupdel are clean. Safe default.
+  listOrphanAgentUsers: (): OrphanRecord[] => [],
+
+  createAgentUser: async (_s: CreateAgentUserSpec): Promise<AgentUserSummary> => notImplemented('createAgentUser'),
+  destroyAgentUser: async (_s: DestroyAgentUserSpec): Promise<void> => notImplemented('destroyAgentUser'),
+
+  installBridgeSupervisor: async (_s: BridgeSupervisorSpec): Promise<void> => notImplemented('installBridgeSupervisor'),
+  removeBridgeSupervisor: async (_n: string): Promise<void> => notImplemented('removeBridgeSupervisor'),
+  restartBridgeSupervisor: async (_n: string): Promise<void> => notImplemented('restartBridgeSupervisor'),
+  installSyncSupervisor: async (_s: SyncSupervisorSpec): Promise<void> => notImplemented('installSyncSupervisor'),
+  removeSyncSupervisor: async (_n: string): Promise<void> => notImplemented('removeSyncSupervisor'),
+  installNestSupervisor: async (_s: NestSupervisorSpec): Promise<void> => notImplemented('installNestSupervisor'),
+  uninstallNestSupervisor: async (_s: NestSupervisorSpec): Promise<void> => notImplemented('uninstallNestSupervisor'),
+
+  runAsAgentUser: async (_n: string, _argv: string[]): Promise<ExecResult> => notImplemented('runAsAgentUser'),
+}

--- a/packages/apes/src/lib/macos-user.ts
+++ b/packages/apes/src/lib/macos-user.ts
@@ -5,8 +5,10 @@ export interface MacOSUserSummary {
   name: string
   uid: number | null
   shell: string | null
-  /** Resolved NFSHomeDirectory — varies between /Users/<name> for
-   *  legacy agents and /var/openape/homes/<name> for Phase G+ agents. */
+  /**
+   * Resolved NFSHomeDirectory — varies between /Users/<name> for
+   *  legacy agents and /var/openape/homes/<name> for Phase G+ agents.
+   */
   homeDir: string | null
 }
 

--- a/packages/apes/src/lib/nest-registry.ts
+++ b/packages/apes/src/lib/nest-registry.ts
@@ -37,8 +37,10 @@ interface RegistryFile {
   agents: AgentEntry[]
 }
 
-/** Resolve the registry path. Prefers the post-migration system
- *  location; falls back to the per-user location otherwise. */
+/**
+ * Resolve the registry path. Prefers the post-migration system
+ *  location; falls back to the per-user location otherwise.
+ */
 export function resolveRegistryPath(): string {
   if (existsSync('/var/openape/nest/agents.json')) return '/var/openape/nest/agents.json'
   if (existsSync('/var/openape/nest')) return '/var/openape/nest/agents.json'

--- a/packages/apes/test/agents-destroy.test.ts
+++ b/packages/apes/test/agents-destroy.test.ts
@@ -25,6 +25,29 @@ const macosUserMock = {
 }
 vi.mock('../src/lib/macos-user.js', () => macosUserMock)
 
+// Production code now imports isDarwin + getHostPlatform from the new
+// host-platform module instead of macos-user. Without this mock, CI on
+// Linux uses linuxHostPlatform whose methods either throw or branch
+// differently, breaking the destroy-flow assertions below.
+const hostPlatformMock = {
+  isDarwin: vi.fn(() => true),
+  isLinux: vi.fn(() => false),
+  getHostPlatform: vi.fn(() => ({
+    getHostId: () => 'host-id',
+    getHostname: () => 'host',
+    agentUsername: (n: string) => macosUserMock.macOSUsernameForAgent(n),
+    lookupAgentUser: (n: string) => macosUserMock.lookupMacOSUserForAgent(n),
+    readAgentUser: () => macosUserMock.readMacOSUser(),
+    listAgentUserNames: () => macosUserMock.listMacOSUserNames(),
+    listOrphanAgentUsers: () => [],
+    installNestSupervisor: vi.fn(async () => {}),
+    uninstallNestSupervisor: vi.fn(async () => {}),
+    runPrivilegedBash: vi.fn(async () => {}),
+    runAsAgentUser: vi.fn(async () => ({ stdout: '', stderr: '', exitCode: 0 })),
+  })),
+}
+vi.mock('../src/lib/host-platform/index.js', () => hostPlatformMock)
+
 vi.mock('node:child_process', () => ({
   execFileSync: vi.fn(),
 }))
@@ -56,6 +79,7 @@ describe('apes agents destroy', () => {
     // both the legacy and the prefix-aware lookup paths uniformly.
     macosUserMock.lookupMacOSUserForAgent.mockImplementation(() => macosUserMock.readMacOSUser())
     macosUserMock.isDarwin.mockReturnValue(true)
+    hostPlatformMock.isDarwin.mockReturnValue(true)
     // The OS-teardown path collects the local admin password; CI never
     // has a TTY so we set the env-var resolution path explicitly. Tests
     // that exercise the "no password" failure case delete this first.

--- a/packages/apes/test/agents-list.test.ts
+++ b/packages/apes/test/agents-list.test.ts
@@ -24,6 +24,28 @@ vi.mock('../src/lib/macos-user.js', () => ({
   isShellRegistered: vi.fn(),
 }))
 
+// Production code now imports isDarwin + getHostPlatform from the new
+// host-platform module instead of macos-user. Without this mock, CI on
+// Linux invokes linuxHostPlatform methods that throw "not implemented".
+vi.mock('../src/lib/host-platform/index.js', () => ({
+  isDarwin: vi.fn(() => true),
+  isLinux: vi.fn(() => false),
+  getHostPlatform: vi.fn(() => ({
+    getHostId: () => 'host-id',
+    getHostname: () => 'host',
+    agentUsername: (n: string) => `openape-agent-${n}`,
+    lookupAgentUser: (name: string) =>
+      name === 'agent-a' ? { name: 'agent-a', uid: 250, shell: '/bin/zsh', homeDir: '/Users/agent-a' } : null,
+    readAgentUser: () => null,
+    listAgentUserNames: () => new Set(['agent-a', 'patrick']),
+    listOrphanAgentUsers: () => [],
+    installNestSupervisor: vi.fn(async () => {}),
+    uninstallNestSupervisor: vi.fn(async () => {}),
+    runPrivilegedBash: vi.fn(async () => {}),
+    runAsAgentUser: vi.fn(async () => ({ stdout: '', stderr: '', exitCode: 0 })),
+  })),
+}))
+
 const TWO_AGENTS = [
   { email: 'agent-a+patrick+hofmann_eco@id.openape.ai', name: 'agent-a', owner: 'patrick@hofmann.eco', approver: 'patrick@hofmann.eco', type: 'agent', isActive: true, createdAt: 1 },
   { email: 'agent-b+patrick+hofmann_eco@id.openape.ai', name: 'agent-b', owner: 'patrick@hofmann.eco', approver: 'patrick@hofmann.eco', type: 'agent', isActive: true, createdAt: 2 },

--- a/packages/apes/test/agents-spawn.test.ts
+++ b/packages/apes/test/agents-spawn.test.ts
@@ -21,6 +21,24 @@ const macosUserMock = {
 }
 vi.mock('../src/lib/macos-user.js', () => macosUserMock)
 
+// The host-platform indirection replaces direct imports of macOS helpers
+// in production code. Mock its surface here too so the tests can flip
+// isDarwin / control the agent-user lookups deterministically.
+const hostPlatformMock = {
+  isDarwin: vi.fn(() => true),
+  isLinux: vi.fn(() => false),
+  getHostPlatform: vi.fn(() => ({
+    getHostId: () => 'host-id',
+    getHostname: () => 'host',
+    agentUsername: (n: string) => macosUserMock.macOSUsernameForAgent(n),
+    lookupAgentUser: () => null,
+    readAgentUser: () => macosUserMock.readMacOSUser(),
+    listAgentUserNames: () => macosUserMock.listMacOSUserNames(),
+    listOrphanAgentUsers: () => [],
+  })),
+}
+vi.mock('../src/lib/host-platform/index.js', () => hostPlatformMock)
+
 vi.mock('../src/lib/keygen.js', async () => {
   const actual = await vi.importActual<typeof import('../src/lib/keygen.js')>('../src/lib/keygen.js')
   return {
@@ -97,6 +115,7 @@ describe('apes agents spawn', () => {
     macosUserMock.readMacOSUser.mockReturnValue(null)
     macosUserMock.whichBinary.mockImplementation((name: string) => `/usr/local/bin/${name}`)
     macosUserMock.isShellRegistered.mockReturnValue(true)
+    hostPlatformMock.isDarwin.mockReturnValue(true)
   })
 
   afterEach(() => {
@@ -113,6 +132,7 @@ describe('apes agents spawn', () => {
 
   it('rejects on non-darwin platforms', async () => {
     macosUserMock.isDarwin.mockReturnValue(false)
+    hostPlatformMock.isDarwin.mockReturnValue(false)
     const { spawnAgentCommand } = await import('../src/commands/agents/spawn.js')
     await expect((spawnAgentCommand as any).run({
       args: { name: 'agent-a' },


### PR DESCRIPTION
## Summary

Milestone A of the [Linux-only-via-Docker plan](https://plans.openape.ai/p/01KSQ2WS4SX33VC42HFB2NN3Y5). Concentrates macOS-specific host ops behind a single `HostPlatform` interface so the Linux impl can land alongside in Milestone B without further churn at the call sites.

- New `packages/apes/src/lib/host-platform/` with `index.ts` (interface + factory + `isDarwin/isLinux` predicates), `darwin.ts` (façade over existing `macos-host` + `macos-user`), `linux.ts` (skeleton — all methods throw "not implemented (Milestone B)").
- Read methods (host id, agent-user lookup, orphan scan, `agentUsername`) wired through to existing modules — no behaviour change on macOS.
- Lifecycle + supervisor methods declared but throw pending the `spawn` / `destroy` / `nest-install` refactor (follow-up PR, before Milestone B).
- Call sites in `commands/agents/{sync,list,allow,cleanup-orphans,spawn,destroy}` + `commands/run` migrated from direct `lib/macos-host` / `lib/macos-user` imports to `getHostPlatform()`.
- POSIX helpers `whichBinary` + `isShellRegistered` deliberately stay in `lib/macos-user.ts` (they're cross-platform; the file name will change with the follow-up).
- `agents-spawn.test.ts` mocks the new `host-platform` module surface alongside the existing `macos-user` mock so per-test `isDarwin` flipping still works.

## Verification

- `pnpm --filter @openape/apes typecheck` — clean
- `pnpm --filter @openape/apes lint` — 1 pre-existing JSDoc warning, 0 errors
- `pnpm --filter @openape/apes test` — 734 passed / 3 skipped / 0 failed
- `pnpm -r typecheck` (full monorepo) — clean

## Test plan

- [ ] CI green
- [ ] Manual smoke: `apes agents list`, `apes agents sync`, `apes run --as coder echo ok` still behave identically on macOS
- [ ] Confirm bridges + cron-runner pick up the new build (no behaviour change expected — the interface is a façade)

## Follow-up before Milestone B

The lifecycle + supervisor methods (`createAgentUser`, `destroyAgentUser`, `install*Supervisor`, `runAsAgentUser`) need the bash-script generators in `agent-bootstrap.ts` + the plist generators in `launchd-reconcile.ts` / `troop-bootstrap.ts` / `llm-bridge.ts` to move behind the interface. Tracking in the plan; separate PR.