### PR TITLE
fix(org): escape literal @ in i18n — unbreak deploy build

### DIFF
--- a/apps/openape-org/i18n/locales/de.json
+++ b/apps/openape-org/i18n/locales/de.json
@@ -130,7 +130,7 @@
         "label": "Agent-Email",
         "description": "Die vollständige DDISA-Email des Agents.",
         "descriptionOptional": "Optional — leer lassen wenn der Agent noch nicht gespawnt ist. Der Slot bleibt reserviert, Email später nachtragen.",
-        "placeholderOptional": "agent+alice+example.com@id.openape.ai (optional)",
+        "placeholderOptional": "agent+alice+example.com{'@'}id.openape.ai (optional)",
         "pendingTitle": "Planungs-Modus",
         "pendingDescription": "Leerlassen legt einen Pending-Slot an. In der Chart erscheint eine gestrichelte Karte mit 'Agent verbinden'-Link — fülle das nach dem Spawn in troop aus."
       },

--- a/apps/openape-org/i18n/locales/en.json
+++ b/apps/openape-org/i18n/locales/en.json
@@ -130,7 +130,7 @@
         "label": "Agent email",
         "description": "The full DDISA email of the agent.",
         "descriptionOptional": "Optional — leave blank if you haven't spawned the agent yet. The slot is reserved and you can link the agent later.",
-        "placeholderOptional": "agent+alice+example.com@id.openape.ai (optional)",
+        "placeholderOptional": "agent+alice+example.com{'@'}id.openape.ai (optional)",
         "pendingTitle": "Planning mode",
         "pendingDescription": "Leaving this empty creates a pending slot. The chart will show a dashed card with a 'Link agent' action — fill it in after you've spawned the agent in troop."
       },


### PR DESCRIPTION
unplugin-vue-i18n compile-time bug, see troop #515. {'@'} escape in en.json + de.json.