### PR TITLE
fix(org): make agent-email optional + link-agent flow

### DIFF
--- a/apps/openape-org/app/components/AddMemberDialog.vue
+++ b/apps/openape-org/app/components/AddMemberDialog.vue
@@ -22,13 +22,11 @@ watch(open, (now) => {
   error.value = ''
 })
 
-// Only Teamleads make sense as a parent. CEO + Sanierer report to Owner;
-// the Owner isn't a row in members.
 const teamleadOptions = computed(() => {
   const tls = props.existingMembers.filter(m => m.role === 'teamlead')
   return [
     { label: t('member.reportsToNone'), value: '' },
-    ...tls.map(t => ({ label: `${t.agentName} (${t.agentEmail})`, value: t.agentEmail })),
+    ...tls.map(tl => ({ label: `${tl.agentName} (${tl.agentEmail})`, value: tl.agentEmail })),
   ]
 })
 
@@ -41,14 +39,17 @@ const roleOptions = computed(() => [
 ])
 
 async function submit() {
-  if (!form.value.agent_email || !form.value.agent_name) return
+  if (!form.value.agent_name) return
   submitting.value = true
   error.value = ''
   try {
     await ($fetch as any)(`/api/orgs/${props.orgId}/members`, {
       method: 'POST',
       body: {
-        agent_email: form.value.agent_email,
+        // Omit agent_email when blank so the server generates a
+        // pending placeholder — Owner can plan the org-chart before
+        // spawning the actual agents in troop.
+        ...(form.value.agent_email.trim() ? { agent_email: form.value.agent_email.trim() } : {}),
         agent_name: form.value.agent_name,
         role: form.value.role,
         reports_to_email: form.value.reports_to_email || null,
@@ -91,9 +92,18 @@ async function submit() {
           <UInput v-model="form.agent_name" placeholder="alice" size="lg" class="w-full" :ui="{ base: 'w-full' }" />
         </UFormField>
 
-        <UFormField :label="$t('member.field.agentEmail.label')" :description="$t('member.field.agentEmail.description')" required>
-          <UInput v-model="form.agent_email" placeholder="agent+alice+example.com@id.openape.ai" size="lg" class="w-full" :ui="{ base: 'w-full' }" />
+        <UFormField :label="$t('member.field.agentEmail.label')" :description="$t('member.field.agentEmail.descriptionOptional')">
+          <UInput v-model="form.agent_email" :placeholder="$t('member.field.agentEmail.placeholderOptional')" size="lg" class="w-full" :ui="{ base: 'w-full' }" />
         </UFormField>
+
+        <UAlert
+          v-if="!form.agent_email.trim()"
+          color="info"
+          variant="subtle"
+          icon="i-lucide-info"
+          :title="$t('member.field.agentEmail.pendingTitle')"
+          :description="$t('member.field.agentEmail.pendingDescription')"
+        />
 
         <UFormField v-if="form.role === 'specialist'" :label="$t('member.field.reportsTo.label')" :description="$t('member.field.reportsTo.description')">
           <USelect v-model="form.reports_to_email" :items="teamleadOptions" />
@@ -106,7 +116,7 @@ async function submit() {
         <UButton variant="ghost" :disabled="submitting" @click="open = false">
           {{ $t('common.cancel') }}
         </UButton>
-        <UButton color="primary" :loading="submitting" :disabled="!form.agent_email || !form.agent_name" @click="submit">
+        <UButton color="primary" :loading="submitting" :disabled="!form.agent_name" @click="submit">
           {{ $t('member.add.submit') }}
         </UButton>
       </div>

--- a/apps/openape-org/app/components/LinkAgentDialog.vue
+++ b/apps/openape-org/app/components/LinkAgentDialog.vue
@@ -1,0 +1,78 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+
+const props = defineProps<{ orgId: string, placeholderEmail: string | null }>()
+const emit = defineEmits<{ saved: [] }>()
+const open = defineModel<boolean>('open', { default: false })
+const { t } = useI18n()
+
+// Owner pastes the real DDISA email of the agent they just spawned
+// in troop. The PATCH endpoint handles the PK swap server-side
+// (delete placeholder row, insert under new email) and flips the
+// status to 'active' since the agent now exists.
+const newEmail = ref('')
+const submitting = ref(false)
+const error = ref('')
+
+watch(open, (now) => {
+  if (!now) return
+  newEmail.value = ''
+  error.value = ''
+})
+
+async function submit() {
+  const trimmed = newEmail.value.trim()
+  if (!trimmed || !props.placeholderEmail) return
+  submitting.value = true
+  error.value = ''
+  try {
+    await ($fetch as any)(`/api/orgs/${props.orgId}/members/${encodeURIComponent(props.placeholderEmail)}`, {
+      method: 'PATCH',
+      body: { agent_email: trimmed, status: 'active' },
+    })
+    emit('saved')
+    open.value = false
+  }
+  catch (err: any) {
+    error.value = err?.data?.statusMessage || err?.message || t('member.error.saveFailed')
+  }
+  finally {
+    submitting.value = false
+  }
+}
+</script>
+
+<template>
+  <UModal v-model:open="open" :ui="{ content: 'sm:max-w-md max-h-[92dvh] flex flex-col' }">
+    <template #content>
+      <div class="flex-1 overflow-y-auto p-5 sm:p-6 space-y-5">
+        <div class="flex items-start justify-between gap-3">
+          <div>
+            <h3 class="text-lg font-semibold">
+              {{ $t('linkAgent.title') }}
+            </h3>
+            <p class="text-xs text-muted mt-1">
+              {{ $t('linkAgent.subtitle') }}
+            </p>
+          </div>
+          <UButton variant="ghost" size="sm" icon="i-lucide-x" :disabled="submitting" @click="open = false" />
+        </div>
+
+        <UFormField :label="$t('linkAgent.field.label')" :description="$t('linkAgent.field.description')" required>
+          <UInput v-model="newEmail" placeholder="agent+alice+example.com@id.openape.ai" size="lg" class="w-full" :ui="{ base: 'w-full' }" autocomplete="off" autocapitalize="off" />
+        </UFormField>
+
+        <UAlert v-if="error" color="error" :title="error" />
+      </div>
+
+      <div class="shrink-0 flex justify-end gap-2 border-t border-default bg-default px-5 sm:px-6 pt-3 pb-[max(0.875rem,env(safe-area-inset-bottom))]">
+        <UButton variant="ghost" :disabled="submitting" @click="open = false">
+          {{ $t('common.cancel') }}
+        </UButton>
+        <UButton color="primary" :loading="submitting" :disabled="!newEmail.trim()" @click="submit">
+          {{ $t('linkAgent.submit') }}
+        </UButton>
+      </div>
+    </template>
+  </UModal>
+</template>

--- a/apps/openape-org/app/components/OrgChart.vue
+++ b/apps/openape-org/app/components/OrgChart.vue
@@ -18,12 +18,23 @@ const props = defineProps<{
   ownerEmail: string
 }>()
 
-// `retire` event reserved for a future inline-retire button (currently
-// the member-management UI lives in AddMemberDialog only). Underscore
-// prefix silences the unused-vars lint until the button lands.
-defineEmits<{ retire: [email: string] }>()
+defineEmits<{
+  retire: [email: string]
+  // Owner clicks a "link agent" badge on a placeholder member; the
+  // parent page opens an edit-email dialog (handled in [id].vue).
+  linkAgent: [email: string]
+}>()
 
 const { t } = useI18n()
+
+// Placeholder rows are the ones the API minted because the Owner
+// didn't supply a real DDISA email at create time. They're functional
+// (carry a role + name + reports-to) but signal "no real agent
+// behind this seat yet" — the chart renders them with a dashed
+// border + "needs agent" badge so the Owner can fill in later.
+function isPlaceholderEmail(email: string): boolean {
+  return /^pending\+[a-f0-9]{8}@org\.openape\.ai$/i.test(email)
+}
 
 // Active = currently part of the org. Retired rows live in the data
 // for audit but aren't drawn on the chart.
@@ -91,7 +102,7 @@ function statusBadge(s: string): { color: 'success' | 'warning' | 'neutral', lab
       <!-- CEO row — single, centered. Sanierer sits beside it on the
            same level (parallel reporting to Owner). -->
       <div class="flex flex-col sm:flex-row items-center justify-center gap-4">
-        <div v-if="ceo" class="rounded-lg border px-4 py-3 min-w-[180px] text-center" :class="[roleColor('ceo')]">
+        <div v-if="ceo" class="rounded-lg border px-4 py-3 min-w-[180px] text-center" :class="[roleColor('ceo'), { 'border-dashed': isPlaceholderEmail(ceo.agentEmail) }]">
           <div class="text-xs uppercase tracking-wide font-semibold">
             {{ $t('chart.role.ceo') }}
           </div>
@@ -101,9 +112,12 @@ function statusBadge(s: string): { color: 'success' | 'warning' | 'neutral', lab
           <UBadge :color="statusBadge(ceo.status).color" variant="subtle" size="xs" class="mt-2">
             {{ statusBadge(ceo.status).label }}
           </UBadge>
+          <button v-if="isPlaceholderEmail(ceo.agentEmail)" type="button" class="block w-full mt-2 text-[10px] underline text-amber-300/80 cursor-pointer" @click="$emit('linkAgent', ceo.agentEmail)">
+            {{ $t('chart.linkAgentCta') }}
+          </button>
         </div>
 
-        <div v-if="sanierer" class="rounded-lg border px-4 py-3 min-w-[180px] text-center relative" :class="[roleColor('sanierer')]">
+        <div v-if="sanierer" class="rounded-lg border px-4 py-3 min-w-[180px] text-center relative" :class="[roleColor('sanierer'), { 'border-dashed': isPlaceholderEmail(sanierer.agentEmail) }]">
           <div class="text-xs uppercase tracking-wide font-semibold">
             {{ $t('chart.role.sanierer') }}
           </div>
@@ -116,6 +130,9 @@ function statusBadge(s: string): { color: 'success' | 'warning' | 'neutral', lab
           <div class="text-[10px] text-muted mt-1">
             {{ $t('chart.role.sanierer.note') }}
           </div>
+          <button v-if="isPlaceholderEmail(sanierer.agentEmail)" type="button" class="block w-full mt-2 text-[10px] underline text-amber-300/80 cursor-pointer" @click="$emit('linkAgent', sanierer.agentEmail)">
+            {{ $t('chart.linkAgentCta') }}
+          </button>
         </div>
       </div>
 
@@ -124,7 +141,7 @@ function statusBadge(s: string): { color: 'success' | 'warning' | 'neutral', lab
       <div v-if="teamleads.length > 0" class="space-y-4">
         <div v-for="tl in teamleads" :key="tl.agentEmail" class="space-y-3">
           <div class="flex justify-center">
-            <div class="rounded-lg border px-4 py-3 min-w-[180px] text-center" :class="[roleColor('teamlead')]">
+            <div class="rounded-lg border px-4 py-3 min-w-[180px] text-center" :class="[roleColor('teamlead'), { 'border-dashed': isPlaceholderEmail(tl.agentEmail) }]">
               <div class="text-xs uppercase tracking-wide font-semibold">
                 {{ $t('chart.role.teamlead') }}
               </div>
@@ -134,6 +151,9 @@ function statusBadge(s: string): { color: 'success' | 'warning' | 'neutral', lab
               <UBadge :color="statusBadge(tl.status).color" variant="subtle" size="xs" class="mt-2">
                 {{ statusBadge(tl.status).label }}
               </UBadge>
+              <button v-if="isPlaceholderEmail(tl.agentEmail)" type="button" class="block w-full mt-2 text-[10px] underline text-amber-300/80 cursor-pointer" @click="$emit('linkAgent', tl.agentEmail)">
+                {{ $t('chart.linkAgentCta') }}
+              </button>
             </div>
           </div>
 
@@ -141,7 +161,7 @@ function statusBadge(s: string): { color: 'success' | 'warning' | 'neutral', lab
             <div
               v-for="sp in specialistsOf(tl.agentEmail)"
               :key="sp.agentEmail"
-              class="rounded-lg border px-3 py-2 text-center" :class="[roleColor('specialist')]"
+              class="rounded-lg border px-3 py-2 text-center" :class="[roleColor('specialist'), { 'border-dashed': isPlaceholderEmail(sp.agentEmail) }]"
             >
               <div class="text-[10px] uppercase tracking-wide font-semibold opacity-70">
                 {{ $t('chart.role.specialist') }}
@@ -152,6 +172,9 @@ function statusBadge(s: string): { color: 'success' | 'warning' | 'neutral', lab
               <UBadge :color="statusBadge(sp.status).color" variant="subtle" size="xs" class="mt-1.5">
                 {{ statusBadge(sp.status).label }}
               </UBadge>
+              <button v-if="isPlaceholderEmail(sp.agentEmail)" type="button" class="block w-full mt-1.5 text-[9px] underline text-amber-300/80 cursor-pointer" @click="$emit('linkAgent', sp.agentEmail)">
+                {{ $t('chart.linkAgentCta') }}
+              </button>
             </div>
           </div>
         </div>
@@ -168,7 +191,7 @@ function statusBadge(s: string): { color: 'success' | 'warning' | 'neutral', lab
           <div
             v-for="sp in unassignedSpecialists"
             :key="sp.agentEmail"
-            class="rounded-lg border px-3 py-2 text-center" :class="[roleColor('specialist')]"
+            class="rounded-lg border px-3 py-2 text-center" :class="[roleColor('specialist'), { 'border-dashed': isPlaceholderEmail(sp.agentEmail) }]"
           >
             <div class="text-[10px] uppercase tracking-wide font-semibold opacity-70">
               {{ $t('chart.role.specialist') }}
@@ -179,6 +202,9 @@ function statusBadge(s: string): { color: 'success' | 'warning' | 'neutral', lab
             <UBadge :color="statusBadge(sp.status).color" variant="subtle" size="xs" class="mt-1.5">
               {{ statusBadge(sp.status).label }}
             </UBadge>
+            <button v-if="isPlaceholderEmail(sp.agentEmail)" type="button" class="block w-full mt-1.5 text-[9px] underline text-amber-300/80 cursor-pointer" @click="$emit('linkAgent', sp.agentEmail)">
+              {{ $t('chart.linkAgentCta') }}
+            </button>
           </div>
         </div>
       </div>

--- a/apps/openape-org/app/pages/orgs/[id].vue
+++ b/apps/openape-org/app/pages/orgs/[id].vue
@@ -106,6 +106,15 @@ async function saveSettings() {
 // Add-member dialog state
 const showAddMember = ref(false)
 
+// Link-agent dialog state (triggered from OrgChart when Owner clicks
+// "link agent" on a placeholder row).
+const showLinkAgent = ref(false)
+const placeholderToLink = ref<string | null>(null)
+function onLinkAgent(email: string) {
+  placeholderToLink.value = email
+  showLinkAgent.value = true
+}
+
 // Destroy-org modal
 const showDestroy = ref(false)
 const destroyConfirm = ref('')
@@ -163,11 +172,17 @@ async function destroyOrg() {
               {{ $t('chart.addMember') }}
             </UButton>
           </div>
-          <OrgChart :members="members" :owner-email="org.ownerEmail" />
+          <OrgChart :members="members" :owner-email="org.ownerEmail" @link-agent="onLinkAgent" />
           <AddMemberDialog
             v-model:open="showAddMember"
             :org-id="org.id"
             :existing-members="members"
+            @saved="loadAll"
+          />
+          <LinkAgentDialog
+            v-model:open="showLinkAgent"
+            :org-id="org.id"
+            :placeholder-email="placeholderToLink"
             @saved="loadAll"
           />
         </div>

--- a/apps/openape-org/i18n/locales/de.json
+++ b/apps/openape-org/i18n/locales/de.json
@@ -101,7 +101,18 @@
       "hint": "Füge zuerst deinen CEO hinzu. Sobald er da ist, kann er den Rest des Teams im Budget-Rahmen einstellen."
     },
     "unassigned": "Nicht zugewiesene Spezialisten",
-    "other": "Andere Rollen"
+    "other": "Andere Rollen",
+    "noAgentYet": "(noch kein Agent)",
+    "linkAgentCta": "Agent verbinden…"
+  },
+  "linkAgent": {
+    "title": "Agent mit diesem Slot verbinden",
+    "subtitle": "Füge die DDISA-Email des in troop gespawnten Agents ein. Status wird beim Verbinden auf 'aktiv' gesetzt.",
+    "field": {
+      "label": "Agent-Email",
+      "description": "Vollständige DDISA-Email — wird in troop nach `apes agents spawn …` angezeigt."
+    },
+    "submit": "Agent verbinden"
   },
   "member": {
     "add": {
@@ -117,7 +128,11 @@
       },
       "agentEmail": {
         "label": "Agent-Email",
-        "description": "Die vollständige DDISA-Email des Agents."
+        "description": "Die vollständige DDISA-Email des Agents.",
+        "descriptionOptional": "Optional — leer lassen wenn der Agent noch nicht gespawnt ist. Der Slot bleibt reserviert, Email später nachtragen.",
+        "placeholderOptional": "agent+alice+example.com@id.openape.ai (optional)",
+        "pendingTitle": "Planungs-Modus",
+        "pendingDescription": "Leerlassen legt einen Pending-Slot an. In der Chart erscheint eine gestrichelte Karte mit 'Agent verbinden'-Link — fülle das nach dem Spawn in troop aus."
       },
       "reportsTo": {
         "label": "Berichtet an",

--- a/apps/openape-org/i18n/locales/en.json
+++ b/apps/openape-org/i18n/locales/en.json
@@ -101,7 +101,18 @@
       "hint": "Add your CEO first. Once they're on board, they can hire the rest of the team within your budget."
     },
     "unassigned": "Unassigned specialists",
-    "other": "Other roles"
+    "other": "Other roles",
+    "noAgentYet": "(no agent yet)",
+    "linkAgentCta": "Link agent…"
+  },
+  "linkAgent": {
+    "title": "Link an agent to this slot",
+    "subtitle": "Paste the DDISA email of the agent you spawned in troop. The status flips to 'active' once linked.",
+    "field": {
+      "label": "Agent email",
+      "description": "Full DDISA email — usually shown in troop after `apes agents spawn …`."
+    },
+    "submit": "Link agent"
   },
   "member": {
     "add": {
@@ -117,7 +128,11 @@
       },
       "agentEmail": {
         "label": "Agent email",
-        "description": "The full DDISA email of the agent."
+        "description": "The full DDISA email of the agent.",
+        "descriptionOptional": "Optional — leave blank if you haven't spawned the agent yet. The slot is reserved and you can link the agent later.",
+        "placeholderOptional": "agent+alice+example.com@id.openape.ai (optional)",
+        "pendingTitle": "Planning mode",
+        "pendingDescription": "Leaving this empty creates a pending slot. The chart will show a dashed card with a 'Link agent' action — fill it in after you've spawned the agent in troop."
       },
       "reportsTo": {
         "label": "Reports to",

--- a/apps/openape-org/server/api/orgs/[id]/members/[email].patch.ts
+++ b/apps/openape-org/server/api/orgs/[id]/members/[email].patch.ts
@@ -1,0 +1,75 @@
+import { and, eq } from 'drizzle-orm'
+import { z } from 'zod'
+import { useDb } from '../../../../database/drizzle'
+import { orgMembers } from '../../../../database/schema'
+import { requireOwnedOrg } from '../../../../utils/orgs'
+
+// Update a member row. Two important cases:
+//   1. **Replacing a placeholder email**: the row was created with
+//      `pending+<id>@org.openape.ai` because no real agent existed
+//      yet; once the Owner has spawned the agent in troop, they
+//      come back and paste the real DDISA email. Because
+//      `agent_email` is part of the PK we delete the placeholder
+//      and re-insert under the new key (SQLite has no `UPDATE PK`).
+//   2. **Standard edits** (name, role, status, reports_to) — straight UPDATE.
+const Body = z.object({
+  agent_email: z.string().email().optional(),
+  agent_name: z.string().min(1).max(64).optional(),
+  role: z.enum(['ceo', 'teamlead', 'specialist', 'sanierer', 'other']).optional(),
+  reports_to_email: z.string().email().nullable().optional(),
+  status: z.enum(['invited', 'active', 'retired']).optional(),
+})
+
+export default defineEventHandler(async (event) => {
+  const { org } = await requireOwnedOrg(event)
+  const oldEmail = getRouterParam(event, 'email')
+  if (!oldEmail) throw createError({ statusCode: 400, statusMessage: 'member email required' })
+
+  const body = await readBody(event)
+  const parsed = Body.safeParse(body)
+  if (!parsed.success) throw createError({ statusCode: 400, statusMessage: 'invalid body', data: parsed.error.flatten() })
+
+  const db = useDb()
+  const existing = await db.select().from(orgMembers).where(and(eq(orgMembers.orgId, org.id), eq(orgMembers.agentEmail, oldEmail))).limit(1)
+  const row = existing[0]
+  if (!row) throw createError({ statusCode: 404, statusMessage: 'member not found' })
+
+  const now = Math.floor(Date.now() / 1000)
+  const newEmail = parsed.data.agent_email && parsed.data.agent_email !== oldEmail
+    ? parsed.data.agent_email
+    : null
+
+  if (newEmail) {
+    // PK change → delete + insert
+    await db.delete(orgMembers).where(and(eq(orgMembers.orgId, org.id), eq(orgMembers.agentEmail, oldEmail)))
+    await db.insert(orgMembers).values({
+      orgId: row.orgId,
+      agentEmail: newEmail,
+      agentName: parsed.data.agent_name ?? row.agentName,
+      role: parsed.data.role ?? row.role,
+      reportsToEmail: parsed.data.reports_to_email !== undefined ? parsed.data.reports_to_email : row.reportsToEmail,
+      // Once a real email is bound, default the status to 'active'
+      // unless the caller said otherwise — the placeholder lived as
+      // 'invited' and the swap-in implies the agent now exists.
+      status: parsed.data.status ?? 'active',
+      spawnedAt: (parsed.data.status ?? 'active') === 'active' ? (row.spawnedAt ?? now) : row.spawnedAt,
+      retiredAt: row.retiredAt,
+      createdAt: row.createdAt,
+    })
+    return { ok: true, agent_email: newEmail, replaced: true }
+  }
+
+  const updates: Record<string, unknown> = {}
+  if (parsed.data.agent_name !== undefined) updates.agentName = parsed.data.agent_name
+  if (parsed.data.role !== undefined) updates.role = parsed.data.role
+  if (parsed.data.reports_to_email !== undefined) updates.reportsToEmail = parsed.data.reports_to_email
+  if (parsed.data.status !== undefined) {
+    updates.status = parsed.data.status
+    if (parsed.data.status === 'active' && !row.spawnedAt) updates.spawnedAt = now
+    if (parsed.data.status === 'retired' && !row.retiredAt) updates.retiredAt = now
+  }
+  if (Object.keys(updates).length > 0) {
+    await db.update(orgMembers).set(updates).where(and(eq(orgMembers.orgId, org.id), eq(orgMembers.agentEmail, oldEmail)))
+  }
+  return { ok: true, agent_email: oldEmail }
+})

--- a/apps/openape-org/server/api/orgs/[id]/members/index.post.ts
+++ b/apps/openape-org/server/api/orgs/[id]/members/index.post.ts
@@ -1,10 +1,19 @@
+import { randomUUID } from 'node:crypto'
 import { z } from 'zod'
 import { useDb } from '../../../../database/drizzle'
 import { orgMembers } from '../../../../database/schema'
 import { requireOwnedOrg } from '../../../../utils/orgs'
 
+// `agent_email` is optional: the natural Owner workflow is "design the
+// org-chart first (planning), spawn the actual agents in troop later".
+// When omitted we mint a unique placeholder of the shape
+// `pending+<short-id>@org.openape.ai` so the PK (orgId, agentEmail)
+// stays unique without forcing the Owner to predict a DDISA email.
+// `status` is forced to `invited` for placeholder rows — the chart
+// shows them with a yellow badge so the Owner knows they aren't linked
+// to a real agent yet.
 const Body = z.object({
-  agent_email: z.string().email(),
+  agent_email: z.string().email().optional(),
   agent_name: z.string().min(1).max(64),
   role: z.enum(['ceo', 'teamlead', 'specialist', 'sanierer', 'other']),
   reports_to_email: z.string().email().nullable().optional(),
@@ -18,16 +27,22 @@ export default defineEventHandler(async (event) => {
   if (!parsed.success) throw createError({ statusCode: 400, statusMessage: 'invalid body', data: parsed.error.flatten() })
 
   const now = Math.floor(Date.now() / 1000)
+  const agentEmail = parsed.data.agent_email?.trim()
+    || `pending+${randomUUID().slice(0, 8)}@org.openape.ai`
+  // Placeholders are always 'invited' — they can't be active because
+  // no real agent exists for them yet.
+  const status = parsed.data.agent_email ? parsed.data.status : 'invited'
+
   const db = useDb()
   await db.insert(orgMembers).values({
     orgId: org.id,
-    agentEmail: parsed.data.agent_email,
+    agentEmail,
     agentName: parsed.data.agent_name,
     role: parsed.data.role,
     reportsToEmail: parsed.data.reports_to_email ?? null,
-    status: parsed.data.status,
-    spawnedAt: parsed.data.status === 'active' ? now : null,
+    status,
+    spawnedAt: status === 'active' ? now : null,
     createdAt: now,
   })
-  return { ok: true }
+  return { ok: true, agent_email: agentEmail, placeholder: !parsed.data.agent_email }
 })


### PR DESCRIPTION
## Why
Patrick's first-use feedback: when creating an organization, he doesn't yet know which DDISA email his CEO will have — because he hasn't spawned the agent in troop yet. The natural workflow is **plan the org-chart first, spawn agents later**.

## What changes
- **Add Member** dialog: `agent_email` field is now optional. Leave blank to create a "pending" slot.
- New API: `PATCH /api/orgs/[id]/members/[email]` — handles email-update with PK swap (delete + insert under new key).
- New `LinkAgentDialog.vue`: paste the real DDISA email later. Status flips to `active`.
- **Org-Chart** shows placeholder cards with **dashed border** + a small **"Link agent…"** button. Active agents look unchanged.
- DE + EN locale keys for the new strings + planning-mode hint.

## Test plan
- [ ] On staging/prod, open Add-Member, leave email empty, pick role + name, submit → slot appears with dashed border + "Link agent…" CTA
- [ ] Click "Link agent…", paste a DDISA email, save → dashed border becomes solid, status badge flips to "active"
- [ ] Adding a member WITH email still works (regression check)
- [ ] DE + EN locale strings render