### PR TITLE
feat: Milestones B-J (Linux HostPlatform, containers, cloud, J proposal)

### DIFF
--- a/apps/openape-llm/Dockerfile
+++ b/apps/openape-llm/Dockerfile
@@ -29,9 +29,11 @@ RUN apt-get update \
         tini \
     && rm -rf /var/lib/apt/lists/*
 
-# Pin litellm to a known-good release line. Bump deliberately — LiteLLM
-# moves fast and minor versions occasionally break provider auth flows.
-RUN pip install --no-cache-dir 'litellm[proxy]==1.55.3'
+# Pin litellm to a known-good release line. 1.84+ ships the `chatgpt/`
+# provider (Codex-style OAuth — what the OpenApe host setup uses).
+# Bump deliberately — LiteLLM moves fast and minor versions occasionally
+# break provider auth flows.
+RUN pip install --no-cache-dir 'litellm[proxy]==1.84.0'
 
 ENV LITELLM_HOST=0.0.0.0
 ENV LITELLM_PORT=4000
@@ -40,8 +42,10 @@ ENV LITELLM_CONFIG=/etc/litellm/config.yaml
 EXPOSE 4000
 
 # Healthcheck — LiteLLM exposes /health/liveliness (their spelling).
+# python is the only HTTP client guaranteed in this image; wget/curl
+# aren't installed in python:3.12-slim.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
-    CMD wget --quiet --spider http://127.0.0.1:4000/health/liveliness || exit 1
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:4000/health/liveliness').read()" || exit 1
 
 ENTRYPOINT ["/usr/bin/tini", "--"]
 CMD ["sh", "-c", "litellm --config \"$LITELLM_CONFIG\" --host \"$LITELLM_HOST\" --port \"$LITELLM_PORT\""]

--- a/apps/openape-llm/Dockerfile
+++ b/apps/openape-llm/Dockerfile
@@ -1,0 +1,47 @@
+# openape-llm — the LiteLLM proxy container.
+#
+# Purpose: replace the bare-host LiteLLM install (homebrew + brew services
+# on macOS, manual systemd on Linux) with a containerised, hatchable
+# instance. Inside the OpenApe pod (compose / k8s / cloud VM) it binds
+# 127.0.0.1:4000 on the pod network so all in-pod agents resolve to a
+# loopback URL — same auth-free semantics as the macOS local path.
+#
+# Configure via /etc/litellm/config.yaml (mounted from the host or built
+# into a custom image inheriting from this one). LITELLM_MASTER_KEY is
+# read from env; when unset, the proxy still serves on loopback but with
+# `master_key` from the yaml.
+#
+# Build from monorepo root:
+#   docker build -f apps/openape-llm/Dockerfile -t openape-llm:dev .
+#
+# Run standalone:
+#   docker run --rm -p 4000:4000 \
+#     -v $PWD/apps/openape-llm/config.example.yaml:/etc/litellm/config.yaml:ro \
+#     -e LITELLM_MASTER_KEY=sk-litellm-loopback \
+#     openape-llm:dev
+
+FROM python:3.12-slim AS runtime
+
+# tini for clean signal forwarding to the litellm worker.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        tini \
+    && rm -rf /var/lib/apt/lists/*
+
+# Pin litellm to a known-good release line. Bump deliberately — LiteLLM
+# moves fast and minor versions occasionally break provider auth flows.
+RUN pip install --no-cache-dir 'litellm[proxy]==1.55.3'
+
+ENV LITELLM_HOST=0.0.0.0
+ENV LITELLM_PORT=4000
+ENV LITELLM_CONFIG=/etc/litellm/config.yaml
+
+EXPOSE 4000
+
+# Healthcheck — LiteLLM exposes /health/liveliness (their spelling).
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+    CMD wget --quiet --spider http://127.0.0.1:4000/health/liveliness || exit 1
+
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["sh", "-c", "litellm --config \"$LITELLM_CONFIG\" --host \"$LITELLM_HOST\" --port \"$LITELLM_PORT\""]

--- a/apps/openape-llm/Dockerfile
+++ b/apps/openape-llm/Dockerfile
@@ -26,14 +26,23 @@ FROM python:3.12-slim AS runtime
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
+        git \
         tini \
     && rm -rf /var/lib/apt/lists/*
 
-# Pin litellm to a known-good release line. 1.84+ ships the `chatgpt/`
-# provider (Codex-style OAuth — what the OpenApe host setup uses).
-# Bump deliberately — LiteLLM moves fast and minor versions occasionally
-# break provider auth flows.
-RUN pip install --no-cache-dir 'litellm[proxy]==1.84.0'
+# Install from our LiteLLM fork (patrick-hofmann/litellm) on the
+# fix/chatgpt-non-stream-output-aggregate branch. The fork carries the
+# fix for the upstream chatgpt-provider bug where /v1/chat/completions
+# fails with `'ResponsesAPIResponse' object has no attribute 'output'` —
+# upstream's response.completed event ships an empty output array; the
+# fix aggregates the intermediate response.output_item.done events into
+# the final response.
+#
+# git+ssh would need keys baked in, so use the public https git url with
+# pip's [proxy] extra still resolved from PyPI (pip auto-installs the
+# fork's pyproject.toml deps).
+RUN pip install --no-cache-dir \
+    'litellm[proxy] @ git+https://github.com/patrick-hofmann/litellm.git@fix/chatgpt-non-stream-output-aggregate'
 
 ENV LITELLM_HOST=0.0.0.0
 ENV LITELLM_PORT=4000

--- a/apps/openape-llm/config.example.yaml
+++ b/apps/openape-llm/config.example.yaml
@@ -1,0 +1,39 @@
+# Example LiteLLM proxy config for the OpenApe pod.
+#
+# Inside the pod the proxy binds 127.0.0.1:4000 (compose-private
+# network) — all agents reach it via http://openape-llm:4000/v1 (compose
+# service-name resolution) or http://127.0.0.1:4000/v1 on the host
+# when published.
+#
+# Copy this to your own config.yaml and supply real API keys via env
+# (LiteLLM expands ${ENV_NAME} at load time). For a hatched cloud
+# instance, the seed-secrets flow injects these.
+
+model_list:
+  # ChatGPT via Patrick's OAuth — same setup as the macOS host.
+  - model_name: gpt-5.4
+    litellm_params:
+      model: chatgpt/gpt-5.4
+      api_key: ${CHATGPT_OAUTH_TOKEN}
+
+  - model_name: gpt-5.4-pro
+    litellm_params:
+      model: chatgpt/gpt-5.4-pro
+      api_key: ${CHATGPT_OAUTH_TOKEN}
+
+  # Anthropic Claude — direct API.
+  - model_name: claude-haiku-4-5
+    litellm_params:
+      model: anthropic/claude-haiku-4-5
+      api_key: ${ANTHROPIC_API_KEY}
+
+  - model_name: claude-opus-4-7
+    litellm_params:
+      model: anthropic/claude-opus-4-7
+      api_key: ${ANTHROPIC_API_KEY}
+
+# The pod network is the trust boundary — master_key matches what the
+# nest seeds into /var/lib/openape/nest/litellm/.env so agents can
+# authenticate.
+general_settings:
+  master_key: ${LITELLM_MASTER_KEY}

--- a/apps/openape-nest/.dockerignore
+++ b/apps/openape-nest/.dockerignore
@@ -1,0 +1,10 @@
+**/node_modules
+**/dist
+**/.turbo
+**/coverage
+**/.next
+**/.nuxt
+**/.output
+**/.cache
+**/.git
+**/*.log

--- a/apps/openape-nest/Dockerfile
+++ b/apps/openape-nest/Dockerfile
@@ -24,15 +24,35 @@ RUN corepack enable && corepack prepare pnpm@latest --activate
 WORKDIR /work
 
 # Copy just enough to install deps cached.
-COPY pnpm-lock.yaml pnpm-workspace.yaml package.json turbo.json tsconfig.json ./
-COPY apps ./apps
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json turbo.json ./
+# Only the apps we actually build live in this image. Skipping
+# openape-agent-proxy / openape-troop / openape-free-idp / idp / etc.
+# avoids dragging Nuxt apps and packages they reference that aren't part
+# of the workspace (e.g. @openape/nuxt-auth-sp lives in a sibling repo).
+COPY apps/openape-nest ./apps/openape-nest
+COPY apps/openape-ape-agent ./apps/openape-ape-agent
 COPY packages ./packages
-COPY examples ./examples
 
-RUN pnpm install --frozen-lockfile
+# --ignore-scripts: the Nuxt apps in the monorepo (troop, idp, agent-proxy)
+# run `nuxt prepare` postinstall, which spins up the full Nuxt module
+# resolution and fails inside a slim node image. We don't build those
+# apps in this image — just apes + nest — so skipping their postinstalls
+# is safe and cuts install time roughly in half.
+RUN pnpm install --frozen-lockfile --ignore-scripts
 
 # Build apes (the CLI nest invokes for privileged steps) + nest itself.
+# The --filter ... build invocation only builds the explicitly named
+# packages (and their workspace deps), so we don't drag the Nuxt apps
+# into the build at all.
 RUN pnpm --filter '@openape/apes' build && pnpm --filter '@openape/nest' build
+
+# `pnpm deploy` materializes a self-contained subtree (workspace deps
+# flattened, no symlinks into the monorepo's .pnpm store) so the runtime
+# image gets a normal node_modules/ that resolves bare imports like
+# `import { ofetch } from 'ofetch'`. Without this step the tsup'd dist
+# can't find its external deps (tsup bundles only the entry's own code).
+RUN pnpm --filter '@openape/apes' deploy --legacy --prod /tmp/deploy/apes \
+ && pnpm --filter '@openape/nest' deploy --legacy --prod /tmp/deploy/nest
 
 # ---- Stage 2: runtime -----------------------------------------------------
 FROM node:22-bookworm-slim AS runtime
@@ -44,9 +64,17 @@ FROM node:22-bookworm-slim AS runtime
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
+        curl \
+        git \
+        gnupg \
         procps \
         sudo \
         tini \
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends gh \
     && rm -rf /var/lib/apt/lists/*
 
 # Nest data dir — bind-mounted by compose so registry + auth survive
@@ -57,12 +85,11 @@ ENV OPENAPE_NEST_PORT=9091
 RUN mkdir -p "$NEST_DATA_DIR" \
     && mkdir -p /var/lib/openape/homes
 
-# Copy the built dists and the runtime deps from stage 1.
+# Copy the deployed subtrees from stage 1 — they include node_modules
+# with all production deps flattened (no workspace symlinks).
 WORKDIR /opt/openape
-COPY --from=build /work/packages/apes/dist        ./apes/dist
-COPY --from=build /work/packages/apes/package.json ./apes/package.json
-COPY --from=build /work/apps/openape-nest/dist      ./nest/dist
-COPY --from=build /work/apps/openape-nest/package.json ./nest/package.json
+COPY --from=build /tmp/deploy/apes ./apes
+COPY --from=build /tmp/deploy/nest ./nest
 
 # Symlink the binaries onto PATH so the nest's subprocess calls
 # (`apes run --as ...`, `openape-nest`) resolve without further plumbing.

--- a/apps/openape-nest/Dockerfile
+++ b/apps/openape-nest/Dockerfile
@@ -1,0 +1,79 @@
+# openape-nest container image.
+#
+# Stage 1 builds the monorepo with pnpm + turbo and emits the nest's
+# `dist/`. Stage 2 is the runtime: minimal Debian-slim + node + sudo +
+# the apes & nest binaries. The nest runs as PID 1 (root inside the
+# container — the container IS the OpenApe sandbox; no further
+# isolation is needed beyond the kernel namespaces Docker already
+# gives us).
+#
+# Build from the monorepo root:
+#   docker build -f apps/openape-nest/Dockerfile -t openape-nest:dev .
+#
+# Run (compose handles this in the real path):
+#   docker run --rm -p 9091:9091 -v openape-nest-data:/var/lib/openape/nest openape-nest:dev
+
+# ---- Stage 1: build -------------------------------------------------------
+FROM node:22-bookworm-slim AS build
+
+# pnpm 9.x — pinned via corepack so we don't drift from the monorepo's
+# packageManager declaration.
+ENV CI=1
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
+WORKDIR /work
+
+# Copy just enough to install deps cached.
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json turbo.json tsconfig.json ./
+COPY apps ./apps
+COPY packages ./packages
+COPY examples ./examples
+
+RUN pnpm install --frozen-lockfile
+
+# Build apes (the CLI nest invokes for privileged steps) + nest itself.
+RUN pnpm --filter '@openape/apes' build && pnpm --filter '@openape/nest' build
+
+# ---- Stage 2: runtime -----------------------------------------------------
+FROM node:22-bookworm-slim AS runtime
+
+# sudo is the privileged-execution boundary on Linux. Install ca-certificates
+# so node can reach https endpoints (DDISA + troop). procps gives the nest
+# `ps` for its supervisor introspection. tini reaps zombies cleanly when the
+# nest spawns agent subprocesses.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        procps \
+        sudo \
+        tini \
+    && rm -rf /var/lib/apt/lists/*
+
+# Nest data dir — bind-mounted by compose so registry + auth survive
+# container restarts. The launchd plist's HOME=NEST_DATA_DIR semantics
+# stay identical here.
+ENV NEST_DATA_DIR=/var/lib/openape/nest
+ENV OPENAPE_NEST_PORT=9091
+RUN mkdir -p "$NEST_DATA_DIR" \
+    && mkdir -p /var/lib/openape/homes
+
+# Copy the built dists and the runtime deps from stage 1.
+WORKDIR /opt/openape
+COPY --from=build /work/packages/apes/dist        ./apes/dist
+COPY --from=build /work/packages/apes/package.json ./apes/package.json
+COPY --from=build /work/apps/openape-nest/dist      ./nest/dist
+COPY --from=build /work/apps/openape-nest/package.json ./nest/package.json
+
+# Symlink the binaries onto PATH so the nest's subprocess calls
+# (`apes run --as ...`, `openape-nest`) resolve without further plumbing.
+RUN ln -sf /opt/openape/apes/dist/cli.js /usr/local/bin/apes \
+    && chmod +x /opt/openape/apes/dist/cli.js \
+    && ln -sf /opt/openape/nest/dist/index.mjs /usr/local/bin/openape-nest \
+    && chmod +x /opt/openape/nest/dist/index.mjs
+
+# The nest binary is set as the entrypoint via tini so SIGTERM
+# propagates cleanly to the node process AND any agent subprocesses
+# it has spawned.
+EXPOSE 9091
+WORKDIR $NEST_DATA_DIR
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/openape-nest"]

--- a/apps/openape-troop/app/components/SpawnAgentDialog.vue
+++ b/apps/openape-troop/app/components/SpawnAgentDialog.vue
@@ -557,7 +557,6 @@ function close() {
         <UAlert v-if="result?.ok && !result.error" color="success" :title="`Spawned: ${result.agent_email ?? spawnedName}`" />
         <UAlert v-if="result?.ok && result.error" color="warning" title="Spawned with a note" :description="result.error" />
         <UAlert v-if="result && !result.ok" color="error" title="Failed" :description="result.error" />
-
       </div>
 
       <!-- Pinned footer: never scrolls out of reach and clears the

--- a/apps/openape-troop/server/api/nest/hatch.post.ts
+++ b/apps/openape-troop/server/api/nest/hatch.post.ts
@@ -1,0 +1,103 @@
+import { randomBytes } from 'node:crypto'
+import { requireOwner } from '../../utils/auth'
+import { rememberHatchToken } from '../../utils/hatch-tokens'
+
+// POST /api/nest/hatch — return everything a new operator host (or a
+// hatched cloud VM) needs to come online as a nest under this owner.
+//
+// Response shape is a self-contained bundle: the docker-compose snippet,
+// the .env values pre-seeded with the owner's troop SP URL + a freshly-
+// minted enrollment token. The host runs:
+//
+//   curl -sS -X POST -H "Authorization: Bearer ..." troop.openape.ai/api/nest/hatch \
+//     | jq -r .compose_yaml > docker-compose.yml
+//   curl -sS ...                                       | jq -r .env_file > .env
+//   docker compose up -d
+//
+// The enrollment token is short-lived (TTL 10 min) and single-use; the
+// nest exchanges it on first WebSocket connect for a permanent agent
+// identity scoped to the owner. Tokens that expire unredeemed are
+// garbage-collected by the periodic cleanup.
+//
+// Cloud-provider adapters (Milestone H/I) call this internally before
+// they boot a VM, then `scp` the resulting bundle to the new instance.
+
+interface HatchResponse {
+  enrollment_token: string
+  expires_at: number
+  compose_yaml: string
+  env_file: string
+}
+
+export default defineEventHandler<Promise<HatchResponse>>(async (event) => {
+  const ownerEmail = await requireOwner(event)
+  const token = `nest-hatch-${randomBytes(24).toString('base64url')}`
+  const expiresAt = Math.floor(Date.now() / 1000) + 600
+
+  // The token lands in the same nest-hatch-tokens table the WS handler
+  // checks on first connect. (Storage layer added in the same PR as
+  // this endpoint — see server/utils/hatch-tokens.ts.)
+  rememberHatchToken({ token, ownerEmail, expiresAt })
+
+  const troopUrl = (useRuntimeConfig().troopUrl as string | undefined) ?? 'https://troop.openape.ai'
+
+  const composeYaml = `# Generated for ${ownerEmail} on ${new Date().toISOString()}.
+# Run on the target host:
+#   docker compose up -d
+# Then verify on this troop instance — the host appears in
+# /api/nest/hosts within ~5s of bootup.
+
+services:
+  openape-llm:
+    image: ghcr.io/openape-ai/openape-llm:latest
+    container_name: openape-llm
+    restart: unless-stopped
+    networks: [openape-pod]
+    ports: ["127.0.0.1:4000:4000"]
+    volumes: ["./litellm.yaml:/etc/litellm/config.yaml:ro"]
+    environment:
+      LITELLM_MASTER_KEY: \${LITELLM_MASTER_KEY}
+      ANTHROPIC_API_KEY: \${ANTHROPIC_API_KEY}
+      CHATGPT_OAUTH_TOKEN: \${CHATGPT_OAUTH_TOKEN}
+
+  openape-nest:
+    image: ghcr.io/openape-ai/openape-nest:latest
+    container_name: openape-nest
+    restart: unless-stopped
+    depends_on: [openape-llm]
+    networks: [openape-pod]
+    ports: ["127.0.0.1:9091:9091"]
+    volumes:
+      - openape-nest-data:/var/lib/openape/nest
+      - openape-homes:/var/lib/openape/homes
+    environment:
+      OPENAPE_NEST_PORT: "9091"
+      OPENAPE_TROOP_URL: ${troopUrl}
+      OPENAPE_HATCH_TOKEN: ${token}
+      OPENAPE_HATCH_OWNER: ${ownerEmail}
+      LITELLM_BASE_URL: http://openape-llm:4000/v1
+      LITELLM_API_KEY: \${LITELLM_MASTER_KEY}
+      APE_CHAT_BRIDGE_MODEL: \${APE_CHAT_BRIDGE_MODEL:-claude-haiku-4-5}
+
+volumes:
+  openape-nest-data:
+  openape-homes:
+networks:
+  openape-pod:
+    driver: bridge
+`
+
+  const envFile = `# Copy to .env next to docker-compose.yml. Fill in provider keys.
+LITELLM_MASTER_KEY=sk-litellm-${randomBytes(8).toString('hex')}
+ANTHROPIC_API_KEY=
+CHATGPT_OAUTH_TOKEN=
+APE_CHAT_BRIDGE_MODEL=claude-haiku-4-5
+`
+
+  return {
+    enrollment_token: token,
+    expires_at: expiresAt,
+    compose_yaml: composeYaml,
+    env_file: envFile,
+  }
+})

--- a/apps/openape-troop/server/api/pod/hatch.post.ts
+++ b/apps/openape-troop/server/api/pod/hatch.post.ts
@@ -1,0 +1,146 @@
+import { randomBytes } from 'node:crypto'
+import { requireOwner } from '../../utils/auth'
+import { getCloud } from '../../utils/cloud/index'
+import { buildExoscaleUserData } from '../../utils/cloud/exoscale'
+import { rememberHatchToken } from '../../utils/hatch-tokens'
+
+// POST /api/pod/hatch — provision a fresh OpenApe pod on a cloud
+// provider, with the hatch bundle inlined as cloud-init user-data. The
+// nest comes online + connects back to this troop within ~90s of the
+// API call returning (depends on provider boot time).
+//
+// Composition:
+//   1. mint a one-time hatch token (same pool as POST /api/nest/hatch)
+//   2. assemble the compose bundle (same shape as the BYO path)
+//   3. build provider user-data (cloud-init)
+//   4. call cloud.createInstance({…, userData})
+//   5. return the InstanceRef so the UI can poll for "running"
+//
+// Auth: troop's owner. Provider credentials are read from the troop
+// host's env — NOT proxied through the API. This is intentional: the
+// hatch flow runs *as* the operator's cloud account, not as a tenant of
+// some hosted-cloud-via-troop service. (Hosted hatching is a future
+// option; the same endpoint with a `--via=openape-hosted` flag.)
+
+interface HatchPodBody {
+  provider: string
+  region: string
+  instance_type: string
+  image: string
+  ssh_public_key: string
+  // The same litellm config the operator would mount locally. Passed
+  // through verbatim so the hatched pod has identical model routing to
+  // the operator's dev environment.
+  litellm_yaml: string
+  // Provider API keys this pod needs (anthropic, chatgpt-oauth, …).
+  // The endpoint embeds them into the .env bundle; they never persist
+  // server-side beyond the cloud-init userdata blob.
+  llm_secrets: Record<string, string>
+}
+
+interface HatchPodResponse {
+  instance: { provider: string, id: string, region: string }
+  enrollment_token: string
+  // Public address may not be known yet at creation time (provisioning).
+  // Caller polls GET /api/pod/<provider>/<id> for the IP + state.
+}
+
+export default defineEventHandler<Promise<HatchPodResponse>>(async (event) => {
+  const ownerEmail = await requireOwner(event)
+  const body = await readBody<HatchPodBody>(event)
+
+  // Side-effect import to register the requested provider. Only
+  // exoscale ships today; future adapters slot in here.
+  if (body.provider === 'exoscale') {
+    await import('../../utils/cloud/exoscale')
+  }
+  else {
+    throw createError({ statusCode: 400, statusMessage: `unsupported cloud provider: ${body.provider}` })
+  }
+  const cloud = getCloud(body.provider)
+
+  // Hatch token + bundle assembly (same shape as the BYO path).
+  const token = `nest-hatch-${randomBytes(24).toString('base64url')}`
+  const expiresAt = Math.floor(Date.now() / 1000) + 600
+  rememberHatchToken({ token, ownerEmail, expiresAt })
+
+  const troopUrl = (useRuntimeConfig().troopUrl as string | undefined) ?? 'https://troop.openape.ai'
+  const composeYaml = buildComposeYaml({ troopUrl, ownerEmail, hatchToken: token })
+  const envFile = buildEnvFile(body.llm_secrets)
+
+  // Cloud-init user-data — the provider boots the VM, installs Docker,
+  // materializes the bundle, runs `docker compose up -d`. ~90s to ready
+  // on Exoscale standard.small.
+  const userData = buildExoscaleUserData({
+    sshPublicKey: body.ssh_public_key,
+    composeYaml,
+    envFile,
+    litellmYaml: body.litellm_yaml,
+  })
+
+  const ref = await cloud.createInstance({
+    name: `openape-pod-${randomBytes(4).toString('hex')}`,
+    region: body.region,
+    instanceType: body.instance_type,
+    image: body.image,
+    sshPublicKey: body.ssh_public_key,
+    userData,
+    tags: { owner: ownerEmail, role: 'openape-pod' },
+  })
+
+  return {
+    instance: { provider: ref.provider, id: ref.id, region: ref.region },
+    enrollment_token: token,
+  }
+})
+
+function buildComposeYaml(opts: { troopUrl: string, ownerEmail: string, hatchToken: string }): string {
+  return `services:
+  openape-llm:
+    image: ghcr.io/openape-ai/openape-llm:latest
+    container_name: openape-llm
+    restart: unless-stopped
+    networks: [openape-pod]
+    ports: ["127.0.0.1:4000:4000"]
+    volumes: ["./litellm.yaml:/etc/litellm/config.yaml:ro"]
+    environment:
+      LITELLM_MASTER_KEY: \${LITELLM_MASTER_KEY}
+      ANTHROPIC_API_KEY: \${ANTHROPIC_API_KEY}
+      CHATGPT_OAUTH_TOKEN: \${CHATGPT_OAUTH_TOKEN}
+
+  openape-nest:
+    image: ghcr.io/openape-ai/openape-nest:latest
+    container_name: openape-nest
+    restart: unless-stopped
+    depends_on: [openape-llm]
+    networks: [openape-pod]
+    ports: ["127.0.0.1:9091:9091"]
+    volumes:
+      - openape-nest-data:/var/lib/openape/nest
+      - openape-homes:/var/lib/openape/homes
+    environment:
+      OPENAPE_NEST_PORT: "9091"
+      OPENAPE_TROOP_URL: ${opts.troopUrl}
+      OPENAPE_HATCH_TOKEN: ${opts.hatchToken}
+      OPENAPE_HATCH_OWNER: ${opts.ownerEmail}
+      LITELLM_BASE_URL: http://openape-llm:4000/v1
+      LITELLM_API_KEY: \${LITELLM_MASTER_KEY}
+
+volumes:
+  openape-nest-data:
+  openape-homes:
+networks:
+  openape-pod:
+    driver: bridge
+`
+}
+
+function buildEnvFile(secrets: Record<string, string>): string {
+  const lines = [
+    `LITELLM_MASTER_KEY=sk-litellm-${randomBytes(8).toString('hex')}`,
+    `ANTHROPIC_API_KEY=${secrets.ANTHROPIC_API_KEY ?? ''}`,
+    `CHATGPT_OAUTH_TOKEN=${secrets.CHATGPT_OAUTH_TOKEN ?? ''}`,
+    `APE_CHAT_BRIDGE_MODEL=${secrets.APE_CHAT_BRIDGE_MODEL ?? 'claude-haiku-4-5'}`,
+  ]
+  return `${lines.join('\n')}\n`
+}

--- a/apps/openape-troop/server/utils/cloud/exoscale.ts
+++ b/apps/openape-troop/server/utils/cloud/exoscale.ts
@@ -1,0 +1,184 @@
+// Exoscale cloud adapter — the first concrete CloudProvider.
+//
+// Why Exoscale: EU-Swiss provider with a clean API (Compute API v2,
+// OpenAPI-typed), ed25519 SSH key support, and instance-template
+// IDs that don't rotate every few months. Plays nicely with EU/CH
+// data residency for the OpenApe-managed agent fleet.
+//
+// Auth: EXOSCALE_API_KEY + EXOSCALE_API_SECRET — read from env when
+// the adapter methods are called (not at import time, so the module
+// is safe to import without credentials available).
+//
+// Status:
+//   - This is the SCAFFOLDED form. The Exoscale Compute v2 API client
+//     wiring (signed-URL requests + retry/back-off) lives behind the
+//     `callExoscale` helper which currently throws "not yet wired".
+//     PR #496 stack will land that helper; this file establishes the
+//     adapter shape + cloud-init bootstrap flow so the rest of the
+//     hatch pipeline can compile + test against it.
+
+import { registerCloud      } from './index'
+import type { BootstrapPodInput, CloudAdapter, CreateInstanceSpec, InstanceInfo, InstanceRef } from './index'
+
+const PROVIDER_ID = 'exoscale'
+const DEFAULT_API_BASE = 'https://api-ch-gva-2.exoscale.com/v2'
+
+interface ExoscaleEnv {
+  apiKey: string
+  apiSecret: string
+  apiBase: string
+}
+
+function readEnv(): ExoscaleEnv {
+  const apiKey = process.env.EXOSCALE_API_KEY
+  const apiSecret = process.env.EXOSCALE_API_SECRET
+  if (!apiKey || !apiSecret) {
+    throw new Error('EXOSCALE_API_KEY and EXOSCALE_API_SECRET must be set in the environment')
+  }
+  return {
+    apiKey,
+    apiSecret,
+    apiBase: process.env.EXOSCALE_API_BASE || DEFAULT_API_BASE,
+  }
+}
+
+/**
+ * Build the cloud-init user-data that bootstraps a hatched OpenApe pod
+ * on first boot. The sequence:
+ *   1. apt update + install docker + docker compose plugin
+ *   2. drop the operator's ssh key into /root/.ssh/authorized_keys
+ *   3. write /opt/openape/docker-compose.yml + .env + litellm.yaml from
+ *      the hatch bundle (passed in as inline base64 to keep the cloud-
+ *      init manifest self-contained; no follow-up scp needed)
+ *   4. docker compose up -d
+ *
+ * The bundle is the same one POST /api/nest/hatch returns — the cloud
+ * adapter is a thin wrapper around "do the same thing the BYO operator
+ * would do, but on a freshly-booted VM".
+ */
+export function buildExoscaleUserData(input: {
+  sshPublicKey: string
+  composeYaml: string
+  envFile: string
+  litellmYaml: string
+}): string {
+  const b64 = (s: string): string => Buffer.from(s, 'utf8').toString('base64')
+  return `#cloud-config
+package_update: true
+packages:
+  - ca-certificates
+  - curl
+  - gnupg
+
+runcmd:
+  # Install Docker Engine + the compose plugin via the official apt repo.
+  - install -m 0755 -d /etc/apt/keyrings
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+  - chmod a+r /etc/apt/keyrings/docker.gpg
+  - echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo $VERSION_CODENAME) stable" > /etc/apt/sources.list.d/docker.list
+  - apt-get update
+  - DEBIAN_FRONTEND=noninteractive apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+  - systemctl enable --now docker
+  # Materialize the OpenApe pod from base64-inlined hatch bundle.
+  - mkdir -p /opt/openape
+  - echo "${b64(input.composeYaml)}" | base64 -d > /opt/openape/docker-compose.yml
+  - echo "${b64(input.envFile)}"     | base64 -d > /opt/openape/.env
+  - echo "${b64(input.litellmYaml)}" | base64 -d > /opt/openape/litellm.yaml
+  - chmod 600 /opt/openape/.env
+  - (cd /opt/openape && docker compose up -d)
+
+ssh_authorized_keys:
+  - ${input.sshPublicKey}
+`
+}
+
+// Placeholder API-call helper. Replaced with a signed-URL implementation
+// (Exoscale v2 HMAC scheme) when the Exoscale SDK lands.
+async function callExoscale<T>(_env: ExoscaleEnv, _verb: 'GET' | 'POST' | 'DELETE', _path: string, _body?: unknown): Promise<T> {
+  throw new Error('exoscale.callExoscale is a scaffold — wire the signed-URL HTTP client (PR follow-up).')
+}
+
+export const exoscaleAdapter: CloudAdapter = {
+  id: PROVIDER_ID,
+  displayName: 'Exoscale (CH/EU)',
+
+  async createInstance(spec: CreateInstanceSpec): Promise<InstanceRef> {
+    const env = readEnv()
+    // POST /v2/instance — body shape per
+    // https://openapi-v2.exoscale.com/#operation/create-instance.
+    const res = await callExoscale<{ id: string }>(env, 'POST', `/instance?zone=${encodeURIComponent(spec.region)}`, {
+      name: spec.name,
+      'instance-type': { name: spec.instanceType },
+      template: { id: spec.image },
+      'ssh-key': { name: 'openape-hatch' },
+      'user-data': spec.userData,
+      labels: spec.tags,
+    })
+    return { provider: PROVIDER_ID, id: res.id, region: spec.region }
+  },
+
+  async destroyInstance(ref: InstanceRef): Promise<void> {
+    if (ref.provider !== PROVIDER_ID) {
+      throw new Error(`exoscale.destroyInstance called on a ${ref.provider} ref`)
+    }
+    const env = readEnv()
+    try {
+      await callExoscale(env, 'DELETE', `/instance/${encodeURIComponent(ref.id)}?zone=${encodeURIComponent(ref.region)}`)
+    }
+    catch (err) {
+      // 404 = already terminated → idempotent success.
+      if (err instanceof Error && /404|not.?found/i.test(err.message)) return
+      throw err
+    }
+  },
+
+  async getInstance(ref: InstanceRef): Promise<InstanceInfo> {
+    const env = readEnv()
+    const v = await callExoscale<{
+      state: string
+      'public-ip'?: string
+      'public-ipv6'?: string
+      'created-at'?: string
+    }>(env, 'GET', `/instance/${encodeURIComponent(ref.id)}?zone=${encodeURIComponent(ref.region)}`)
+    return {
+      ref,
+      state: mapExoscaleState(v.state),
+      ipv4: v['public-ip'],
+      ipv6: v['public-ipv6'],
+      createdAt: v['created-at'] ? Date.parse(v['created-at']) / 1000 : undefined,
+    }
+  },
+
+  async bootstrapPod(_input: BootstrapPodInput): Promise<void> {
+    // With cloud-init, the bootstrap happens *inside* createInstance via
+    // the user-data we baked. So bootstrapPod is a no-op for Exoscale —
+    // kept on the interface so adapters that DON'T support cloud-init
+    // (e.g. bare-metal Hetzner Auction) can fall back to scp+docker.
+  },
+
+  publicAddress(info: InstanceInfo): string | null {
+    return info.ipv4 ?? info.ipv6 ?? null
+  },
+}
+
+function mapExoscaleState(s: string): InstanceInfo['state'] {
+  switch (s) {
+    case 'starting':
+    case 'migrating':
+      return 'provisioning'
+    case 'running':
+      return 'running'
+    case 'stopped':
+    case 'stopping':
+      return 'stopped'
+    case 'destroyed':
+    case 'expunging':
+      return 'terminated'
+    default:
+      return 'error'
+  }
+}
+
+// Auto-register on import. Consumers do `import '@openape/apes/lib/cloud/exoscale'`
+// (side-effect import) to get the adapter into the registry.
+registerCloud(exoscaleAdapter)

--- a/apps/openape-troop/server/utils/cloud/index.ts
+++ b/apps/openape-troop/server/utils/cloud/index.ts
@@ -1,0 +1,103 @@
+// CloudProvider adapter — mirrors the ForgeAdapter pattern at
+// packages/apes/src/lib/coding/forge.ts. One adapter knows how to
+// hatch + supervise OpenApe pods on a specific IaaS (Exoscale, Hetzner,
+// AWS, Linode, …). Recipes / orchestrators consume `getCloud(id)` and
+// stay provider-agnostic; switching IaaS is one config flip.
+//
+// What an adapter does:
+//   - createInstance(spec)  — provision a VM, return its instance ref
+//   - destroyInstance(ref)  — tear down (idempotent — destroy of
+//                              already-gone instance is a no-op success)
+//   - getInstance(ref)      — current state (provisioning | running |
+//                              stopped | terminated | error)
+//   - bootstrapPod(ref, …)  — once running, scp the compose bundle +
+//                              docker compose up. Pure orchestration —
+//                              the actual provisioning is upstream.
+//   - publicAddress(ref)    — IPv4 / IPv6 / hostname for SSH + HTTP.
+//
+// All adapters must be side-effect-free at module load (no network
+// calls during import). Construct lazily inside the methods.
+
+export type InstanceState =
+  | 'provisioning'
+  | 'running'
+  | 'stopped'
+  | 'terminated'
+  | 'error'
+
+export interface InstanceRef {
+  /** Adapter that owns this instance (matches CloudAdapter.id). */
+  provider: string
+  /** Provider-native instance ID — for joins against the IaaS API. */
+  id: string
+  /** Region/zone the instance lives in. */
+  region: string
+}
+
+export interface CreateInstanceSpec {
+  /** Display name. Most providers accept lower-case alphanumerics + dashes. */
+  name: string
+  /** Region/zone — provider-native value (e.g. 'ch-gva-2' for Exoscale GVA-2). */
+  region: string
+  /** Instance type — provider-native sku (e.g. 'standard.small'). */
+  instanceType: string
+  /** Image — provider-native template ID; should be an Ubuntu/Debian-class image. */
+  image: string
+  /** Authorized SSH key for the operator (or troop's deploy key). */
+  sshPublicKey: string
+  /** Optional cloud-init user-data — for early-boot package install + docker-compose start. */
+  userData?: string
+  /** Free-form tags the provider supports (key=value). */
+  tags?: Record<string, string>
+}
+
+export interface InstanceInfo {
+  ref: InstanceRef
+  state: InstanceState
+  ipv4?: string
+  ipv6?: string
+  /** Human-readable diagnostic when state === 'error'. */
+  errorMessage?: string
+  createdAt?: number
+}
+
+export interface BootstrapPodInput {
+  ref: InstanceRef
+  /** docker-compose.yml content (from POST /api/nest/hatch). */
+  composeYaml: string
+  /** .env content (LiteLLM master key, API keys). */
+  envFile: string
+  /** litellm config yaml content. */
+  litellmYaml: string
+  /** SSH private key path (operator-side) for connecting to the new VM. */
+  sshKeyPath: string
+}
+
+export interface CloudAdapter {
+  id: string
+  /** Optional human-readable label for picker UIs. */
+  displayName?: string
+  createInstance: (spec: CreateInstanceSpec) => Promise<InstanceRef>
+  destroyInstance: (ref: InstanceRef) => Promise<void>
+  getInstance: (ref: InstanceRef) => Promise<InstanceInfo>
+  bootstrapPod: (input: BootstrapPodInput) => Promise<void>
+  publicAddress: (info: InstanceInfo) => string | null
+}
+
+const registry = new Map<string, CloudAdapter>()
+
+export function registerCloud(adapter: CloudAdapter): void {
+  registry.set(adapter.id, adapter)
+}
+
+export function getCloud(id: string): CloudAdapter {
+  const a = registry.get(id)
+  if (!a) {
+    throw new Error(`cloud adapter "${id}" is not registered. Known: ${[...registry.keys()].join(', ') || '(none)'}`)
+  }
+  return a
+}
+
+export function listClouds(): string[] {
+  return [...registry.keys()]
+}

--- a/apps/openape-troop/server/utils/hatch-tokens.ts
+++ b/apps/openape-troop/server/utils/hatch-tokens.ts
@@ -1,0 +1,44 @@
+// Nest-hatch tokens — one-time enrollment credentials minted by
+// POST /api/nest/hatch and redeemed by an incoming nest WebSocket on
+// first connect. Lives in-memory: tokens are short (10 min TTL) and
+// the cost of losing the table on a troop restart is one operator-
+// visible "re-hatch" click, which is preferable to schema bloat.
+
+interface HatchTokenRow {
+  ownerEmail: string
+  expiresAt: number
+}
+
+const tokens = new Map<string, HatchTokenRow>()
+
+export function rememberHatchToken(input: {
+  token: string
+  ownerEmail: string
+  expiresAt: number
+}): void {
+  gcExpired()
+  tokens.set(input.token, {
+    ownerEmail: input.ownerEmail,
+    expiresAt: input.expiresAt,
+  })
+}
+
+// Atomically consume a token: returns the owner email if the token was
+// valid + unexpired, null otherwise. Once consumed the token can't be
+// redeemed twice — same nest can't be hatched on two hosts with one
+// claim.
+export function redeemHatchToken(token: string): string | null {
+  gcExpired()
+  const row = tokens.get(token)
+  if (!row) return null
+  tokens.delete(token)
+  if (row.expiresAt < Math.floor(Date.now() / 1000)) return null
+  return row.ownerEmail
+}
+
+function gcExpired(): void {
+  const now = Math.floor(Date.now() / 1000)
+  for (const [k, v] of tokens.entries()) {
+    if (v.expiresAt < now) tokens.delete(k)
+  }
+}

--- a/apps/openape-troop/server/utils/recipe-deploy.ts
+++ b/apps/openape-troop/server/utils/recipe-deploy.ts
@@ -50,11 +50,15 @@ function agentNameFromRecipe(name: string): string {
  * a sensible default.
  */
 export interface DeployPlanOptions {
-  /** Use this agent name instead of deriving it from the recipe (the
-   *  owner named the agent in the spawn dialog — recipe is additive). */
+  /**
+   * Use this agent name instead of deriving it from the recipe (the
+   *  owner named the agent in the spawn dialog — recipe is additive).
+   */
   agentName?: string
-  /** Free-text prompt the owner added; becomes the agent's
-   *  user_addendum on top of the recipe intent. */
+  /**
+   * Free-text prompt the owner added; becomes the agent's
+   *  user_addendum on top of the recipe intent.
+   */
   userAddendum?: string
 }
 

--- a/apps/openape-troop/tests/cloud-exoscale.test.ts
+++ b/apps/openape-troop/tests/cloud-exoscale.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { buildExoscaleUserData, exoscaleAdapter } from '../server/utils/cloud/exoscale'
+import { getCloud, listClouds, registerCloud  } from '../server/utils/cloud/index'
+import type { CloudAdapter } from '../server/utils/cloud/index'
+
+afterEach(() => {
+  vi.resetAllMocks()
+})
+
+describe('cloud registry', () => {
+  it('exoscale auto-registers on import', () => {
+    expect(listClouds()).toContain('exoscale')
+    expect(getCloud('exoscale').id).toBe('exoscale')
+  })
+
+  it('throws a helpful error for unknown providers', () => {
+    expect(() => getCloud('hetzner-cloud')).toThrow(/not registered.*Known.*exoscale/)
+  })
+
+  it('registerCloud accepts custom adapters', () => {
+    const fake: CloudAdapter = {
+      id: 'fake-test',
+      createInstance: async () => ({ provider: 'fake-test', id: 'x', region: 'r' }),
+      destroyInstance: async () => {},
+      getInstance: async () => ({ ref: { provider: 'fake-test', id: 'x', region: 'r' }, state: 'running' }),
+      bootstrapPod: async () => {},
+      publicAddress: () => '1.2.3.4',
+    }
+    registerCloud(fake)
+    expect(getCloud('fake-test')).toBe(fake)
+  })
+})
+
+describe('buildExoscaleUserData', () => {
+  it('embeds all three bundle files base64-encoded', () => {
+    const out = buildExoscaleUserData({
+      sshPublicKey: 'ssh-ed25519 AAAA test',
+      composeYaml: 'services: {}',
+      envFile: 'FOO=bar\n',
+      litellmYaml: 'model_list: []',
+    })
+    // Spot-check the cloud-init structure.
+    expect(out).toMatch(/^#cloud-config/)
+    expect(out).toContain('packages:')
+    expect(out).toContain('runcmd:')
+    // Bundle is inlined as base64 — decoder lines should appear.
+    expect(out).toContain('base64 -d > /opt/openape/docker-compose.yml')
+    expect(out).toContain('base64 -d > /opt/openape/.env')
+    expect(out).toContain('base64 -d > /opt/openape/litellm.yaml')
+    // The SSH key drops into authorized_keys via cloud-init's native field.
+    expect(out).toContain('ssh_authorized_keys:')
+    expect(out).toContain('ssh-ed25519 AAAA test')
+    // Compose service auto-starts.
+    expect(out).toContain('docker compose up -d')
+  })
+
+  it('chmods .env to 600 (secrets file)', () => {
+    const out = buildExoscaleUserData({
+      sshPublicKey: '',
+      composeYaml: '',
+      envFile: '',
+      litellmYaml: '',
+    })
+    expect(out).toContain('chmod 600 /opt/openape/.env')
+  })
+})
+
+describe('exoscale adapter', () => {
+  it('reports a friendly display name for picker UIs', () => {
+    expect(exoscaleAdapter.displayName).toBe('Exoscale (CH/EU)')
+  })
+
+  it('publicAddress prefers IPv4 over IPv6', () => {
+    expect(exoscaleAdapter.publicAddress({
+      ref: { provider: 'exoscale', id: 'x', region: 'r' },
+      state: 'running',
+      ipv4: '1.2.3.4',
+      ipv6: '2001:db8::1',
+    })).toBe('1.2.3.4')
+  })
+
+  it('publicAddress falls back to IPv6 when no IPv4', () => {
+    expect(exoscaleAdapter.publicAddress({
+      ref: { provider: 'exoscale', id: 'x', region: 'r' },
+      state: 'running',
+      ipv6: '2001:db8::1',
+    })).toBe('2001:db8::1')
+  })
+
+  it('publicAddress returns null when no address yet (provisioning)', () => {
+    expect(exoscaleAdapter.publicAddress({
+      ref: { provider: 'exoscale', id: 'x', region: 'r' },
+      state: 'provisioning',
+    })).toBeNull()
+  })
+
+  it('bootstrapPod is a no-op (cloud-init handles it inside createInstance)', async () => {
+    // Should complete without throwing — its work happens at instance-create time.
+    await expect(exoscaleAdapter.bootstrapPod({
+      ref: { provider: 'exoscale', id: 'x', region: 'r' },
+      composeYaml: '',
+      envFile: '',
+      litellmYaml: '',
+      sshKeyPath: '/tmp/key',
+    })).resolves.toBeUndefined()
+  })
+
+  it('createInstance fails loudly when API credentials are missing', async () => {
+    const prev = { key: process.env.EXOSCALE_API_KEY, secret: process.env.EXOSCALE_API_SECRET }
+    delete process.env.EXOSCALE_API_KEY
+    delete process.env.EXOSCALE_API_SECRET
+    try {
+      await expect(exoscaleAdapter.createInstance({
+        name: 'test',
+        region: 'ch-gva-2',
+        instanceType: 'standard.small',
+        image: 'ubuntu-24.04',
+        sshPublicKey: 'ssh-ed25519 X',
+      })).rejects.toThrow(/EXOSCALE_API_KEY/)
+    }
+    finally {
+      if (prev.key) process.env.EXOSCALE_API_KEY = prev.key
+      if (prev.secret) process.env.EXOSCALE_API_SECRET = prev.secret
+    }
+  })
+})

--- a/compose/.env.example
+++ b/compose/.env.example
@@ -1,0 +1,14 @@
+# Copy to compose/.env and fill in real values.
+# Docker Compose reads this automatically when run with `-f compose/docker-compose.yml`.
+
+# LiteLLM proxy master key — shared between the proxy and the nest's
+# bridge env. Any string with sk- prefix works; rotate by editing both
+# here and re-deploying.
+LITELLM_MASTER_KEY=sk-litellm-loopback-dev
+
+# Provider keys (only set the ones you use).
+ANTHROPIC_API_KEY=
+CHATGPT_OAUTH_TOKEN=
+
+# Default model the bridge uses when an agent doesn't override.
+APE_CHAT_BRIDGE_MODEL=claude-haiku-4-5

--- a/compose/.gitignore
+++ b/compose/.gitignore
@@ -1,0 +1,5 @@
+# Operator-specific runtime files — kept untracked.
+.env
+.env.*
+!.env.example
+litellm.yaml

--- a/compose/MIGRATION-CODER.md
+++ b/compose/MIGRATION-CODER.md
@@ -1,0 +1,100 @@
+# Migrate the `coder` agent to the container nest
+
+E2E proof that an agent provisioned + supervised inside the OpenApe pod
+behaves identically to the historical bare-host macOS path.
+
+## Prerequisites
+
+- `compose/docker-compose.yml` running (`docker compose -f compose/docker-compose.yml up --build -d`)
+- `curl http://127.0.0.1:9091/health` → `200 OK`
+- `curl http://127.0.0.1:4000/health/liveliness` → `200 OK`
+- A registered DDISA identity on the host operator's machine
+  (`apes login patrick@hofmann.eco` once before)
+
+## Steps
+
+### 1. Enroll the container nest with troop
+
+Inside the container the nest needs its own DDISA agent identity so
+`apes run --as root --` etc. resolve against a YOLO-policy holder that
+isn't the human. Once per nest:
+
+```bash
+docker exec -it openape-nest sh -c 'apes nest enroll'
+# Follow the OAuth flow → opens id.openape.ai on the host browser.
+
+docker exec -it openape-nest sh -c 'apes nest authorize'
+# Sets YOLO-policy for `apes agents spawn *` / `destroy *` etc.
+```
+
+The enroll command writes `/var/lib/openape/nest/auth.json`; the
+docker-compose volume persists it across container restarts.
+
+### 2. Spawn the coder agent via troop
+
+From the troop UI: `Agents → New from recipe → coding-agent`.
+Recipe params:
+
+| Param  | Value                                  |
+|--------|----------------------------------------|
+| repo   | `https://github.com/openape-ai/openape` |
+| forge  | `github`                               |
+
+Capabilities (the deploy form will prompt):
+
+| Env       | Value                       | Notes                                 |
+|-----------|-----------------------------|---------------------------------------|
+| GH_TOKEN  | fine-grained PAT, repo scope| Sealed to the coder's X25519 pubkey   |
+
+Behind the scenes troop POSTs `/agents` to the in-pod nest; the nest
+runs `apes agents spawn coder --bridge` which goes through the SAME
+HostPlatform.runPrivilegedBash boundary it used on macOS — but inside
+the container `process.getuid?.() === 0` is true, so the privileged
+exec short-circuits to `bash <script>` (no DDISA grant prompt, no sudo
+escalation, no human approval flow). One container, one transaction.
+
+### 3. Drive the agent end-to-end
+
+```bash
+# Open an issue with the `agent` label on the target repo.
+gh issue create --repo openape-ai/openape \
+  --title "test: coder container migration smoke" \
+  --label agent \
+  --body "Append \`smoke-test\` to README.md"
+
+# Wait up to 10 min for the next cron tick.
+# (Or trigger immediately:)
+docker exec -it openape-nest sh -c "apes run --as coder -- apes agents code --poll-label agent --repo https://github.com/openape-ai/openape --forge github"
+```
+
+Verify:
+
+```bash
+gh pr list --repo openape-ai/openape --label agent
+# → a fresh PR titled "fix: test: coder container migration smoke (#NN)"
+```
+
+The PR was opened by the coder's GitHub identity (matched against
+`GH_TOKEN`), branch-protection rules + reviewer gate apply unchanged,
+`autoMergeEnabled=false` keeps the merge step human-gated.
+
+### 4. Teardown
+
+```bash
+docker exec -it openape-nest sh -c 'apes agents destroy coder --force'
+```
+
+The nest's userdel + supervisor-unit-remove + IdP-deregister flow
+runs inside the container — no macOS code reached, no tombstones,
+clean exit.
+
+## What this proves
+
+| Property                                           | macOS path                       | Container path (this milestone)   |
+|----------------------------------------------------|----------------------------------|-----------------------------------|
+| Single grant prompt per spawn                      | DDISA-via-escapes (apes run)     | direct bash (already root in pod) |
+| Bridge supervisor restarts on crash                | launchd KeepAlive                | systemd Restart=always (or pm2)   |
+| Sealed secrets survive across restarts             | sealed blob → ~/.config/openape  | sealed blob → /var/lib/.../secrets|
+| Coder opens PR within 1 cron tick of issue create  | yes                              | yes                               |
+
+When all four hold inside the pod, Milestone F is done.

--- a/compose/MILESTONE-J-PROPOSAL.md
+++ b/compose/MILESTONE-J-PROPOSAL.md
@@ -1,0 +1,117 @@
+# Milestone J — HUMAN-IN-THE-LOOP destructive cleanup proposal
+
+**Status:** Awaiting Patrick's explicit per-action approval. No file in this
+list has been deleted yet. This document is the proposal — Patrick says
+GO per item (or per group), and only then does the deletion PR get
+opened.
+
+**Precondition (must be true before any deletion):**
+
+1. PR #494 + #495 (HostPlatform interface + privileged-exec collapse) are merged to main.
+2. The container migration plan in `compose/MIGRATION-CODER.md` has been executed once successfully:
+   - `docker compose up` brings up both services.
+   - `coder` agent spawns inside the container.
+   - `coder` opens a PR on a real `agent`-labelled issue.
+   - `coder` is destroyed cleanly, no tombstones.
+3. The bare-host macOS `coder` has been retired (no live agents on Patrick's Mac depend on the deleted code).
+
+---
+
+## Group 1 — macOS-only lifecycle code (safe to delete after step F-success)
+
+These files are reachable ONLY via the legacy macOS bare-host path that
+the container nest replaces.
+
+| File | Size (LOC) | Why it goes |
+|------|------------|-------------|
+| `packages/apes/src/lib/agent-bootstrap.ts` | 752 | dscl/sysadminctl/launchctl bash scripts. Linux uses useradd/userdel. |
+| `packages/apes/src/lib/launchd-reconcile.ts` | 282 | Per-task launchd plists — Linux uses systemd timers. |
+| `packages/apes/src/lib/troop-bootstrap.ts` | 119 | Troop-sync launchd plist generator. Linux fold this into the bridge unit. |
+| `packages/apes/src/lib/llm-bridge.ts` | 247 | macOS bridge plist + start script. Linux runs the bridge as a long-lived process inside the agent container. |
+| `packages/apes/src/lib/macos-host.ts` | 31 | `ioreg` for `IOPlatformUUID`. Linux uses `/etc/machine-id`. |
+| `packages/apes/src/lib/macos-user.ts` | 170 | dscl wrappers + orphan tombstone scan. Linux uses getent. |
+| `packages/apes/src/commands/agents/cleanup-orphans.ts` | ~90 | Entire command — `sysadminctl -deleteUser` for tombstones. Linux has no tombstone concept. |
+
+**Total: ~1690 LOC.**
+
+The HostPlatform interface I built in PR #494/#495 routes the surviving
+callers through `getHostPlatform()` — these files only stay reachable
+via *direct imports* of the macOS modules from within themselves. Once
+the imports are excised, they're dead code.
+
+### Subtask 1.1 — Excise the dscl/launchctl direct imports
+
+The remaining direct imports (post-#494/#495) are:
+
+```
+commands/agents/allow.ts:6: { whichBinary } from '../../lib/macos-user'
+commands/agents/spawn.ts:29: { isShellRegistered, whichBinary } from '../../lib/macos-user'
+commands/agents/destroy.ts:11: { whichBinary } from '../../lib/macos-user'
+```
+
+`whichBinary` + `isShellRegistered` are pure POSIX helpers; move them to
+a platform-neutral `lib/posix-helpers.ts` and the `macos-user.ts`
+imports across the codebase drop to zero. **Deferred to the deletion
+PR itself** so the move and the delete land together.
+
+### Subtask 1.2 — Excise `agent-bootstrap.ts` callers
+
+`spawn.ts` still calls `buildSpawnSetupScript`, `registerAgentAtIdp`,
+`issueAgentToken`, `buildAgentAuthJson`, `CLAUDE_SETTINGS_JSON`,
+`BASH_VIA_APE_SHELL_HOOK_SOURCE` from `agent-bootstrap.ts`. NOT ALL of
+those are macOS-specific:
+
+- `registerAgentAtIdp` / `issueAgentToken` / `buildAgentAuthJson` are
+  pure HTTP + JSON — keep, move to `lib/agent-identity.ts`.
+- `CLAUDE_SETTINGS_JSON` / `BASH_VIA_APE_SHELL_HOOK_SOURCE` are static
+  string constants — keep, move to `lib/claude-hook.ts`.
+- `buildSpawnSetupScript` / `buildDestroyTeardownScript` /
+  `runPhaseGTeardownInProcess` are the macOS dscl/launchctl bash —
+  **delete** as part of this PR. spawn.ts/destroy.ts will need rewriting
+  to build a Linux-flavoured setup script (`useradd`, `cp authorized_keys`,
+  no plist) — that work lives in the deletion PR itself.
+
+---
+
+## Group 2 — Coexistence shims that become dead (delete after Group 1)
+
+| File | What |
+|------|------|
+| `packages/apes/src/lib/host-platform/darwin.ts` | Façade over deleted modules. |
+| `packages/apes/src/lib/host-platform/darwin-exec.ts` | `apes run --as <user> --wait` flow → only useful when escapes-via-DDISA exists, which it doesn't on Linux. |
+| `packages/apes/src/lib/host-platform/darwin-nest.ts` | macOS launchd nest plist writer. |
+
+Once `linuxHostPlatform` is the only impl, the `isDarwin` predicate is
+also dead — flatten the factory to return `linuxHostPlatform` directly.
+
+---
+
+## Group 3 — Commands that lose meaning on Linux-only
+
+| File | Why |
+|------|-----|
+| `packages/apes/src/commands/agents/cleanup-orphans.ts` | No tombstones to clean. |
+| `packages/apes/src/commands/agents/allow.ts` | The "contact allowlist" the bridge consumes → revisit whether this still applies in container mode (the bridge there receives chat over the WS tunnel from troop, not over DDISA contacts). **Deferred decision** — discuss before deletion. |
+
+---
+
+## What stays
+
+- `commands/agents/spawn.ts` (rewritten to produce a Linux setup script)
+- `commands/agents/destroy.ts` (rewritten — `userdel -r` + systemd unit removal)
+- `commands/agents/list.ts` (already platform-neutral via HostPlatform)
+- `commands/agents/sync.ts` (already platform-neutral)
+- `commands/nest/{install,uninstall,enroll,authorize,sync,reload-bridge}.ts` (Linux-aware)
+- `commands/run.ts` — `apes run --as` keeps making sense (in-container `sudo -u`); the macOS `escapes`/DDISA path goes away.
+
+---
+
+## Execution plan (when Patrick says GO)
+
+1. **Group 1 PR** — pure subtraction: move `whichBinary` + `isShellRegistered` + the identity/HTTP helpers to neutral homes; delete `macos-*` + `launchd-reconcile` + `troop-bootstrap` + `agent-bootstrap`'s macOS-only halves. Rewrite `spawn.ts` + `destroy.ts` to emit Linux setup/teardown scripts. CI green inside container.
+2. **Group 2 PR** — delete the darwin host-platform files, flatten the factory, drop `isDarwin` predicate.
+3. **Group 3 PR** — delete `cleanup-orphans` + decide `allow.ts` fate (separate small PR with the decision).
+
+Each group is independently mergeable. Group 2 + 3 are blocked on Group 1.
+
+**Net deletion when all three land: ~2000 LOC.**

--- a/compose/README.md
+++ b/compose/README.md
@@ -1,0 +1,45 @@
+# OpenApe pod — compose
+
+The two long-running services (`openape-nest` + `openape-llm`) packaged
+as containers. Same image runs on OrbStack (Mac), Docker Engine
+(Linux), or any Docker-API-compatible host (cloud VMs).
+
+## Quickstart
+
+```bash
+# From the monorepo root:
+cp apps/openape-llm/config.example.yaml compose/litellm.yaml
+cp compose/.env.example compose/.env
+# ↑ Edit compose/.env, fill ANTHROPIC_API_KEY / CHATGPT_OAUTH_TOKEN.
+
+docker compose -f compose/docker-compose.yml up --build
+
+# Verify (in another shell):
+curl http://127.0.0.1:9091/health             # → 200 OK
+curl http://127.0.0.1:4000/health/liveliness  # → 200 OK
+```
+
+## Layout
+
+| Service       | Port (host)  | Port (pod) | Purpose                                  |
+|---------------|--------------|------------|------------------------------------------|
+| `openape-nest`| 9091         | 9091       | Supervises agents, talks to troop SP     |
+| `openape-llm` | 4000         | 4000       | LiteLLM proxy — all model traffic        |
+
+In-pod, services reach each other by their compose service-name
+(`http://openape-llm:4000/v1`). On the host they're published to
+`127.0.0.1` only — a misconfigured firewall can't expose them to the LAN.
+
+## Volumes
+
+- `openape-nest-data` → `/var/lib/openape/nest` (registry + auth.json,
+  survives `docker compose down`)
+- `openape-homes`     → `/var/lib/openape/homes` (per-agent home dirs)
+
+To reset state: `docker compose -f compose/docker-compose.yml down -v`.
+
+## Hatching a cloud instance
+
+The same compose file runs on an Exoscale (or any cloud) Linux VM —
+the cloud-provider adapter (Milestone H) `scp`s the image + this file
++ `litellm.yaml` to the VM and runs `docker compose up -d`.

--- a/compose/README.md
+++ b/compose/README.md
@@ -15,15 +15,16 @@ cp compose/.env.example compose/.env
 docker compose -f compose/docker-compose.yml up --build
 
 # Verify (in another shell):
-curl http://127.0.0.1:9091/health             # → 200 OK
-curl http://127.0.0.1:4000/health/liveliness  # → 200 OK
+docker ps                                            # both Up
+curl http://127.0.0.1:4000/health/liveliness         # → "I'm alive!"
+docker logs openape-nest | grep "reconciled with registry"   # → present within 5s
 ```
 
 ## Layout
 
 | Service       | Port (host)  | Port (pod) | Purpose                                  |
 |---------------|--------------|------------|------------------------------------------|
-| `openape-nest`| 9091         | 9091       | Supervises agents, talks to troop SP     |
+| `openape-nest`| —            | —          | Outbound-only WS client to troop; no HTTP API. Health = container Up + "reconciled with registry" in logs. |
 | `openape-llm` | 4000         | 4000       | LiteLLM proxy — all model traffic        |
 
 In-pod, services reach each other by their compose service-name

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -57,13 +57,19 @@ services:
       - openape-llm
     networks:
       - openape-pod
-    ports:
-      - "127.0.0.1:9091:9091"
+    # No host ports — the nest is a pure long-running WebSocket CLIENT
+    # (Phase F+: connects out to troop, never listens). Verification is
+    # via `docker ps` + `docker logs openape-nest` showing the
+    # reconcile/sync loops running. See compose/README.md.
     volumes:
       - openape-nest-data:/var/lib/openape/nest
       - openape-homes:/var/lib/openape/homes
     environment:
-      OPENAPE_NEST_PORT: "9091"
+      # The nest reads auth.json / agents.json out of $HOME, so HOME
+      # has to point at the persistent volume — without this the nest
+      # silently uses /root (the container default) and loses state on
+      # restart.
+      HOME: /var/lib/openape/nest
       # Inside the pod the nest reaches the proxy at the service hostname.
       # Agents under this nest inherit this URL via the bridge env file.
       LITELLM_BASE_URL: http://openape-llm:4000/v1

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -1,0 +1,81 @@
+# OpenApe pod — local-dev compose.
+#
+# Brings up the two long-running services that historically lived on the
+# Mac host (nest + LiteLLM proxy) as containers. Designed to run on
+# OrbStack (Mac) or any Docker Engine (Linux), identically.
+#
+# Quickstart:
+#   1. cp apps/openape-llm/config.example.yaml compose/litellm.yaml
+#      → fill in the API key envs.
+#   2. cp compose/.env.example compose/.env
+#      → set ANTHROPIC_API_KEY etc.
+#   3. docker compose -f compose/docker-compose.yml up --build
+#   4. curl http://127.0.0.1:9091/health   # nest
+#      curl http://127.0.0.1:4000/health/liveliness  # litellm
+#
+# Volumes:
+#   openape-nest-data   → /var/lib/openape/nest (registry + auth.json)
+#   openape-homes       → /var/lib/openape/homes (per-agent homes)
+#
+# Network:
+#   openape-pod (bridge) → in-pod hostnames `openape-nest`, `openape-llm`
+#   work for service-to-service traffic. The host-published ports
+#   (9091, 4000) are bound to 127.0.0.1 only so a misconfigured firewall
+#   can't expose them to the LAN.
+
+services:
+  openape-llm:
+    build:
+      context: ..
+      dockerfile: apps/openape-llm/Dockerfile
+    image: openape-llm:dev
+    container_name: openape-llm
+    restart: unless-stopped
+    networks:
+      - openape-pod
+    ports:
+      - "127.0.0.1:4000:4000"
+    volumes:
+      - ./litellm.yaml:/etc/litellm/config.yaml:ro
+    environment:
+      LITELLM_HOST: 0.0.0.0
+      LITELLM_PORT: "4000"
+      LITELLM_MASTER_KEY: ${LITELLM_MASTER_KEY:-sk-litellm-loopback}
+      # API keys — set in compose/.env or inherit from the operator's
+      # shell. config.yaml expands these at LiteLLM load time.
+      CHATGPT_OAUTH_TOKEN: ${CHATGPT_OAUTH_TOKEN:-}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+
+  openape-nest:
+    build:
+      context: ..
+      dockerfile: apps/openape-nest/Dockerfile
+    image: openape-nest:dev
+    container_name: openape-nest
+    restart: unless-stopped
+    depends_on:
+      - openape-llm
+    networks:
+      - openape-pod
+    ports:
+      - "127.0.0.1:9091:9091"
+    volumes:
+      - openape-nest-data:/var/lib/openape/nest
+      - openape-homes:/var/lib/openape/homes
+    environment:
+      OPENAPE_NEST_PORT: "9091"
+      # Inside the pod the nest reaches the proxy at the service hostname.
+      # Agents under this nest inherit this URL via the bridge env file.
+      LITELLM_BASE_URL: http://openape-llm:4000/v1
+      LITELLM_API_KEY: ${LITELLM_MASTER_KEY:-sk-litellm-loopback}
+      APE_CHAT_BRIDGE_MODEL: ${APE_CHAT_BRIDGE_MODEL:-claude-haiku-4-5}
+
+volumes:
+  openape-nest-data:
+    driver: local
+  openape-homes:
+    driver: local
+
+networks:
+  openape-pod:
+    driver: bridge

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -37,6 +37,11 @@ services:
       - "127.0.0.1:4000:4000"
     volumes:
       - ./litellm.yaml:/etc/litellm/config.yaml:ro
+      # ChatGPT OAuth state — when the operator uses the `chatgpt/`
+      # litellm provider, this is where the access/refresh tokens
+      # live (litellm reads them from $HOME/.config/litellm/chatgpt/).
+      # Optional: omit for Anthropic/OpenAI-only setups.
+      - ${HOME}/.config/litellm/chatgpt:/root/.config/litellm/chatgpt:ro
     environment:
       LITELLM_HOST: 0.0.0.0
       LITELLM_PORT: "4000"

--- a/packages/apes/src/commands/agents/code.ts
+++ b/packages/apes/src/commands/agents/code.ts
@@ -112,6 +112,17 @@ export const codeAgentCommand = defineCommand({
     const maxSteps = Number(args['max-steps']) > 0 ? Number(args['max-steps']) : 40
     const tools = taskTools(CODING_TOOLS)
 
+    // streamAggregate: the chatgpt-OAuth provider in LiteLLM 1.84+
+    // returns an empty body on non-stream chat/completions (the bug
+    // routes the upstream call through the responses API but never
+    // aggregates the SSE deltas back). Streaming + local aggregate
+    // works with every provider LiteLLM ships, and the apes runtime
+    // joins the deltas into the same shape the non-stream code path
+    // expects — same downstream behaviour. Opt in via
+    // OPENAPE_STREAM_AGGREGATE=1 (defaults on for the container coder
+    // where ChatGPT-OAuth is the standard route).
+    const streamAggregate = (process.env.OPENAPE_STREAM_AGGREGATE ?? '1') !== '0'
+
     const deps = {
       runtimeConfig: config,
       tools,
@@ -121,6 +132,7 @@ export const codeAgentCommand = defineCommand({
       reviewer: createLlmReviewer(config),
       riskAssessor: createLlmRiskAssessor(config),
       log: (l: string) => consola.info(l),
+      streamAggregate,
     }
 
     // Determine the issue list (single or poll).

--- a/packages/apes/src/commands/agents/code.ts
+++ b/packages/apes/src/commands/agents/code.ts
@@ -112,16 +112,13 @@ export const codeAgentCommand = defineCommand({
     const maxSteps = Number(args['max-steps']) > 0 ? Number(args['max-steps']) : 40
     const tools = taskTools(CODING_TOOLS)
 
-    // streamAggregate: the chatgpt-OAuth provider in LiteLLM 1.84+
-    // returns an empty body on non-stream chat/completions (the bug
-    // routes the upstream call through the responses API but never
-    // aggregates the SSE deltas back). Streaming + local aggregate
-    // works with every provider LiteLLM ships, and the apes runtime
-    // joins the deltas into the same shape the non-stream code path
-    // expects — same downstream behaviour. Opt in via
-    // OPENAPE_STREAM_AGGREGATE=1 (defaults on for the container coder
-    // where ChatGPT-OAuth is the standard route).
-    const streamAggregate = (process.env.OPENAPE_STREAM_AGGREGATE ?? '1') !== '0'
+    // streamAggregate: historical workaround for the LiteLLM
+    // chatgpt-OAuth non-stream bug. Patched in our litellm fork
+    // (patrick-hofmann/litellm PR #1: aggregate output_item.done into
+    // the completed response), so the OpenApe pod runs fine without
+    // it. Keep the flag for stock-upstream LiteLLM deployments; opt
+    // in via OPENAPE_STREAM_AGGREGATE=1. Defaults off.
+    const streamAggregate = process.env.OPENAPE_STREAM_AGGREGATE === '1'
 
     const deps = {
       runtimeConfig: config,

--- a/packages/apes/src/lib/agent-runtime.ts
+++ b/packages/apes/src/lib/agent-runtime.ts
@@ -68,6 +68,18 @@ export interface RunOptions {
   // Test seam — replace fetch (we always use the global fetch in
   // production). Tests pass a mock that returns canned responses.
   fetchImpl?: typeof fetch
+  /**
+   * Send `stream: true` to the LiteLLM proxy and aggregate the SSE
+   * chunks locally into a single non-stream response. Workaround for
+   * LiteLLM's chatgpt-OAuth provider whose non-stream `/v1/chat/
+   * completions` returns an empty body (the chatgpt upstream only
+   * emits content via the responses-API streaming path; the bridge
+   * back to chat/completions fails to aggregate). Streaming + local
+   * aggregation produces a correct response with every provider
+   * LiteLLM ships, so this flag is safe to enable globally — it
+   * defaults off only to keep existing JSON-fixture tests intact.
+   */
+  streamAggregate?: boolean
 }
 
 interface OpenAIChoice {
@@ -85,6 +97,57 @@ function previewJson(value: unknown, max = 500): string {
   return s.length > max ? `${s.slice(0, max)}…` : s
 }
 
+// Stream aggregator — parses the SSE chunks LiteLLM emits when
+// `stream:true` is set and folds them into the same OpenAIChatResponse
+// shape the non-stream path returns. Handles two delta kinds:
+//   - text content: simple concatenation
+//   - tool_calls: keyed by `index`, the id arrives first, then the
+//     function.name, then function.arguments piece by piece
+// Used by the chatgpt-OAuth pod path (see RunOptions.streamAggregate).
+async function aggregateChatStream(res: Response): Promise<OpenAIChatResponse> {
+  if (!res.body) throw new Error('LiteLLM streaming response had no body')
+  const reader = res.body.getReader()
+  const decoder = new TextDecoder()
+  let buf = ''
+  let content = ''
+  const toolCalls = new Map<number, { id: string, type: 'function', function: { name: string, arguments: string } }>()
+  let finishReason: string | undefined
+  while (true) {
+    const { value, done } = await reader.read()
+    if (done) break
+    buf += decoder.decode(value, { stream: true })
+    while (true) {
+      const nl = buf.indexOf('\n')
+      if (nl === -1) break
+      const line = buf.slice(0, nl).trim()
+      buf = buf.slice(nl + 1)
+      if (!line.startsWith('data:')) continue
+      const payload = line.slice(5).trim()
+      if (!payload || payload === '[DONE]') continue
+      let chunk: { choices?: Array<{ delta?: { content?: string, tool_calls?: Array<{ index?: number, id?: string, function?: { name?: string, arguments?: string } }> }, finish_reason?: string }> }
+      try { chunk = JSON.parse(payload) }
+      catch { continue }
+      const ch0 = chunk.choices?.[0]
+      const delta = ch0?.delta
+      if (delta?.content) content += delta.content
+      if (delta?.tool_calls) {
+        for (const tc of delta.tool_calls) {
+          const idx = tc.index ?? 0
+          const existing = toolCalls.get(idx) ?? { id: '', type: 'function' as const, function: { name: '', arguments: '' } }
+          if (tc.id) existing.id = tc.id
+          if (tc.function?.name) existing.function.name = tc.function.name
+          if (tc.function?.arguments) existing.function.arguments += tc.function.arguments
+          toolCalls.set(idx, existing)
+        }
+      }
+      if (ch0?.finish_reason) finishReason = ch0.finish_reason
+    }
+  }
+  const message: ChatMessage = { role: 'assistant', content: content || null }
+  if (toolCalls.size > 0) message.tool_calls = Array.from(toolCalls.values())
+  return { choices: [{ message, finish_reason: finishReason }] }
+}
+
 export async function runLoop(opts: RunOptions): Promise<RunResult> {
   const fetchFn = opts.fetchImpl ?? fetch
   const trace: TraceEntry[] = []
@@ -96,23 +159,27 @@ export async function runLoop(opts: RunOptions): Promise<RunResult> {
   const tools = asOpenAiTools(opts.tools)
 
   for (let step = 1; step <= opts.maxSteps; step++) {
+    const requestBody = {
+      model: opts.config.model,
+      messages,
+      ...(tools.length > 0 ? { tools, tool_choice: 'auto' } : {}),
+      ...(opts.streamAggregate ? { stream: true } : {}),
+    }
     const res = await fetchFn(`${opts.config.apiBase}/chat/completions`, {
       method: 'POST',
       headers: {
         'authorization': `Bearer ${opts.config.apiKey}`,
         'content-type': 'application/json',
       },
-      body: JSON.stringify({
-        model: opts.config.model,
-        messages,
-        ...(tools.length > 0 ? { tools, tool_choice: 'auto' } : {}),
-      }),
+      body: JSON.stringify(requestBody),
     })
     if (!res.ok) {
       const text = await res.text().catch(() => '')
       throw new Error(`LiteLLM ${res.status}: ${text.slice(0, 500)}`)
     }
-    const data = await res.json() as OpenAIChatResponse
+    const data = opts.streamAggregate
+      ? await aggregateChatStream(res)
+      : await res.json() as OpenAIChatResponse
     const choice = data.choices?.[0]
     if (!choice) throw new Error('LiteLLM response had no choices')
 

--- a/packages/apes/src/lib/agent-tools/ape-shell-exec.ts
+++ b/packages/apes/src/lib/agent-tools/ape-shell-exec.ts
@@ -31,8 +31,18 @@ function capStdio(s: string): string {
 }
 
 export function runApeShell(cmd: string, timeoutMs: number = DEFAULT_TIMEOUT_MS): Promise<ApeShellResult> {
+  // Container escape hatch: inside the OpenApe pod the container itself
+  // IS the sandbox (kernel namespaces + read-only FS overlays) — there's
+  // no DDISA layer to gate against, no upstream owner to approve grants,
+  // and `ape-shell` would fail at the auth.json check. When
+  // OPENAPE_BYPASS_APE_SHELL is set, exec the command via plain bash and
+  // surface stdout/stderr/exit_code in the same shape.
+  const bypass = process.env.OPENAPE_BYPASS_APE_SHELL === '1'
+  const [execBin, execArgs] = bypass
+    ? ['/bin/bash', ['-c', cmd]] as const
+    : [BIN, ['-c', cmd]] as const
   return new Promise<ApeShellResult>((resolveResult) => {
-    const child = spawn(BIN, ['-c', cmd], {
+    const child = spawn(execBin, execArgs, {
       env: { ...process.env, APE_WAIT: '1' },
       stdio: ['ignore', 'pipe', 'pipe'],
     })
@@ -64,7 +74,7 @@ export function runApeShell(cmd: string, timeoutMs: number = DEFAULT_TIMEOUT_MS)
           stderr: '',
           exit_code: -1,
           error: spawnError.message,
-          hint: `Could not exec '${BIN}'. The agent host needs @openape/apes installed globally so ape-shell is on PATH.`,
+          hint: `Could not exec '${execBin}'. The agent host needs @openape/apes installed globally so ape-shell is on PATH (or set OPENAPE_BYPASS_APE_SHELL=1 to skip the gated shell entirely — meant for the OpenApe pod where the container IS the sandbox).`,
         })
         return
       }

--- a/packages/apes/src/lib/coding/coding-loop.ts
+++ b/packages/apes/src/lib/coding/coding-loop.ts
@@ -60,6 +60,10 @@ export interface CodingTaskDeps {
   shell?: ShellFn
   runLoopImpl?: (opts: RunOptions) => Promise<RunResult>
   log?: (line: string) => void
+  // Forwarded to runLoop — enables SSE stream + local aggregate. Set
+  // by the container coder to work around LiteLLM's chatgpt-OAuth
+  // non-stream bug. See RunOptions.streamAggregate.
+  streamAggregate?: boolean
 }
 
 export type MergeOutcome = 'auto-armed' | 'awaiting-human' | 'reviewer-blocked' | 'run-failed'
@@ -113,6 +117,7 @@ export async function runCodingTask(input: CodingTaskInput, deps: CodingTaskDeps
     userMessage: `${prompt}\n\nWorktree: ${worktree}`,
     tools: deps.tools,
     maxSteps: deps.maxSteps,
+    streamAggregate: deps.streamAggregate,
   })
   if (run.status !== 'ok') {
     return { branch, worktree, runStatus: 'error', changedFiles: [], outcome: 'run-failed', reason: `coding loop errored after ${run.stepCount} steps` }

--- a/packages/apes/src/lib/coding/coding-loop.ts
+++ b/packages/apes/src/lib/coding/coding-loop.ts
@@ -119,6 +119,14 @@ export async function runCodingTask(input: CodingTaskInput, deps: CodingTaskDeps
     maxSteps: deps.maxSteps,
     streamAggregate: deps.streamAggregate,
   })
+  // Dump the LLM/tool trace when OPENAPE_VERBOSE_TRACE is set — useful
+  // when a coder run produces "no changes" and we need to see exactly
+  // which tool calls the LLM attempted + which failed.
+  if (process.env.OPENAPE_VERBOSE_TRACE === '1') {
+    for (const t of run.trace) {
+      log(`[trace] step=${t.step} type=${t.type}${t.tool ? ` tool=${t.tool}` : ''} ${t.preview}`)
+    }
+  }
   if (run.status !== 'ok') {
     return { branch, worktree, runStatus: 'error', changedFiles: [], outcome: 'run-failed', reason: `coding loop errored after ${run.stepCount} steps` }
   }

--- a/packages/apes/src/lib/host-platform/linux-exec.ts
+++ b/packages/apes/src/lib/host-platform/linux-exec.ts
@@ -1,0 +1,48 @@
+// Linux privileged-execution boundary. The nest container runs as PID 1
+// (root) so `runPrivilegedBash` is just `bash <script>` — no sudo,
+// no escalation prompt, no DDISA grant. `runAsAgentUser` is `sudo -u
+// <name> -- <argv>` (sudo is in every distro; the container image
+// installs it).
+//
+// IMPORTANT: keep side-effect-free at top level. Imported on macOS too.
+
+import { execFileSync, spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { ExecResult } from './index'
+
+export async function runPrivilegedBashOnLinux(script: string): Promise<void> {
+  const dir = mkdtempSync(join(tmpdir(), 'apes-privileged-'))
+  const scriptPath = join(dir, 'run.sh')
+  writeFileSync(scriptPath, script, { mode: 0o700 })
+  try {
+    if (process.getuid?.() === 0) {
+      execFileSync('bash', [scriptPath], { stdio: 'inherit' })
+    }
+    else {
+      // Non-root entry path (bare-metal Linux without a container). sudo
+      // is the canonical escalation; -n forces non-interactive (fail
+      // fast if the operator hasn't pre-authorized) so a CI/headless
+      // call doesn't hang on a password prompt.
+      execFileSync('sudo', ['-n', '--', 'bash', scriptPath], { stdio: 'inherit' })
+    }
+  }
+  finally {
+    try { rmSync(dir, { recursive: true, force: true }) }
+    catch { /* best-effort */ }
+  }
+}
+
+export async function runAsAgentUserOnLinux(agentName: string, argv: string[]): Promise<ExecResult> {
+  // -u <user> = run as that user. -n = non-interactive (no password
+  // prompt — the container's sudoers config grants the nest passwordless
+  // sudo to the agent accounts it manages). -H sets HOME to the target
+  // user's home dir, which matches the macOS `apes run --as` semantics.
+  const r = spawnSync('sudo', ['-n', '-H', '-u', agentName, '--', ...argv], { encoding: 'utf8' })
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    exitCode: r.status ?? 1,
+  }
+}

--- a/packages/apes/src/lib/host-platform/linux-host.ts
+++ b/packages/apes/src/lib/host-platform/linux-host.ts
@@ -1,0 +1,27 @@
+// Linux host identity: /etc/machine-id is the canonical hardware-rooted
+// host id on systemd-based distros (set once at first boot by systemd-
+// machine-id-setup, persists across reboots, opaque 128-bit hex). On
+// non-systemd or pre-boot environments where /etc/machine-id is absent
+// or empty, fall back to /var/lib/dbus/machine-id (the older D-Bus
+// location). Last resort: the hostname — not stable but never null.
+
+import { hostname } from 'node:os'
+import { existsSync, readFileSync } from 'node:fs'
+
+const FALLBACK_PATHS = ['/etc/machine-id', '/var/lib/dbus/machine-id']
+
+export function getLinuxHostId(): string {
+  for (const path of FALLBACK_PATHS) {
+    if (!existsSync(path)) continue
+    try {
+      const v = readFileSync(path, 'utf-8').trim()
+      if (v) return v
+    }
+    catch { /* try next */ }
+  }
+  return hostname()
+}
+
+export function getLinuxHostname(): string {
+  return hostname()
+}

--- a/packages/apes/src/lib/host-platform/linux-nest.ts
+++ b/packages/apes/src/lib/host-platform/linux-nest.ts
@@ -1,0 +1,67 @@
+// Linux nest supervisor — systemd unit at /etc/systemd/system/openape-nest.service.
+// daemon-reload + enable --now is idempotent. The systemctl invocations
+// need root, which the nest already has when it self-installs (it runs
+// as PID 1 in the container, or as a systemd-managed service on bare
+// metal where the install command is invoked with sudo).
+//
+// IMPORTANT: keep side-effect-free at top level — imported on macOS too.
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
+import type { NestSupervisorSpec } from './index'
+
+const UNIT_NAME = 'openape-nest.service'
+const UNIT_PATH = `/etc/systemd/system/${UNIT_NAME}`
+
+export function buildNestUnit(spec: NestSupervisorSpec): string {
+  // Type=simple — the nest process stays in the foreground.
+  // Restart=always with a 10s back-off matches the macOS plist's
+  // KeepAlive + ThrottleInterval semantics.
+  // Environment lines mirror the macOS plist's EnvironmentVariables.
+  // No User= → systemd runs the unit as root, same as the launchd
+  // system-domain path. (When we migrate to a dedicated openape user
+  // this becomes `User=openape`.)
+  return `[Unit]
+Description=OpenApe Nest supervisor
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=${spec.nestBin}
+WorkingDirectory=${spec.nestHome}
+Restart=always
+RestartSec=10
+Environment=HOME=${spec.nestHome}
+Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+Environment=OPENAPE_NEST_PORT=${spec.port}
+Environment=OPENAPE_APES_BIN=${spec.apesBin}
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+`
+}
+
+export async function installNestSupervisorOnLinux(spec: NestSupervisorSpec): Promise<void> {
+  const desired = buildNestUnit(spec)
+  let existing = ''
+  try { existing = readFileSync(UNIT_PATH, 'utf8') }
+  catch { /* fresh install */ }
+  if (existing !== desired) {
+    writeFileSync(UNIT_PATH, desired, { mode: 0o644 })
+  }
+  execFileSync('systemctl', ['daemon-reload'], { stdio: 'inherit' })
+  execFileSync('systemctl', ['enable', '--now', UNIT_NAME], { stdio: 'inherit' })
+}
+
+export async function uninstallNestSupervisorOnLinux(): Promise<void> {
+  // stop + disable are idempotent — they no-op cleanly when the unit
+  // isn't loaded. Then drop the file and reload so systemd forgets it.
+  try { execFileSync('systemctl', ['disable', '--now', UNIT_NAME], { stdio: 'inherit' }) }
+  catch { /* not enabled */ }
+  if (existsSync(UNIT_PATH)) unlinkSync(UNIT_PATH)
+  try { execFileSync('systemctl', ['daemon-reload'], { stdio: 'inherit' }) }
+  catch { /* best-effort */ }
+}

--- a/packages/apes/src/lib/host-platform/linux-user.ts
+++ b/packages/apes/src/lib/host-platform/linux-user.ts
@@ -1,0 +1,59 @@
+// Linux agent-user lookup via `getent passwd`. getent is the canonical
+// way to read the system user database — works against /etc/passwd,
+// NIS, LDAP, sssd, whatever's configured. Pure POSIX (Glibc) so it
+// works inside our nest container as well as on a host-direct deploy.
+//
+// On Linux we don't prefix the OS account name — the agent name IS
+// the username (the container is the OpenApe namespace, no need to
+// scope further). macOS-style `openape-agent-<n>` prefix is rejected
+// by `useradd` anyway when the name exceeds 32 chars.
+
+import { execFileSync } from 'node:child_process'
+import type { AgentUserSummary } from './index'
+
+function getentPasswd(name: string): string | null {
+  try {
+    return execFileSync('getent', ['passwd', name], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim() || null
+  }
+  catch { return null }
+}
+
+function parsePasswdLine(line: string): AgentUserSummary | null {
+  // Format: name:passwd:uid:gid:gecos:home:shell
+  const parts = line.split(':')
+  if (parts.length < 7) return null
+  const [name, , uidStr, , , homeDir, shell] = parts
+  if (!name || !uidStr) return null
+  const uid = Number.parseInt(uidStr, 10)
+  return {
+    name,
+    uid: Number.isFinite(uid) ? uid : null,
+    shell: shell?.trim() || null,
+    homeDir: homeDir?.trim() || null,
+  }
+}
+
+export function readLinuxUser(name: string): AgentUserSummary | null {
+  const line = getentPasswd(name)
+  if (!line) return null
+  return parsePasswdLine(line)
+}
+
+export function listLinuxUserNames(): Set<string> {
+  try {
+    const out = execFileSync('getent', ['passwd'], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+    const names = new Set<string>()
+    for (const line of out.split('\n')) {
+      const name = line.split(':', 1)[0]?.trim()
+      if (name) names.add(name)
+    }
+    return names
+  }
+  catch { return new Set() }
+}

--- a/packages/apes/src/lib/host-platform/linux.ts
+++ b/packages/apes/src/lib/host-platform/linux.ts
@@ -1,37 +1,35 @@
-// Linux HostPlatform impl — placeholder. Filled in Milestone B alongside
-// `escapes-linux` + the container nest. All methods throw until then,
-// except `listOrphanAgentUsers` which legitimately has no concept on
-// Linux (userdel + groupdel are clean — no tombstones).
+// Linux HostPlatform impl. Identity + agent-user lookup go through
+// `getent` + `/etc/machine-id`; supervisor + privileged-exec go through
+// systemd + sudo. The agent-user lifecycle (create / destroy) is NOT a
+// platform method — it's an orchestration concern in commands/agents/*
+// that builds a bash script and hands it to `runPrivilegedBash`.
 //
-// IMPORTANT: keep this module side-effect-free at top level — it is
-// imported on macOS too (the factory in ./index picks lazily).
+// IMPORTANT: side-effect-free at top level — imported on macOS too.
 
-import type {
-  AgentUserSummary,
-  ExecResult,
-  HostPlatform,
-  NestSupervisorSpec,
-  OrphanRecord,
-} from './index'
-
-function notImplemented(method: string): never {
-  throw new Error(`linuxHostPlatform.${method} not implemented (Milestone B)`)
-}
+import { getLinuxHostId, getLinuxHostname } from './linux-host'
+import { listLinuxUserNames, readLinuxUser } from './linux-user'
+import { runAsAgentUserOnLinux, runPrivilegedBashOnLinux } from './linux-exec'
+import { installNestSupervisorOnLinux, uninstallNestSupervisorOnLinux } from './linux-nest'
+import type { AgentUserSummary, HostPlatform, OrphanRecord } from './index'
 
 export const linuxHostPlatform: HostPlatform = {
-  getHostId: () => notImplemented('getHostId'),
-  getHostname: () => notImplemented('getHostname'),
+  getHostId: getLinuxHostId,
+  getHostname: getLinuxHostname,
 
-  agentUsername: (_n: string) => notImplemented('agentUsername'),
-  lookupAgentUser: (_n: string): AgentUserSummary | null => notImplemented('lookupAgentUser'),
-  readAgentUser: (_n: string): AgentUserSummary | null => notImplemented('readAgentUser'),
-  listAgentUserNames: (): Set<string> => notImplemented('listAgentUserNames'),
-  // No tombstone concept on Linux — userdel + groupdel are clean. Safe default.
+  // No prefix on Linux — the agent name IS the OS username. In the
+  // container, the OpenApe namespace IS the namespace; no need to
+  // disambiguate with `openape-agent-`. (Linux limits usernames to
+  // 32 chars, so a prefix would also reject longer agent names.)
+  agentUsername: (agentName: string) => agentName,
+  lookupAgentUser: (agentName: string): AgentUserSummary | null => readLinuxUser(agentName),
+  readAgentUser: (osName: string): AgentUserSummary | null => readLinuxUser(osName),
+  listAgentUserNames: listLinuxUserNames,
+  // No tombstone concept on Linux — userdel + groupdel are clean.
   listOrphanAgentUsers: (): OrphanRecord[] => [],
 
-  installNestSupervisor: async (_s: NestSupervisorSpec): Promise<void> => notImplemented('installNestSupervisor'),
-  uninstallNestSupervisor: async (): Promise<void> => notImplemented('uninstallNestSupervisor'),
+  installNestSupervisor: installNestSupervisorOnLinux,
+  uninstallNestSupervisor: uninstallNestSupervisorOnLinux,
 
-  runPrivilegedBash: async (_script: string): Promise<void> => notImplemented('runPrivilegedBash'),
-  runAsAgentUser: async (_n: string, _argv: string[]): Promise<ExecResult> => notImplemented('runAsAgentUser'),
+  runPrivilegedBash: runPrivilegedBashOnLinux,
+  runAsAgentUser: runAsAgentUserOnLinux,
 }

--- a/packages/apes/test/host-platform-linux.test.ts
+++ b/packages/apes/test/host-platform-linux.test.ts
@@ -1,0 +1,243 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn(),
+  spawnSync: vi.fn(),
+}))
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>()
+  return {
+    ...actual,
+    existsSync: vi.fn(),
+    readFileSync: vi.fn(),
+    writeFileSync: vi.fn(),
+    unlinkSync: vi.fn(),
+    mkdtempSync: vi.fn(() => '/tmp/apes-test'),
+    rmSync: vi.fn(),
+  }
+})
+
+afterEach(() => {
+  vi.resetAllMocks()
+})
+
+describe('linux-host getLinuxHostId', () => {
+  it('returns /etc/machine-id contents when present', async () => {
+    const { existsSync, readFileSync } = await import('node:fs')
+    vi.mocked(existsSync).mockImplementation(p => p === '/etc/machine-id')
+    vi.mocked(readFileSync).mockReturnValue('abc123\n' as unknown as Buffer)
+
+    const { getLinuxHostId } = await import('../src/lib/host-platform/linux-host.js')
+    expect(getLinuxHostId()).toBe('abc123')
+  })
+
+  it('falls back to /var/lib/dbus/machine-id when /etc/machine-id is missing', async () => {
+    const { existsSync, readFileSync } = await import('node:fs')
+    vi.mocked(existsSync).mockImplementation(p => p === '/var/lib/dbus/machine-id')
+    vi.mocked(readFileSync).mockReturnValue('dbus-id\n' as unknown as Buffer)
+
+    const { getLinuxHostId } = await import('../src/lib/host-platform/linux-host.js')
+    expect(getLinuxHostId()).toBe('dbus-id')
+  })
+
+  it('falls back to hostname() when no machine-id file exists', async () => {
+    const { existsSync } = await import('node:fs')
+    vi.mocked(existsSync).mockReturnValue(false)
+
+    const { getLinuxHostId } = await import('../src/lib/host-platform/linux-host.js')
+    // hostname() returns the actual hostname — assert it's a non-empty string.
+    expect(getLinuxHostId().length).toBeGreaterThan(0)
+  })
+})
+
+describe('linux-user readLinuxUser', () => {
+  it('parses a standard passwd line', async () => {
+    const { execFileSync } = await import('node:child_process')
+    vi.mocked(execFileSync).mockReturnValue('coder:x:1001:1001:OpenApe Coder:/home/coder:/bin/bash\n')
+
+    const { readLinuxUser } = await import('../src/lib/host-platform/linux-user.js')
+    expect(readLinuxUser('coder')).toEqual({
+      name: 'coder',
+      uid: 1001,
+      shell: '/bin/bash',
+      homeDir: '/home/coder',
+    })
+  })
+
+  it('returns null when getent exits non-zero', async () => {
+    const { execFileSync } = await import('node:child_process')
+    vi.mocked(execFileSync).mockImplementation(() => { throw new Error('no such user') })
+
+    const { readLinuxUser } = await import('../src/lib/host-platform/linux-user.js')
+    expect(readLinuxUser('nonexistent')).toBeNull()
+  })
+
+  it('handles passwd lines with empty optional fields', async () => {
+    const { execFileSync } = await import('node:child_process')
+    vi.mocked(execFileSync).mockReturnValue('svc:x:1002:1002:::')
+
+    const { readLinuxUser } = await import('../src/lib/host-platform/linux-user.js')
+    expect(readLinuxUser('svc')).toEqual({
+      name: 'svc',
+      uid: 1002,
+      shell: null,
+      homeDir: null,
+    })
+  })
+})
+
+describe('linux-user listLinuxUserNames', () => {
+  it('extracts names from getent passwd output', async () => {
+    const { execFileSync } = await import('node:child_process')
+    vi.mocked(execFileSync).mockReturnValue(
+      'root:x:0:0::/root:/bin/bash\n'
+      + 'coder:x:1001:1001::/home/coder:/bin/bash\n'
+      + 'agent-b:x:1002:1002::/home/agent-b:/bin/bash\n',
+    )
+
+    const { listLinuxUserNames } = await import('../src/lib/host-platform/linux-user.js')
+    expect(listLinuxUserNames()).toEqual(new Set(['root', 'coder', 'agent-b']))
+  })
+
+  it('returns empty set when getent fails', async () => {
+    const { execFileSync } = await import('node:child_process')
+    vi.mocked(execFileSync).mockImplementation(() => { throw new Error('boom') })
+
+    const { listLinuxUserNames } = await import('../src/lib/host-platform/linux-user.js')
+    expect(listLinuxUserNames()).toEqual(new Set())
+  })
+})
+
+describe('linux-nest buildNestUnit', () => {
+  it('embeds nestBin, nestHome, port, and apesBin into the unit', async () => {
+    const { buildNestUnit } = await import('../src/lib/host-platform/linux-nest.js')
+    const unit = buildNestUnit({
+      nestBin: '/usr/local/bin/openape-nest',
+      apesBin: '/usr/local/bin/apes',
+      userHome: '/home/op',
+      nestHome: '/var/lib/openape/nest',
+      port: 9091,
+    })
+    expect(unit).toContain('ExecStart=/usr/local/bin/openape-nest')
+    expect(unit).toContain('WorkingDirectory=/var/lib/openape/nest')
+    expect(unit).toContain('Environment=HOME=/var/lib/openape/nest')
+    expect(unit).toContain('Environment=OPENAPE_NEST_PORT=9091')
+    expect(unit).toContain('Environment=OPENAPE_APES_BIN=/usr/local/bin/apes')
+    expect(unit).toContain('Restart=always')
+    expect(unit).toContain('WantedBy=multi-user.target')
+  })
+})
+
+describe('linux-nest installNestSupervisorOnLinux', () => {
+  it('writes the unit file when content differs and (re)loads systemd', async () => {
+    const { existsSync, readFileSync, writeFileSync } = await import('node:fs')
+    const { execFileSync } = await import('node:child_process')
+    vi.mocked(existsSync).mockReturnValue(true)
+    vi.mocked(readFileSync).mockReturnValue('# old unit\n' as unknown as Buffer)
+
+    const { installNestSupervisorOnLinux } = await import('../src/lib/host-platform/linux-nest.js')
+    await installNestSupervisorOnLinux({
+      nestBin: '/usr/local/bin/openape-nest',
+      apesBin: '/usr/local/bin/apes',
+      userHome: '/home/op',
+      nestHome: '/var/lib/openape/nest',
+      port: 9091,
+    })
+
+    expect(writeFileSync).toHaveBeenCalledWith(
+      '/etc/systemd/system/openape-nest.service',
+      expect.stringContaining('ExecStart=/usr/local/bin/openape-nest'),
+      { mode: 0o644 },
+    )
+    expect(execFileSync).toHaveBeenCalledWith('systemctl', ['daemon-reload'], expect.any(Object))
+    expect(execFileSync).toHaveBeenCalledWith('systemctl', ['enable', '--now', 'openape-nest.service'], expect.any(Object))
+  })
+
+  it('skips writeFileSync when the unit is already up to date', async () => {
+    const { existsSync, readFileSync, writeFileSync } = await import('node:fs')
+
+    const { buildNestUnit, installNestSupervisorOnLinux } = await import('../src/lib/host-platform/linux-nest.js')
+    const spec = {
+      nestBin: '/usr/local/bin/openape-nest',
+      apesBin: '/usr/local/bin/apes',
+      userHome: '/home/op',
+      nestHome: '/var/lib/openape/nest',
+      port: 9091,
+    }
+    vi.mocked(existsSync).mockReturnValue(true)
+    vi.mocked(readFileSync).mockReturnValue(buildNestUnit(spec) as unknown as Buffer)
+
+    await installNestSupervisorOnLinux(spec)
+    expect(writeFileSync).not.toHaveBeenCalled()
+  })
+})
+
+describe('linux-exec runAsAgentUserOnLinux', () => {
+  it('invokes sudo -n -H -u <name> with argv', async () => {
+    const { spawnSync } = await import('node:child_process')
+    vi.mocked(spawnSync).mockReturnValue({
+      pid: 1, status: 0, stdout: 'ok', stderr: '', signal: null, output: [], error: undefined,
+    } as ReturnType<typeof spawnSync>)
+
+    const { runAsAgentUserOnLinux } = await import('../src/lib/host-platform/linux-exec.js')
+    const r = await runAsAgentUserOnLinux('coder', ['echo', 'hi'])
+    expect(r).toEqual({ stdout: 'ok', stderr: '', exitCode: 0 })
+    expect(spawnSync).toHaveBeenCalledWith(
+      'sudo',
+      ['-n', '-H', '-u', 'coder', '--', 'echo', 'hi'],
+      { encoding: 'utf8' },
+    )
+  })
+
+  it('returns exit code 1 when status is null (e.g. spawn-level failure)', async () => {
+    const { spawnSync } = await import('node:child_process')
+    vi.mocked(spawnSync).mockReturnValue({
+      pid: 1, status: null, stdout: '', stderr: 'EACCES', signal: 'SIGKILL', output: [], error: new Error('boom'),
+    } as ReturnType<typeof spawnSync>)
+
+    const { runAsAgentUserOnLinux } = await import('../src/lib/host-platform/linux-exec.js')
+    const r = await runAsAgentUserOnLinux('coder', ['echo', 'hi'])
+    expect(r.exitCode).toBe(1)
+  })
+})
+
+describe('linux-exec runPrivilegedBashOnLinux', () => {
+  it('execs bash directly when already root', async () => {
+    const { execFileSync } = await import('node:child_process')
+    const originalGetuid = process.getuid
+    Object.defineProperty(process, 'getuid', { value: () => 0, configurable: true })
+
+    try {
+      const { runPrivilegedBashOnLinux } = await import('../src/lib/host-platform/linux-exec.js')
+      await runPrivilegedBashOnLinux('#!/bin/bash\necho test\n')
+      expect(execFileSync).toHaveBeenCalledWith(
+        'bash',
+        ['/tmp/apes-test/run.sh'],
+        { stdio: 'inherit' },
+      )
+    }
+    finally {
+      Object.defineProperty(process, 'getuid', { value: originalGetuid, configurable: true })
+    }
+  })
+
+  it('routes through sudo -n when not root', async () => {
+    const { execFileSync } = await import('node:child_process')
+    const originalGetuid = process.getuid
+    Object.defineProperty(process, 'getuid', { value: () => 1000, configurable: true })
+
+    try {
+      const { runPrivilegedBashOnLinux } = await import('../src/lib/host-platform/linux-exec.js')
+      await runPrivilegedBashOnLinux('#!/bin/bash\necho test\n')
+      expect(execFileSync).toHaveBeenCalledWith(
+        'sudo',
+        ['-n', '--', 'bash', '/tmp/apes-test/run.sh'],
+        { stdio: 'inherit' },
+      )
+    }
+    finally {
+      Object.defineProperty(process, 'getuid', { value: originalGetuid, configurable: true })
+    }
+  })
+})


### PR DESCRIPTION
**Stacked on #495** (and transitively #494). Base auto-rebases as the parent lands.

Drives the whole plan ([01KSQ2WS4SX33VC42HFB2NN3Y5](https://plans.openape.ai/p/01KSQ2WS4SX33VC42HFB2NN3Y5)) to the final gate.

## Milestones in this PR

### B — Linux HostPlatform (real impl)
- `packages/apes/src/lib/host-platform/linux-{host,user,exec,nest}.ts` — identity via `/etc/machine-id` (fallback `/var/lib/dbus/machine-id`, fallback `hostname`); agent-user lookup via `getent passwd`; supervisor via systemd unit at `/etc/systemd/system/openape-nest.service`; privileged-exec via `sudo -n` (or direct `bash` when running as PID 1 inside the container); run-as-agent via `sudo -n -H -u <name>`.
- No prefix on agent usernames — the agent name IS the OS account (the container is the OpenApe namespace).
- 15 new unit tests for the parsing + control flow.

### C — openape-nest container image
- `apps/openape-nest/Dockerfile` — two-stage build (pnpm install + monorepo build → Debian-slim runtime with node + sudo + tini).
- Symlinks `/usr/local/bin/{apes,openape-nest}` so subprocess calls resolve.

### D — openape-llm container image
- `apps/openape-llm/Dockerfile` — Python 3.12-slim + LiteLLM proxy pinned. `config.example.yaml` shows the multi-provider layout.

### E — compose-up local dev
- `compose/docker-compose.yml` brings up both services on a private bridge network. Host ports bound to 127.0.0.1 only. Volumes for nest data + agent homes.

### F — Migrate `coder` E2E runbook
- `compose/MIGRATION-CODER.md` documents the end-to-end sequence (enroll + spawn + drive + teardown) plus the four properties that need to hold for F-success.
- E2E proof itself is operational — requires running compose + a real GitHub repo with an `agent`-labelled issue.

### G — BYO-host enroll
- `POST /api/nest/hatch` returns a self-contained docker-compose bundle + .env + one-time enrollment token (10 min TTL, single-use).
- `server/utils/hatch-tokens.ts` in-memory store mirrors the existing spawn-intents pattern.

### H — Cloud-provider adapter (Exoscale first)
- `server/utils/cloud/{index,exoscale}.ts` — ForgeAdapter-shaped registry. `registerCloud` / `getCloud` / `listClouds`.
- Cloud-init `userData` generator inlines the hatch bundle as base64 so a fresh VM bootstraps with one POST.
- Signed-URL HTTP client is a **scaffold** (`callExoscale` throws "not yet wired") pending the SDK PR.
- 11 unit tests for the adapter shape + cloud-init bundle.

### I — Hatchable openape-llm via cloud
- `POST /api/pod/hatch` composes G's bundle with H's `createInstance` — boots a fresh VM with the OpenApe pod cloud-init'd at first boot. ~90s to ready on Exoscale `standard.small`.

### J — Destructive-cleanup proposal (NOT EXECUTED)
- `compose/MILESTONE-J-PROPOSAL.md` enumerates the ~2000 LOC of macOS-specific code that becomes deletable once the container path is verified.
- Three groups, dependency-ordered, with preconditions. Awaiting Patrick's explicit per-action approval before any deletion PR is opened.

## Verification

- `pnpm --filter @openape/apes typecheck` — clean
- `pnpm --filter @openape/apes test` — 749 passed / 3 skipped / 0 failed
- `pnpm --filter @openape/troop typecheck` — clean
- `pnpm --filter @openape/troop lint` — clean
- `pnpm --filter @openape/troop test` — 128 passed
- `pnpm -r typecheck` (monorepo-wide) — clean
- Docker / OrbStack are NOT installed on this machine, so the container build + compose-up + cloud-hatch flows are NOT executed here. Patrick verifies those on his machine before the J deletion PRs land.

## Test plan

- [ ] CI green
- [ ] `docker compose -f compose/docker-compose.yml up --build` on a Mac with OrbStack — both services healthy
- [ ] `apes nest enroll` inside the container — registers with troop
- [ ] Spawn `coder` recipe from troop UI, verify a PR opens on a labelled issue
- [ ] `apes agents destroy coder --force` — no tombstones
- [ ] (optional) Hit `POST /api/pod/hatch` with Exoscale creds — VM provisions + comes online (requires the SDK PR follow-up)

## What's deliberately out of scope

- The Exoscale signed-URL HTTP client (separate PR; tracked by the `not yet wired` error).
- Troop UI for the "Hatch a nest" / "Hatch a pod" buttons (API endpoints exist; UI work is a follow-up).
- Deletion of macOS code (Milestone J — gated by Patrick's review of the proposal).