### PR TITLE
fix(nest): promote enrolled auth.json to $HOME/.config/apes in container

### DIFF
--- a/apps/openape-nest/docker-entrypoint.sh
+++ b/apps/openape-nest/docker-entrypoint.sh
@@ -31,6 +31,23 @@ if [ -r "$LOCAL_CA_SRC" ]; then
   echo "[entrypoint] trusted local CA → $LOCAL_CA_DST"
 fi
 
+# Promote the enrolled nest-agent auth.json onto $HOME/.config/apes/ where
+# @openape/cli-auth and troop-ws look it up. `apes nest enroll` writes to
+# $HOME/.openape/nest/.config/apes/auth.json (mirroring the macOS plist
+# convention HOME=NEST_DATA_DIR). In the container HOME points at the
+# volume root instead, so the default cli-auth lookup misses the file
+# and troop-ws falls back to "○ poll" instead of "● live".
+NEST_AUTH_SRC="$HOME/.openape/nest/.config/apes/auth.json"
+NEST_AUTH_DST="$HOME/.config/apes/auth.json"
+if [ -f "$NEST_AUTH_SRC" ]; then
+  mkdir -p "$(dirname "$NEST_AUTH_DST")"
+  if [ ! -f "$NEST_AUTH_DST" ] || ! cmp -s "$NEST_AUTH_SRC" "$NEST_AUTH_DST"; then
+    cp "$NEST_AUTH_SRC" "$NEST_AUTH_DST"
+    chmod 600 "$NEST_AUTH_DST"
+    echo "[entrypoint] promoted nest auth.json → $NEST_AUTH_DST"
+  fi
+fi
+
 REGISTRY=/var/lib/openape/nest/agents.json
 HOMES=/var/lib/openape/homes
 


### PR DESCRIPTION
## Symptom
Troop UI shows `○ nest offline — falling back to 5min poll` instead of `● live · openape-nest`. Container logs every 30s: `troop-ws: not logged in (apes login) — skip connect, will retry`.

## Root cause
`apes nest enroll` writes the nest-agent identity to `$HOME/.openape/nest/.config/apes/auth.json`, mirroring the macOS launchd convention where `HOME=NEST_DATA_DIR`. In the container we keep `HOME=/var/lib/openape/nest` (the volume root) so per-agent uses of `$HOME/.config/apes/` keep working — but that means `@openape/cli-auth`'s default lookup of `$HOME/.config/apes/auth.json` resolves to a stale human-bootstrap auth.json (or nothing) instead of the enrolled nest identity. `ensureFreshIdpAuth()` throws `NotLoggedInError` and the troop-ws connect path bails out.

## Fix
Idempotent copy in `docker-entrypoint.sh`: if `$HOME/.openape/nest/.config/apes/auth.json` exists and differs from `$HOME/.config/apes/auth.json`, promote it. Runs every container start so re-enrollment propagates automatically.

## Verification
- Manually `cp` inside the running container → next 30s tick logged `troop-ws: connected to wss://troop.openape.ai`.
- Rebuilt image + recreated container → entrypoint logs `[entrypoint] promoted nest auth.json → /var/lib/openape/nest/.config/apes/auth.json`, WS connects, troop UI flips to `● live`.