### PR TITLE
feat(troop): translate every page + component to DE/EN (M3-M8)

### DIFF
--- a/apps/openape-troop/app/components/AgentChat.vue
+++ b/apps/openape-troop/app/components/AgentChat.vue
@@ -29,6 +29,8 @@ interface Chat {
   lastMessageAt: number | null
 }
 
+const { t, locale } = useI18n()
+
 const messages = ref<ChatMessage[]>([])
 const chat = ref<Chat | null>(null)
 const loading = ref(true)
@@ -50,7 +52,7 @@ async function load(): Promise<void> {
     scrollToBottom()
   }
   catch (err: any) {
-    error.value = err?.data?.statusMessage || err?.message || 'failed to load chat'
+    error.value = err?.data?.statusMessage || err?.message || t('chat.error.loadFailed')
   }
   finally {
     loading.value = false
@@ -105,7 +107,7 @@ async function send(): Promise<void> {
     await load()
   }
   catch (err: any) {
-    error.value = err?.data?.statusMessage || err?.message || 'failed to send'
+    error.value = err?.data?.statusMessage || err?.message || t('chat.error.sendFailed')
     messages.value = messages.value.filter(m => m.id !== localId)
   }
   finally {
@@ -135,7 +137,7 @@ function formatTs(unixSec: number): string {
   const hh = String(d.getHours()).padStart(2, '0')
   const mm = String(d.getMinutes()).padStart(2, '0')
   if (sameDay) return `${hh}:${mm}`
-  return `${d.toLocaleDateString()} ${hh}:${mm}`
+  return `${d.toLocaleDateString(locale.value)} ${hh}:${mm}`
 }
 
 watch(() => props.agentName, () => {
@@ -162,7 +164,7 @@ onBeforeUnmount(() => stopPolling())
         class="banner-action"
         @click="error = null; loading = true; void load()"
       >
-        Retry
+        {{ $t('common.retry') }}
       </button>
     </div>
 
@@ -174,17 +176,17 @@ onBeforeUnmount(() => stopPolling())
         v-if="loading"
         class="state state-loading"
       >
-        Loading chat…
+        {{ $t('chat.loading') }}
       </div>
       <div
         v-else-if="empty"
         class="state state-empty"
       >
         <p class="empty-title">
-          Noch keine Nachrichten
+          {{ $t('chat.empty.title') }}
         </p>
         <p class="empty-sub">
-          Schreib dem Agent unten — die Antwort landet hier oben.
+          {{ $t('chat.empty.sub') }}
         </p>
       </div>
 
@@ -213,7 +215,7 @@ onBeforeUnmount(() => stopPolling())
             </div>
           </div>
           <div class="meta">
-            {{ formatTs(m.createdAt) }}<span v-if="m.editedAt"> · edited</span>
+            {{ formatTs(m.createdAt) }}<span v-if="m.editedAt"> · {{ $t('chat.edited') }}</span>
           </div>
         </li>
       </ul>
@@ -224,7 +226,7 @@ onBeforeUnmount(() => stopPolling())
         ref="composerEl"
         v-model="composer"
         rows="1"
-        placeholder="Schreib dem Agent…"
+        :placeholder="$t('chat.composer.placeholder')"
         :disabled="sending || loading || !chat"
         @keydown="onComposerKey"
       />

--- a/apps/openape-troop/app/components/CronInput.vue
+++ b/apps/openape-troop/app/components/CronInput.vue
@@ -7,6 +7,8 @@ defineProps<{
 
 const model = defineModel<string>({ default: '*/5 * * * *' })
 
+const { t, locale } = useI18n()
+
 // Tiny cron preview — only handles the subset we accept server-side
 // (`*` / `N` / `*/N` per field). Returns the next ~5 fire times in
 // human-readable form so the user can sanity-check their expression
@@ -35,7 +37,7 @@ function fieldMatches(f: Field, value: number): boolean {
 
 const preview = computed(() => {
   const parts = model.value.trim().split(/\s+/)
-  if (parts.length !== 5) return { ok: false as const, msg: 'expected 5 space-separated fields' }
+  if (parts.length !== 5) return { ok: false as const, msg: t('cron.error.expectFiveFields') }
   const [m, h, dom, mo, dow] = parts as [string, string, string, string, string]
   const minute = parseField(m, 59)
   const hour = parseField(h, 23)
@@ -43,7 +45,7 @@ const preview = computed(() => {
   const month = parseField(mo, 12)
   const weekDay = parseField(dow, 7)
   if (!minute || !hour || !monthDay || !month || !weekDay) {
-    return { ok: false as const, msg: 'invalid field — see help' }
+    return { ok: false as const, msg: t('cron.error.invalidField') }
   }
 
   const now = new Date()
@@ -66,7 +68,7 @@ const preview = computed(() => {
       && fieldMatches(month, mn)
       && (fieldMatches(weekDay, wd) || (weekDay.kind === 'fixed' && weekDay.value === 7 && wd === 0))
     ) {
-      matches.push(cursor.toLocaleString('de-AT', {
+      matches.push(cursor.toLocaleString(locale.value, {
         weekday: 'short',
         day: '2-digit',
         month: '2-digit',
@@ -77,7 +79,7 @@ const preview = computed(() => {
   }
 
   if (matches.length === 0) {
-    return { ok: true as const, msg: 'no fire times in the next 7 days' }
+    return { ok: true as const, msg: t('cron.preview.noFireTimes') }
   }
   return { ok: true as const, msg: matches.join(' · ') }
 })
@@ -99,9 +101,16 @@ const preview = computed(() => {
       <UIcon v-else name="i-lucide-alert-triangle" class="inline" />
       {{ preview.msg }}
     </p>
-    <p class="text-xs text-muted">
-      Subset: <code>*</code>, <code>N</code> (fixed), <code>*/N</code> (only on minute + hour). 5 fields:
-      minute hour day-of-month month day-of-week.
-    </p>
+    <i18n-t keypath="cron.help" tag="p" class="text-xs text-muted">
+      <template #any>
+        <code>*</code>
+      </template>
+      <template #fixed>
+        <code>N</code>
+      </template>
+      <template #step>
+        <code>*/N</code>
+      </template>
+    </i18n-t>
   </div>
 </template>

--- a/apps/openape-troop/app/components/SpawnAgentDialog.vue
+++ b/apps/openape-troop/app/components/SpawnAgentDialog.vue
@@ -10,6 +10,8 @@ interface NestHost {
 
 const open = defineModel<boolean>('open', { default: false })
 
+const { t } = useI18n()
+
 const hosts = ref<NestHost[]>([])
 const hostsError = ref('')
 const loadingHosts = ref(false)
@@ -19,7 +21,7 @@ async function loadHosts() {
   hostsError.value = ''
   try { hosts.value = await ($fetch as any)('/api/nest/hosts') }
   catch (err: any) {
-    hostsError.value = err?.data?.statusMessage || err?.data?.message || err?.message || 'failed to load nest hosts'
+    hostsError.value = err?.data?.statusMessage || err?.data?.message || err?.message || t('spawn.error.hostsLoadFailed')
   }
   finally {
     loadingHosts.value = false
@@ -37,7 +39,7 @@ watch(open, (now) => { if (now) loadHosts() })
 // paste any github.com/<owner>/<name>@<ref>. `caps` lets the recipe
 // pre-declare which secrets to add; if a recipe doesn't, the Help
 // button points at its repo where the README documents them.
-interface RecipeIndexEntry { id: string, label: string, repo_ref: string, repo_url: string, hint: string, caps: string[] }
+interface RecipeIndexEntry { id: string, label: string, repo_ref: string, repo_url: string, hintKey: string, caps: string[] }
 const RECIPE_NONE = '__none__'
 const RECIPE_CUSTOM = '__custom__'
 const RECIPE_INDEX: RecipeIndexEntry[] = [
@@ -46,7 +48,7 @@ const RECIPE_INDEX: RecipeIndexEntry[] = [
     label: 'Bluesky feed summary',
     repo_ref: 'github.com/openape-ai/bluesky-summary@v0.1.0',
     repo_url: 'https://github.com/openape-ai/bluesky-summary',
-    hint: 'Twice-daily digest of your Bluesky home timeline. Param: topic.',
+    hintKey: 'spawn.recipe.entries.blueskySummary.hint',
     caps: ['BLUESKY_HANDLE', 'BLUESKY_APP_PASSWORD'],
   },
 ]
@@ -56,14 +58,20 @@ const recipeForm = ref({ repo_ref: '', params: '' })
 // Free-text persona presets — fill the system-prompt textarea. With a
 // recipe this rides along as the additive user_addendum; without one
 // it is the agent's system prompt.
+//
+// Note: only the UI label/description are i18n'd. The `prompt` body is
+// what gets sent TO the agent (the agent's runtime instructions) and
+// is kept in German — that is the language the agent operates in.
+// Operators who want an English-speaking agent rewrite the prompt
+// manually after picking the closest preset.
 interface SystemPromptPreset { id: string, label: string, description: string, prompt: string }
 const MEMORY_NOTE = `Persistente Notizen, Account-Namen, Standard-Filter und alles was du dir konversationsübergreifend merken willst, schreibst du nach ~/.openape/agent/MEMORY.md (Markdown, lege es bei Bedarf neu an). Du liest das File am Beginn jeder Konversation und aktualisierst es wenn der Owner dir neue dauerhafte Vorgaben gibt.`
-const PRESETS: SystemPromptPreset[] = [
-  { id: 'custom', label: 'Custom (leer)', description: 'Eigenen System-Prompt schreiben oder später im Agent-Detail setzen.', prompt: '' },
+const PRESETS = computed<SystemPromptPreset[]>(() => [
+  { id: 'custom', label: t('spawn.preset.custom.label'), description: t('spawn.preset.custom.description'), prompt: '' },
   {
     id: 'calendar',
-    label: '📅 Kalender-Assistent',
-    description: 'Tagesüberblick am Morgen, Hinweise zu Verschiebungen / Konflikten.',
+    label: t('spawn.preset.calendar.label'),
+    description: t('spawn.preset.calendar.description'),
     prompt: `Du bist ein Kalender-Assistent. Du gibst werktags am Morgen einen Tagesüberblick per DM und meldest dich bei kurzfristigen Terminverschiebungen oder Konflikten. Halte dich kurz und antworte auf Deutsch.
 
 Tools: das bash-Tool ist dein Hauptwerkzeug — ruf damit das passende CLI auf, das der Owner für seinen Kalender nutzt (z.B. o365-cli für Microsoft 365 oder gcalcli für Google). Falls noch keines konfiguriert ist, frag den Owner nach dem CLI-Namen und dem zu verwendenden Account.
@@ -72,8 +80,8 @@ ${MEMORY_NOTE}`,
   },
   {
     id: 'mail-triage',
-    label: '📬 Mail-Triage',
-    description: 'Sichtet ungelesene Mails, priorisiert Action / Important / FYI / Spam.',
+    label: t('spawn.preset.mailTriage.label'),
+    description: t('spawn.preset.mailTriage.description'),
     prompt: `Du bist ein Mail-Triage-Assistent. Du sichtest die Inbox, fasst neue ungelesene Mails zusammen und priorisierst nach Action / Important / FYI / Spam. Top-5-Übersicht per DM, max. eine Zeile pro Mail (Absender · Betreff · Empfehlung). Knapp, deutsche Sprache.
 
 Tools: bash. Nutz dafür o365-cli (für Microsoft 365) oder ein anderes Mail-CLI das auf dem Host installiert ist.
@@ -82,8 +90,8 @@ ${MEMORY_NOTE}`,
   },
   {
     id: 'time-tracker',
-    label: '⏱ Zeiterfassung',
-    description: 'Wertet activity-logs aus, fasst Stunden pro Projekt / Firma zusammen.',
+    label: t('spawn.preset.timeTracker.label'),
+    description: t('spawn.preset.timeTracker.description'),
     prompt: `Du bist ein Zeiterfassungs-Assistent. Du liest die activity-logs des Owners (JSONL pro Tag), gruppierst nach Firma + Projekt und meldest pro Tag eine Markdown-Tabelle: Firma / Projekt / Stunden / Stichworte.
 
 Tools: bash und file.read. Der Owner sagt dir beim ersten Mal wo die logs liegen — merke dir den Pfad in MEMORY.md.
@@ -92,15 +100,15 @@ ${MEMORY_NOTE}`,
   },
   {
     id: 'daily-summary',
-    label: '🗞 Daily Summary',
-    description: 'Synthetisiert activity-logs + tasks + Termine zu einem End-of-day Bericht.',
+    label: t('spawn.preset.dailySummary.label'),
+    description: t('spawn.preset.dailySummary.description'),
     prompt: `Du bist ein Daily-Summary-Bot. Jeden Werktag am Abend fasst du zusammen: 1. Was wurde heute gemacht? 2. Was wurde abgeschlossen? 3. Was steht morgen an? Drei kurze Abschnitte, je 3-5 Bulletpoints, deutsche Sprache.
 
 Tools: bash, file.read, http.get. Welche Pfade / APIs / Accounts der Owner verwendet, fragst du beim ersten Mal ab und speicherst es in MEMORY.md.
 
 ${MEMORY_NOTE}`,
   },
-]
+])
 const selectedPreset = ref<string>('custom')
 
 const AGENT_NAME_POOL: readonly string[] = [
@@ -162,9 +170,9 @@ function rollName(): void {
 }
 
 watch(selectedPreset, (id) => {
-  const preset = PRESETS.find(p => p.id === id)
+  const preset = PRESETS.value.find(p => p.id === id)
   if (!preset) return
-  if (!form.value.system_prompt || PRESETS.some(p => p.prompt === form.value.system_prompt)) {
+  if (!form.value.system_prompt || PRESETS.value.some(p => p.prompt === form.value.system_prompt)) {
     form.value.system_prompt = preset.prompt
   }
 })
@@ -217,7 +225,7 @@ function parseParams(text: string): Record<string, string> {
     const line = raw.trim()
     if (!line) continue
     const eq = line.indexOf('=')
-    if (eq <= 0) throw new Error(`bad param line: "${line}" (expected KEY=value)`)
+    if (eq <= 0) throw new Error(t('spawn.error.badParamLine', { line }))
     out[line.slice(0, eq).trim()] = line.slice(eq + 1)
   }
   return out
@@ -257,7 +265,7 @@ async function submit() {
     pollResult()
   }
   catch (err: any) {
-    result.value = { ok: false, error: err?.data?.statusMessage || err?.data?.message || err?.message || 'spawn failed' }
+    result.value = { ok: false, error: err?.data?.statusMessage || err?.data?.message || err?.message || t('spawn.error.spawnFailed') }
   }
   finally {
     submitting.value = false
@@ -279,7 +287,7 @@ async function pollResult() {
     await bindSecrets(res.agent_email)
   }
   catch (err: any) {
-    result.value = { ok: false, error: err?.data?.statusMessage || err?.data?.message || err?.message || 'poll failed' }
+    result.value = { ok: false, error: err?.data?.statusMessage || err?.data?.message || err?.message || t('spawn.error.pollFailed') }
   }
 }
 
@@ -302,7 +310,8 @@ async function bindSecrets(agentEmail?: string) {
         }
         catch (err: any) {
           if (i === 39) {
-            result.value = { ok: false, error: `binding ${env} failed: ${err?.data?.statusMessage || err?.data?.message || err?.message}` }
+            const detail = err?.data?.statusMessage || err?.data?.message || err?.message
+            result.value = { ok: false, error: t('spawn.error.bindingFailed', { env, detail }) }
             binding.value = false
             return
           }
@@ -316,7 +325,7 @@ async function bindSecrets(agentEmail?: string) {
     ok: true,
     agent_email: agentEmail,
     error: missingRequired.length > 0
-      ? `Spawned. Still missing secrets ${missingRequired.join(', ')} — add them on the agent page.`
+      ? t('spawn.result.missingSecrets', { names: missingRequired.join(', ') })
       : undefined,
   }
 }
@@ -338,10 +347,10 @@ function close() {
         <div class="flex items-start justify-between gap-3">
           <div>
             <h3 class="text-lg font-semibold">
-              Spawn agent
+              {{ $t('spawn.title') }}
             </h3>
             <p class="text-xs text-muted">
-              Name + prompt are the base. A recipe and secrets are optional, additive layers — expand them if you need them. You'll get a DDISA grant request on your iPhone — approve to complete.
+              {{ $t('spawn.subtitle') }}
             </p>
           </div>
           <UButton variant="ghost" size="sm" icon="i-lucide-x" :disabled="submitting" @click="close" />
@@ -351,11 +360,11 @@ function close() {
         <UAlert
           v-else-if="!loadingHosts && hosts.length === 0"
           color="warning"
-          title="No connected nest"
-          description="Start the nest daemon on a Mac (apes nest install + run) and refresh."
+          :title="$t('spawn.alert.noNestTitle')"
+          :description="$t('spawn.alert.noNestDescription')"
         />
 
-        <UFormField v-if="hosts.length > 1" label="Host" description="You have multiple Macs connected — pick the one to spawn on.">
+        <UFormField v-if="hosts.length > 1" :label="$t('spawn.field.host.label')" :description="$t('spawn.field.host.description')">
           <USelect
             v-model="form.host_id"
             :items="hosts.map(h => ({ label: `${h.hostname} (${h.version})`, value: h.host_id }))"
@@ -363,7 +372,7 @@ function close() {
           />
         </UFormField>
 
-        <UFormField label="Name" description="lowercase, [a-z0-9-], max 24 chars — or pick from the list">
+        <UFormField :label="$t('spawn.field.name.label')" :description="$t('spawn.field.name.description')">
           <div class="flex items-stretch gap-2">
             <UInput
               v-model="form.name"
@@ -377,7 +386,7 @@ function close() {
               variant="soft"
               color="neutral"
               icon="i-lucide-dices"
-              aria-label="Roll a random name"
+              :aria-label="$t('spawn.field.name.rollAria')"
               :disabled="!!intentId"
               @click="rollName"
             />
@@ -391,14 +400,14 @@ function close() {
                 variant="soft"
                 color="neutral"
                 icon="i-lucide-list"
-                aria-label="Pick from name list"
+                :aria-label="$t('spawn.field.name.pickAria')"
                 :disabled="!!intentId"
               />
             </UDropdownMenu>
           </div>
         </UFormField>
 
-        <UFormField label="Preset" description="Quick-start prompt. Tweak the textarea or pick 'Custom' for a blank slate.">
+        <UFormField :label="$t('spawn.field.preset.label')" :description="$t('spawn.field.preset.description')">
           <USelect
             v-model="selectedPreset"
             :items="PRESETS.map(p => ({ label: p.label, value: p.id, description: p.description }))"
@@ -406,13 +415,13 @@ function close() {
           />
         </UFormField>
 
-        <UFormField label="System prompt" description="With a recipe this is added on top of the recipe's intent (user_addendum) — editable later without re-deploy.">
+        <UFormField :label="$t('spawn.field.systemPrompt.label')" :description="$t('spawn.field.systemPrompt.description')">
           <UTextarea
             v-model="form.system_prompt"
             :rows="5"
             autoresize
             :disabled="!!intentId"
-            placeholder="Du bist …"
+            :placeholder="$t('spawn.field.systemPrompt.placeholder')"
             class="w-full"
             :ui="{ base: 'w-full' }"
           />
@@ -422,22 +431,22 @@ function close() {
         <details class="rounded border border-(--ui-border) px-3 py-2">
           <summary class="cursor-pointer select-none text-sm font-medium flex items-center gap-2">
             <UIcon name="i-lucide-package" class="size-4 text-muted" />
-            Recipe <span class="text-xs text-muted font-normal">(optional, additive)</span>
+            {{ $t('spawn.recipe.summary') }} <span class="text-xs text-muted font-normal">{{ $t('spawn.recipe.summaryHint') }}</span>
           </summary>
           <div class="space-y-3 mt-3">
-            <UFormField label="Recipe" description="Pick a curated recipe, Custom for any pinned repo, or None.">
+            <UFormField :label="$t('spawn.recipe.field.label')" :description="$t('spawn.recipe.field.description')">
               <USelect
                 v-model="selectedRecipe"
                 :items="[
-                  { label: 'None', value: RECIPE_NONE },
-                  ...RECIPE_INDEX.map(r => ({ label: r.label, value: r.id, description: r.hint })),
-                  { label: 'Custom…', value: RECIPE_CUSTOM, description: 'Paste any github.com/<owner>/<name>@<ref>' },
+                  { label: $t('spawn.recipe.option.none'), value: RECIPE_NONE },
+                  ...RECIPE_INDEX.map(r => ({ label: r.label, value: r.id, description: $t(r.hintKey) })),
+                  { label: $t('spawn.recipe.option.custom'), value: RECIPE_CUSTOM, description: $t('spawn.recipe.option.customDescription') },
                 ]"
                 :disabled="!!intentId"
               />
             </UFormField>
             <template v-if="selectedRecipe !== RECIPE_NONE">
-              <UFormField label="Repository" description="github.com/<owner>/<name>@<tag|commit> — the pinned ref is mandatory.">
+              <UFormField :label="$t('spawn.recipe.repo.label')" :description="$t('spawn.recipe.repo.description')">
                 <div class="flex items-stretch gap-2">
                   <UInput
                     v-model="recipeForm.repo_ref"
@@ -454,17 +463,17 @@ function close() {
                     icon="i-lucide-help-circle"
                     :to="recipeRepoUrl"
                     target="_blank"
-                    aria-label="Open recipe repo (docs + required secrets)"
+                    :aria-label="$t('spawn.recipe.repo.openAria')"
                   />
                 </div>
               </UFormField>
-              <UFormField label="Params" description="One KEY=value per line (recipe params, e.g. topic=AI agents).">
+              <UFormField :label="$t('spawn.recipe.params.label')" :description="$t('spawn.recipe.params.description')">
                 <UTextarea
                   v-model="recipeForm.params"
                   :rows="2"
                   autoresize
                   :disabled="!!intentId"
-                  placeholder="topic=AI agents"
+                  :placeholder="$t('spawn.recipe.params.placeholder')"
                   class="w-full"
                   :ui="{ base: 'w-full' }"
                 />
@@ -477,16 +486,16 @@ function close() {
         <details class="rounded border border-(--ui-border) px-3 py-2" :open="secrets.length > 0">
           <summary class="cursor-pointer select-none text-sm font-medium flex items-center gap-2">
             <UIcon name="i-lucide-key-round" class="size-4 text-muted" />
-            Secrets <span class="text-xs text-muted font-normal">({{ secrets.length }})</span>
+            {{ $t('spawn.secrets.summary') }} <span class="text-xs text-muted font-normal">({{ secrets.length }})</span>
           </summary>
           <div class="space-y-2 mt-3">
             <p class="text-xs text-muted">
-              Sealed to the agent before they're stored — troop never keeps the plaintext. A chosen recipe pre-fills the names it needs; you can add more. Also editable later on the agent's page.
+              {{ $t('spawn.secrets.hint') }}
             </p>
             <div v-for="(s, i) in secrets" :key="i" class="flex items-stretch gap-2">
               <UInput
                 v-model="s.env"
-                placeholder="ENV_NAME"
+                :placeholder="$t('spawn.secrets.envPlaceholder')"
                 :disabled="!!intentId"
                 class="flex-1"
                 :ui="{ base: 'w-full' }"
@@ -494,7 +503,7 @@ function close() {
               <UInput
                 v-model="s.value"
                 type="password"
-                placeholder="value"
+                :placeholder="$t('spawn.secrets.valuePlaceholder')"
                 :disabled="binding || !!result?.ok"
                 class="flex-1"
                 :ui="{ base: 'w-full' }"
@@ -504,7 +513,7 @@ function close() {
                 variant="ghost"
                 color="error"
                 icon="i-lucide-trash-2"
-                aria-label="Remove secret"
+                :aria-label="$t('spawn.secrets.removeAria')"
                 :disabled="!!intentId"
                 @click="removeSecretRow(i)"
               />
@@ -518,23 +527,23 @@ function close() {
               :disabled="!!intentId"
               @click="addSecretRow"
             >
-              Add secret
+              {{ $t('spawn.secrets.addButton') }}
             </UButton>
           </div>
         </details>
 
         <details class="text-xs text-muted">
           <summary class="cursor-pointer select-none">
-            Bridge overrides (optional)
+            {{ $t('spawn.bridge.summary') }}
           </summary>
           <div class="space-y-3 mt-3">
-            <UFormField label="LITELLM_API_KEY" description="Defaults to ~/litellm/.env on the host.">
-              <UInput v-model="form.bridge_key" type="password" placeholder="sk-… or token" :disabled="!!intentId" />
+            <UFormField label="LITELLM_API_KEY" :description="$t('spawn.bridge.apiKeyDescription')">
+              <UInput v-model="form.bridge_key" type="password" :placeholder="$t('spawn.bridge.apiKeyPlaceholder')" :disabled="!!intentId" />
             </UFormField>
-            <UFormField label="LITELLM_BASE_URL" description="Defaults to http://127.0.0.1:4000/v1">
+            <UFormField label="LITELLM_BASE_URL" :description="$t('spawn.bridge.baseUrlDescription')">
               <UInput v-model="form.bridge_base_url" placeholder="https://your-proxy.example/openai" :disabled="!!intentId" />
             </UFormField>
-            <UFormField label="APE_CHAT_BRIDGE_MODEL" description="Required by the bridge at runtime.">
+            <UFormField label="APE_CHAT_BRIDGE_MODEL" :description="$t('spawn.bridge.modelDescription')">
               <UInput v-model="form.bridge_model" placeholder="gpt-5.4" :disabled="!!intentId" />
             </UFormField>
           </div>
@@ -544,26 +553,24 @@ function close() {
           <UIcon name="i-lucide-loader-circle" class="animate-spin shrink-0 size-4 mt-0.5" />
           <div>
             <div class="font-medium">
-              {{ binding ? 'Binding secrets…' : 'Waiting for DDISA approval…' }}
+              {{ binding ? $t('spawn.pending.bindingTitle') : $t('spawn.pending.approvalTitle') }}
             </div>
             <div class="text-xs text-muted mt-1">
-              {{ binding
-                ? 'Sealing each value to the agent and pushing it.'
-                : 'Approve the as=root grant in the OpenApe app on your phone. This dialog updates automatically.' }}
+              {{ binding ? $t('spawn.pending.bindingHint') : $t('spawn.pending.approvalHint') }}
             </div>
           </div>
         </div>
 
-        <UAlert v-if="result?.ok && !result.error" color="success" :title="`Spawned: ${result.agent_email ?? spawnedName}`" />
-        <UAlert v-if="result?.ok && result.error" color="warning" title="Spawned with a note" :description="result.error" />
-        <UAlert v-if="result && !result.ok" color="error" title="Failed" :description="result.error" />
+        <UAlert v-if="result?.ok && !result.error" color="success" :title="$t('spawn.result.successTitle', { name: result.agent_email ?? spawnedName })" />
+        <UAlert v-if="result?.ok && result.error" color="warning" :title="$t('spawn.result.successWithNoteTitle')" :description="result.error" />
+        <UAlert v-if="result && !result.ok" color="error" :title="$t('spawn.result.failedTitle')" :description="result.error" />
       </div>
 
       <!-- Pinned footer: never scrolls out of reach and clears the
            iOS home-indicator / browser chrome via the safe-area inset. -->
       <div class="shrink-0 flex justify-end gap-2 border-t border-default bg-default px-5 sm:px-6 pt-3 pb-[max(0.875rem,env(safe-area-inset-bottom))]">
         <UButton variant="ghost" :disabled="submitting" @click="close">
-          {{ result?.ok ? 'Close' : 'Cancel' }}
+          {{ result?.ok ? $t('common.close') : $t('common.cancel') }}
         </UButton>
         <UButton
           v-if="!result?.ok"
@@ -572,7 +579,7 @@ function close() {
           :disabled="!canSubmit"
           @click="submit"
         >
-          Spawn
+          {{ $t('spawn.submitButton') }}
         </UButton>
       </div>
     </template>

--- a/apps/openape-troop/app/components/ToolPicker.vue
+++ b/apps/openape-troop/app/components/ToolPicker.vue
@@ -10,6 +10,7 @@ interface ToolEntry {
 
 defineProps<{ disabled?: boolean }>()
 const model = defineModel<string[]>({ default: () => [] })
+const { t } = useI18n()
 const catalog = ref<ToolEntry[]>([])
 const loading = ref(true)
 const error = ref('')
@@ -20,7 +21,7 @@ onMounted(async () => {
     catalog.value = res.tools
   }
   catch (err: any) {
-    error.value = err?.message ?? 'failed to load tool catalog'
+    error.value = err?.message ?? t('toolPicker.error.loadFailed')
   }
   finally {
     loading.value = false
@@ -45,7 +46,7 @@ const riskColor: Record<ToolEntry['risk'], 'success' | 'warning' | 'error'> = {
 <template>
   <div class="space-y-2">
     <p v-if="loading" class="text-sm text-muted">
-      Loading tools…
+      {{ $t('toolPicker.loading') }}
     </p>
     <p v-else-if="error" class="text-sm text-error">
       {{ error }}
@@ -68,7 +69,7 @@ const riskColor: Record<ToolEntry['risk'], 'success' | 'warning' | 'error'> = {
           <div class="flex items-center gap-2">
             <code class="font-mono text-sm">{{ tool.name }}</code>
             <UBadge :color="riskColor[tool.risk]" variant="subtle" size="xs">
-              {{ tool.risk }}
+              {{ $t(`toolPicker.risk.${tool.risk}`) }}
             </UBadge>
           </div>
           <p class="text-xs text-muted mt-0.5">

--- a/apps/openape-troop/app/composables/useDateFormat.ts
+++ b/apps/openape-troop/app/composables/useDateFormat.ts
@@ -1,0 +1,27 @@
+// useDateFormat — locale-aware absolute date/time formatting via Intl.
+// Returns a stable formatter bound to the current i18n locale.
+
+export function useDateFormat() {
+  const { locale } = useI18n()
+
+  function fmtDate(unixSec: number | null): string {
+    if (!unixSec) return '—'
+    return new Date(unixSec * 1000).toLocaleString(locale.value, {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+  }
+
+  function fmtTime(unixSec: number | null): string {
+    if (!unixSec) return '—'
+    return new Date(unixSec * 1000).toLocaleTimeString(locale.value, {
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+  }
+
+  return { fmtDate, fmtTime }
+}

--- a/apps/openape-troop/app/composables/useRelativeTime.ts
+++ b/apps/openape-troop/app/composables/useRelativeTime.ts
@@ -1,0 +1,28 @@
+// useRelativeTime — locale-aware "X seconds ago" / "vor X Sekunden" output.
+//
+// Returns a function bound to the current locale via @nuxtjs/i18n. Switching
+// language with the LocaleSwitcher swaps the formatter immediately — no
+// page reload needed.
+//
+// `Intl.RelativeTimeFormat` handles plurals + auto-pick of "just now" /
+// "yesterday" via { numeric: 'auto' } so "0s" → "now"/"jetzt".
+
+export function useRelativeTime() {
+  const { locale, t } = useI18n()
+
+  function fmtRelative(unixSec: number | null): string {
+    if (!unixSec) return t('time.never')
+    const deltaSec = Math.floor(Date.now() / 1000) - unixSec
+    if (deltaSec < 0) return t('time.justNow')
+    if (deltaSec < 5) return t('time.justNow')
+    const rtf = new Intl.RelativeTimeFormat(locale.value, { numeric: 'auto' })
+    if (deltaSec < 60) return rtf.format(-deltaSec, 'second')
+    if (deltaSec < 3600) return rtf.format(-Math.floor(deltaSec / 60), 'minute')
+    if (deltaSec < 86400) return rtf.format(-Math.floor(deltaSec / 3600), 'hour')
+    if (deltaSec < 86400 * 30) return rtf.format(-Math.floor(deltaSec / 86400), 'day')
+    if (deltaSec < 86400 * 365) return rtf.format(-Math.floor(deltaSec / (86400 * 30)), 'month')
+    return rtf.format(-Math.floor(deltaSec / (86400 * 365)), 'year')
+  }
+
+  return { fmtRelative }
+}

--- a/apps/openape-troop/app/pages/agents/[name].vue
+++ b/apps/openape-troop/app/pages/agents/[name].vue
@@ -5,7 +5,10 @@ import { useOpenApeAuth } from '#imports'
 const route = useRoute()
 const agentName = computed(() => String(route.params.name))
 
-useSeoMeta({ title: () => `Agent ${agentName.value}` })
+const { t } = useI18n()
+const { fmtDate } = useDateFormat()
+const { fmtRelative } = useRelativeTime()
+useSeoMeta({ title: () => t('agentDetail.tabTitle', { name: agentName.value }) })
 
 const { user, fetchUser } = useOpenApeAuth()
 await fetchUser()
@@ -67,7 +70,7 @@ async function load() {
   }
   catch (err: any) {
     if (err?.statusCode === 401) { await navigateTo('/login'); return }
-    error.value = err?.data?.statusMessage || err?.message || 'failed to load agent'
+    error.value = err?.data?.statusMessage || err?.message || t('agentDetail.error.loadFailed')
   }
   finally {
     loading.value = false
@@ -96,9 +99,9 @@ onBeforeUnmount(() => { if (nestHostsTimer) clearInterval(nestHostsTimer) })
 
 const nestOnline = computed(() => nestHosts.value.length > 0)
 const nestLabel = computed(() => {
-  if (!nestOnline.value) return 'nest offline — falling back to 5min poll'
+  if (!nestOnline.value) return t('agentDetail.nest.offlineLabel')
   const names = nestHosts.value.map(h => h.hostname).join(', ')
-  return `live · ${names}`
+  return t('agentDetail.nest.onlineLabel', { names })
 })
 
 // Agent-level system prompt editor — saved on blur via PATCH
@@ -128,7 +131,7 @@ async function saveSystemPrompt() {
     if (detail.value) detail.value.agent.systemPrompt = systemPromptDraft.value
   }
   catch (err: any) {
-    systemPromptError.value = err?.data?.statusMessage || err?.message || 'save failed'
+    systemPromptError.value = err?.data?.statusMessage || err?.message || t('common.error.saveFailed')
   }
   finally {
     systemPromptSaving.value = false
@@ -160,7 +163,7 @@ async function applyRecipe() {
     if (detail.value) detail.value.agent.systemPrompt = (await ($fetch as any)(`/api/agents/${agentName.value}`)).agent.systemPrompt
   }
   catch (err: any) {
-    recipeError.value = err?.data?.statusMessage || err?.message || 'apply failed'
+    recipeError.value = err?.data?.statusMessage || err?.message || t('agentDetail.recipe.error.applyFailed')
   }
   finally {
     recipeSaving.value = false
@@ -196,7 +199,7 @@ async function saveTools() {
     if (detail.value) detail.value.agent.tools = [...toolsDraft.value]
   }
   catch (err: any) {
-    toolsError.value = err?.data?.statusMessage || err?.message || 'save failed'
+    toolsError.value = err?.data?.statusMessage || err?.message || t('common.error.saveFailed')
   }
   finally {
     toolsSaving.value = false
@@ -230,8 +233,8 @@ const skillSaving = ref(false)
 async function loadSkills() {
   if (!agentName.value) return
   skillsError.value = ''
-  try { skills.value = await ($fetch as any)(`/api/agents/${agentName.value}/skills`) }
-  catch (err: any) { skillsError.value = err?.data?.statusMessage || err?.message || 'failed to load skills' }
+  try { skills.value = await ($fetch as any)(`/api/agents/${agentName.value}/skills`); skillsError.value = '' }
+  catch (err: any) { skillsError.value = err?.data?.statusMessage || err?.message || t('agentDetail.skills.error.loadFailed') }
 }
 watch(detail, (d) => { if (d) loadSkills() })
 
@@ -259,7 +262,7 @@ async function saveSkill() {
     await loadSkills()
   }
   catch (err: any) {
-    skillsError.value = err?.data?.statusMessage || err?.message || 'save failed'
+    skillsError.value = err?.data?.statusMessage || err?.message || t('common.error.saveFailed')
   }
   finally {
     skillSaving.value = false
@@ -267,13 +270,13 @@ async function saveSkill() {
 }
 async function deleteSkill(name: string) {
   if (!agentName.value) return
-  if (!confirm(`Delete skill '${name}'? This is permanent — to keep it but hide it from the agent use 'disabled'.`)) return
+  if (!confirm(t('agentDetail.skills.confirmDelete', { name }))) return
   try {
     await ($fetch as any)(`/api/agents/${agentName.value}/skills/${encodeURIComponent(name)}`, { method: 'DELETE' })
     await loadSkills()
   }
   catch (err: any) {
-    skillsError.value = err?.data?.statusMessage || err?.message || 'delete failed'
+    skillsError.value = err?.data?.statusMessage || err?.message || t('common.error.deleteFailed')
   }
 }
 
@@ -293,7 +296,7 @@ async function loadSecrets() {
     const res: { secrets: SecretRow[] } = await ($fetch as any)(`/api/agents/${agentName.value}/secrets`)
     secrets.value = res.secrets
   }
-  catch (err: any) { secretsError.value = err?.data?.statusMessage || err?.message || 'failed to load secrets' }
+  catch (err: any) { secretsError.value = err?.data?.statusMessage || err?.message || t('agentDetail.secrets.error.loadFailed') }
 }
 watch(detail, (d) => { if (d) loadSecrets() })
 
@@ -310,7 +313,7 @@ async function saveSecret() {
     await loadSecrets()
   }
   catch (err: any) {
-    secretsError.value = err?.data?.statusMessage || err?.message || 'save failed (the agent must have synced once after spawn)'
+    secretsError.value = err?.data?.statusMessage || err?.message || t('agentDetail.secrets.error.saveFailed')
   }
   finally {
     secretSaving.value = false
@@ -319,13 +322,13 @@ async function saveSecret() {
 
 async function revokeSecret(env: string) {
   if (!agentName.value) return
-  if (!confirm(`Revoke '${env}'? The agent's copy is cleared on its next connect.`)) return
+  if (!confirm(t('agentDetail.secrets.confirmRevoke', { env }))) return
   try {
     await ($fetch as any)(`/api/agents/${agentName.value}/secrets/${encodeURIComponent(env)}`, { method: 'DELETE' })
     await loadSecrets()
   }
   catch (err: any) {
-    secretsError.value = err?.data?.statusMessage || err?.message || 'revoke failed'
+    secretsError.value = err?.data?.statusMessage || err?.message || t('agentDetail.secrets.error.revokeFailed')
   }
 }
 
@@ -401,38 +404,22 @@ async function save() {
     await load()
   }
   catch (err: any) {
-    saveError.value = err?.data?.statusMessage || err?.message || 'save failed'
+    saveError.value = err?.data?.statusMessage || err?.message || t('common.error.saveFailed')
   }
   finally {
     saving.value = false
   }
 }
 
-async function remove(t: Task) {
-  if (!confirm(`Delete task "${t.name}"? Active launchd jobs on the agent host will be removed on the next sync.`)) return
+async function remove(task: Task) {
+  if (!confirm(t('agentDetail.tasks.confirmDelete', { name: task.name }))) return
   try {
-    await ($fetch as any)(`/api/agents/${agentName.value}/tasks/${t.taskId}`, { method: 'DELETE' })
+    await ($fetch as any)(`/api/agents/${agentName.value}/tasks/${task.taskId}`, { method: 'DELETE' })
     await load()
   }
   catch (err: any) {
-    error.value = err?.data?.statusMessage || err?.message || 'delete failed'
+    error.value = err?.data?.statusMessage || err?.message || t('common.error.deleteFailed')
   }
-}
-
-function fmtDate(ts: number | null): string {
-  if (!ts) return '—'
-  return new Date(ts * 1000).toLocaleString('de-AT', {
-    day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit',
-  })
-}
-
-function fmtRelative(ts: number | null): string {
-  if (!ts) return 'never'
-  const sec = Math.max(0, Math.floor(Date.now() / 1000) - ts)
-  if (sec < 60) return 'just now'
-  if (sec < 3600) return `${Math.floor(sec / 60)}m ago`
-  if (sec < 86400) return `${Math.floor(sec / 3600)}h ago`
-  return `${Math.floor(sec / 86400)}d ago`
 }
 
 const statusColor: Record<Run['status'], string> = { running: 'info', ok: 'success', error: 'error' }
@@ -471,11 +458,11 @@ async function pollDestroy(): Promise<void> {
       await navigateTo('/agents')
       return
     }
-    destroyError.value = res.error || 'destroy failed on the nest'
+    destroyError.value = res.error || t('agentDetail.destroy.error.nestFailed')
   }
   catch (err: any) {
     destroying.value = false
-    destroyError.value = err?.data?.statusMessage || err?.message || 'poll failed'
+    destroyError.value = err?.data?.statusMessage || err?.message || t('agentDetail.destroy.error.pollFailed')
   }
 }
 
@@ -492,7 +479,7 @@ async function submitDestroy() {
   }
   catch (err: any) {
     destroying.value = false
-    destroyError.value = err?.data?.statusMessage || err?.message || 'failed to start destroy'
+    destroyError.value = err?.data?.statusMessage || err?.message || t('agentDetail.destroy.error.startFailed')
   }
 }
 
@@ -503,7 +490,7 @@ onBeforeUnmount(() => { if (destroyPollTimer) clearTimeout(destroyPollTimer) })
   <div class="min-h-dvh bg-zinc-950 text-zinc-100">
     <header class="border-b border-(--ui-border) px-3 sm:px-6 py-3 flex items-center gap-2 sticky top-0 z-10 bg-zinc-950/95 backdrop-blur">
       <UButton to="/agents" variant="ghost" size="sm" icon="i-lucide-arrow-left" :ui="{ base: 'shrink-0' }">
-        <span class="hidden sm:inline">Agents</span>
+        <span class="hidden sm:inline">{{ $t('agentDetail.backToAgents') }}</span>
       </UButton>
       <span v-if="detail" class="font-mono font-semibold truncate flex-1">
         🦍 {{ detail.agent.agentName }}
@@ -513,7 +500,7 @@ onBeforeUnmount(() => { if (destroyPollTimer) clearTimeout(destroyPollTimer) })
         :class="nestOnline ? 'text-emerald-400 bg-emerald-500/10' : 'text-zinc-500 bg-zinc-800/50'"
         :title="nestLabel"
       >
-        {{ nestOnline ? '● live' : '○ poll' }}
+        {{ nestOnline ? $t('agentDetail.nest.badgeLive') : $t('agentDetail.nest.badgePoll') }}
       </span>
       <LocaleSwitcher />
     </header>
@@ -523,7 +510,7 @@ onBeforeUnmount(() => { if (destroyPollTimer) clearTimeout(destroyPollTimer) })
 
       <UCard v-if="loading">
         <p class="text-muted text-sm">
-          Loading…
+          {{ $t('common.loading') }}
         </p>
       </UCard>
 
@@ -548,16 +535,16 @@ onBeforeUnmount(() => { if (destroyPollTimer) clearTimeout(destroyPollTimer) })
             <summary class="cursor-pointer list-none px-4 py-3 flex items-center justify-between gap-2">
               <div class="flex items-center gap-2 text-sm">
                 <UIcon name="i-lucide-info" class="text-muted size-4" />
-                <span class="font-medium">Agent details</span>
+                <span class="font-medium">{{ $t('agentDetail.details.title') }}</span>
                 <span class="text-xs text-muted">·</span>
-                <span class="text-xs text-muted">last sync {{ fmtRelative(detail.agent.lastSeenAt) }}</span>
+                <span class="text-xs text-muted">{{ $t('agentDetail.details.lastSyncShort', { value: fmtRelative(detail.agent.lastSeenAt) }) }}</span>
               </div>
               <UIcon name="i-lucide-chevron-down" class="size-4 text-muted transition-transform group-open:rotate-180" />
             </summary>
             <dl class="px-4 pb-4 pt-1 space-y-3 text-sm border-t border-(--ui-border)">
               <div>
                 <dt class="text-xs text-muted mb-0.5">
-                  Email
+                  {{ $t('agentDetail.details.email') }}
                 </dt>
                 <dd class="font-mono text-xs break-all">
                   {{ detail.agent.email }}
@@ -565,7 +552,7 @@ onBeforeUnmount(() => { if (destroyPollTimer) clearTimeout(destroyPollTimer) })
               </div>
               <div>
                 <dt class="text-xs text-muted mb-0.5">
-                  Hostname
+                  {{ $t('agentDetail.details.hostname') }}
                 </dt>
                 <dd class="font-mono">
                   {{ detail.agent.hostname || '—' }}
@@ -573,7 +560,7 @@ onBeforeUnmount(() => { if (destroyPollTimer) clearTimeout(destroyPollTimer) })
               </div>
               <div>
                 <dt class="text-xs text-muted mb-0.5">
-                  Host ID
+                  {{ $t('agentDetail.details.hostId') }}
                 </dt>
                 <dd class="font-mono text-xs break-all">
                   {{ detail.agent.hostId || '—' }}
@@ -581,7 +568,7 @@ onBeforeUnmount(() => { if (destroyPollTimer) clearTimeout(destroyPollTimer) })
               </div>
               <div>
                 <dt class="text-xs text-muted mb-0.5">
-                  Public SSH key
+                  {{ $t('agentDetail.details.pubkey') }}
                 </dt>
                 <dd class="font-mono text-xs break-all">
                   {{ detail.agent.pubkeySsh || '—' }}
@@ -590,7 +577,7 @@ onBeforeUnmount(() => { if (destroyPollTimer) clearTimeout(destroyPollTimer) })
               <div class="grid grid-cols-2 gap-3">
                 <div>
                   <dt class="text-xs text-muted mb-0.5">
-                    First sync
+                    {{ $t('agentDetail.details.firstSync') }}
                   </dt>
                   <dd class="text-sm">
                     {{ fmtDate(detail.agent.firstSeenAt) }}
@@ -598,7 +585,7 @@ onBeforeUnmount(() => { if (destroyPollTimer) clearTimeout(destroyPollTimer) })
                 </div>
                 <div>
                   <dt class="text-xs text-muted mb-0.5">
-                    Last sync
+                    {{ $t('agentDetail.details.lastSync') }}
                   </dt>
                   <dd class="text-sm">
                     {{ fmtDate(detail.agent.lastSeenAt) }}
@@ -621,15 +608,15 @@ onBeforeUnmount(() => { if (destroyPollTimer) clearTimeout(destroyPollTimer) })
             <summary class="cursor-pointer list-none px-4 py-3 flex items-center justify-between gap-2">
               <div class="flex items-center gap-2 text-sm">
                 <UIcon name="i-lucide-message-square" class="text-muted size-4" />
-                <span class="font-medium">System prompt</span>
+                <span class="font-medium">{{ $t('agentDetail.systemPrompt.title') }}</span>
                 <UBadge v-if="systemPromptDirty" color="warning" variant="subtle" size="xs">
-                  unsaved
+                  {{ $t('common.badge.unsaved') }}
                 </UBadge>
                 <UBadge v-else-if="systemPromptDraft" color="success" variant="subtle" size="xs">
-                  set
+                  {{ $t('common.badge.set') }}
                 </UBadge>
                 <UBadge v-else color="neutral" variant="subtle" size="xs">
-                  empty
+                  {{ $t('common.badge.empty') }}
                 </UBadge>
               </div>
               <UIcon name="i-lucide-chevron-down" class="size-4 text-muted transition-transform group-open:rotate-180" />
@@ -642,16 +629,16 @@ onBeforeUnmount(() => { if (destroyPollTimer) clearTimeout(destroyPollTimer) })
                 size="lg"
                 class="w-full"
                 :ui="{ base: 'w-full' }"
-                placeholder="Du bist … (Persönlichkeit, Stil, Grundregeln in 1–3 Sätzen)"
+                :placeholder="$t('agentDetail.systemPrompt.placeholder')"
                 @blur="saveSystemPrompt"
               />
               <p class="text-xs text-muted mt-2">
-                Persönlichkeit, Stil, Grundregeln — gilt für jede Nachricht im Chat und für jeden Task-Run. Wird via Sync (~5min) auf den Agent-Host übertragen.
+                {{ $t('agentDetail.systemPrompt.hint') }}
               </p>
               <UAlert v-if="systemPromptError" color="error" :title="systemPromptError" class="mt-3" />
               <div v-if="systemPromptDirty" class="flex justify-end mt-3">
                 <UButton size="sm" color="primary" :loading="systemPromptSaving" @click="saveSystemPrompt">
-                  Save
+                  {{ $t('common.save') }}
                 </UButton>
               </div>
             </div>
@@ -666,27 +653,27 @@ onBeforeUnmount(() => { if (destroyPollTimer) clearTimeout(destroyPollTimer) })
             <summary class="cursor-pointer list-none px-4 py-3 flex items-center justify-between gap-2">
               <div class="flex items-center gap-2 text-sm">
                 <UIcon name="i-lucide-package" class="text-muted size-4" />
-                <span class="font-medium">Recipe</span>
+                <span class="font-medium">{{ $t('agentDetail.recipe.title') }}</span>
               </div>
               <UIcon name="i-lucide-chevron-down" class="size-4 text-muted transition-transform group-open:rotate-180" />
             </summary>
             <div class="px-4 pb-4 pt-3 border-t border-(--ui-border) space-y-3">
-              <UFormField label="Recipe ref" description="owner/repo@ref (pinned), e.g. openape-ai/coding-agent@main">
+              <UFormField :label="$t('agentDetail.recipe.ref.label')" :description="$t('agentDetail.recipe.ref.description')">
                 <UInput v-model="recipeRef" placeholder="openape-ai/coding-agent@main" class="w-full" :ui="{ base: 'w-full' }" />
               </UFormField>
-              <UFormField label="Params (JSON)" description="e.g. {&quot;repo&quot;:&quot;https://github.com/openape-ai/openape.git&quot;,&quot;forge&quot;:&quot;github&quot;}">
+              <UFormField :label="$t('agentDetail.recipe.params.label')" :description="$t('agentDetail.recipe.params.description')">
                 <UTextarea v-model="recipeParams" :rows="2" class="w-full" :ui="{ base: 'w-full' }" />
               </UFormField>
               <UAlert v-if="recipeError" color="error" :title="recipeError" />
               <UAlert
                 v-if="recipeResult"
                 color="success"
-                :title="`Applied ${recipeResult.ref}`"
-                :description="recipeResult.required_capabilities.length ? `Bind secrets: ${recipeResult.required_capabilities.join(', ')}` : 'No new secrets required.'"
+                :title="$t('agentDetail.recipe.applied', { ref: recipeResult.ref })"
+                :description="recipeResult.required_capabilities.length ? $t('agentDetail.recipe.bindSecrets', { names: recipeResult.required_capabilities.join(', ') }) : $t('agentDetail.recipe.noNewSecrets')"
               />
               <div class="flex justify-end">
                 <UButton size="sm" color="primary" :loading="recipeSaving" :disabled="!recipeRef.trim()" @click="applyRecipe">
-                  Set / update recipe
+                  {{ $t('agentDetail.recipe.applyButton') }}
                 </UButton>
               </div>
             </div>
@@ -701,21 +688,19 @@ onBeforeUnmount(() => { if (destroyPollTimer) clearTimeout(destroyPollTimer) })
             <summary class="cursor-pointer list-none px-4 py-3 flex items-center justify-between gap-2">
               <div class="flex items-center gap-2 text-sm">
                 <UIcon name="i-lucide-wrench" class="text-muted size-4" />
-                <span class="font-medium">Tools</span>
+                <span class="font-medium">{{ $t('agentDetail.tools.title') }}</span>
                 <UBadge color="neutral" variant="subtle" size="xs">
-                  {{ toolsDraft.length }} selected
+                  {{ $t('agentDetail.tools.selectedCount', { n: toolsDraft.length }) }}
                 </UBadge>
                 <UBadge v-if="toolsDirty" color="warning" variant="subtle" size="xs">
-                  unsaved
+                  {{ $t('common.badge.unsaved') }}
                 </UBadge>
               </div>
               <UIcon name="i-lucide-chevron-down" class="size-4 text-muted transition-transform group-open:rotate-180" />
             </summary>
             <div class="px-4 pb-4 pt-3 border-t border-(--ui-border)">
               <p class="text-xs text-muted mb-3">
-                Welche Tools darf der Agent im Chat verwenden? Default: alle. Nach
-                Speichern via Sync (~5min) auf den Agent-Host übertragen — kein
-                Bridge-Restart nötig (jeder neue Chat-Thread liest die Liste frisch).
+                {{ $t('agentDetail.tools.hint') }}
               </p>
               <ToolPicker v-model="toolsDraft" :disabled="toolsSaving" />
               <UAlert v-if="toolsError" color="error" :title="toolsError" class="mt-3" />
@@ -734,7 +719,7 @@ onBeforeUnmount(() => { if (destroyPollTimer) clearTimeout(destroyPollTimer) })
             <summary class="cursor-pointer list-none px-4 py-3 flex items-center justify-between gap-2">
               <div class="flex items-center gap-2 text-sm">
                 <UIcon name="i-lucide-book-open" class="text-muted size-4" />
-                <span class="font-medium">Skills</span>
+                <span class="font-medium">{{ $t('agentDetail.skills.title') }}</span>
                 <UBadge color="neutral" variant="subtle" size="xs">
                   {{ skills.length }}
                 </UBadge>
@@ -744,19 +729,18 @@ onBeforeUnmount(() => { if (destroyPollTimer) clearTimeout(destroyPollTimer) })
             <div class="border-t border-(--ui-border)">
               <div class="flex items-start justify-between gap-3 px-4 py-3">
                 <p class="text-xs text-muted">
-                  Lazy-loaded SKILL.md instructions. The agent sees name + description in every
-                  system prompt; the body is read on demand via the file.read tool when the task
-                  matches.
+                  {{ $t('agentDetail.skills.hint') }}
                 </p>
                 <UButton color="primary" size="sm" icon="i-lucide-plus" :ui="{ base: 'shrink-0' }" @click="openCreateSkill">
-                  New skill
+                  {{ $t('agentDetail.skills.newButton') }}
                 </UButton>
               </div>
               <UAlert v-if="skillsError" color="error" :title="skillsError" class="m-4" />
-              <div v-if="skills.length === 0" class="px-4 pb-6 pt-2 text-center text-muted text-sm">
-                No custom skills yet — the agent runs with the default skills bundled in
-                <code class="text-zinc-300">@openape/ape-agent</code> (one per built-in tool).
-              </div>
+              <i18n-t v-if="skills.length === 0" keypath="agentDetail.skills.empty" tag="div" class="px-4 pb-6 pt-2 text-center text-muted text-sm">
+                <template #pkg>
+                  <code class="text-zinc-300">@openape/ape-agent</code>
+                </template>
+              </i18n-t>
               <ul v-else class="divide-y divide-(--ui-border)">
                 <li v-for="s in skills" :key="s.name">
                   <button
@@ -768,7 +752,7 @@ onBeforeUnmount(() => { if (destroyPollTimer) clearTimeout(destroyPollTimer) })
                       <div class="flex items-center gap-2 flex-wrap mb-1">
                         <span class="font-medium text-base">{{ s.name }}</span>
                         <UBadge v-if="!s.enabled" color="neutral" variant="subtle" size="xs">
-                          disabled
+                          {{ $t('common.badge.disabled') }}
                         </UBadge>
                       </div>
                       <div class="text-xs text-muted line-clamp-2">
@@ -780,7 +764,7 @@ onBeforeUnmount(() => { if (destroyPollTimer) clearTimeout(destroyPollTimer) })
                       color="error"
                       variant="ghost"
                       icon="i-lucide-trash-2"
-                      aria-label="Delete skill"
+                      :aria-label="$t('agentDetail.skills.deleteAria')"
                       @click.stop="deleteSkill(s.name)"
                     />
                   </button>
@@ -795,26 +779,26 @@ onBeforeUnmount(() => { if (destroyPollTimer) clearTimeout(destroyPollTimer) })
           <template #content>
             <div class="p-5 space-y-4">
               <h3 class="text-lg font-semibold">
-                {{ skillEditor.isNew ? 'New skill' : `Edit ${skillEditor.name}` }}
+                {{ skillEditor.isNew ? $t('agentDetail.skills.editor.titleNew') : $t('agentDetail.skills.editor.titleEdit', { name: skillEditor.name }) }}
               </h3>
-              <UFormField label="Name" :description="skillEditor.isNew ? 'lowercase, [a-z0-9-], max 32 — becomes the directory name on disk' : 'name is immutable after creation'">
+              <UFormField :label="$t('agentDetail.skills.editor.name.label')" :description="skillEditor.isNew ? $t('agentDetail.skills.editor.name.descriptionNew') : $t('agentDetail.skills.editor.name.descriptionImmutable')">
                 <UInput v-model="skillEditor.name" :disabled="!skillEditor.isNew || skillSaving" placeholder="iurio" />
               </UFormField>
-              <UFormField label="Description" description="One-liner the LLM sees in every system prompt; tells it when to load this skill">
-                <UInput v-model="skillEditor.description" :disabled="skillSaving" placeholder="When the user asks about IURIO projects, cases, or documents, load this." />
+              <UFormField :label="$t('agentDetail.skills.editor.description.label')" :description="$t('agentDetail.skills.editor.description.description')">
+                <UInput v-model="skillEditor.description" :disabled="skillSaving" :placeholder="$t('agentDetail.skills.editor.description.placeholder')" />
               </UFormField>
-              <UFormField label="Body (markdown)" description="Full SKILL.md content — workflows, commands, conventions">
-                <UTextarea v-model="skillEditor.body" :rows="14" :disabled="skillSaving" placeholder="# IURIO CLI usage…" />
+              <UFormField :label="$t('agentDetail.skills.editor.body.label')" :description="$t('agentDetail.skills.editor.body.description')">
+                <UTextarea v-model="skillEditor.body" :rows="14" :disabled="skillSaving" :placeholder="$t('agentDetail.skills.editor.body.placeholder')" />
               </UFormField>
-              <UFormField label="Enabled" description="Disabled skills stay on disk but the agent doesn't see them.">
+              <UFormField :label="$t('agentDetail.skills.editor.enabled.label')" :description="$t('agentDetail.skills.editor.enabled.description')">
                 <USwitch v-model="skillEditor.enabled" :disabled="skillSaving" />
               </UFormField>
               <div class="flex justify-end gap-2">
                 <UButton variant="ghost" :disabled="skillSaving" @click="skillEditor.open = false">
-                  Cancel
+                  {{ $t('common.cancel') }}
                 </UButton>
                 <UButton color="primary" :loading="skillSaving" @click="saveSkill">
-                  Save
+                  {{ $t('common.save') }}
                 </UButton>
               </div>
             </div>
@@ -827,7 +811,7 @@ onBeforeUnmount(() => { if (destroyPollTimer) clearTimeout(destroyPollTimer) })
             <summary class="cursor-pointer list-none px-4 py-3 flex items-center justify-between gap-2">
               <div class="flex items-center gap-2 text-sm">
                 <UIcon name="i-lucide-key-round" class="text-muted size-4" />
-                <span class="font-medium">Secrets</span>
+                <span class="font-medium">{{ $t('agentDetail.secrets.title') }}</span>
                 <UBadge color="neutral" variant="subtle" size="xs">
                   {{ secrets.filter(s => s.status === 'active').length }}
                 </UBadge>
@@ -836,7 +820,7 @@ onBeforeUnmount(() => { if (destroyPollTimer) clearTimeout(destroyPollTimer) })
             </summary>
             <div class="border-t border-(--ui-border)">
               <p class="text-xs text-muted px-4 py-3">
-                Capability values for this agent. The value is sealed to the agent's key before it's stored — troop never keeps the plaintext and can't show it back. Set a value again to rotate it.
+                {{ $t('agentDetail.secrets.hint') }}
               </p>
               <UAlert v-if="secretsError" color="error" :title="secretsError" class="m-4" />
               <ul v-if="secrets.length > 0" class="divide-y divide-(--ui-border)">
@@ -845,7 +829,7 @@ onBeforeUnmount(() => { if (destroyPollTimer) clearTimeout(destroyPollTimer) })
                     <div class="flex items-center gap-2">
                       <code class="font-medium">{{ s.env }}</code>
                       <UBadge :color="s.status === 'active' ? 'success' : 'neutral'" variant="subtle" size="xs">
-                        {{ s.status }}
+                        {{ $t(`agentDetail.secrets.status.${s.status}`) }}
                       </UBadge>
                     </div>
                   </div>
@@ -855,7 +839,7 @@ onBeforeUnmount(() => { if (destroyPollTimer) clearTimeout(destroyPollTimer) })
                     color="error"
                     variant="ghost"
                     icon="i-lucide-trash-2"
-                    aria-label="Revoke secret"
+                    :aria-label="$t('agentDetail.secrets.revokeAria')"
                     @click="revokeSecret(s.env)"
                   />
                 </li>
@@ -864,7 +848,7 @@ onBeforeUnmount(() => { if (destroyPollTimer) clearTimeout(destroyPollTimer) })
                 <div class="flex items-stretch gap-2">
                   <UInput
                     v-model="newSecret.env"
-                    placeholder="ENV_NAME"
+                    :placeholder="$t('agentDetail.secrets.envPlaceholder')"
                     class="flex-1"
                     :ui="{ base: 'w-full' }"
                     :disabled="secretSaving"
@@ -872,7 +856,7 @@ onBeforeUnmount(() => { if (destroyPollTimer) clearTimeout(destroyPollTimer) })
                   <UInput
                     v-model="newSecret.value"
                     type="password"
-                    placeholder="value"
+                    :placeholder="$t('agentDetail.secrets.valuePlaceholder')"
                     class="flex-1"
                     :ui="{ base: 'w-full' }"
                     :disabled="secretSaving"
@@ -883,11 +867,11 @@ onBeforeUnmount(() => { if (destroyPollTimer) clearTimeout(destroyPollTimer) })
                     :disabled="!newSecret.env || !newSecret.value"
                     @click="saveSecret"
                   >
-                    Set
+                    {{ $t('agentDetail.secrets.setButton') }}
                   </UButton>
                 </div>
                 <p class="text-[11px] text-muted">
-                  UPPER_SNAKE_CASE. Binding works once the agent has synced after spawn.
+                  {{ $t('agentDetail.secrets.casingHint') }}
                 </p>
               </div>
             </div>
@@ -900,7 +884,7 @@ onBeforeUnmount(() => { if (destroyPollTimer) clearTimeout(destroyPollTimer) })
             <summary class="cursor-pointer list-none px-4 py-3 flex items-center justify-between gap-2">
               <div class="flex items-center gap-2 text-sm">
                 <UIcon name="i-lucide-clock" class="text-muted size-4" />
-                <span class="font-medium">Tasks</span>
+                <span class="font-medium">{{ $t('agentDetail.tasks.title') }}</span>
                 <UBadge color="neutral" variant="subtle" size="xs">
                   {{ detail.tasks.length }}
                 </UBadge>
@@ -910,41 +894,41 @@ onBeforeUnmount(() => { if (destroyPollTimer) clearTimeout(destroyPollTimer) })
             <div class="border-t border-(--ui-border)">
               <div class="flex items-center justify-end px-4 py-3">
                 <UButton color="primary" size="sm" icon="i-lucide-plus" @click="openCreate">
-                  New task
+                  {{ $t('agentDetail.tasks.newButton') }}
                 </UButton>
               </div>
               <div v-if="detail.tasks.length === 0" class="px-4 pb-6 text-center text-muted text-sm">
-                No tasks yet — tap "New task" to schedule the agent.
+                {{ $t('agentDetail.tasks.empty') }}
               </div>
               <ul v-else class="divide-y divide-(--ui-border)">
-                <li v-for="t in detail.tasks" :key="t.taskId">
+                <li v-for="task in detail.tasks" :key="task.taskId">
                   <button
                     type="button"
                     class="w-full text-left px-4 py-4 active:bg-zinc-900 transition-colors flex items-start gap-3"
-                    @click="openEdit(t)"
+                    @click="openEdit(task)"
                   >
                     <div class="flex-1 min-w-0">
                       <div class="flex items-center gap-2 flex-wrap mb-1">
-                        <span class="font-medium text-base">{{ t.name }}</span>
-                        <UBadge v-if="!t.enabled" color="neutral" variant="subtle" size="xs">
-                          disabled
+                        <span class="font-medium text-base">{{ task.name }}</span>
+                        <UBadge v-if="!task.enabled" color="neutral" variant="subtle" size="xs">
+                          {{ $t('common.badge.disabled') }}
                         </UBadge>
                       </div>
                       <div class="flex items-center gap-2 text-xs text-muted">
                         <UIcon name="i-lucide-clock" class="size-3.5 shrink-0" />
-                        <code class="font-mono">{{ t.cron }}</code>
+                        <code class="font-mono">{{ task.cron }}</code>
                       </div>
-                      <p v-if="t.userPrompt" class="text-xs text-muted mt-1 line-clamp-2">
-                        {{ t.userPrompt }}
+                      <p v-if="task.userPrompt" class="text-xs text-muted mt-1 line-clamp-2">
+                        {{ task.userPrompt }}
                       </p>
                       <div class="flex items-center gap-2 text-xs text-muted mt-1.5 flex-wrap">
-                        <span v-if="t.tools.length > 0" class="flex items-center gap-1">
+                        <span v-if="task.tools.length > 0" class="flex items-center gap-1">
                           <UIcon name="i-lucide-wrench" class="size-3.5 shrink-0" />
-                          {{ t.tools.length }} {{ t.tools.length === 1 ? 'tool' : 'tools' }}
+                          {{ $t('agentDetail.tasks.toolsCount', task.tools.length) }}
                         </span>
                         <span class="flex items-center gap-1">
                           <UIcon name="i-lucide-list-checks" class="size-3.5 shrink-0" />
-                          max {{ t.maxSteps }} steps
+                          {{ $t('agentDetail.tasks.maxSteps', { n: task.maxSteps }) }}
                         </span>
                       </div>
                     </div>
@@ -954,7 +938,7 @@ onBeforeUnmount(() => { if (destroyPollTimer) clearTimeout(destroyPollTimer) })
                       size="sm"
                       icon="i-lucide-trash-2"
                       :ui="{ base: 'shrink-0' }"
-                      @click.stop="remove(t)"
+                      @click.stop="remove(task)"
                     />
                   </button>
                 </li>
@@ -969,7 +953,7 @@ onBeforeUnmount(() => { if (destroyPollTimer) clearTimeout(destroyPollTimer) })
             <summary class="cursor-pointer list-none px-4 py-3 flex items-center justify-between gap-2">
               <div class="flex items-center gap-2 text-sm">
                 <UIcon name="i-lucide-history" class="text-muted size-4" />
-                <span class="font-medium">Recent runs</span>
+                <span class="font-medium">{{ $t('agentDetail.runs.title') }}</span>
                 <UBadge color="neutral" variant="subtle" size="xs">
                   {{ detail.recentRuns.length }}
                 </UBadge>
@@ -978,7 +962,7 @@ onBeforeUnmount(() => { if (destroyPollTimer) clearTimeout(destroyPollTimer) })
             </summary>
             <div class="border-t border-(--ui-border)">
               <div v-if="detail.recentRuns.length === 0" class="px-4 py-6 text-center text-muted text-sm">
-                No runs yet.
+                {{ $t('agentDetail.runs.empty') }}
               </div>
               <ul v-else class="divide-y divide-(--ui-border)">
                 <li v-for="r in detail.recentRuns" :key="r.id" class="px-4 py-3">
@@ -986,12 +970,12 @@ onBeforeUnmount(() => { if (destroyPollTimer) clearTimeout(destroyPollTimer) })
                     <div class="flex-1 min-w-0">
                       <div class="flex items-center gap-2">
                         <UBadge :color="(statusColor[r.status] as any)" variant="subtle" size="xs">
-                          {{ r.status }}
+                          {{ $t(`agentDetail.runs.status.${r.status}`) }}
                         </UBadge>
                         <code class="font-mono text-xs">{{ r.taskId }}</code>
                         <span class="text-xs text-muted">
                           {{ fmtDate(r.startedAt) }}
-                          <span v-if="r.finishedAt"> · {{ (r.finishedAt - r.startedAt).toFixed(0) }}s</span>
+                          <span v-if="r.finishedAt"> · {{ $t('agentDetail.runs.elapsedSec', { n: (r.finishedAt - r.startedAt).toFixed(0) }) }}</span>
                         </span>
                       </div>
                       <p v-if="r.finalMessage" class="text-sm mt-1 break-words">
@@ -999,7 +983,7 @@ onBeforeUnmount(() => { if (destroyPollTimer) clearTimeout(destroyPollTimer) })
                       </p>
                       <details v-if="r.trace" class="mt-1">
                         <summary class="cursor-pointer text-xs text-muted">
-                          trace
+                          {{ $t('agentDetail.runs.trace') }}
                         </summary>
                         <pre class="text-xs mt-1 p-2 bg-(--ui-bg-elevated) rounded overflow-auto max-h-72">{{ JSON.stringify(r.trace, null, 2) }}</pre>
                       </details>
@@ -1020,28 +1004,26 @@ onBeforeUnmount(() => { if (destroyPollTimer) clearTimeout(destroyPollTimer) })
            script + agent-home wipe). -->
       <section class="mt-12 pt-6 border-t border-red-500/20">
         <h2 class="text-sm font-medium text-red-400 mb-1">
-          Danger zone
+          {{ $t('agentDetail.danger.title') }}
         </h2>
         <p class="text-xs text-muted mb-3">
-          Destroys the agent on the nest where it lives. The IdP record is
-          removed, the bridge is stopped, the agent's home directory is
-          wiped, and this troop entry disappears.
+          {{ $t('agentDetail.danger.hint') }}
         </p>
         <UButton color="error" variant="soft" icon="i-lucide-trash-2" @click="openDestroy">
-          Delete agent
+          {{ $t('agentDetail.danger.deleteButton') }}
         </UButton>
       </section>
     </main>
 
-    <UModal v-model:open="showDestroy" title="Delete agent?" :ui="{ content: 'sm:max-w-md' }">
+    <UModal v-model:open="showDestroy" :title="$t('agentDetail.destroy.title')" :ui="{ content: 'sm:max-w-md' }">
       <template #body>
         <div class="space-y-4">
-          <p class="text-sm">
-            This destroys <span class="font-mono font-semibold">{{ agentName }}</span> on its nest
-            (IdP record gone, bridge stopped, home wiped). The chat history on
-            chat.openape.ai stays intact, but the agent won't reply anymore.
-          </p>
-          <UFormField :label="`Type ${agentName} to confirm`">
+          <i18n-t keypath="agentDetail.destroy.body" tag="p" class="text-sm">
+            <template #name>
+              <span class="font-mono font-semibold">{{ agentName }}</span>
+            </template>
+          </i18n-t>
+          <UFormField :label="$t('agentDetail.destroy.typeToConfirm', { name: agentName })">
             <UInput v-model="destroyConfirmInput" :placeholder="agentName" :disabled="destroying" autocomplete="off" />
           </UFormField>
           <UAlert v-if="destroyError" color="error" :title="destroyError" />
@@ -1049,11 +1031,10 @@ onBeforeUnmount(() => { if (destroyPollTimer) clearTimeout(destroyPollTimer) })
             <UIcon name="i-lucide-loader-circle" class="animate-spin shrink-0 size-4 mt-0.5" />
             <div>
               <div class="font-medium">
-                Destroying on the nest…
+                {{ $t('agentDetail.destroy.pending.title') }}
               </div>
               <div class="text-muted mt-1">
-                Approve the as=root grant on your iPhone if asked. This dialog
-                closes when the nest reports back.
+                {{ $t('agentDetail.destroy.pending.hint') }}
               </div>
             </div>
           </div>
@@ -1067,10 +1048,10 @@ onBeforeUnmount(() => { if (destroyPollTimer) clearTimeout(destroyPollTimer) })
             :disabled="destroying || destroyConfirmInput !== agentName"
             @click="submitDestroy"
           >
-            Delete forever
+            {{ $t('agentDetail.destroy.confirmButton') }}
           </UButton>
           <UButton variant="ghost" :disabled="destroying" @click="showDestroy = false">
-            Cancel
+            {{ $t('common.cancel') }}
           </UButton>
         </div>
       </template>
@@ -1080,13 +1061,13 @@ onBeforeUnmount(() => { if (destroyPollTimer) clearTimeout(destroyPollTimer) })
          doesn't push the save button under the textarea. -->
     <UModal
       v-model:open="showEditor"
-      :title="editing.isNew ? 'New task' : `Edit ${editing.taskId}`"
+      :title="editing.isNew ? $t('agentDetail.taskEditor.titleNew') : $t('agentDetail.taskEditor.titleEdit', { id: editing.taskId })"
       fullscreen
       :ui="{ content: 'sm:max-w-2xl sm:max-h-[90vh]' }"
     >
       <template #body>
         <form class="space-y-5" @submit.prevent="save">
-          <UFormField label="task_id" hint="lowercase letters, digits, dashes — immutable" :required="editing.isNew">
+          <UFormField label="task_id" :hint="$t('agentDetail.taskEditor.taskId.hint')" :required="editing.isNew">
             <UInput
               v-model="form.task_id"
               :disabled="!editing.isNew"
@@ -1100,30 +1081,30 @@ onBeforeUnmount(() => { if (destroyPollTimer) clearTimeout(destroyPollTimer) })
               @input="form.task_id = String($event.target.value).toLowerCase().replace(/[^a-z0-9-]/g, '')"
             />
           </UFormField>
-          <UFormField label="Display name" required>
+          <UFormField :label="$t('agentDetail.taskEditor.displayName')" required>
             <UInput v-model="form.name" placeholder="Daily Summary" size="lg" class="w-full" />
           </UFormField>
-          <UFormField label="When to run" hint="Cron syntax — see preview below">
+          <UFormField :label="$t('agentDetail.taskEditor.cron.label')" :hint="$t('agentDetail.taskEditor.cron.hint')">
             <CronInput v-model="form.cron" />
           </UFormField>
-          <UFormField label="What should run?" hint="The job for this run — agent's persona/style is set on the agent itself." required>
+          <UFormField :label="$t('agentDetail.taskEditor.userPrompt.label')" :hint="$t('agentDetail.taskEditor.userPrompt.hint')" required>
             <UTextarea
               v-model="form.user_prompt"
               :rows="8"
               autoresize
               size="lg"
               class="w-full"
-              placeholder="Lese mein Postfach durch und mach mir eine Zusammenfassung der wichtigsten neuen Mails."
+              :placeholder="$t('agentDetail.taskEditor.userPrompt.placeholder')"
             />
           </UFormField>
-          <UFormField label="Tools available">
+          <UFormField :label="$t('agentDetail.taskEditor.toolsLabel')">
             <ToolPicker v-model="form.tools" />
           </UFormField>
-          <UFormField label="Max tool-call rounds per run">
+          <UFormField :label="$t('agentDetail.taskEditor.maxStepsLabel')">
             <UInput v-model.number="form.max_steps" type="number" :min="1" :max="50" size="lg" class="w-full" />
           </UFormField>
           <UFormField>
-            <UCheckbox v-model="form.enabled" label="Enabled" />
+            <UCheckbox v-model="form.enabled" :label="$t('agentDetail.taskEditor.enabledLabel')" />
           </UFormField>
 
           <UAlert v-if="saveError" color="error" :title="saveError" />
@@ -1132,10 +1113,10 @@ onBeforeUnmount(() => { if (destroyPollTimer) clearTimeout(destroyPollTimer) })
       <template #footer>
         <div class="flex flex-row-reverse w-full gap-2">
           <UButton type="submit" color="primary" :loading="saving" size="lg" class="flex-1 sm:flex-none justify-center" @click="save">
-            {{ editing.isNew ? 'Create task' : 'Save changes' }}
+            {{ editing.isNew ? $t('agentDetail.taskEditor.createButton') : $t('agentDetail.taskEditor.saveButton') }}
           </UButton>
           <UButton variant="ghost" :disabled="saving" size="lg" @click="showEditor = false">
-            Cancel
+            {{ $t('common.cancel') }}
           </UButton>
         </div>
       </template>

--- a/apps/openape-troop/app/pages/agents/index.vue
+++ b/apps/openape-troop/app/pages/agents/index.vue
@@ -2,8 +2,11 @@
 import { computed, onMounted, ref, watch } from 'vue'
 import { useOpenApeAuth } from '#imports'
 
-useSeoMeta({ title: 'My Agents' })
+const { t } = useI18n()
+useSeoMeta({ title: () => t('agentsIndex.tabTitle') })
 
+const { fmtRelative } = useRelativeTime()
+const { fmtDate } = useDateFormat()
 const { user, fetchUser, logout } = useOpenApeAuth()
 await fetchUser()
 
@@ -51,7 +54,7 @@ async function load() {
       await navigateTo('/login')
       return
     }
-    error.value = err?.data?.statusMessage || err?.message || 'failed to load agents'
+    error.value = err?.data?.statusMessage || err?.message || t('agentsIndex.error.loadFailed')
   }
   finally {
     loading.value = false
@@ -60,22 +63,6 @@ async function load() {
 
 watch(user, (u) => { if (u) load() }, { immediate: true })
 onMounted(() => { if (!user.value) navigateTo('/login') })
-
-function fmtDate(ts: number | null): string {
-  if (!ts) return '—'
-  return new Date(ts * 1000).toLocaleString('de-AT', { day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit' })
-}
-
-// Relative time for the at-a-glance "is this agent alive?" signal —
-// absolute timestamps don't work on a phone-sized card.
-function fmtRelative(ts: number | null): string {
-  if (!ts) return 'never'
-  const sec = Math.max(0, Math.floor(Date.now() / 1000) - ts)
-  if (sec < 60) return 'just now'
-  if (sec < 3600) return `${Math.floor(sec / 60)}m ago`
-  if (sec < 86400) return `${Math.floor(sec / 3600)}h ago`
-  return `${Math.floor(sec / 86400)}d ago`
-}
 
 const statusColor: Record<NonNullable<AgentRow['lastRunStatus']>, string> = {
   running: 'info',
@@ -94,7 +81,7 @@ const nestGroups = computed<NestGroup[]>(() => {
   const buckets = new Map<string, NestGroup>()
   for (const a of agents.value) {
     const key = a.hostId ?? PENDING_SYNC_KEY
-    const label = a.hostId ? (a.hostname || a.hostId) : 'Pending first sync'
+    const label = a.hostId ? (a.hostname || a.hostId) : t('agentsIndex.group.pendingSync')
     const existing = buckets.get(key)
     if (existing) {
       existing.agents.push(a)
@@ -138,7 +125,7 @@ const nestGroups = computed<NestGroup[]>(() => {
       <div class="flex items-center gap-2 min-w-0">
         <span class="text-2xl shrink-0">🦍</span>
         <h1 class="text-xl font-semibold">
-          Troop
+          {{ $t('app.title') }}
         </h1>
       </div>
       <div class="flex items-center gap-2 shrink-0">
@@ -149,7 +136,7 @@ const nestGroups = computed<NestGroup[]>(() => {
           icon="i-lucide-plus"
           @click="showSpawn = true"
         >
-          <span class="hidden sm:inline">Spawn agent</span>
+          <span class="hidden sm:inline">{{ $t('agentsIndex.spawnButton') }}</span>
         </UButton>
         <UButton
           variant="ghost"
@@ -158,7 +145,7 @@ const nestGroups = computed<NestGroup[]>(() => {
           :ui="{ base: 'shrink-0' }"
           @click="logout"
         >
-          <span class="hidden sm:inline">Logout</span>
+          <span class="hidden sm:inline">{{ $t('common.logout') }}</span>
         </UButton>
       </div>
     </header>
@@ -166,29 +153,32 @@ const nestGroups = computed<NestGroup[]>(() => {
 
     <main class="px-4 sm:px-6 py-6 max-w-5xl mx-auto">
       <h2 class="text-2xl font-bold mb-1">
-        My Agents
+        {{ $t('agentsIndex.heading') }}
       </h2>
-      <p class="text-muted mb-6">
-        Cron-scheduled jobs you've spawned with <code>apes agents spawn</code>.
-      </p>
+      <i18n-t keypath="agentsIndex.subheading" tag="p" class="text-muted mb-6">
+        <template #cmd>
+          <code>apes agents spawn</code>
+        </template>
+      </i18n-t>
 
       <UAlert v-if="error" color="error" :title="error" class="mb-4" />
 
       <UCard v-if="loading">
         <p class="text-muted text-sm">
-          Loading…
+          {{ $t('common.loading') }}
         </p>
       </UCard>
 
       <UCard v-else-if="agents.length === 0">
         <div class="text-center py-8 space-y-3">
           <p class="text-muted">
-            No agents registered yet.
+            {{ $t('agentsIndex.empty.title') }}
           </p>
-          <p class="text-sm text-muted">
-            Run <code class="bg-(--ui-bg-elevated) px-2 py-0.5 rounded">apes agents spawn &lt;name&gt;</code>
-            on a Mac to provision one. It'll show up here once it's done its first sync.
-          </p>
+          <i18n-t keypath="agentsIndex.empty.hint" tag="p" class="text-sm text-muted">
+            <template #cmd>
+              <code class="bg-(--ui-bg-elevated) px-2 py-0.5 rounded">apes agents spawn &lt;name&gt;</code>
+            </template>
+          </i18n-t>
         </div>
       </UCard>
 
@@ -239,7 +229,7 @@ const nestGroups = computed<NestGroup[]>(() => {
                 <dl class="mt-3 grid grid-cols-2 gap-x-4 gap-y-2 text-xs">
                   <div>
                     <dt class="text-muted">
-                      Tasks
+                      {{ $t('agentsIndex.card.tasks') }}
                     </dt>
                     <dd class="font-medium">
                       {{ a.taskCount }}
@@ -247,7 +237,7 @@ const nestGroups = computed<NestGroup[]>(() => {
                   </div>
                   <div>
                     <dt class="text-muted">
-                      Last sync
+                      {{ $t('agentsIndex.card.lastSync') }}
                     </dt>
                     <dd class="truncate">
                       {{ fmtRelative(a.lastSeenAt) }}
@@ -255,7 +245,7 @@ const nestGroups = computed<NestGroup[]>(() => {
                   </div>
                   <div v-if="a.lastRunAt" class="col-span-2">
                     <dt class="text-muted">
-                      Last run
+                      {{ $t('agentsIndex.card.lastRun') }}
                     </dt>
                     <dd>{{ fmtDate(a.lastRunAt) }}</dd>
                   </div>

--- a/apps/openape-troop/app/pages/index.vue
+++ b/apps/openape-troop/app/pages/index.vue
@@ -2,6 +2,7 @@
 import { ref } from 'vue'
 import { useOpenApeAuth } from '#imports'
 
+const { t } = useI18n()
 const { user, loading, fetchUser, login } = useOpenApeAuth()
 await fetchUser()
 
@@ -16,7 +17,7 @@ const submitting = ref(false)
 async function handleLogin() {
   error.value = ''
   if (!email.value || !email.value.includes('@')) {
-    error.value = 'Bitte eine gültige Email-Adresse eingeben.'
+    error.value = t('index.error.invalidEmail')
     return
   }
   submitting.value = true
@@ -24,7 +25,7 @@ async function handleLogin() {
     await login(email.value.trim())
   }
   catch (e: any) {
-    error.value = e?.data?.statusMessage || e?.message || 'Login fehlgeschlagen.'
+    error.value = e?.data?.statusMessage || e?.message || t('index.error.loginFailed')
     submitting.value = false
   }
 }
@@ -37,7 +38,7 @@ async function handleLogin() {
         <OpenApeOAuthErrorAlert
           class="text-left mb-6 w-full"
           :messages="{
-            access_denied: 'Login wurde vom Identity Provider abgelehnt. Wahrscheinlich hat dein Domain-Admin Troop noch nicht freigegeben — frag deinen Admin oder verwende eine andere Email-Adresse.',
+            access_denied: $t('login.oauth.accessDenied'),
           }"
         />
 
@@ -46,20 +47,20 @@ async function handleLogin() {
         </div>
 
         <h1 class="text-4xl sm:text-5xl font-bold tracking-tight leading-tight">
-          We feed<br>
-          baby apes<br>
-          <span class="text-primary-500">with inference.</span>
+          {{ $t('index.hero.line1') }}<br>
+          {{ $t('index.hero.line2') }}<br>
+          <span class="text-primary-500">{{ $t('index.hero.line3') }}</span>
         </h1>
 
         <p class="mt-4 text-zinc-400 text-lg">
-          Cron-scheduled, single-purpose, OpenApe-identity. Manage from anywhere.
+          {{ $t('index.hero.subtitle') }}
         </p>
 
         <form class="mt-10 w-full space-y-3" @submit.prevent="handleLogin">
           <UInput
             v-model="email"
             type="email"
-            placeholder="you@example.com"
+            :placeholder="$t('index.email.placeholder')"
             size="xl"
             autocomplete="email"
             icon="i-lucide-mail"
@@ -78,18 +79,18 @@ async function handleLogin() {
             icon="i-lucide-fingerprint"
             :loading="submitting || loading"
           >
-            Sign in with OpenApe
+            {{ $t('index.submit') }}
           </UButton>
         </form>
 
         <p class="mt-10 italic text-sm text-zinc-500">
-          "Hatched by you. Loyal to you. Lives on your computer."
+          {{ $t('index.tagline') }}
         </p>
       </div>
     </main>
 
     <footer class="py-6 text-center text-xs text-zinc-600">
-      Powered by
+      {{ $t('index.footer.poweredBy') }}
       <a
         href="https://openape.ai"
         target="_blank"

--- a/apps/openape-troop/app/pages/login.vue
+++ b/apps/openape-troop/app/pages/login.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-useSeoMeta({ title: 'Sign in' })
+const { t } = useI18n()
+useSeoMeta({ title: () => t('login.tabTitle') })
 </script>
 
 <template>
@@ -9,15 +10,15 @@ useSeoMeta({ title: 'Sign in' })
         <OpenApeOAuthErrorAlert
           class="text-left mb-6 w-full"
           :messages="{
-            access_denied: 'Login wurde vom Identity Provider abgelehnt. Wahrscheinlich hat dein Domain-Admin Troop noch nicht freigegeben — frag deinen Admin oder verwende eine andere Email-Adresse.',
+            access_denied: $t('login.oauth.accessDenied'),
           }"
         />
 
         <UCard>
           <OpenApeAuth
-            title="Sign in to Troop"
-            subtitle="Enter your email to manage your agents"
-            button-text="Continue"
+            :title="$t('login.card.title')"
+            :subtitle="$t('login.card.subtitle')"
+            :button-text="$t('login.card.button')"
             post-login-redirect="/"
           />
         </UCard>

--- a/apps/openape-troop/i18n/locales/de.json
+++ b/apps/openape-troop/i18n/locales/de.json
@@ -1,13 +1,398 @@
 {
   "app": {
-    "title": "troop"
+    "title": "Troop"
+  },
+  "common": {
+    "loading": "Lädt…",
+    "save": "Speichern",
+    "cancel": "Abbrechen",
+    "close": "Schließen",
+    "retry": "Erneut versuchen",
+    "logout": "Abmelden",
+    "error": {
+      "saveFailed": "Speichern fehlgeschlagen",
+      "deleteFailed": "Löschen fehlgeschlagen"
+    },
+    "badge": {
+      "set": "gesetzt",
+      "empty": "leer",
+      "unsaved": "ungespeichert",
+      "disabled": "deaktiviert"
+    }
   },
   "locale": {
     "english": "Englisch",
     "german": "Deutsch"
   },
+  "time": {
+    "never": "nie",
+    "justNow": "gerade eben"
+  },
   "login": {
-    "email": "E-Mail",
-    "submit": "Anmelden"
+    "tabTitle": "Anmelden",
+    "oauth": {
+      "accessDenied": "Login wurde vom Identity Provider abgelehnt. Wahrscheinlich hat dein Domain-Admin Troop noch nicht freigegeben — frag deinen Admin oder verwende eine andere Email-Adresse."
+    },
+    "card": {
+      "title": "Bei Troop anmelden",
+      "subtitle": "Email eingeben um deine Agents zu verwalten",
+      "button": "Weiter"
+    }
+  },
+  "index": {
+    "hero": {
+      "line1": "Wir füttern",
+      "line2": "kleine Affen",
+      "line3": "mit Inference.",
+      "subtitle": "Cron-getriggert, Single-Purpose, OpenApe-Identity. Verwalte sie von überall."
+    },
+    "email": {
+      "placeholder": "du{'@'}beispiel.at"
+    },
+    "submit": "Mit OpenApe anmelden",
+    "tagline": "\"Von dir geschlüpft. Dir treu. Lebt auf deinem Computer.\"",
+    "footer": {
+      "poweredBy": "Powered by"
+    },
+    "error": {
+      "invalidEmail": "Bitte eine gültige Email-Adresse eingeben.",
+      "loginFailed": "Login fehlgeschlagen."
+    }
+  },
+  "agentsIndex": {
+    "tabTitle": "Meine Agents",
+    "heading": "Meine Agents",
+    "subheading": "Cron-Jobs, die du mit {cmd} angelegt hast.",
+    "spawnButton": "Agent anlegen",
+    "empty": {
+      "title": "Noch keine Agents registriert.",
+      "hint": "Führe {cmd} auf einem Mac aus, um einen anzulegen. Sobald der erste Sync durchgelaufen ist, taucht er hier auf."
+    },
+    "card": {
+      "tasks": "Tasks",
+      "lastSync": "Letzter Sync",
+      "lastRun": "Letzter Lauf"
+    },
+    "group": {
+      "pendingSync": "Wartet auf ersten Sync"
+    },
+    "error": {
+      "loadFailed": "Agents konnten nicht geladen werden"
+    }
+  },
+  "agentDetail": {
+    "tabTitle": "Agent {name}",
+    "backToAgents": "Agents",
+    "error": {
+      "loadFailed": "Agent konnte nicht geladen werden"
+    },
+    "nest": {
+      "offlineLabel": "Nest offline — fällt auf 5-min-Poll zurück",
+      "onlineLabel": "live · {names}",
+      "badgeLive": "● live",
+      "badgePoll": "○ poll"
+    },
+    "details": {
+      "title": "Agent-Details",
+      "lastSyncShort": "letzter Sync {value}",
+      "email": "Email",
+      "hostname": "Hostname",
+      "hostId": "Host-ID",
+      "pubkey": "Public SSH Key",
+      "firstSync": "Erster Sync",
+      "lastSync": "Letzter Sync"
+    },
+    "systemPrompt": {
+      "title": "System-Prompt",
+      "placeholder": "Du bist … (Persönlichkeit, Stil, Grundregeln in 1–3 Sätzen)",
+      "hint": "Persönlichkeit, Stil, Grundregeln — gilt für jede Nachricht im Chat und für jeden Task-Run. Wird via Sync (~5 min) auf den Agent-Host übertragen."
+    },
+    "recipe": {
+      "title": "Recipe",
+      "ref": {
+        "label": "Recipe-Ref",
+        "description": "owner/repo{'@'}ref (pinned), z.B. openape-ai/coding-agent{'@'}main"
+      },
+      "params": {
+        "label": "Params (JSON)",
+        "description": "JSON-Objekt mit den Recipe-Params (Keys siehe README des Recipes)."
+      },
+      "applied": "{ref} angewandt",
+      "bindSecrets": "Secrets binden: {names}",
+      "noNewSecrets": "Keine neuen Secrets erforderlich.",
+      "applyButton": "Recipe setzen / aktualisieren",
+      "error": {
+        "applyFailed": "Recipe-Anwendung fehlgeschlagen"
+      }
+    },
+    "tools": {
+      "title": "Tools",
+      "selectedCount": "{n} ausgewählt",
+      "hint": "Welche Tools darf der Agent im Chat verwenden? Default: alle. Nach Speichern via Sync (~5 min) auf den Agent-Host übertragen — kein Bridge-Restart nötig (jeder neue Chat-Thread liest die Liste frisch)."
+    },
+    "skills": {
+      "title": "Skills",
+      "hint": "Lazy geladene SKILL.md-Instructions. Der Agent sieht Name + Beschreibung in jedem System-Prompt; den Body lädt er bei Bedarf über file.read.",
+      "newButton": "Neue Skill",
+      "empty": "Noch keine eigenen Skills — der Agent läuft mit den Default-Skills aus {pkg} (eine pro eingebautem Tool).",
+      "deleteAria": "Skill löschen",
+      "confirmDelete": "Skill '{name}' löschen? Das ist permanent — wenn du sie nur vor dem Agent verstecken willst, setze sie auf 'disabled'.",
+      "error": {
+        "loadFailed": "Skills konnten nicht geladen werden"
+      },
+      "editor": {
+        "titleNew": "Neue Skill",
+        "titleEdit": "{name} bearbeiten",
+        "name": {
+          "label": "Name",
+          "descriptionNew": "lowercase, [a-z0-9-], max. 32 — wird der Directory-Name auf der Disk",
+          "descriptionImmutable": "Name ist nach dem Anlegen unveränderlich"
+        },
+        "description": {
+          "label": "Beschreibung",
+          "description": "Ein-Zeiler, den das LLM in jedem System-Prompt sieht; sagt dem Agent, wann er diese Skill laden soll",
+          "placeholder": "Wenn der User über IURIO-Projekte, Cases oder Dokumente spricht, lade das."
+        },
+        "body": {
+          "label": "Body (Markdown)",
+          "description": "Voller SKILL.md-Inhalt — Workflows, Befehle, Konventionen",
+          "placeholder": "# IURIO CLI Verwendung…"
+        },
+        "enabled": {
+          "label": "Aktiv",
+          "description": "Deaktivierte Skills bleiben auf der Disk, der Agent sieht sie aber nicht."
+        }
+      }
+    },
+    "secrets": {
+      "title": "Secrets",
+      "hint": "Capability-Values für diesen Agent. Der Wert wird vor dem Speichern auf den Schlüssel des Agents sealed — Troop kennt den Klartext nie und kann ihn nicht mehr anzeigen. Wert nochmal setzen = rotieren.",
+      "status": {
+        "active": "aktiv",
+        "revoked": "widerrufen"
+      },
+      "envPlaceholder": "ENV_NAME",
+      "valuePlaceholder": "Wert",
+      "setButton": "Setzen",
+      "revokeAria": "Secret widerrufen",
+      "casingHint": "UPPER_SNAKE_CASE. Binding funktioniert sobald der Agent nach dem Spawn einmal gesynct hat.",
+      "confirmRevoke": "'{env}' widerrufen? Die Kopie beim Agent wird beim nächsten Connect gelöscht.",
+      "error": {
+        "loadFailed": "Secrets konnten nicht geladen werden",
+        "saveFailed": "Speichern fehlgeschlagen (der Agent muss nach dem Spawn einmal gesynct haben)",
+        "revokeFailed": "Widerrufen fehlgeschlagen"
+      }
+    },
+    "tasks": {
+      "title": "Tasks",
+      "newButton": "Neuer Task",
+      "empty": "Noch keine Tasks — tippe \"Neuer Task\" um den Agent zu schedulen.",
+      "toolsCount": "keine Tools | 1 Tool | {count} Tools",
+      "maxSteps": "max. {n} Schritte",
+      "confirmDelete": "Task \"{name}\" löschen? Aktive launchd-Jobs auf dem Agent-Host werden beim nächsten Sync entfernt."
+    },
+    "taskEditor": {
+      "titleNew": "Neuer Task",
+      "titleEdit": "{id} bearbeiten",
+      "taskId": {
+        "hint": "Kleinbuchstaben, Ziffern, Bindestriche — unveränderlich"
+      },
+      "displayName": "Anzeigename",
+      "cron": {
+        "label": "Wann ausführen",
+        "hint": "Cron-Syntax — siehe Preview unten"
+      },
+      "userPrompt": {
+        "label": "Was soll laufen?",
+        "hint": "Der Job für diesen Run — die Persönlichkeit/Stil ist am Agent selbst gesetzt.",
+        "placeholder": "Lese mein Postfach durch und mach mir eine Zusammenfassung der wichtigsten neuen Mails."
+      },
+      "toolsLabel": "Verfügbare Tools",
+      "maxStepsLabel": "Max. Tool-Call-Runden pro Run",
+      "enabledLabel": "Aktiv",
+      "createButton": "Task anlegen",
+      "saveButton": "Änderungen speichern"
+    },
+    "runs": {
+      "title": "Letzte Läufe",
+      "empty": "Noch keine Läufe.",
+      "status": {
+        "running": "läuft",
+        "ok": "ok",
+        "error": "Fehler"
+      },
+      "elapsedSec": "{n} s",
+      "trace": "Trace"
+    },
+    "danger": {
+      "title": "Danger Zone",
+      "hint": "Zerstört den Agent auf seinem Nest. Der IdP-Eintrag wird entfernt, die Bridge gestoppt, das Home-Directory gelöscht — und dieser Troop-Eintrag verschwindet.",
+      "deleteButton": "Agent löschen"
+    },
+    "destroy": {
+      "title": "Agent löschen?",
+      "body": "Das zerstört {name} auf seinem Nest (IdP weg, Bridge gestoppt, Home gelöscht). Der Chat-Verlauf bleibt erhalten, der Agent antwortet aber nicht mehr.",
+      "typeToConfirm": "Tippe {name} zur Bestätigung",
+      "confirmButton": "Für immer löschen",
+      "pending": {
+        "title": "Zerstörung läuft auf dem Nest…",
+        "hint": "Bestätige den as=root-Grant auf deinem iPhone wenn gefragt. Dieser Dialog schließt sich, sobald das Nest zurückmeldet."
+      },
+      "error": {
+        "nestFailed": "Zerstörung auf dem Nest fehlgeschlagen",
+        "pollFailed": "Polling fehlgeschlagen",
+        "startFailed": "Zerstörung konnte nicht gestartet werden"
+      }
+    }
+  },
+  "chat": {
+    "loading": "Chat lädt…",
+    "edited": "bearbeitet",
+    "empty": {
+      "title": "Noch keine Nachrichten",
+      "sub": "Schreib dem Agent unten — die Antwort landet hier oben."
+    },
+    "composer": {
+      "placeholder": "Schreib dem Agent…"
+    },
+    "error": {
+      "loadFailed": "Chat konnte nicht geladen werden",
+      "sendFailed": "Senden fehlgeschlagen"
+    }
+  },
+  "spawn": {
+    "title": "Agent anlegen",
+    "subtitle": "Name + Prompt sind die Basis. Recipe und Secrets sind optionale, additive Layer — aufklappen wenn du sie brauchst. Du bekommst einen DDISA-Grant-Request auf dein iPhone — bestätigen zum Abschließen.",
+    "submitButton": "Anlegen",
+    "alert": {
+      "noNestTitle": "Kein verbundenes Nest",
+      "noNestDescription": "Starte den Nest-Daemon auf einem Mac (apes nest install + run) und lade neu."
+    },
+    "field": {
+      "host": {
+        "label": "Host",
+        "description": "Mehrere Macs verbunden — wähle den, auf dem der Agent angelegt werden soll."
+      },
+      "name": {
+        "label": "Name",
+        "description": "lowercase, [a-z0-9-], max. 24 Zeichen — oder aus der Liste wählen",
+        "rollAria": "Zufälligen Namen würfeln",
+        "pickAria": "Aus Namensliste wählen"
+      },
+      "preset": {
+        "label": "Preset",
+        "description": "Quick-Start-Prompt. Im Textfeld anpassen oder 'Custom' für eine leere Vorlage."
+      },
+      "systemPrompt": {
+        "label": "System-Prompt",
+        "description": "Mit einem Recipe wird das on top des Recipe-Intents gehängt (user_addendum) — später ohne Re-Deploy editierbar.",
+        "placeholder": "Du bist …"
+      }
+    },
+    "preset": {
+      "custom": {
+        "label": "Custom (leer)",
+        "description": "Eigenen System-Prompt schreiben oder später im Agent-Detail setzen."
+      },
+      "calendar": {
+        "label": "📅 Kalender-Assistent",
+        "description": "Tagesüberblick am Morgen, Hinweise zu Verschiebungen / Konflikten."
+      },
+      "mailTriage": {
+        "label": "📬 Mail-Triage",
+        "description": "Sichtet ungelesene Mails, priorisiert Action / Important / FYI / Spam."
+      },
+      "timeTracker": {
+        "label": "⏱ Zeiterfassung",
+        "description": "Wertet activity-logs aus, fasst Stunden pro Projekt / Firma zusammen."
+      },
+      "dailySummary": {
+        "label": "🗞 Daily Summary",
+        "description": "Synthetisiert activity-logs + tasks + Termine zu einem End-of-day Bericht."
+      }
+    },
+    "recipe": {
+      "summary": "Recipe",
+      "summaryHint": "(optional, additiv)",
+      "field": {
+        "label": "Recipe",
+        "description": "Kuratiertes Recipe wählen, Custom für jedes Pinned-Repo oder Keines."
+      },
+      "option": {
+        "none": "Keines",
+        "custom": "Custom…",
+        "customDescription": "github.com/<owner>/<name>{'@'}<ref> einfügen"
+      },
+      "repo": {
+        "label": "Repository",
+        "description": "github.com/<owner>/<name>{'@'}<tag|commit> — die Pinned-Ref ist verpflichtend.",
+        "openAria": "Recipe-Repo öffnen (Docs + benötigte Secrets)"
+      },
+      "params": {
+        "label": "Params",
+        "description": "Ein KEY=value pro Zeile (Recipe-Params, z.B. topic=AI agents).",
+        "placeholder": "topic=AI agents"
+      },
+      "entries": {
+        "blueskySummary": {
+          "hint": "Zweimal täglich ein Digest deiner Bluesky-Home-Timeline. Param: topic."
+        }
+      }
+    },
+    "secrets": {
+      "summary": "Secrets",
+      "hint": "Vor dem Speichern auf den Agent sealed — Troop hat den Klartext nie. Ein gewähltes Recipe trägt die benötigten Namen ein; du kannst weitere hinzufügen. Später auch im Agent-Detail editierbar.",
+      "envPlaceholder": "ENV_NAME",
+      "valuePlaceholder": "Wert",
+      "removeAria": "Secret entfernen",
+      "addButton": "Secret hinzufügen"
+    },
+    "bridge": {
+      "summary": "Bridge-Overrides (optional)",
+      "apiKeyDescription": "Standard: ~/litellm/.env am Host.",
+      "apiKeyPlaceholder": "sk-… oder Token",
+      "baseUrlDescription": "Standard: http://127.0.0.1:4000/v1",
+      "modelDescription": "Wird zur Laufzeit von der Bridge benötigt."
+    },
+    "pending": {
+      "bindingTitle": "Secrets werden gebunden…",
+      "bindingHint": "Jeder Wert wird auf den Agent sealed und gepusht.",
+      "approvalTitle": "Warte auf DDISA-Freigabe…",
+      "approvalHint": "Bestätige den as=root-Grant in der OpenApe-App auf deinem Phone. Dieser Dialog aktualisiert sich automatisch."
+    },
+    "result": {
+      "successTitle": "Angelegt: {name}",
+      "successWithNoteTitle": "Angelegt mit Hinweis",
+      "failedTitle": "Fehlgeschlagen",
+      "missingSecrets": "Angelegt. Fehlen noch Secrets {names} — füge sie auf der Agent-Seite hinzu."
+    },
+    "error": {
+      "hostsLoadFailed": "Nest-Hosts konnten nicht geladen werden",
+      "spawnFailed": "Anlegen fehlgeschlagen",
+      "pollFailed": "Polling fehlgeschlagen",
+      "badParamLine": "Schlechte Param-Zeile: \"{line}\" (erwartet KEY=value)",
+      "bindingFailed": "Binden von {env} fehlgeschlagen: {detail}"
+    }
+  },
+  "toolPicker": {
+    "loading": "Tools werden geladen…",
+    "risk": {
+      "low": "low",
+      "medium": "medium",
+      "high": "high"
+    },
+    "error": {
+      "loadFailed": "Tool-Catalog konnte nicht geladen werden"
+    }
+  },
+  "cron": {
+    "help": "Subset: {any}, {fixed} (fix), {step} (nur bei Minute + Stunde). 5 Felder: Minute Stunde Tag-des-Monats Monat Wochentag.",
+    "preview": {
+      "noFireTimes": "Keine Ausführungen in den nächsten 7 Tagen"
+    },
+    "error": {
+      "expectFiveFields": "5 leerzeichengetrennte Felder erwartet",
+      "invalidField": "Ungültiges Feld — siehe Hilfe"
+    }
   }
 }

--- a/apps/openape-troop/i18n/locales/en.json
+++ b/apps/openape-troop/i18n/locales/en.json
@@ -1,13 +1,398 @@
 {
   "app": {
-    "title": "troop"
+    "title": "Troop"
+  },
+  "common": {
+    "loading": "Loading…",
+    "save": "Save",
+    "cancel": "Cancel",
+    "close": "Close",
+    "retry": "Retry",
+    "logout": "Logout",
+    "error": {
+      "saveFailed": "Save failed",
+      "deleteFailed": "Delete failed"
+    },
+    "badge": {
+      "set": "set",
+      "empty": "empty",
+      "unsaved": "unsaved",
+      "disabled": "disabled"
+    }
   },
   "locale": {
     "english": "English",
     "german": "German"
   },
+  "time": {
+    "never": "never",
+    "justNow": "just now"
+  },
   "login": {
-    "email": "Email",
-    "submit": "Sign in"
+    "tabTitle": "Sign in",
+    "oauth": {
+      "accessDenied": "Login was denied by the identity provider — most likely your domain admin hasn't approved Troop yet. Ask your admin or use a different email address."
+    },
+    "card": {
+      "title": "Sign in to Troop",
+      "subtitle": "Enter your email to manage your agents",
+      "button": "Continue"
+    }
+  },
+  "index": {
+    "hero": {
+      "line1": "We feed",
+      "line2": "baby apes",
+      "line3": "with inference.",
+      "subtitle": "Cron-scheduled, single-purpose, OpenApe-identity. Manage from anywhere."
+    },
+    "email": {
+      "placeholder": "you{'@'}example.com"
+    },
+    "submit": "Sign in with OpenApe",
+    "tagline": "\"Hatched by you. Loyal to you. Lives on your computer.\"",
+    "footer": {
+      "poweredBy": "Powered by"
+    },
+    "error": {
+      "invalidEmail": "Please enter a valid email address.",
+      "loginFailed": "Login failed."
+    }
+  },
+  "agentsIndex": {
+    "tabTitle": "My Agents",
+    "heading": "My Agents",
+    "subheading": "Cron-scheduled jobs you've spawned with {cmd}.",
+    "spawnButton": "Spawn agent",
+    "empty": {
+      "title": "No agents registered yet.",
+      "hint": "Run {cmd} on a Mac to provision one. It'll show up here once it's done its first sync."
+    },
+    "card": {
+      "tasks": "Tasks",
+      "lastSync": "Last sync",
+      "lastRun": "Last run"
+    },
+    "group": {
+      "pendingSync": "Pending first sync"
+    },
+    "error": {
+      "loadFailed": "Failed to load agents"
+    }
+  },
+  "agentDetail": {
+    "tabTitle": "Agent {name}",
+    "backToAgents": "Agents",
+    "error": {
+      "loadFailed": "Failed to load agent"
+    },
+    "nest": {
+      "offlineLabel": "Nest offline — falling back to 5 min poll",
+      "onlineLabel": "live · {names}",
+      "badgeLive": "● live",
+      "badgePoll": "○ poll"
+    },
+    "details": {
+      "title": "Agent details",
+      "lastSyncShort": "last sync {value}",
+      "email": "Email",
+      "hostname": "Hostname",
+      "hostId": "Host ID",
+      "pubkey": "Public SSH key",
+      "firstSync": "First sync",
+      "lastSync": "Last sync"
+    },
+    "systemPrompt": {
+      "title": "System prompt",
+      "placeholder": "You are … (personality, style, ground rules in 1–3 sentences)",
+      "hint": "Personality, style, ground rules — applies to every chat message and every task run. Synced to the agent host every ~5 min."
+    },
+    "recipe": {
+      "title": "Recipe",
+      "ref": {
+        "label": "Recipe ref",
+        "description": "owner/repo{'@'}ref (pinned), e.g. openape-ai/coding-agent{'@'}main"
+      },
+      "params": {
+        "label": "Params (JSON)",
+        "description": "JSON object with the recipe params (see the recipe README for keys)."
+      },
+      "applied": "Applied {ref}",
+      "bindSecrets": "Bind secrets: {names}",
+      "noNewSecrets": "No new secrets required.",
+      "applyButton": "Set / update recipe",
+      "error": {
+        "applyFailed": "Recipe apply failed"
+      }
+    },
+    "tools": {
+      "title": "Tools",
+      "selectedCount": "{n} selected",
+      "hint": "Which tools may the agent use in chat? Default: all. Synced to the agent host every ~5 min after save — no bridge restart needed (every new chat thread reads the list fresh)."
+    },
+    "skills": {
+      "title": "Skills",
+      "hint": "Lazy-loaded SKILL.md instructions. The agent sees name + description in every system prompt; the body is read on demand via the file.read tool when the task matches.",
+      "newButton": "New skill",
+      "empty": "No custom skills yet — the agent runs with the default skills bundled in {pkg} (one per built-in tool).",
+      "deleteAria": "Delete skill",
+      "confirmDelete": "Delete skill '{name}'? This is permanent — to keep it but hide it from the agent use 'disabled'.",
+      "error": {
+        "loadFailed": "Failed to load skills"
+      },
+      "editor": {
+        "titleNew": "New skill",
+        "titleEdit": "Edit {name}",
+        "name": {
+          "label": "Name",
+          "descriptionNew": "lowercase, [a-z0-9-], max 32 — becomes the directory name on disk",
+          "descriptionImmutable": "Name is immutable after creation"
+        },
+        "description": {
+          "label": "Description",
+          "description": "One-liner the LLM sees in every system prompt; tells it when to load this skill",
+          "placeholder": "When the user asks about IURIO projects, cases, or documents, load this."
+        },
+        "body": {
+          "label": "Body (markdown)",
+          "description": "Full SKILL.md content — workflows, commands, conventions",
+          "placeholder": "# IURIO CLI usage…"
+        },
+        "enabled": {
+          "label": "Enabled",
+          "description": "Disabled skills stay on disk but the agent doesn't see them."
+        }
+      }
+    },
+    "secrets": {
+      "title": "Secrets",
+      "hint": "Capability values for this agent. The value is sealed to the agent's key before it's stored — Troop never keeps the plaintext and can't show it back. Set a value again to rotate it.",
+      "status": {
+        "active": "active",
+        "revoked": "revoked"
+      },
+      "envPlaceholder": "ENV_NAME",
+      "valuePlaceholder": "value",
+      "setButton": "Set",
+      "revokeAria": "Revoke secret",
+      "casingHint": "UPPER_SNAKE_CASE. Binding works once the agent has synced after spawn.",
+      "confirmRevoke": "Revoke '{env}'? The agent's copy is cleared on its next connect.",
+      "error": {
+        "loadFailed": "Failed to load secrets",
+        "saveFailed": "Save failed (the agent must have synced once after spawn)",
+        "revokeFailed": "Revoke failed"
+      }
+    },
+    "tasks": {
+      "title": "Tasks",
+      "newButton": "New task",
+      "empty": "No tasks yet — tap \"New task\" to schedule the agent.",
+      "toolsCount": "no tools | 1 tool | {count} tools",
+      "maxSteps": "max {n} steps",
+      "confirmDelete": "Delete task \"{name}\"? Active launchd jobs on the agent host will be removed on the next sync."
+    },
+    "taskEditor": {
+      "titleNew": "New task",
+      "titleEdit": "Edit {id}",
+      "taskId": {
+        "hint": "lowercase letters, digits, dashes — immutable"
+      },
+      "displayName": "Display name",
+      "cron": {
+        "label": "When to run",
+        "hint": "Cron syntax — see preview below"
+      },
+      "userPrompt": {
+        "label": "What should run?",
+        "hint": "The job for this run — agent's persona/style is set on the agent itself.",
+        "placeholder": "Read my inbox and summarize the most important new mails."
+      },
+      "toolsLabel": "Tools available",
+      "maxStepsLabel": "Max tool-call rounds per run",
+      "enabledLabel": "Enabled",
+      "createButton": "Create task",
+      "saveButton": "Save changes"
+    },
+    "runs": {
+      "title": "Recent runs",
+      "empty": "No runs yet.",
+      "status": {
+        "running": "running",
+        "ok": "ok",
+        "error": "error"
+      },
+      "elapsedSec": "{n}s",
+      "trace": "trace"
+    },
+    "danger": {
+      "title": "Danger zone",
+      "hint": "Destroys the agent on the nest where it lives. The IdP record is removed, the bridge is stopped, the agent's home directory is wiped, and this Troop entry disappears.",
+      "deleteButton": "Delete agent"
+    },
+    "destroy": {
+      "title": "Delete agent?",
+      "body": "This destroys {name} on its nest (IdP record gone, bridge stopped, home wiped). The chat history stays intact, but the agent won't reply anymore.",
+      "typeToConfirm": "Type {name} to confirm",
+      "confirmButton": "Delete forever",
+      "pending": {
+        "title": "Destroying on the nest…",
+        "hint": "Approve the as=root grant on your iPhone if asked. This dialog closes when the nest reports back."
+      },
+      "error": {
+        "nestFailed": "Destroy failed on the nest",
+        "pollFailed": "Poll failed",
+        "startFailed": "Failed to start destroy"
+      }
+    }
+  },
+  "chat": {
+    "loading": "Loading chat…",
+    "edited": "edited",
+    "empty": {
+      "title": "No messages yet",
+      "sub": "Write to the agent below — the reply lands up here."
+    },
+    "composer": {
+      "placeholder": "Write to the agent…"
+    },
+    "error": {
+      "loadFailed": "Failed to load chat",
+      "sendFailed": "Failed to send"
+    }
+  },
+  "spawn": {
+    "title": "Spawn agent",
+    "subtitle": "Name + prompt are the base. A recipe and secrets are optional, additive layers — expand them if you need them. You'll get a DDISA grant request on your iPhone — approve to complete.",
+    "submitButton": "Spawn",
+    "alert": {
+      "noNestTitle": "No connected nest",
+      "noNestDescription": "Start the nest daemon on a Mac (apes nest install + run) and refresh."
+    },
+    "field": {
+      "host": {
+        "label": "Host",
+        "description": "You have multiple Macs connected — pick the one to spawn on."
+      },
+      "name": {
+        "label": "Name",
+        "description": "lowercase, [a-z0-9-], max 24 chars — or pick from the list",
+        "rollAria": "Roll a random name",
+        "pickAria": "Pick from name list"
+      },
+      "preset": {
+        "label": "Preset",
+        "description": "Quick-start prompt. Tweak the textarea or pick 'Custom' for a blank slate."
+      },
+      "systemPrompt": {
+        "label": "System prompt",
+        "description": "With a recipe this is added on top of the recipe's intent (user_addendum) — editable later without re-deploy.",
+        "placeholder": "You are …"
+      }
+    },
+    "preset": {
+      "custom": {
+        "label": "Custom (empty)",
+        "description": "Write your own system prompt or set it later on the agent's page."
+      },
+      "calendar": {
+        "label": "📅 Calendar assistant",
+        "description": "Morning daily overview, alerts on schedule changes / conflicts."
+      },
+      "mailTriage": {
+        "label": "📬 Mail triage",
+        "description": "Triages unread mail, prioritizes Action / Important / FYI / Spam."
+      },
+      "timeTracker": {
+        "label": "⏱ Time tracker",
+        "description": "Parses activity logs, summarizes hours per project / company."
+      },
+      "dailySummary": {
+        "label": "🗞 Daily summary",
+        "description": "Synthesizes activity logs + tasks + calendar into an end-of-day report."
+      }
+    },
+    "recipe": {
+      "summary": "Recipe",
+      "summaryHint": "(optional, additive)",
+      "field": {
+        "label": "Recipe",
+        "description": "Pick a curated recipe, Custom for any pinned repo, or None."
+      },
+      "option": {
+        "none": "None",
+        "custom": "Custom…",
+        "customDescription": "Paste any github.com/<owner>/<name>{'@'}<ref>"
+      },
+      "repo": {
+        "label": "Repository",
+        "description": "github.com/<owner>/<name>{'@'}<tag|commit> — the pinned ref is mandatory.",
+        "openAria": "Open recipe repo (docs + required secrets)"
+      },
+      "params": {
+        "label": "Params",
+        "description": "One KEY=value per line (recipe params, e.g. topic=AI agents).",
+        "placeholder": "topic=AI agents"
+      },
+      "entries": {
+        "blueskySummary": {
+          "hint": "Twice-daily digest of your Bluesky home timeline. Param: topic."
+        }
+      }
+    },
+    "secrets": {
+      "summary": "Secrets",
+      "hint": "Sealed to the agent before they're stored — Troop never keeps the plaintext. A chosen recipe pre-fills the names it needs; you can add more. Also editable later on the agent's page.",
+      "envPlaceholder": "ENV_NAME",
+      "valuePlaceholder": "value",
+      "removeAria": "Remove secret",
+      "addButton": "Add secret"
+    },
+    "bridge": {
+      "summary": "Bridge overrides (optional)",
+      "apiKeyDescription": "Defaults to ~/litellm/.env on the host.",
+      "apiKeyPlaceholder": "sk-… or token",
+      "baseUrlDescription": "Defaults to http://127.0.0.1:4000/v1",
+      "modelDescription": "Required by the bridge at runtime."
+    },
+    "pending": {
+      "bindingTitle": "Binding secrets…",
+      "bindingHint": "Sealing each value to the agent and pushing it.",
+      "approvalTitle": "Waiting for DDISA approval…",
+      "approvalHint": "Approve the as=root grant in the OpenApe app on your phone. This dialog updates automatically."
+    },
+    "result": {
+      "successTitle": "Spawned: {name}",
+      "successWithNoteTitle": "Spawned with a note",
+      "failedTitle": "Failed",
+      "missingSecrets": "Spawned. Still missing secrets {names} — add them on the agent page."
+    },
+    "error": {
+      "hostsLoadFailed": "Failed to load nest hosts",
+      "spawnFailed": "Spawn failed",
+      "pollFailed": "Poll failed",
+      "badParamLine": "Bad param line: \"{line}\" (expected KEY=value)",
+      "bindingFailed": "Binding {env} failed: {detail}"
+    }
+  },
+  "toolPicker": {
+    "loading": "Loading tools…",
+    "risk": {
+      "low": "low",
+      "medium": "medium",
+      "high": "high"
+    },
+    "error": {
+      "loadFailed": "Failed to load tool catalog"
+    }
+  },
+  "cron": {
+    "help": "Subset: {any}, {fixed} (fixed), {step} (only on minute + hour). 5 fields: minute hour day-of-month month day-of-week.",
+    "preview": {
+      "noFireTimes": "No fire times in the next 7 days"
+    },
+    "error": {
+      "expectFiveFields": "Expected 5 space-separated fields",
+      "invalidField": "Invalid field — see help"
+    }
   }
 }

--- a/apps/openape-troop/nuxt.config.ts
+++ b/apps/openape-troop/nuxt.config.ts
@@ -37,6 +37,11 @@ export default defineNuxtConfig({
       alwaysRedirect: false,
     },
     bundle: { optimizeTranslationDirective: false },
+    // Messages contain literal `@` (e.g. "you@example.com", "repo@ref")
+    // which vue-i18n's default compiler reads as linked-message markers
+    // and rejects with "Invalid linked format". Strict=false + no
+    // escape on `@` keeps the messages as plain strings.
+    compilation: { strictMessage: false, escapeHtml: false },
   },
 
   app: {


### PR DESCRIPTION
## Summary
- Translates the entire UI: login + index + agents/index + agents/[name] (~1500 LOC of templates), plus AgentChat, SpawnAgentDialog, ToolPicker, CronInput.
- New `useRelativeTime` composable (Intl.RelativeTimeFormat) + `useDateFormat` (Intl.DateTimeFormat), both reactive to locale changes — flipping DE↔EN swaps "30 sec ago" ↔ "vor 30 Sek." in place.
- All `error.value = '...'` fallbacks route through `t()` so toast messages localize too.
- Locale files live at `apps/openape-troop/i18n/locales/{en,de}.json` (~280 keys).
- vue-i18n compiler tweak: `compilation.strictMessage: false` plus `{'@'}` escapes so literals like `you@example.com` and `owner/repo@ref` aren't interpreted as linked-message markers.
- Spawn-dialog preset bodies stay in German on purpose — they ARE the agent's runtime instructions, not UI text. Only their dropdown labels + descriptions are i18n'd.

M3-M8 of plan https://plans.openape.ai/01KSXDTH01MJQN2FP06PZA943G. Stacks on the now-merged M1 + M2.

## Test plan
- [ ] `pnpm --filter @openape/troop dev` boots clean; no `[intlify] Not found` warnings
- [ ] Fresh incognito with `Accept-Language: de` lands on DE; switcher click → EN re-renders in place; reload → still EN (cookie)
- [ ] Date/time formats follow locale (DE: "30.5.2026, 23:42" / EN: "5/30/2026, 11:42 PM")
- [ ] Mobile (< 375 px): header switcher + chat composer + spawn dialog still readable in both locales
- [ ] Vercel preview deploys