### PR TITLE
fix(compose): publish openape-llm on host 4001, not 4000

### DIFF
--- a/compose/README.md
+++ b/compose/README.md
@@ -16,7 +16,7 @@ docker compose -f compose/docker-compose.yml up --build
 
 # Verify (in another shell):
 docker ps                                            # both Up
-curl http://127.0.0.1:4000/health/liveliness         # → "I'm alive!"
+curl http://127.0.0.1:4001/health/liveliness         # → "I'm alive!"
 docker logs openape-nest | grep "reconciled with registry"   # → present within 5s
 ```
 
@@ -25,11 +25,14 @@ docker logs openape-nest | grep "reconciled with registry"   # → present withi
 | Service       | Port (host)  | Port (pod) | Purpose                                  |
 |---------------|--------------|------------|------------------------------------------|
 | `openape-nest`| —            | —          | Outbound-only WS client to troop; no HTTP API. Health = container Up + "reconciled with registry" in logs. |
-| `openape-llm` | 4000         | 4000       | LiteLLM proxy — all model traffic        |
+| `openape-llm` | 4001         | 4000       | LiteLLM proxy — all model traffic        |
 
 In-pod, services reach each other by their compose service-name
-(`http://openape-llm:4000/v1`). On the host they're published to
-`127.0.0.1` only — a misconfigured firewall can't expose them to the LAN.
+(`http://openape-llm:4000/v1`). On the host the proxy is published to
+`127.0.0.1:4001` only — `4001` (not `4000`) so a host-side litellm
+install bound to `*:4000` keeps its loopback traffic. On macOS/OrbStack
+the specific `127.0.0.1` docker binding wins over the host process's
+wildcard `*:4000`, silently stealing requests otherwise.
 
 ## Volumes
 

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -10,8 +10,9 @@
 #   2. cp compose/.env.example compose/.env
 #      → set ANTHROPIC_API_KEY etc.
 #   3. docker compose -f compose/docker-compose.yml up --build
-#   4. curl http://127.0.0.1:9091/health   # nest
-#      curl http://127.0.0.1:4000/health/liveliness  # litellm
+#   4. docker ps                                            # both Up
+#      curl http://127.0.0.1:4001/health/liveliness         # litellm
+#      docker logs openape-nest | grep "reconciled with registry"
 #
 # Volumes:
 #   openape-nest-data   → /var/lib/openape/nest (registry + auth.json)
@@ -19,9 +20,13 @@
 #
 # Network:
 #   openape-pod (bridge) → in-pod hostnames `openape-nest`, `openape-llm`
-#   work for service-to-service traffic. The host-published ports
-#   (9091, 4000) are bound to 127.0.0.1 only so a misconfigured firewall
-#   can't expose them to the LAN.
+#   work for service-to-service traffic. The host-published port
+#   (4001 → container :4000) is bound to 127.0.0.1 only so a
+#   misconfigured firewall can't expose it to the LAN. 4001 (not 4000)
+#   so a host-side litellm install on *:4000 — the default for OpenApe
+#   operators who started before the containerisation — keeps its
+#   loopback traffic; on macOS/OrbStack the specific 127.0.0.1 binding
+#   wins over wildcard, silently stealing requests otherwise.
 
 services:
   openape-llm:
@@ -34,7 +39,7 @@ services:
     networks:
       - openape-pod
     ports:
-      - "127.0.0.1:4000:4000"
+      - "127.0.0.1:4001:4000"
     volumes:
       - ./litellm.yaml:/etc/litellm/config.yaml:ro
       # ChatGPT OAuth state — when the operator uses the `chatgpt/`


### PR DESCRIPTION
Small follow-up to PR #496. Surfaced today when my F-proof pod stayed up and the operator's host-LiteLLM lost its loopback traffic — bridge returned `No connected db` because requests were silently landing in the container with the wrong master_key. Moves the published host port from 4000 → 4001 so a coexisting host-side litellm keeps its traffic.