### PR TITLE
feat(nest,compose): forward OPENAPE_BRIDGE_TARGET + APE_CHAT_ENDPOINT into bridges

### DIFF
--- a/apps/openape-nest/src/lib/pm2-supervisor.ts
+++ b/apps/openape-nest/src/lib/pm2-supervisor.ts
@@ -96,6 +96,10 @@ function ecosystemContents(apesBin: string, agentName: string): string {
     'APE_CHAT_BRIDGE_TOOLS',
     'APE_CHAT_BRIDGE_MAX_STEPS',
     'APE_CHAT_BRIDGE_SYSTEM_PROMPT',
+    // Chat backend selection (chat.openape.ai vs troop.openape.ai) —
+    // honoured by the bridge at startup. See ape-agent/src/bridge.ts.
+    'OPENAPE_BRIDGE_TARGET',
+    'APE_CHAT_ENDPOINT',
   ]
   const envLines = envForwards
     .filter(k => process.env[k] !== undefined)

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -85,6 +85,12 @@ services:
       # `apes run --as <agent>`, and the agent-tool runApeShell helper
       # to exec via /bin/bash instead of the gated ape-shell.
       OPENAPE_BYPASS_APE_SHELL: "1"
+      # Chat backend the per-agent bridges connect to. Default 'chat'
+      # (chat.openape.ai) for back-compat with operators who haven't
+      # migrated; flip via compose/.env to 'troop' to point bridges at
+      # troop.openape.ai's native chat. See compose/CUTOVER-CHAT-TO-TROOP.md.
+      OPENAPE_BRIDGE_TARGET: ${OPENAPE_BRIDGE_TARGET:-chat}
+      APE_CHAT_ENDPOINT: ${APE_CHAT_ENDPOINT:-https://chat.openape.ai}
 
 volumes:
   openape-nest-data:


### PR DESCRIPTION
Tiny follow-up to PR #507 — closes the env-forwarding gap so the per-agent bridges actually see the cutover env when an operator flips them in `compose/.env`. Verified live: ran the cutover on Patrick's pod today (2026-05-30T17:18:30Z), all 4 bridges reconnected to https://troop.openape.ai.