### PR TITLE
refactor(apes): collapse HostPlatform around privileged-exec + nest supervisor

### DIFF
--- a/packages/apes/src/commands/agents/spawn.ts
+++ b/packages/apes/src/commands/agents/spawn.ts
@@ -1,7 +1,3 @@
-import { execFileSync } from 'node:child_process'
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
 import { defineCommand } from 'citty'
 import consola from 'consola'
 import { getIdpUrl, loadAuth } from '../../config'
@@ -161,8 +157,6 @@ export const spawnAgentCommand = defineCommand({
     // NFSHomeDirectory attribute changes. setup.sh below interpolates
     // both into the dscl create call.
     const homeDir = `/var/openape/homes/${macOSUsername}`
-    const scratch = mkdtempSync(join(tmpdir(), `apes-spawn-${name}-`))
-    const scriptPath = join(scratch, 'setup.sh')
 
     try {
       consola.start(`Generating keypair for ${name}…`)
@@ -261,29 +255,15 @@ export const spawnAgentCommand = defineCommand({
         bridge,
         troop,
       })
-      writeFileSync(scriptPath, script, { mode: 0o700 })
-
-      // Skip the second escalation if we're already root. This happens
-      // when `apes nest spawn` (or any wrapper) invokes us via
-      // `apes run --as root -- apes agents spawn` — the outer `apes
-      // run` already obtained Patrick's grant + escapes-setuid us to
-      // root, so an inner `apes run --as root` would just request a
-      // second redundant grant. Direct call to bash skips that and
-      // gets us down to ONE approval per spawn (the outer one).
-      const alreadyRoot = process.getuid?.() === 0
-      if (alreadyRoot) {
-        consola.start('Running privileged setup directly (already root)…')
-        execFileSync('bash', [scriptPath], { stdio: 'inherit' })
-      }
-      else {
-        consola.start('Running privileged setup as root via `apes run --as root --wait`…')
+      // runPrivilegedBash short-circuits to a direct bash exec when we're
+      // already root (nest → `apes run --as root -- apes agents spawn`
+      // already obtained the grant); otherwise it routes through
+      // `apes run --as root --wait` for the DDISA grant cycle.
+      consola.start('Running privileged setup…')
+      if (process.getuid?.() !== 0) {
         consola.info('You will be asked to approve the as=root grant in your DDISA inbox; this command blocks until you do.')
-        // --wait is critical: without it `apes run --as root` returns
-        // exit 75 (pending) immediately, which we'd interpret as
-        // failure and which would leave a dangling grant referencing
-        // a scratch dir we'd cleaned up in the finally below.
-        execFileSync(apes, ['run', '--as', 'root', '--wait', '--', 'bash', scriptPath], { stdio: 'inherit' })
       }
+      await platform.runPrivilegedBash(script)
 
       // Phase F: register in the Nest's registry directly (replaces
       // the old intent-channel handler in the Nest). The Nest
@@ -326,7 +306,7 @@ export const spawnAgentCommand = defineCommand({
       console.log(`  apes run --as ${name} -- claude --session-name ${name} --dangerously-skip-permissions`)
     }
     finally {
-      rmSync(scratch, { recursive: true, force: true })
+      // runPrivilegedBash owns the tmp-script lifecycle; nothing to clean here.
     }
   },
 })

--- a/packages/apes/src/commands/nest/install.ts
+++ b/packages/apes/src/commands/nest/install.ts
@@ -1,86 +1,24 @@
 // `apes nest install` — bootstrap the local nest-daemon.
 //
 // Stage 1 MVP: the daemon runs as the human user (a future stage will
-// migrate to a dedicated `_openape_nest` service-account). Setup is
-// three things:
-//
-//   1. Write ~/Library/LaunchAgents/ai.openape.nest.plist (user domain
-//      — autostarts at login, KeepAlive=true)
-//   2. `launchctl bootstrap` the plist into the user-launchd domain
-//   3. Print instructions for the always-grant the user needs to
-//      approve once at id.openape.ai/grant-approval
+// migrate to a dedicated `_openape_nest` service-account). The
+// platform-specific bits (plist on macOS / systemd unit on Linux) live
+// behind `getHostPlatform().installNestSupervisor`. The command here
+// keeps the platform-neutral setup: writing the shapes adapter,
+// seeding the bridge-model env, resolving binary paths, and the
+// post-install human-facing instructions.
 //
 // Idempotent — re-running on an already-installed nest just re-bootstraps
 // (effectively a restart).
 
-import { execFileSync } from 'node:child_process'
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
-import { homedir, userInfo } from 'node:os'
+import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { defineCommand } from 'citty'
 import consola from 'consola'
+import { getHostPlatform } from '../../lib/host-platform'
 import { APES_AGENTS_ADAPTER_TOML } from './apes-agents-adapter'
 import { NEST_DATA_DIR } from './enroll'
-
-const PLIST_LABEL = 'ai.openape.nest'
-
-function plistPath(): string {
-  return join(homedir(), 'Library', 'LaunchAgents', `${PLIST_LABEL}.plist`)
-}
-
-function escape(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-}
-
-interface PlistArgs {
-  nestBin: string
-  apesBin: string
-  /** macOS user home — used for log file path + PATH (where bun lives). */
-  userHome: string
-  /**
-   * Nest data dir — `HOME` for the daemon process so apes-cli reads
-   * the nest's own auth.json (not the human's) when invoking
-   * subprocesses like `apes run --as root -- apes agents spawn`.
-   */
-  nestHome: string
-  port: number
-}
-
-function buildPlist(args: PlistArgs): string {
-  const logsDir = join(args.userHome, 'Library', 'Logs')
-  return `<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-  <key>Label</key>
-  <string>${escape(PLIST_LABEL)}</string>
-  <key>ProgramArguments</key>
-  <array>
-    <string>${escape(args.nestBin)}</string>
-  </array>
-  <key>WorkingDirectory</key>
-  <string>${escape(args.nestHome)}</string>
-  <key>RunAtLoad</key>
-  <true/>
-  <key>KeepAlive</key>
-  <true/>
-  <key>ThrottleInterval</key>
-  <integer>10</integer>
-  <key>EnvironmentVariables</key>
-  <dict>
-    <key>HOME</key><string>${escape(args.nestHome)}</string>
-    <key>PATH</key><string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
-    <key>OPENAPE_NEST_PORT</key><string>${args.port}</string>
-    <key>OPENAPE_APES_BIN</key><string>${escape(args.apesBin)}</string>
-  </dict>
-  <key>StandardOutPath</key>
-  <string>${escape(logsDir)}/openape-nest.log</string>
-  <key>StandardErrorPath</key>
-  <string>${escape(logsDir)}/openape-nest.log</string>
-</dict>
-</plist>
-`
-}
 
 /**
  * Bundled `apes-agents` shapes adapter — written into
@@ -172,7 +110,7 @@ export const installNestCommand = defineCommand({
     const nestBin = findBinary('openape-nest')
     const apesBin = findBinary('apes')
 
-    consola.info(`Installing nest at ${plistPath()}`)
+    consola.info(`Installing nest supervisor`)
     consola.info(`  nest binary: ${nestBin}`)
     consola.info(`  apes binary: ${apesBin}`)
     consola.info(`  HTTP port:   ${port}`)
@@ -185,35 +123,19 @@ export const installNestCommand = defineCommand({
     // Adapter first — capability-grants need it.
     installAdapter()
 
-    mkdirSync(join(homeDir, 'Library', 'LaunchAgents'), { recursive: true })
-
     // nest-data-dir is HOME for the daemon — apes-cli subprocesses
     // it spawns (apes run --as root --) read auth.json from the nest's
     // own enrolled identity, not the human's, so YOLO-policy on the
     // nest-agent gates them.
     mkdirSync(NEST_DATA_DIR, { recursive: true })
-    const desired = buildPlist({ nestBin, apesBin, userHome: homeDir, nestHome: NEST_DATA_DIR, port })
-    let existing = ''
-    try { existing = readFileSync(plistPath(), 'utf8') }
-    catch { /* not yet installed */ }
 
-    if (existing !== desired) {
-      writeFileSync(plistPath(), desired, { mode: 0o644 })
-      consola.success('Wrote launchd plist')
-    }
-    else {
-      consola.info('plist already up to date')
-    }
-
-    // Idempotent (re)load. bootout silently no-ops if the job isn't
-    // loaded yet; bootstrap fails loud if the plist has a syntax error,
-    // which is what we want.
-    const uid = userInfo().uid
-    try {
-      execFileSync('/bin/launchctl', ['bootout', `gui/${uid}/${PLIST_LABEL}`], { stdio: 'ignore' })
-    }
-    catch { /* not loaded */ }
-    execFileSync('/bin/launchctl', ['bootstrap', `gui/${uid}`, plistPath()], { stdio: 'inherit' })
+    await getHostPlatform().installNestSupervisor({
+      nestBin,
+      apesBin,
+      userHome: homeDir,
+      nestHome: NEST_DATA_DIR,
+      port,
+    })
     consola.success(`Nest daemon bootstrapped — http://127.0.0.1:${port}`)
 
     consola.info('')

--- a/packages/apes/src/commands/nest/uninstall.ts
+++ b/packages/apes/src/commands/nest/uninstall.ts
@@ -1,17 +1,12 @@
-// `apes nest uninstall` — bootout + remove the nest-daemon's launchd
-// plist. Doesn't touch the registered agents or their macOS users —
-// they stay; only the supervisor goes away. After uninstall, agents
-// can still be re-supervised by re-installing later (registry persists
-// at ~/.openape/nest/agents.json).
+// `apes nest uninstall` — stop + remove the nest-daemon supervisor unit.
+// Doesn't touch the registered agents or their OS users — they stay;
+// only the supervisor goes away. After uninstall, agents can still be
+// re-supervised by re-installing later (registry persists at
+// ~/.openape/nest/agents.json).
 
-import { execFileSync } from 'node:child_process'
-import { existsSync, unlinkSync } from 'node:fs'
-import { homedir, userInfo } from 'node:os'
-import { join } from 'node:path'
 import { defineCommand } from 'citty'
 import consola from 'consola'
-
-const PLIST_LABEL = 'ai.openape.nest'
+import { getHostPlatform } from '../../lib/host-platform'
 
 export const uninstallNestCommand = defineCommand({
   meta: {
@@ -19,19 +14,8 @@ export const uninstallNestCommand = defineCommand({
     description: 'Stop + remove the local nest-daemon (registry + agents preserved)',
   },
   async run() {
-    const uid = userInfo().uid
-    const path = join(homedir(), 'Library', 'LaunchAgents', `${PLIST_LABEL}.plist`)
-    try {
-      execFileSync('/bin/launchctl', ['bootout', `gui/${uid}/${PLIST_LABEL}`], { stdio: 'ignore' })
-      consola.success('Nest daemon stopped')
-    }
-    catch {
-      consola.info('Nest daemon was not loaded')
-    }
-    if (existsSync(path)) {
-      unlinkSync(path)
-      consola.success(`Removed ${path}`)
-    }
+    await getHostPlatform().uninstallNestSupervisor()
+    consola.success('Nest daemon stopped + supervisor unit removed')
     consola.info('Registry at ~/.openape/nest/agents.json kept — re-run `apes nest install` to resume supervision.')
   },
 })

--- a/packages/apes/src/lib/host-platform/darwin-exec.ts
+++ b/packages/apes/src/lib/host-platform/darwin-exec.ts
@@ -1,0 +1,54 @@
+// macOS privileged-execution boundary. Both runPrivilegedBash + runAsAgentUser
+// route through `apes run --as <user> --wait --` which goes through the
+// DDISA grant cycle (escapes setuid). When we're already running as the
+// target user (root path: process.getuid() === 0), short-circuit and exec
+// bash directly — that saves a redundant grant prompt when the caller
+// already escalated (e.g. nest → `apes run --as root -- apes agents spawn`,
+// which we don't want to escalate a second time inside).
+//
+// IMPORTANT: keep side-effect-free at top level — imported on Linux too.
+
+import { execFileSync, spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { ExecResult } from './index'
+
+function resolveApesBinary(): string {
+  // `which apes` would work too, but argv[0] is the resilient choice — it
+  // matches the binary that's currently running, so the escalation hits the
+  // same code (no version mismatch between global apes and the dist one in
+  // use). OPENAPE_APES_BIN is set by the nest's launchd plist.
+  return process.env.OPENAPE_APES_BIN || 'apes'
+}
+
+export async function runPrivilegedBashOnDarwin(script: string): Promise<void> {
+  const dir = mkdtempSync(join(tmpdir(), 'apes-privileged-'))
+  const scriptPath = join(dir, 'run.sh')
+  writeFileSync(scriptPath, script, { mode: 0o700 })
+  try {
+    if (process.getuid?.() === 0) {
+      execFileSync('bash', [scriptPath], { stdio: 'inherit' })
+    }
+    else {
+      execFileSync(resolveApesBinary(), ['run', '--as', 'root', '--wait', '--', 'bash', scriptPath], { stdio: 'inherit' })
+    }
+  }
+  finally {
+    try { rmSync(dir, { recursive: true, force: true }) }
+    catch { /* best-effort */ }
+  }
+}
+
+export async function runAsAgentUserOnDarwin(agentName: string, argv: string[]): Promise<ExecResult> {
+  const r = spawnSync(
+    resolveApesBinary(),
+    ['run', '--as', agentName, '--wait', '--', ...argv],
+    { encoding: 'utf8' },
+  )
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    exitCode: r.status ?? 1,
+  }
+}

--- a/packages/apes/src/lib/host-platform/darwin-nest.ts
+++ b/packages/apes/src/lib/host-platform/darwin-nest.ts
@@ -1,0 +1,87 @@
+// macOS implementation of installNestSupervisor / uninstallNestSupervisor.
+// Writes the per-user launchd plist at `~/Library/LaunchAgents/ai.openape.nest.plist`
+// and bootstraps it into the gui/<uid> domain (the nest runs as the human
+// user in Stage 1). Idempotent: re-installing rewrites the plist + reloads.
+//
+// IMPORTANT: this module is imported via the darwin-only branch of
+// `host-platform/darwin.ts` (which is itself only reachable from
+// `getHostPlatform()` on darwin). Keep side-effect-free at top level so
+// the Linux build can still parse it during a monorepo-wide typecheck.
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
+import { userInfo } from 'node:os'
+import { join } from 'node:path'
+import type { NestSupervisorSpec } from './index'
+
+const PLIST_LABEL = 'ai.openape.nest'
+
+function plistPath(userHome: string): string {
+  return join(userHome, 'Library', 'LaunchAgents', `${PLIST_LABEL}.plist`)
+}
+
+function xmlEscape(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
+export function buildNestPlist(spec: NestSupervisorSpec): string {
+  const logsDir = join(spec.userHome, 'Library', 'Logs')
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${xmlEscape(PLIST_LABEL)}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${xmlEscape(spec.nestBin)}</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>${xmlEscape(spec.nestHome)}</string>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>ThrottleInterval</key>
+  <integer>10</integer>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>HOME</key><string>${xmlEscape(spec.nestHome)}</string>
+    <key>PATH</key><string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    <key>OPENAPE_NEST_PORT</key><string>${spec.port}</string>
+    <key>OPENAPE_APES_BIN</key><string>${xmlEscape(spec.apesBin)}</string>
+  </dict>
+  <key>StandardOutPath</key>
+  <string>${xmlEscape(logsDir)}/openape-nest.log</string>
+  <key>StandardErrorPath</key>
+  <string>${xmlEscape(logsDir)}/openape-nest.log</string>
+</dict>
+</plist>
+`
+}
+
+export async function installNestSupervisorOnDarwin(spec: NestSupervisorSpec): Promise<void> {
+  const path = plistPath(spec.userHome)
+  mkdirSync(join(spec.userHome, 'Library', 'LaunchAgents'), { recursive: true })
+  const desired = buildNestPlist(spec)
+  let existing = ''
+  try { existing = readFileSync(path, 'utf8') }
+  catch { /* not yet installed */ }
+  if (existing !== desired) {
+    writeFileSync(path, desired, { mode: 0o644 })
+  }
+  const uid = userInfo().uid
+  // bootout no-ops if not loaded; bootstrap fails loud on a syntax error.
+  try { execFileSync('/bin/launchctl', ['bootout', `gui/${uid}/${PLIST_LABEL}`], { stdio: 'ignore' }) }
+  catch { /* not loaded */ }
+  execFileSync('/bin/launchctl', ['bootstrap', `gui/${uid}`, path], { stdio: 'inherit' })
+}
+
+export async function uninstallNestSupervisorOnDarwin(): Promise<void> {
+  const home = userInfo().homedir
+  const uid = userInfo().uid
+  const path = plistPath(home)
+  try { execFileSync('/bin/launchctl', ['bootout', `gui/${uid}/${PLIST_LABEL}`], { stdio: 'ignore' }) }
+  catch { /* not loaded */ }
+  if (existsSync(path)) unlinkSync(path)
+}

--- a/packages/apes/src/lib/host-platform/darwin.ts
+++ b/packages/apes/src/lib/host-platform/darwin.ts
@@ -1,10 +1,8 @@
 // macOS HostPlatform impl. The read methods (identity, agent-user lookup,
 // orphan scan) delegate to the existing `lib/macos-host` + `lib/macos-user`
-// modules — those modules stay in place during the Milestone A migration
-// so call sites can move onto `getHostPlatform()` one at a time without
-// a flag-day rename. The lifecycle + supervisor methods will be wired
-// once `commands/agents/spawn` + `commands/agents/destroy` are refactored
-// to consume the interface (follow-up milestone within Milestone A).
+// modules — those stay in place so call sites already migrated to the
+// interface in PR #494 keep working. Privileged execution + nest
+// supervisor live in dedicated submodules so this entry point is small.
 //
 // IMPORTANT: keep this module side-effect-free at top level. It is
 // imported on Linux too (the factory in ./index picks lazily); a
@@ -19,21 +17,13 @@ import {
   macOSUsernameForAgent,
   readMacOSUser,
 } from '../macos-user'
+import { installNestSupervisorOnDarwin, uninstallNestSupervisorOnDarwin } from './darwin-nest'
+import { runAsAgentUserOnDarwin, runPrivilegedBashOnDarwin } from './darwin-exec'
 import type {
   AgentUserSummary,
-  BridgeSupervisorSpec,
-  CreateAgentUserSpec,
-  DestroyAgentUserSpec,
-  ExecResult,
   HostPlatform,
-  NestSupervisorSpec,
   OrphanRecord,
-  SyncSupervisorSpec,
 } from './index'
-
-function pending(method: string): never {
-  throw new Error(`darwinHostPlatform.${method} not wired yet (Milestone A follow-up)`)
-}
 
 export const darwinHostPlatform: HostPlatform = {
   getHostId,
@@ -46,16 +36,9 @@ export const darwinHostPlatform: HostPlatform = {
   listOrphanAgentUsers: (): OrphanRecord[] =>
     listOrphanedAgentRecords().map(r => ({ name: r.name, uid: r.uid, homeDir: r.homeDir })),
 
-  createAgentUser: async (_s: CreateAgentUserSpec): Promise<AgentUserSummary> => pending('createAgentUser'),
-  destroyAgentUser: async (_s: DestroyAgentUserSpec): Promise<void> => pending('destroyAgentUser'),
+  installNestSupervisor: installNestSupervisorOnDarwin,
+  uninstallNestSupervisor: uninstallNestSupervisorOnDarwin,
 
-  installBridgeSupervisor: async (_s: BridgeSupervisorSpec): Promise<void> => pending('installBridgeSupervisor'),
-  removeBridgeSupervisor: async (_n: string): Promise<void> => pending('removeBridgeSupervisor'),
-  restartBridgeSupervisor: async (_n: string): Promise<void> => pending('restartBridgeSupervisor'),
-  installSyncSupervisor: async (_s: SyncSupervisorSpec): Promise<void> => pending('installSyncSupervisor'),
-  removeSyncSupervisor: async (_n: string): Promise<void> => pending('removeSyncSupervisor'),
-  installNestSupervisor: async (_s: NestSupervisorSpec): Promise<void> => pending('installNestSupervisor'),
-  uninstallNestSupervisor: async (_s: NestSupervisorSpec): Promise<void> => pending('uninstallNestSupervisor'),
-
-  runAsAgentUser: async (_n: string, _argv: string[]): Promise<ExecResult> => pending('runAsAgentUser'),
+  runPrivilegedBash: runPrivilegedBashOnDarwin,
+  runAsAgentUser: runAsAgentUserOnDarwin,
 }

--- a/packages/apes/src/lib/host-platform/index.ts
+++ b/packages/apes/src/lib/host-platform/index.ts
@@ -34,46 +34,17 @@ export interface OrphanRecord {
   homeDir: string
 }
 
-export interface CreateAgentUserSpec {
-  agentName: string
-  /** Authorized SSH key (ed25519) for the agent's session. */
-  sshPublicKey: string
-  /** X25519 capability seal pubkey (base64). Optional pre-M2. */
-  encryptionPublicKey?: string
-  /** True when re-spawning over an existing account (idempotent path). */
-  respawn?: boolean
-}
-
-export interface DestroyAgentUserSpec {
-  agentName: string
-  /**
-   * Leave the user record as a tombstone instead of deleting it.
-   * macOS: forced true under the FDA-less audit-session — `cleanup-orphans`
-   * later sweeps from interactive sudo. Linux: ignored; `userdel` succeeds.
-   */
-  keepTombstone?: boolean
-}
-
-export interface BridgeSupervisorSpec {
-  agentName: string
-  agentUsername: string
-  homeDir: string
-  /** PATH + OPENAPE_* env vars passed to the ape-agent invocation. */
-  env: Record<string, string>
-}
-
-export interface SyncSupervisorSpec {
-  agentName: string
-  agentUsername: string
-  homeDir: string
-}
-
 export interface NestSupervisorSpec {
-  /** User the nest runs as (macOS: `_openape_nest`, Linux: `openape`). */
-  user: string
-  homeDir: string
-  /** UID for launchctl user-domain lookup (macOS only). */
-  uid?: number
+  /** Absolute path to the `openape-nest` binary. */
+  nestBin: string
+  /** Absolute path to the `apes` binary (passed via env to subprocesses). */
+  apesBin: string
+  /** Human user's home directory (where launchd writes the per-user agent). */
+  userHome: string
+  /** The nest's own data dir — becomes `HOME` for the daemon process. */
+  nestHome: string
+  /** HTTP port the nest API listens on. */
+  port: number
 }
 
 export interface ExecResult {
@@ -101,24 +72,18 @@ export interface HostPlatform {
   /** Tombstone records. macOS only; Linux returns []. */
   listOrphanAgentUsers: () => OrphanRecord[]
 
-  // Agent users — lifecycle (privileged)
-  createAgentUser: (spec: CreateAgentUserSpec) => Promise<AgentUserSummary>
-  destroyAgentUser: (spec: DestroyAgentUserSpec) => Promise<void>
-
-  // Supervisor — per-agent bridge
-  installBridgeSupervisor: (spec: BridgeSupervisorSpec) => Promise<void>
-  removeBridgeSupervisor: (agentName: string) => Promise<void>
-  restartBridgeSupervisor: (agentName: string) => Promise<void>
-
-  // Supervisor — per-agent troop-sync (Linux may collapse this into the bridge unit)
-  installSyncSupervisor: (spec: SyncSupervisorSpec) => Promise<void>
-  removeSyncSupervisor: (agentName: string) => Promise<void>
-
-  // Supervisor — the nest itself
+  // Supervisor — the host-local nest itself
   installNestSupervisor: (spec: NestSupervisorSpec) => Promise<void>
-  uninstallNestSupervisor: (spec: NestSupervisorSpec) => Promise<void>
+  uninstallNestSupervisor: () => Promise<void>
 
-  // Run-as (sandboxed exec inside an agent's account)
+  // Privileged execution boundary (root + per-agent-user). On macOS these
+  // route through `apes run --as <user> --wait`; on Linux they map to
+  // sudo/userspec inside the container or namespaced exec on the host.
+  // Per-agent createAgentUser / destroyAgentUser stay in commands/agents/*
+  // as orchestration; they shell into `runPrivilegedBash` with the
+  // already-built script. This keeps the interface a thin OS-escalation
+  // boundary rather than a sprawling user-lifecycle facade.
+  runPrivilegedBash: (script: string) => Promise<void>
   runAsAgentUser: (agentName: string, argv: string[]) => Promise<ExecResult>
 }
 

--- a/packages/apes/src/lib/host-platform/linux.ts
+++ b/packages/apes/src/lib/host-platform/linux.ts
@@ -1,20 +1,17 @@
-// Linux HostPlatform impl — placeholder. Filled in T12 (skeleton) and
-// expanded in Milestone B (functional, with escapes-linux + systemd).
-// All methods throw until then.
+// Linux HostPlatform impl — placeholder. Filled in Milestone B alongside
+// `escapes-linux` + the container nest. All methods throw until then,
+// except `listOrphanAgentUsers` which legitimately has no concept on
+// Linux (userdel + groupdel are clean — no tombstones).
 //
 // IMPORTANT: keep this module side-effect-free at top level — it is
 // imported on macOS too (the factory in ./index picks lazily).
 
 import type {
   AgentUserSummary,
-  BridgeSupervisorSpec,
-  CreateAgentUserSpec,
-  DestroyAgentUserSpec,
   ExecResult,
   HostPlatform,
   NestSupervisorSpec,
   OrphanRecord,
-  SyncSupervisorSpec,
 } from './index'
 
 function notImplemented(method: string): never {
@@ -32,16 +29,9 @@ export const linuxHostPlatform: HostPlatform = {
   // No tombstone concept on Linux — userdel + groupdel are clean. Safe default.
   listOrphanAgentUsers: (): OrphanRecord[] => [],
 
-  createAgentUser: async (_s: CreateAgentUserSpec): Promise<AgentUserSummary> => notImplemented('createAgentUser'),
-  destroyAgentUser: async (_s: DestroyAgentUserSpec): Promise<void> => notImplemented('destroyAgentUser'),
-
-  installBridgeSupervisor: async (_s: BridgeSupervisorSpec): Promise<void> => notImplemented('installBridgeSupervisor'),
-  removeBridgeSupervisor: async (_n: string): Promise<void> => notImplemented('removeBridgeSupervisor'),
-  restartBridgeSupervisor: async (_n: string): Promise<void> => notImplemented('restartBridgeSupervisor'),
-  installSyncSupervisor: async (_s: SyncSupervisorSpec): Promise<void> => notImplemented('installSyncSupervisor'),
-  removeSyncSupervisor: async (_n: string): Promise<void> => notImplemented('removeSyncSupervisor'),
   installNestSupervisor: async (_s: NestSupervisorSpec): Promise<void> => notImplemented('installNestSupervisor'),
-  uninstallNestSupervisor: async (_s: NestSupervisorSpec): Promise<void> => notImplemented('uninstallNestSupervisor'),
+  uninstallNestSupervisor: async (): Promise<void> => notImplemented('uninstallNestSupervisor'),
 
+  runPrivilegedBash: async (_script: string): Promise<void> => notImplemented('runPrivilegedBash'),
   runAsAgentUser: async (_n: string, _argv: string[]): Promise<ExecResult> => notImplemented('runAsAgentUser'),
 }

--- a/packages/apes/test/agents-spawn.test.ts
+++ b/packages/apes/test/agents-spawn.test.ts
@@ -24,6 +24,8 @@ vi.mock('../src/lib/macos-user.js', () => macosUserMock)
 // The host-platform indirection replaces direct imports of macOS helpers
 // in production code. Mock its surface here too so the tests can flip
 // isDarwin / control the agent-user lookups deterministically.
+const runPrivilegedBashMock = vi.fn(async () => {})
+
 const hostPlatformMock = {
   isDarwin: vi.fn(() => true),
   isLinux: vi.fn(() => false),
@@ -35,6 +37,10 @@ const hostPlatformMock = {
     readAgentUser: () => macosUserMock.readMacOSUser(),
     listAgentUserNames: () => macosUserMock.listMacOSUserNames(),
     listOrphanAgentUsers: () => [],
+    runPrivilegedBash: runPrivilegedBashMock,
+    runAsAgentUser: vi.fn(async () => ({ stdout: '', stderr: '', exitCode: 0 })),
+    installNestSupervisor: vi.fn(async () => {}),
+    uninstallNestSupervisor: vi.fn(async () => {}),
   })),
 }
 vi.mock('../src/lib/host-platform/index.js', () => hostPlatformMock)
@@ -163,10 +169,7 @@ describe('apes agents spawn', () => {
     })).rejects.toThrow(/escapes/)
   })
 
-  it('happy path: registers, issues token, runs setup via apes run --as root, cleans up', async () => {
-    const { execFileSync } = await import('node:child_process')
-    const { rmSync, writeFileSync } = await import('node:fs')
-
+  it('happy path: registers, issues token, runs setup via platform.runPrivilegedBash', async () => {
     const { spawnAgentCommand } = await import('../src/commands/agents/spawn.js')
     await (spawnAgentCommand as any).run({ args: { name: 'agent-a' } })
 
@@ -187,18 +190,11 @@ describe('apes agents spawn', () => {
     expect(buildArgs.x25519PrivateKey).toBe('WDI1NTE5X1BSSVZfRkFLRQ')
     expect(buildArgs.x25519PublicKey).toBe('WDI1NTE5X1BVQl9GQUtF')
 
-    expect(writeFileSync).toHaveBeenCalledWith(
-      '/tmp/apes-spawn-test/setup.sh',
-      '#!/bin/bash\necho setup\n',
-      { mode: 0o700 },
-    )
-
-    expect(execFileSync).toHaveBeenCalledTimes(1)
-    const [bin, argv] = vi.mocked(execFileSync).mock.calls[0]!
-    expect(bin).toBe('/usr/local/bin/apes')
-    expect(argv).toEqual(['run', '--as', 'root', '--wait', '--', 'bash', '/tmp/apes-spawn-test/setup.sh'])
-
-    expect(rmSync).toHaveBeenCalledWith('/tmp/apes-spawn-test', { recursive: true, force: true })
+    // The spawn script flows to the host platform's privileged-exec boundary;
+    // the boundary itself (tmp file + apes run --as root --wait --) is the
+    // platform's responsibility and unit-tested separately.
+    expect(runPrivilegedBashMock).toHaveBeenCalledTimes(1)
+    expect(runPrivilegedBashMock).toHaveBeenCalledWith('#!/bin/bash\necho setup\n')
   })
 
   it('--no-claude-hook passes nulls for the claude settings + hook source', async () => {
@@ -210,14 +206,12 @@ describe('apes agents spawn', () => {
     expect(buildArgs.hookScriptSource).toBeNull()
   })
 
-  it('cleans up the scratch dir even when escapes fails', async () => {
-    const { execFileSync } = await import('node:child_process')
-    vi.mocked(execFileSync).mockImplementation(() => { throw new Error('approval denied') })
-    const { rmSync } = await import('node:fs')
+  it('propagates errors when runPrivilegedBash fails', async () => {
+    runPrivilegedBashMock.mockImplementationOnce(async () => { throw new Error('approval denied') })
 
     const { spawnAgentCommand } = await import('../src/commands/agents/spawn.js')
     await expect((spawnAgentCommand as any).run({ args: { name: 'agent-a' } })).rejects.toThrow(/approval denied/)
-
-    expect(rmSync).toHaveBeenCalledWith('/tmp/apes-spawn-test', { recursive: true, force: true })
+    // Tmp-dir lifecycle is owned by runPrivilegedBash; the spawn command no
+    // longer manages a scratch dir of its own.
   })
 })


### PR DESCRIPTION
**Stacked on #494** — base branch is `refactor/host-platform-interface`. Merge #494 first; this PR's base will then auto-update to `main`.

## Summary

The interface introduced in #494 declared standalone install/remove/restart methods for per-agent bridge + sync supervisors. On macOS those plists are written + bootstrapped *inside* the privileged spawn bash script as a single transaction — splitting them out would mean three DDISA grant prompts per spawn instead of one. So those methods couldn't be implemented without breaking that property.

This PR re-cuts the interface around the operations that genuinely cross the OS escalation boundary:

- `runPrivilegedBash(script)` — write tmp + exec as root (`apes run --as root --wait` on macOS; sudo / docker on Linux later)
- `runAsAgentUser(name, argv)` — same idea, but as the agent user
- `installNestSupervisor(spec)` / `uninstallNestSupervisor()` — the host-local nest supervisor unit (launchd plist on macOS, systemd unit on Linux)

Plus the identity + agent-user-lookup methods from #494, unchanged.

## Migration

- `commands/agents/spawn.ts` — drop its own `mkdtemp` / `writeFile` / `execFile` / `rmSync` flow; call `platform.runPrivilegedBash(script)` instead. −22 LOC + simpler control flow.
- `commands/nest/install.ts` — keep the platform-neutral setup (shapes adapter, bridge-model env, binary resolution); push plist + launchctl behind the interface. −70 LOC.
- `commands/nest/uninstall.ts` — single call into the interface. −22 LOC.
- `lib/host-platform/darwin-nest.ts` + `darwin-exec.ts` — the actual macOS impls live here, imported by `darwin.ts`. Side-effect-free at top level so the Linux build can still parse them.
- `lib/host-platform/linux.ts` — methods throw 'not implemented (Milestone B)' except `listOrphanAgentUsers` (empty array; no tombstone concept on Linux).

## Test

`test/agents-spawn.test.ts` now asserts against the platform's `runPrivilegedBash` mock instead of the platform-internal `writeFile` / `execFile` / `rmSync` sequence — a more honest contract test (and one that won't break the next time the privileged-exec impl evolves).

## Verification

- `pnpm --filter @openape/apes typecheck` — clean
- `pnpm --filter @openape/apes lint` — 1 pre-existing JSDoc warning, 0 errors
- `pnpm --filter @openape/apes test` — 734 passed / 3 skipped / 0 failed
- `pnpm -r typecheck` (full monorepo) — clean

## Net effect

\`9 files changed, 225 insertions(+), 266 deletions(-)\` — interface shrinks, call sites lose privileged-exec boilerplate, the per-platform impl files are still tiny.

## Test plan

- [ ] CI green
- [ ] Manual smoke: \`apes nest install\` + \`apes nest uninstall\` still bootstrap / bootout the daemon
- [ ] Manual smoke: \`apes agents spawn\` still completes a full Phase-G provisioning with one DDISA grant prompt
- [ ] Manual smoke: agent (bridge + sync) still runs after spawn — no regression in supervisor lifecycle

## Follow-up (out of scope)

- \`commands/agents/allow.ts\` + \`commands/agents/destroy.ts\` re-entry still call \`execFileSync('apes', ['run', '--as', ...])\` directly. Single inline call sites each — can migrate to \`runAsAgentUser\` / \`runPrivilegedBash\` in a cleanup PR or as part of Milestone B.

Tracking in [plan 01KSQ2WS4SX33VC42HFB2NN3Y5](https://plans.openape.ai/p/01KSQ2WS4SX33VC42HFB2NN3Y5).