### PR TITLE
feat(org): M4 — Owner-triggered spawn via Delegation Grants

### DIFF
--- a/apps/openape-org/DEPLOY.md
+++ b/apps/openape-org/DEPLOY.md
@@ -73,3 +73,28 @@ Add `org.openape.ai` as an OIDC client at id.openape.ai with redirect URI `https
 ## After bootstrap
 
 `scripts/deploy-org.sh` (and the GH workflow that calls it) handles every subsequent release: build → rsync → libsql native-binding pin → symlink swap → systemctl restart → health check → rollback on failure.
+
+## M4 — Cross-SP spawn bootstrap (one-time per host)
+
+For org to spawn agents on troop on the Owner's behalf, it needs:
+
+1. **Its own DDISA agent identity** at id.openape.ai (mints `NUXT_ORG_IDP_ACCESS_TOKEN`)
+2. **A delegation grant per Owner** (Owner runs `apes grants delegate` from their own machine, pastes grant_id into org's Settings)
+
+Step 1 — one-time on the deploy host:
+
+```bash
+ssh openape@chatty.delta-mind.at "bash -s" < scripts/enroll-org-as-agent.sh
+```
+
+The script prints an enrollment URL — open it, approve in DDISA on your iPhone. The script then writes `NUXT_ORG_IDP_ACCESS_TOKEN` + `NUXT_ORG_IDP_AGENT_EMAIL` into `shared/.env` and you restart the service (instructions printed).
+
+Step 2 — Owner-side, once per Owner-org:
+
+```bash
+# On your own machine, logged in via `apes login`
+apes grants delegate --to <NUXT_ORG_IDP_AGENT_EMAIL> --at apes-cli --approval always
+# Paste the resulting grant_id in org.openape.ai → /orgs/<id>/settings → Delegation grants
+```
+
+From then on, "Spawn agent" on the chart works invisibly: org server token-exchanges the Owner's grant for an `apes-cli`-scoped Bearer and calls troop's `/api/agents/spawn-intent` on Owner's behalf. The Owner still gets the standard DDISA iPhone prompt for the spawn itself — only the cross-SP plumbing is invisible.

--- a/apps/openape-org/app/components/DelegationGrantManager.vue
+++ b/apps/openape-org/app/components/DelegationGrantManager.vue
@@ -1,0 +1,146 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+
+interface DelegationGrant {
+  ownerEmail: string
+  audience: string
+  grantId: string
+  createdAt: number
+  revokedAt: number | null
+}
+
+const props = defineProps<{ orgId: string }>()
+
+const { t } = useI18n()
+const { fmtDate } = useDateFormat()
+const config = useRuntimeConfig()
+
+const grants = ref<DelegationGrant[]>([])
+const loading = ref(true)
+const error = ref('')
+
+const pasteForm = ref({ audience: 'apes-cli', grant_id: '' })
+const saving = ref(false)
+
+// Pre-built CLI command the Owner copy-pastes into their terminal.
+// Building it client-side keeps both `delegate` (org's agent email)
+// and `at` (audience) in lockstep with what the spawn API will look
+// for. Fixed `--approval always` because re-entering the grant_id
+// for every spawn would defeat the purpose.
+const cliCommand = computed(() => {
+  const orgEmail = (config.public as { orgIdpAgentEmail?: string }).orgIdpAgentEmail || 'agent+openape-org@id.openape.ai'
+  return `apes grants delegate --to ${orgEmail} --at apes-cli --approval always`
+})
+
+async function load() {
+  loading.value = true
+  error.value = ''
+  try { grants.value = await ($fetch as any)(`/api/orgs/${props.orgId}/delegation-grants`) }
+  catch (err: any) { error.value = err?.data?.statusMessage || err?.message || t('delegation.error.loadFailed') }
+  finally { loading.value = false }
+}
+
+async function savePaste() {
+  if (!pasteForm.value.grant_id.trim()) return
+  saving.value = true
+  error.value = ''
+  try {
+    await ($fetch as any)(`/api/orgs/${props.orgId}/delegation-grants`, {
+      method: 'POST',
+      body: { audience: pasteForm.value.audience, grant_id: pasteForm.value.grant_id.trim() },
+    })
+    pasteForm.value.grant_id = ''
+    await load()
+  }
+  catch (err: any) { error.value = err?.data?.statusMessage || err?.message || t('delegation.error.saveFailed') }
+  finally { saving.value = false }
+}
+
+async function revoke(g: DelegationGrant) {
+  if (!confirm(t('delegation.confirmRevoke', { audience: g.audience }))) return
+  try {
+    await ($fetch as any)(`/api/orgs/${props.orgId}/delegation-grants/${encodeURIComponent(g.audience)}`, { method: 'DELETE' })
+    await load()
+  }
+  catch (err: any) { error.value = err?.data?.statusMessage || err?.message || t('delegation.error.revokeFailed') }
+}
+
+function copy(s: string) {
+  try { navigator.clipboard.writeText(s) }
+  catch { /* clipboard blocked */ }
+}
+
+onMounted(load)
+</script>
+
+<template>
+  <UCard>
+    <template #header>
+      <h3 class="font-semibold">
+        {{ $t('delegation.title') }}
+      </h3>
+      <p class="text-xs text-muted mt-1">
+        {{ $t('delegation.subtitle') }}
+      </p>
+    </template>
+
+    <UAlert v-if="error" color="error" :title="error" class="mb-3" />
+
+    <!-- Existing active grants. Each row shows audience + a short
+         grant_id prefix + a revoke action. The full grant_id is never
+         shown after the first paste — Owner can re-paste if they need
+         to recover it from `apes grants list` output. -->
+    <ul v-if="grants.length > 0" class="space-y-2 mb-4">
+      <li v-for="g in grants" :key="g.audience" class="flex items-center justify-between gap-3 px-3 py-2 rounded-md border border-(--ui-border) bg-(--ui-bg-elevated)">
+        <div class="flex-1 min-w-0">
+          <div class="flex items-center gap-2">
+            <UBadge color="success" variant="subtle" size="xs">
+              {{ $t('delegation.statusActive') }}
+            </UBadge>
+            <code class="text-xs font-mono">{{ g.audience }}</code>
+          </div>
+          <p class="text-[10px] text-muted mt-1 font-mono break-all">
+            {{ g.grantId.slice(0, 12) }}… · {{ fmtDate(g.createdAt) }}
+          </p>
+        </div>
+        <UButton size="xs" color="error" variant="ghost" icon="i-lucide-trash-2" :title="$t('delegation.revoke')" @click="revoke(g)" />
+      </li>
+    </ul>
+
+    <div v-else-if="!loading" class="rounded-md border border-dashed border-(--ui-border) p-4 text-center text-xs text-muted mb-4">
+      {{ $t('delegation.empty') }}
+    </div>
+
+    <!-- Bootstrap instructions: pre-built CLI command + paste form.
+         Two steps shown sequentially so the Owner doesn't get lost. -->
+    <div class="space-y-3 border-t border-(--ui-border) pt-4">
+      <div>
+        <p class="text-xs font-medium uppercase tracking-wide text-muted mb-1">
+          {{ $t('delegation.step1.title') }}
+        </p>
+        <p class="text-xs text-muted mb-2">
+          {{ $t('delegation.step1.description') }}
+        </p>
+        <div class="flex items-stretch gap-2">
+          <code class="flex-1 px-3 py-2 rounded-md bg-(--ui-bg-elevated) text-xs font-mono break-all">{{ cliCommand }}</code>
+          <UButton size="sm" variant="soft" color="neutral" icon="i-lucide-copy" :title="$t('common.copy')" @click="copy(cliCommand)" />
+        </div>
+      </div>
+
+      <div>
+        <p class="text-xs font-medium uppercase tracking-wide text-muted mb-1">
+          {{ $t('delegation.step2.title') }}
+        </p>
+        <p class="text-xs text-muted mb-2">
+          {{ $t('delegation.step2.description') }}
+        </p>
+        <div class="flex items-stretch gap-2">
+          <UInput v-model="pasteForm.grant_id" :placeholder="$t('delegation.step2.placeholder')" class="flex-1" :ui="{ base: 'w-full font-mono text-xs' }" :disabled="saving" autocomplete="off" autocapitalize="off" />
+          <UButton color="primary" :loading="saving" :disabled="!pasteForm.grant_id.trim()" @click="savePaste">
+            {{ $t('delegation.step2.save') }}
+          </UButton>
+        </div>
+      </div>
+    </div>
+  </UCard>
+</template>

--- a/apps/openape-org/app/components/MemberCard.vue
+++ b/apps/openape-org/app/components/MemberCard.vue
@@ -1,0 +1,115 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+interface Member {
+  agentEmail: string
+  agentName: string
+  role: string
+  status: string
+  spawnIntentId?: string | null
+  spawnStatus?: string | null
+  spawnError?: string | null
+}
+
+const props = defineProps<{
+  member: Member
+  /** Visible role label (already localized — caller passes $t output). */
+  roleLabel: string
+  /** Tailwind color classes for the card surface. */
+  colorClass: string
+  /** Size: 'lg' for CEO/Sanierer/Teamlead, 'sm' for Specialists. */
+  size?: 'lg' | 'sm'
+  /** Optional fine-print under the badge (e.g. Sanierer reporting note). */
+  note?: string
+}>()
+
+const emit = defineEmits<{ linkAgent: [email: string], spawnAgent: [email: string] }>()
+
+const { t } = useI18n()
+
+function isPlaceholderEmail(email: string): boolean {
+  return /^pending\+[a-f0-9]{8}@org\.openape\.ai$/i.test(email)
+}
+
+const isPlaceholder = computed(() => isPlaceholderEmail(props.member.agentEmail))
+const isSpawning = computed(() => props.member.spawnStatus === 'pending')
+const spawnFailed = computed(() => props.member.spawnStatus === 'failed')
+
+const isLg = computed(() => (props.size ?? 'lg') === 'lg')
+
+const statusBadge = computed(() => {
+  if (props.member.status === 'active') return { color: 'success' as const, label: t('chart.status.active') }
+  if (props.member.status === 'invited') return { color: 'warning' as const, label: t('chart.status.invited') }
+  return { color: 'neutral' as const, label: props.member.status }
+})
+</script>
+
+<template>
+  <div
+    class="rounded-lg border text-center relative"
+    :class="[
+      colorClass,
+      isLg ? 'px-4 py-3 min-w-[180px]' : 'px-3 py-2',
+      { 'border-dashed': isPlaceholder && !isSpawning, 'opacity-90': isSpawning },
+    ]"
+  >
+    <div
+      class="uppercase tracking-wide font-semibold"
+      :class="isLg ? 'text-xs' : 'text-[10px] opacity-70'"
+    >
+      {{ roleLabel }}
+    </div>
+    <div
+      class="font-mono break-all"
+      :class="isLg ? 'text-sm mt-1' : 'text-xs mt-0.5'"
+    >
+      {{ member.agentName }}
+    </div>
+    <UBadge
+      :color="statusBadge.color"
+      variant="subtle"
+      size="xs"
+      :class="isLg ? 'mt-2' : 'mt-1.5'"
+    >
+      {{ statusBadge.label }}
+    </UBadge>
+    <div v-if="note" class="text-[10px] text-muted mt-1">
+      {{ note }}
+    </div>
+
+    <!-- Spawn-in-flight state: replaces the action buttons with a
+         spinner + status text. The parent page is responsible for the
+         actual polling and re-renders this card as soon as
+         spawn_status flips. -->
+    <div
+      v-if="isSpawning"
+      class="mt-2 flex items-center justify-center gap-1.5 text-[10px] text-amber-300"
+    >
+      <UIcon name="i-lucide-loader-circle" class="animate-spin size-3" />
+      <span>{{ $t('chart.spawning') }}</span>
+    </div>
+
+    <!-- Spawn failure: short error + retry hint. Click "Spawn agent"
+         again to retry; spawn_error is cleared on next POST. -->
+    <div v-else-if="spawnFailed" class="mt-2 space-y-1">
+      <div class="text-[10px] text-red-400 line-clamp-2" :title="member.spawnError ?? undefined">
+        {{ member.spawnError ?? $t('chart.spawnFailedGeneric') }}
+      </div>
+      <button type="button" class="block w-full text-[10px] underline text-amber-300/80 cursor-pointer" @click="emit('spawnAgent', member.agentEmail)">
+        {{ $t('chart.spawnRetry') }}
+      </button>
+    </div>
+
+    <!-- Placeholder, no spawn in flight, no failure: offer both
+         "Spawn agent" (primary, kicks off the auto-flow) and "Link
+         agent…" (manual paste fallback, for already-spawned agents). -->
+    <template v-else-if="isPlaceholder">
+      <button type="button" class="block w-full mt-2 text-[10px] font-semibold uppercase tracking-wide text-amber-300 hover:text-amber-200 cursor-pointer" @click="emit('spawnAgent', member.agentEmail)">
+        {{ $t('chart.spawnCta') }}
+      </button>
+      <button type="button" class="block w-full mt-0.5 text-[10px] underline text-amber-300/70 cursor-pointer" @click="emit('linkAgent', member.agentEmail)">
+        {{ $t('chart.linkAgentCta') }}
+      </button>
+    </template>
+  </div>
+</template>

--- a/apps/openape-org/app/components/OrgChart.vue
+++ b/apps/openape-org/app/components/OrgChart.vue
@@ -11,33 +11,19 @@ interface Member {
   spawnedAt: number | null
   retiredAt: number | null
   createdAt: number
+  spawnIntentId?: string | null
+  spawnStatus?: string | null
+  spawnError?: string | null
 }
 
-const props = defineProps<{
-  members: Member[]
-  ownerEmail: string
-}>()
+const props = defineProps<{ members: Member[], ownerEmail: string }>()
 
 defineEmits<{
   retire: [email: string]
-  // Owner clicks a "link agent" badge on a placeholder member; the
-  // parent page opens an edit-email dialog (handled in [id].vue).
   linkAgent: [email: string]
+  spawnAgent: [email: string]
 }>()
 
-const { t } = useI18n()
-
-// Placeholder rows are the ones the API minted because the Owner
-// didn't supply a real DDISA email at create time. They're functional
-// (carry a role + name + reports-to) but signal "no real agent
-// behind this seat yet" — the chart renders them with a dashed
-// border + "needs agent" badge so the Owner can fill in later.
-function isPlaceholderEmail(email: string): boolean {
-  return /^pending\+[a-f0-9]{8}@org\.openape\.ai$/i.test(email)
-}
-
-// Active = currently part of the org. Retired rows live in the data
-// for audit but aren't drawn on the chart.
 const active = computed(() => props.members.filter(m => m.status !== 'retired'))
 
 const ceo = computed(() => active.value.find(m => m.role === 'ceo') ?? null)
@@ -47,7 +33,7 @@ function specialistsOf(teamleadEmail: string) {
   return active.value.filter(m => m.role === 'specialist' && m.reportsToEmail === teamleadEmail)
 }
 const unassignedSpecialists = computed(() =>
-  active.value.filter(m => m.role === 'specialist' && (!m.reportsToEmail || !teamleads.value.some(t => t.agentEmail === m.reportsToEmail))),
+  active.value.filter(m => m.role === 'specialist' && (!m.reportsToEmail || !teamleads.value.some(tl => tl.agentEmail === m.reportsToEmail))),
 )
 const others = computed(() => active.value.filter(m => !['ceo', 'sanierer', 'teamlead', 'specialist'].includes(m.role)))
 
@@ -60,18 +46,11 @@ function roleColor(role: string): string {
     default: return 'bg-zinc-500/20 text-zinc-300 border-zinc-500/40'
   }
 }
-
-function statusBadge(s: string): { color: 'success' | 'warning' | 'neutral', label: string } {
-  if (s === 'active') return { color: 'success', label: t('chart.status.active') }
-  if (s === 'invited') return { color: 'warning', label: t('chart.status.invited') }
-  return { color: 'neutral', label: s }
-}
 </script>
 
 <template>
   <div class="space-y-6">
-    <!-- Owner card — always shown at top, not a member row but the
-         root of the chart. -->
+    <!-- Owner card — root of the chart, not a member row. -->
     <div class="flex flex-col items-center gap-3">
       <div class="rounded-lg border border-amber-600/40 bg-amber-500/5 px-4 py-3 text-center min-w-[180px]">
         <div class="text-xs uppercase tracking-wide text-amber-400 font-semibold">
@@ -83,9 +62,6 @@ function statusBadge(s: string): { color: 'success' | 'warning' | 'neutral', lab
       </div>
     </div>
 
-    <!-- Empty state — no members yet. The dotted lines hint at the
-         intended structure so the Owner sees what they're about to
-         build. -->
     <div v-if="active.length === 0" class="rounded-lg border border-dashed border-(--ui-border) p-8 text-center space-y-3">
       <div class="text-4xl">
         👔
@@ -99,135 +75,93 @@ function statusBadge(s: string): { color: 'success' | 'warning' | 'neutral', lab
     </div>
 
     <template v-else>
-      <!-- CEO row — single, centered. Sanierer sits beside it on the
-           same level (parallel reporting to Owner). -->
+      <!-- CEO + Sanierer at the same level (parallel reporting to Owner). -->
       <div class="flex flex-col sm:flex-row items-center justify-center gap-4">
-        <div v-if="ceo" class="rounded-lg border px-4 py-3 min-w-[180px] text-center" :class="[roleColor('ceo'), { 'border-dashed': isPlaceholderEmail(ceo.agentEmail) }]">
-          <div class="text-xs uppercase tracking-wide font-semibold">
-            {{ $t('chart.role.ceo') }}
-          </div>
-          <div class="font-mono text-sm mt-1 break-all">
-            {{ ceo.agentName }}
-          </div>
-          <UBadge :color="statusBadge(ceo.status).color" variant="subtle" size="xs" class="mt-2">
-            {{ statusBadge(ceo.status).label }}
-          </UBadge>
-          <button v-if="isPlaceholderEmail(ceo.agentEmail)" type="button" class="block w-full mt-2 text-[10px] underline text-amber-300/80 cursor-pointer" @click="$emit('linkAgent', ceo.agentEmail)">
-            {{ $t('chart.linkAgentCta') }}
-          </button>
-        </div>
-
-        <div v-if="sanierer" class="rounded-lg border px-4 py-3 min-w-[180px] text-center relative" :class="[roleColor('sanierer'), { 'border-dashed': isPlaceholderEmail(sanierer.agentEmail) }]">
-          <div class="text-xs uppercase tracking-wide font-semibold">
-            {{ $t('chart.role.sanierer') }}
-          </div>
-          <div class="font-mono text-sm mt-1 break-all">
-            {{ sanierer.agentName }}
-          </div>
-          <UBadge :color="statusBadge(sanierer.status).color" variant="subtle" size="xs" class="mt-2">
-            {{ statusBadge(sanierer.status).label }}
-          </UBadge>
-          <div class="text-[10px] text-muted mt-1">
-            {{ $t('chart.role.sanierer.note') }}
-          </div>
-          <button v-if="isPlaceholderEmail(sanierer.agentEmail)" type="button" class="block w-full mt-2 text-[10px] underline text-amber-300/80 cursor-pointer" @click="$emit('linkAgent', sanierer.agentEmail)">
-            {{ $t('chart.linkAgentCta') }}
-          </button>
-        </div>
+        <MemberCard
+          v-if="ceo"
+          :member="ceo"
+          :role-label="$t('chart.role.ceo')"
+          :color-class="roleColor('ceo')"
+          size="lg"
+          @link-agent="$emit('linkAgent', $event)"
+          @spawn-agent="$emit('spawnAgent', $event)"
+        />
+        <MemberCard
+          v-if="sanierer"
+          :member="sanierer"
+          :role-label="$t('chart.role.sanierer')"
+          :color-class="roleColor('sanierer')"
+          size="lg"
+          :note="$t('chart.role.sanierer.note')"
+          @link-agent="$emit('linkAgent', $event)"
+          @spawn-agent="$emit('spawnAgent', $event)"
+        />
       </div>
 
-      <!-- Teamleads under CEO. Each Teamlead-card collapses its
-           specialists below it. -->
+      <!-- Teamleads under CEO, each with their specialists collapsed below. -->
       <div v-if="teamleads.length > 0" class="space-y-4">
         <div v-for="tl in teamleads" :key="tl.agentEmail" class="space-y-3">
           <div class="flex justify-center">
-            <div class="rounded-lg border px-4 py-3 min-w-[180px] text-center" :class="[roleColor('teamlead'), { 'border-dashed': isPlaceholderEmail(tl.agentEmail) }]">
-              <div class="text-xs uppercase tracking-wide font-semibold">
-                {{ $t('chart.role.teamlead') }}
-              </div>
-              <div class="font-mono text-sm mt-1 break-all">
-                {{ tl.agentName }}
-              </div>
-              <UBadge :color="statusBadge(tl.status).color" variant="subtle" size="xs" class="mt-2">
-                {{ statusBadge(tl.status).label }}
-              </UBadge>
-              <button v-if="isPlaceholderEmail(tl.agentEmail)" type="button" class="block w-full mt-2 text-[10px] underline text-amber-300/80 cursor-pointer" @click="$emit('linkAgent', tl.agentEmail)">
-                {{ $t('chart.linkAgentCta') }}
-              </button>
-            </div>
+            <MemberCard
+              :member="tl"
+              :role-label="$t('chart.role.teamlead')"
+              :color-class="roleColor('teamlead')"
+              size="lg"
+              @link-agent="$emit('linkAgent', $event)"
+              @spawn-agent="$emit('spawnAgent', $event)"
+            />
           </div>
-
           <div v-if="specialistsOf(tl.agentEmail).length > 0" class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
-            <div
+            <MemberCard
               v-for="sp in specialistsOf(tl.agentEmail)"
               :key="sp.agentEmail"
-              class="rounded-lg border px-3 py-2 text-center" :class="[roleColor('specialist'), { 'border-dashed': isPlaceholderEmail(sp.agentEmail) }]"
-            >
-              <div class="text-[10px] uppercase tracking-wide font-semibold opacity-70">
-                {{ $t('chart.role.specialist') }}
-              </div>
-              <div class="font-mono text-xs mt-0.5 break-all">
-                {{ sp.agentName }}
-              </div>
-              <UBadge :color="statusBadge(sp.status).color" variant="subtle" size="xs" class="mt-1.5">
-                {{ statusBadge(sp.status).label }}
-              </UBadge>
-              <button v-if="isPlaceholderEmail(sp.agentEmail)" type="button" class="block w-full mt-1.5 text-[9px] underline text-amber-300/80 cursor-pointer" @click="$emit('linkAgent', sp.agentEmail)">
-                {{ $t('chart.linkAgentCta') }}
-              </button>
-            </div>
+              :member="sp"
+              :role-label="$t('chart.role.specialist')"
+              :color-class="roleColor('specialist')"
+              size="sm"
+              @link-agent="$emit('linkAgent', $event)"
+              @spawn-agent="$emit('spawnAgent', $event)"
+            />
           </div>
         </div>
       </div>
 
-      <!-- Specialists without a Teamlead parent — surface them so they
-           don't disappear; usually a hint that the Owner needs to set
-           a reports_to_email. -->
+      <!-- Specialists with no Teamlead parent — surfaced so they don't disappear. -->
       <div v-if="unassignedSpecialists.length > 0" class="space-y-2">
         <div class="text-xs text-muted text-center">
           {{ $t('chart.unassigned') }}
         </div>
         <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
-          <div
+          <MemberCard
             v-for="sp in unassignedSpecialists"
             :key="sp.agentEmail"
-            class="rounded-lg border px-3 py-2 text-center" :class="[roleColor('specialist'), { 'border-dashed': isPlaceholderEmail(sp.agentEmail) }]"
-          >
-            <div class="text-[10px] uppercase tracking-wide font-semibold opacity-70">
-              {{ $t('chart.role.specialist') }}
-            </div>
-            <div class="font-mono text-xs mt-0.5 break-all">
-              {{ sp.agentName }}
-            </div>
-            <UBadge :color="statusBadge(sp.status).color" variant="subtle" size="xs" class="mt-1.5">
-              {{ statusBadge(sp.status).label }}
-            </UBadge>
-            <button v-if="isPlaceholderEmail(sp.agentEmail)" type="button" class="block w-full mt-1.5 text-[9px] underline text-amber-300/80 cursor-pointer" @click="$emit('linkAgent', sp.agentEmail)">
-              {{ $t('chart.linkAgentCta') }}
-            </button>
-          </div>
+            :member="sp"
+            :role-label="$t('chart.role.specialist')"
+            :color-class="roleColor('specialist')"
+            size="sm"
+            @link-agent="$emit('linkAgent', $event)"
+            @spawn-agent="$emit('spawnAgent', $event)"
+          />
         </div>
       </div>
 
       <!-- "Other" roles bucket — anything not in the standard 4-tier
-           taxonomy. v1 reserves space, future tiers slot in here. -->
+           taxonomy. v1 reserves space; future tiers slot in here. -->
       <div v-if="others.length > 0" class="space-y-2">
         <div class="text-xs text-muted text-center">
           {{ $t('chart.other') }}
         </div>
         <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
-          <div
+          <MemberCard
             v-for="m in others"
             :key="m.agentEmail"
-            class="rounded-lg border px-3 py-2 text-center" :class="[roleColor(m.role)]"
-          >
-            <div class="text-[10px] uppercase tracking-wide font-semibold opacity-70">
-              {{ m.role }}
-            </div>
-            <div class="font-mono text-xs mt-0.5 break-all">
-              {{ m.agentName }}
-            </div>
-          </div>
+            :member="m"
+            :role-label="m.role"
+            :color-class="roleColor(m.role)"
+            size="sm"
+            @link-agent="$emit('linkAgent', $event)"
+            @spawn-agent="$emit('spawnAgent', $event)"
+          />
         </div>
       </div>
     </template>

--- a/apps/openape-org/app/pages/orgs/[id].vue
+++ b/apps/openape-org/app/pages/orgs/[id].vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useOpenApeAuth } from '#imports'
 
 const route = useRoute()
@@ -10,7 +10,7 @@ const { user, fetchUser, logout } = useOpenApeAuth()
 await fetchUser()
 
 interface Org { id: string, ownerEmail: string, name: string, visionMd: string, budgetMonthlyEur: number, createdAt: number, updatedAt: number }
-interface Member { orgId: string, agentEmail: string, agentName: string, role: string, reportsToEmail: string | null, status: string, spawnedAt: number | null, retiredAt: number | null, createdAt: number }
+interface Member { orgId: string, agentEmail: string, agentName: string, role: string, reportsToEmail: string | null, status: string, spawnedAt: number | null, retiredAt: number | null, createdAt: number, spawnIntentId?: string | null, spawnStatus?: string | null, spawnError?: string | null }
 interface Objective { id: string, orgId: string, title: string, description: string, status: 'planned' | 'in_progress' | 'done' | 'abandoned', targetDate: number | null, parentId: string | null, createdByEmail: string, createdAt: number, updatedAt: number }
 interface Report { id: string, orgId: string, kind: 'daily' | 'weekly' | 'quarterly' | 'alert' | 'adhoc', title: string, bodyMd: string, generatedByEmail: string, createdAt: number }
 interface CostSnapshot { orgId: string, day: string, tokensIn: number, tokensOut: number, inferenceCostCents: number, infraCostCents: number, outputArtifactsCount: number, updatedAt: number }
@@ -115,6 +115,64 @@ function onLinkAgent(email: string) {
   showLinkAgent.value = true
 }
 
+// Spawn-agent flow: POST org's spawn-proxy, kick off polling.
+// Polling lives on a single 2s interval that walks all members and
+// re-fetches status for any in 'pending' state. When a member flips
+// to 'active' we reload the full org snapshot to pick up the new
+// PK (the PK swap from placeholder to real email is server-side).
+const spawnPollTimer = ref<ReturnType<typeof setInterval> | null>(null)
+const spawnError = ref('')
+
+async function onSpawnAgent(email: string) {
+  if (!org.value) return
+  spawnError.value = ''
+  try {
+    await ($fetch as any)(`/api/orgs/${org.value.id}/members/${encodeURIComponent(email)}/spawn`, { method: 'POST' })
+    await loadAll()
+    ensureSpawnPolling()
+  }
+  catch (err: any) {
+    const msg = err?.data?.statusMessage || err?.message || ''
+    // 412 = no delegation grant; gently redirect Owner to Settings.
+    if (err?.statusCode === 412 || /delegation grant/i.test(msg)) {
+      spawnError.value = t('orgDetail.spawn.needsGrant')
+      activeTab.value = 'settings'
+      return
+    }
+    spawnError.value = msg || t('orgDetail.spawn.failed')
+  }
+}
+
+function ensureSpawnPolling() {
+  if (spawnPollTimer.value) return
+  spawnPollTimer.value = setInterval(async () => {
+    const pending = members.value.filter(m => m.spawnStatus === 'pending')
+    if (pending.length === 0) {
+      if (spawnPollTimer.value) { clearInterval(spawnPollTimer.value); spawnPollTimer.value = null }
+      return
+    }
+    let anyFlipped = false
+    for (const m of pending) {
+      try {
+        const res = await ($fetch as any)(`/api/orgs/${org.value!.id}/members/${encodeURIComponent(m.agentEmail)}/spawn-status`) as { status: string, agent_email: string | null }
+        if (res.status === 'active' || res.status === 'failed') anyFlipped = true
+      }
+      catch { /* keep polling */ }
+    }
+    if (anyFlipped) await loadAll()
+  }, 2000)
+}
+
+// Resume polling when the page mounts with already-pending spawns
+// (e.g. Owner refreshed mid-flight).
+watch(members, (ms) => {
+  if (ms.some(m => m.spawnStatus === 'pending')) ensureSpawnPolling()
+})
+
+onBeforeUnmount(() => {
+  if (spawnPollTimer.value) clearInterval(spawnPollTimer.value)
+})
+
 // Destroy-org modal
 const showDestroy = ref(false)
 const destroyConfirm = ref('')
@@ -172,7 +230,8 @@ async function destroyOrg() {
               {{ $t('chart.addMember') }}
             </UButton>
           </div>
-          <OrgChart :members="members" :owner-email="org.ownerEmail" @link-agent="onLinkAgent" />
+          <UAlert v-if="spawnError" color="error" :title="spawnError" :close-button="{}" @close="spawnError = ''" />
+          <OrgChart :members="members" :owner-email="org.ownerEmail" @link-agent="onLinkAgent" @spawn-agent="onSpawnAgent" />
           <AddMemberDialog
             v-model:open="showAddMember"
             :org-id="org.id"
@@ -227,6 +286,8 @@ async function destroyOrg() {
               </template>
             </UInput>
           </UCard>
+
+          <DelegationGrantManager :org-id="org.id" />
 
           <UAlert v-if="settingsError" color="error" :title="settingsError" />
 

--- a/apps/openape-org/i18n/locales/de.json
+++ b/apps/openape-org/i18n/locales/de.json
@@ -8,7 +8,8 @@
     "cancel": "Abbrechen",
     "close": "Schließen",
     "retry": "Erneut versuchen",
-    "logout": "Abmelden"
+    "logout": "Abmelden",
+    "copy": "Kopieren"
   },
   "time": {
     "never": "nie",
@@ -80,6 +81,33 @@
     },
     "destroy": {
       "failed": "Löschen fehlgeschlagen"
+    },
+    "spawn": {
+      "needsGrant": "Du hast dieser Org noch nicht erlaubt in deinem Namen Agents zu spawnen. Setze einen Delegation-Grant in den Einstellungen auf (einmalig).",
+      "failed": "Spawn fehlgeschlagen"
+    }
+  },
+  "delegation": {
+    "title": "Delegation-Grants",
+    "subtitle": "Erlaube dieser Org in deinem Namen Agents auf troop zu spawnen. Einmalige Einrichtung pro Org.",
+    "statusActive": "aktiv",
+    "empty": "Noch keine Grants — folge den zwei Schritten unten.",
+    "revoke": "Widerrufen",
+    "confirmRevoke": "Delegation-Grant für audience '{audience}' widerrufen? In-flight-Spawns schlagen fehl.",
+    "step1": {
+      "title": "Schritt 1 — Grant auf deinem Rechner anlegen",
+      "description": "Führe diesen Befehl in deinem Terminal aus. Du bekommst einen iPhone-DDISA-Prompt; nach Bestätigung gibt das CLI eine grant_id zurück."
+    },
+    "step2": {
+      "title": "Schritt 2 — grant_id hier einfügen",
+      "description": "Die vollständige grant_id aus dem vorherigen Schritt. Wird lokal gespeichert; jederzeit widerrufbar.",
+      "placeholder": "01H8…",
+      "save": "Grant speichern"
+    },
+    "error": {
+      "loadFailed": "Delegation-Grants konnten nicht geladen werden",
+      "saveFailed": "Grant speichern fehlgeschlagen",
+      "revokeFailed": "Widerrufen fehlgeschlagen"
     }
   },
   "chart": {
@@ -103,7 +131,11 @@
     "unassigned": "Nicht zugewiesene Spezialisten",
     "other": "Andere Rollen",
     "noAgentYet": "(noch kein Agent)",
-    "linkAgentCta": "Agent verbinden…"
+    "linkAgentCta": "Bestehenden verbinden…",
+    "spawnCta": "Agent spawnen",
+    "spawnRetry": "Erneut versuchen",
+    "spawning": "Spawne… am iPhone bestätigen",
+    "spawnFailedGeneric": "Spawn fehlgeschlagen"
   },
   "linkAgent": {
     "title": "Agent mit diesem Slot verbinden",

--- a/apps/openape-org/i18n/locales/en.json
+++ b/apps/openape-org/i18n/locales/en.json
@@ -8,7 +8,8 @@
     "cancel": "Cancel",
     "close": "Close",
     "retry": "Retry",
-    "logout": "Logout"
+    "logout": "Logout",
+    "copy": "Copy"
   },
   "time": {
     "never": "never",
@@ -80,6 +81,33 @@
     },
     "destroy": {
       "failed": "Destroy failed"
+    },
+    "spawn": {
+      "needsGrant": "You haven't authorized this org to spawn agents on your behalf. Set up a delegation grant in Settings (one-time).",
+      "failed": "Spawn failed"
+    }
+  },
+  "delegation": {
+    "title": "Delegation grants",
+    "subtitle": "Authorize this org to spawn agents on troop on your behalf. One-time setup per org.",
+    "statusActive": "active",
+    "empty": "No grants yet — follow the two steps below to bootstrap.",
+    "revoke": "Revoke",
+    "confirmRevoke": "Revoke the delegation grant for audience '{audience}'? Active spawns mid-flight will fail.",
+    "step1": {
+      "title": "Step 1 — create the grant on your machine",
+      "description": "Run this command in your terminal. You'll get an iPhone DDISA approval; once approved, the CLI prints a grant_id."
+    },
+    "step2": {
+      "title": "Step 2 — paste the grant_id here",
+      "description": "The full grant_id from the previous step. Stored locally; revokeable any time.",
+      "placeholder": "01H8…",
+      "save": "Save grant"
+    },
+    "error": {
+      "loadFailed": "Failed to load delegation grants",
+      "saveFailed": "Failed to save grant",
+      "revokeFailed": "Failed to revoke"
     }
   },
   "chart": {
@@ -103,7 +131,11 @@
     "unassigned": "Unassigned specialists",
     "other": "Other roles",
     "noAgentYet": "(no agent yet)",
-    "linkAgentCta": "Link agent…"
+    "linkAgentCta": "Link existing…",
+    "spawnCta": "Spawn agent",
+    "spawnRetry": "Retry spawn",
+    "spawning": "Spawning… approve on iPhone",
+    "spawnFailedGeneric": "Spawn failed"
   },
   "linkAgent": {
     "title": "Link an agent to this slot",

--- a/apps/openape-org/nuxt.config.ts
+++ b/apps/openape-org/nuxt.config.ts
@@ -70,14 +70,26 @@ export default defineNuxtConfig({
   runtimeConfig: {
     tursoUrl: process.env.NUXT_TURSO_URL || 'file:./openape-org.db',
     tursoAuthToken: process.env.NUXT_TURSO_AUTH_TOKEN || '',
-    // troop's API base — CEO + Sanierer agents read/write via this from
-    // M4 onward; today UI is the only consumer and reads agent live-
-    // status from there. Inside-pod hostname for nest, public URL for
-    // server-side fetches.
+    // troop's API base — server-side calls from org's spawn-proxy
+    // endpoint use this; UI uses the public mirror below.
     troopApiBase: process.env.NUXT_TROOP_API_BASE || 'https://troop.openape.ai',
+    // org's own IdP-issued agent access token, minted once via
+    // scripts/enroll-org-as-agent.sh. Required for cross-SP
+    // token-exchange when spawning agents on the Owner's behalf.
+    // Empty in dev → spawn endpoints return a 503 with a clear
+    // bootstrap message.
+    orgIdpAccessToken: process.env.NUXT_ORG_IDP_ACCESS_TOKEN || '',
+    // The agent email org enrolled as — used for /api/delegations'
+    // `delegate` field shown to the Owner in the bootstrap UI.
+    orgIdpAgentEmail: process.env.NUXT_ORG_IDP_AGENT_EMAIL || 'agent+openape-org@id.openape.ai',
     public: {
       idpUrl: process.env.NUXT_PUBLIC_IDP_URL || 'https://id.openape.ai',
       troopUiBase: process.env.NUXT_PUBLIC_TROOP_UI_BASE || 'https://troop.openape.ai',
+      // Expose the agent email + the audience publicly so the UI can
+      // build the exact CLI command for the Owner to run when
+      // bootstrapping their delegation grant.
+      orgIdpAgentEmail: process.env.NUXT_ORG_IDP_AGENT_EMAIL || 'agent+openape-org@id.openape.ai',
+      troopAudience: process.env.NUXT_TROOP_AUDIENCE || 'apes-cli',
     },
   },
 })

--- a/apps/openape-org/server/api/orgs/[id]/delegation-grants/[audience].delete.ts
+++ b/apps/openape-org/server/api/orgs/[id]/delegation-grants/[audience].delete.ts
@@ -1,0 +1,15 @@
+import { requireOwnedOrg } from '../../../../utils/orgs'
+import { revokeDelegationGrant } from '../../../../utils/delegation-grants'
+
+// Soft-revoke. The Owner SHOULD also revoke the grant at the IdP via
+//   apes grants delegation-revoke <grant-id>
+// so org can no longer use it even if its own DB still has the row.
+// We document that in the UI; we don't try to call the IdP here
+// because we don't have an authenticated Owner Bearer at this point.
+export default defineEventHandler(async (event) => {
+  const { owner } = await requireOwnedOrg(event)
+  const audience = getRouterParam(event, 'audience')
+  if (!audience) throw createError({ statusCode: 400, statusMessage: 'audience required' })
+  await revokeDelegationGrant(owner, audience)
+  return { ok: true }
+})

--- a/apps/openape-org/server/api/orgs/[id]/delegation-grants/index.get.ts
+++ b/apps/openape-org/server/api/orgs/[id]/delegation-grants/index.get.ts
@@ -1,0 +1,18 @@
+import { and, eq, isNull } from 'drizzle-orm'
+import { useDb } from '../../../../database/drizzle'
+import { delegationGrants } from '../../../../database/schema'
+import { requireOwnedOrg } from '../../../../utils/orgs'
+
+// List the active delegation grants the Owner has bound to this org.
+// One row per audience (today only 'apes-cli' / troop, but Sanierer
+// reading LiteLLM cost log may want its own grant later).
+export default defineEventHandler(async (event) => {
+  const { owner } = await requireOwnedOrg(event)
+  const db = useDb()
+  return db.select()
+    .from(delegationGrants)
+    .where(and(
+      eq(delegationGrants.ownerEmail, owner.toLowerCase()),
+      isNull(delegationGrants.revokedAt),
+    ))
+})

--- a/apps/openape-org/server/api/orgs/[id]/delegation-grants/index.post.ts
+++ b/apps/openape-org/server/api/orgs/[id]/delegation-grants/index.post.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod'
+import { requireOwnedOrg } from '../../../../utils/orgs'
+import { upsertDelegationGrant } from '../../../../utils/delegation-grants'
+
+// Owner pastes a grant_id they obtained via:
+//   apes grants delegate --to <orgIdpAgentEmail> --at apes-cli --approval always
+// (or via the IdP UI). org persists it; from then on the spawn-proxy
+// can mint Owner-scoped Bearers automatically via token-exchange.
+const Body = z.object({
+  audience: z.string().min(1).default('apes-cli'),
+  grant_id: z.string().min(8).max(200),
+})
+
+export default defineEventHandler(async (event) => {
+  const { owner } = await requireOwnedOrg(event)
+  const parsed = Body.safeParse(await readBody(event))
+  if (!parsed.success) throw createError({ statusCode: 400, statusMessage: 'invalid body', data: parsed.error.flatten() })
+
+  await upsertDelegationGrant({
+    ownerEmail: owner,
+    audience: parsed.data.audience,
+    grantId: parsed.data.grant_id,
+  })
+  return { ok: true }
+})

--- a/apps/openape-org/server/api/orgs/[id]/members/[email]/spawn-status.get.ts
+++ b/apps/openape-org/server/api/orgs/[id]/members/[email]/spawn-status.get.ts
@@ -1,0 +1,108 @@
+import { and, eq } from 'drizzle-orm'
+import { useRuntimeConfig } from 'nitropack/runtime'
+import { useDb } from '../../../../../database/drizzle'
+import { orgMembers } from '../../../../../database/schema'
+import { getActiveDelegationGrantId } from '../../../../../utils/delegation-grants'
+import { requireOwnedOrg } from '../../../../../utils/orgs'
+import { exchangeForOwnerBearer } from '../../../../../utils/token-exchange'
+
+// GET /api/orgs/:id/members/:email/spawn-status
+//
+// Long-poll endpoint. Each call:
+//   1. Reads the member row, returns immediately if no intent in flight
+//   2. Mints a fresh Owner-Bearer via token-exchange
+//   3. GETs troop.openape.ai/api/agents/spawn-intent/<intent_id>
+//   4. If troop reports done+agent_email → PATCH org_members PK swap to
+//      the real email, status='active', clear spawn columns
+//   5. If troop reports failure → set spawn_status='failed' + error
+//   6. Returns the latest known state to the UI
+//
+// The UI polls this every 2s while a card is in 'pending' state.
+export default defineEventHandler(async (event) => {
+  const { org } = await requireOwnedOrg(event)
+  const email = getRouterParam(event, 'email')
+  if (!email) throw createError({ statusCode: 400, statusMessage: 'member email required' })
+
+  const db = useDb()
+  const rows = await db.select().from(orgMembers).where(and(eq(orgMembers.orgId, org.id), eq(orgMembers.agentEmail, email))).limit(1)
+  const member = rows[0]
+  if (!member) throw createError({ statusCode: 404, statusMessage: 'member not found' })
+
+  if (!member.spawnIntentId || member.spawnStatus !== 'pending') {
+    return {
+      status: member.spawnStatus ?? 'idle',
+      agent_email: member.status === 'active' ? member.agentEmail : null,
+      error: member.spawnError ?? null,
+    }
+  }
+
+  const config = useRuntimeConfig()
+  const audience = (config.public as { troopAudience?: string }).troopAudience ?? 'apes-cli'
+  const grantId = await getActiveDelegationGrantId(org.ownerEmail, audience)
+  if (!grantId) {
+    // Grant got revoked mid-flight; surface as 'failed' to UI.
+    await db.update(orgMembers)
+      .set({ spawnStatus: 'failed', spawnError: 'delegation grant revoked' })
+      .where(and(eq(orgMembers.orgId, org.id), eq(orgMembers.agentEmail, email)))
+    return { status: 'failed', agent_email: null, error: 'delegation grant revoked' }
+  }
+
+  let bearer: string
+  try {
+    bearer = (await exchangeForOwnerBearer({ delegationGrantId: grantId, audience })).access_token
+  }
+  catch (err: any) {
+    return { status: 'pending', agent_email: null, error: `token-exchange failed: ${err?.message ?? 'unknown'}` }
+  }
+
+  let troopRes: { pending?: boolean, ok?: boolean, agent_email?: string, error?: string }
+  try {
+    const troopBase = config.troopApiBase as string
+    // Cast through `any` because Nuxt's typed `$fetch` overload tries
+    // to resolve the route key from a string-template and hits
+    // "Excessive stack depth" on cross-SP URLs. The shape is
+    // guaranteed by the typed local variable above.
+    troopRes = await ($fetch as any)(`${troopBase}/api/agents/spawn-intent/${member.spawnIntentId}`, {
+      headers: { Authorization: `Bearer ${bearer}` },
+    })
+  }
+  catch (err: any) {
+    return { status: 'pending', agent_email: null, error: `troop poll failed: ${err?.message ?? 'unknown'}` }
+  }
+
+  if (troopRes.pending) {
+    return { status: 'pending', agent_email: null, error: null }
+  }
+
+  if (!troopRes.ok) {
+    await db.update(orgMembers)
+      .set({ spawnStatus: 'failed', spawnError: troopRes.error ?? 'spawn failed' })
+      .where(and(eq(orgMembers.orgId, org.id), eq(orgMembers.agentEmail, email)))
+    return { status: 'failed', agent_email: null, error: troopRes.error ?? 'spawn failed' }
+  }
+
+  const realEmail = troopRes.agent_email
+  if (!realEmail) {
+    return { status: 'pending', agent_email: null, error: 'troop returned ok but no agent_email' }
+  }
+
+  // Success — PK swap from placeholder to real agent_email + mark active.
+  const now = Math.floor(Date.now() / 1000)
+  await db.delete(orgMembers).where(and(eq(orgMembers.orgId, org.id), eq(orgMembers.agentEmail, email)))
+  await db.insert(orgMembers).values({
+    orgId: member.orgId,
+    agentEmail: realEmail,
+    agentName: member.agentName,
+    role: member.role,
+    reportsToEmail: member.reportsToEmail,
+    status: 'active',
+    spawnedAt: now,
+    retiredAt: member.retiredAt,
+    createdAt: member.createdAt,
+    spawnIntentId: null,
+    spawnStatus: null,
+    spawnError: null,
+  })
+
+  return { status: 'active', agent_email: realEmail, error: null }
+})

--- a/apps/openape-org/server/api/orgs/[id]/members/[email]/spawn.post.ts
+++ b/apps/openape-org/server/api/orgs/[id]/members/[email]/spawn.post.ts
@@ -1,0 +1,95 @@
+import { and, eq } from 'drizzle-orm'
+import { useRuntimeConfig } from 'nitropack/runtime'
+import { useDb } from '../../../../../database/drizzle'
+import { orgMembers } from '../../../../../database/schema'
+import { getActiveDelegationGrantId } from '../../../../../utils/delegation-grants'
+import { requireOwnedOrg } from '../../../../../utils/orgs'
+import { getRoleDefaults, instantiateRoleDefaults } from '../../../../../utils/role-defaults'
+import { exchangeForOwnerBearer } from '../../../../../utils/token-exchange'
+
+// POST /api/orgs/:id/members/:email/spawn
+//
+// Triggered by the Owner from the chart UI on a placeholder card.
+// Server-side dance:
+//   1. Verify caller is the org owner + member row exists + status is 'invited'
+//   2. Look up the Owner's delegation grant for audience=apes-cli
+//      → 412 if missing (UI shows the bootstrap-grant flow)
+//   3. token-exchange → Bearer with sub=ownerEmail, act=org
+//   4. POST troop.openape.ai/api/agents/spawn-intent with that Bearer +
+//      per-role defaults (recipe + system prompt)
+//   5. Stash intent_id + status='pending' on the member row
+//   6. Return { intent_id } — UI starts polling spawn-status
+export default defineEventHandler(async (event) => {
+  const { org } = await requireOwnedOrg(event)
+  const email = getRouterParam(event, 'email')
+  if (!email) throw createError({ statusCode: 400, statusMessage: 'member email required' })
+
+  const db = useDb()
+  const rows = await db.select().from(orgMembers).where(and(eq(orgMembers.orgId, org.id), eq(orgMembers.agentEmail, email))).limit(1)
+  const member = rows[0]
+  if (!member) throw createError({ statusCode: 404, statusMessage: 'member not found' })
+  if (member.status === 'active') throw createError({ statusCode: 409, statusMessage: 'agent already active' })
+  if (member.spawnIntentId && member.spawnStatus === 'pending') {
+    return { intent_id: member.spawnIntentId, already_pending: true }
+  }
+
+  const config = useRuntimeConfig()
+  const audience = (config.public as { troopAudience?: string }).troopAudience ?? 'apes-cli'
+  const grantId = await getActiveDelegationGrantId(org.ownerEmail, audience)
+  if (!grantId) {
+    throw createError({
+      statusCode: 412,
+      statusMessage: `no delegation grant for this owner — visit /orgs/${org.id}/settings to bootstrap one`,
+    })
+  }
+
+  let bearer: string
+  try {
+    const exchanged = await exchangeForOwnerBearer({ delegationGrantId: grantId, audience })
+    bearer = exchanged.access_token
+  }
+  catch (err: any) {
+    throw createError({
+      statusCode: 502,
+      statusMessage: `token-exchange against IdP failed: ${err?.message ?? 'unknown'}`,
+    })
+  }
+
+  // Apply per-role defaults + substitute {{org_id}} / {{org_name}}.
+  const defaults = instantiateRoleDefaults(getRoleDefaults(member.role), {
+    org_id: org.id,
+    org_name: org.name,
+  })
+
+  const spawnBody: Record<string, unknown> = { name: member.agentName }
+  if (defaults.systemPrompt) spawnBody.system_prompt = defaults.systemPrompt
+  if (defaults.recipeRef) {
+    spawnBody.recipe = {
+      repo_ref: defaults.recipeRef,
+      params: defaults.recipeParams ?? {},
+    }
+  }
+
+  const troopBase = config.troopApiBase as string
+  let intentId: string
+  try {
+    const res = await $fetch<{ intent_id: string }>(`${troopBase}/api/agents/spawn-intent`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${bearer}` },
+      body: spawnBody,
+    })
+    intentId = res.intent_id
+  }
+  catch (err: any) {
+    throw createError({
+      statusCode: 502,
+      statusMessage: `troop spawn-intent rejected: ${err?.data?.statusMessage ?? err?.message ?? 'unknown'}`,
+    })
+  }
+
+  await db.update(orgMembers)
+    .set({ spawnIntentId: intentId, spawnStatus: 'pending', spawnError: null })
+    .where(and(eq(orgMembers.orgId, org.id), eq(orgMembers.agentEmail, email)))
+
+  return { intent_id: intentId }
+})

--- a/apps/openape-org/server/database/schema.ts
+++ b/apps/openape-org/server/database/schema.ts
@@ -40,10 +40,44 @@ export const orgMembers = sqliteTable('org_members', {
   spawnedAt: integer('spawned_at'),
   retiredAt: integer('retired_at'),
   createdAt: integer('created_at').notNull(),
+  // Tracks an in-flight troop spawn: when the Owner clicks "Spawn
+  // agent" on a placeholder row we POST to troop's /api/agents/spawn-
+  // intent (with a delegation-grant-derived Bearer), get back an
+  // intent_id, and store it here. The polling endpoint reads troop's
+  // /api/agents/spawn-intent/<id> until done, then PATCHes the PK to
+  // the real agent_email and clears these columns.
+  spawnIntentId: text('spawn_intent_id'),
+  // Lifecycle: null (no spawn in flight) → 'pending' (intent created,
+  // waiting for DDISA approval + nest result) → cleared on success +
+  // PK-swap, or → 'failed' with spawnError on failure.
+  spawnStatus: text('spawn_status'),
+  spawnError: text('spawn_error'),
 }, table => [
   primaryKey({ columns: [table.orgId, table.agentEmail] }),
   index('idx_org_members_org').on(table.orgId),
   index('idx_org_members_role').on(table.orgId, table.role),
+])
+
+// delegation_grants — RFC 8693 token-exchange grant IDs.
+//
+// When the Owner first wants to spawn an agent via org, they create
+// a delegation grant at the IdP (`apes grants delegate --to
+// org.openape.ai --at troop.openape.ai --approval always`) and paste
+// the resulting grant_id into org's settings page. From then on
+// org's server uses its own IdP access token + this grant_id to mint
+// a Bearer with sub=ownerEmail act=org via /api/oauth/token-exchange,
+// and calls troop's API as the Owner.
+//
+// One row per (ownerEmail, audience). Owner can revoke; org never
+// renews automatically.
+export const delegationGrants = sqliteTable('delegation_grants', {
+  ownerEmail: text('owner_email').notNull(),
+  audience: text('audience').notNull(),
+  grantId: text('grant_id').notNull(),
+  createdAt: integer('created_at').notNull(),
+  revokedAt: integer('revoked_at'),
+}, table => [
+  primaryKey({ columns: [table.ownerEmail, table.audience] }),
 ])
 
 // objectives — what the org is currently working on. A Kanban-style
@@ -112,3 +146,5 @@ export type Report = typeof reports.$inferSelect
 export type NewReport = typeof reports.$inferInsert
 export type CostSnapshot = typeof costSnapshots.$inferSelect
 export type NewCostSnapshot = typeof costSnapshots.$inferInsert
+export type DelegationGrant = typeof delegationGrants.$inferSelect
+export type NewDelegationGrant = typeof delegationGrants.$inferInsert

--- a/apps/openape-org/server/plugins/02.database.ts
+++ b/apps/openape-org/server/plugins/02.database.ts
@@ -74,6 +74,27 @@ export default defineNitroPlugin(async () => {
       updated_at INTEGER NOT NULL,
       PRIMARY KEY (org_id, day)
     )`)
+
+    await db.run(sql`CREATE TABLE IF NOT EXISTS delegation_grants (
+      owner_email TEXT NOT NULL,
+      audience TEXT NOT NULL,
+      grant_id TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      revoked_at INTEGER,
+      PRIMARY KEY (owner_email, audience)
+    )`)
+
+    // M4 schema migrations — additive columns on org_members for the
+    // in-flight spawn tracking. SQLite has no IF NOT EXISTS for
+    // columns, so each ALTER is wrapped in try/catch.
+    for (const stmt of [
+      sql`ALTER TABLE org_members ADD COLUMN spawn_intent_id TEXT`,
+      sql`ALTER TABLE org_members ADD COLUMN spawn_status TEXT`,
+      sql`ALTER TABLE org_members ADD COLUMN spawn_error TEXT`,
+    ]) {
+      try { await db.run(stmt) }
+      catch { /* already exists */ }
+    }
   }
   catch (err) {
     console.error('[openape-org] database init failed:', err)

--- a/apps/openape-org/server/utils/delegation-grants.ts
+++ b/apps/openape-org/server/utils/delegation-grants.ts
@@ -1,0 +1,48 @@
+// Helpers for the delegation_grants table.
+
+import { and, eq, isNull } from 'drizzle-orm'
+import { useDb } from '../database/drizzle'
+import { delegationGrants } from '../database/schema'
+
+/** Resolve the active (not revoked) grant_id for (owner, audience), or null. */
+export async function getActiveDelegationGrantId(owner: string, audience: string): Promise<string | null> {
+  const db = useDb()
+  const row = await db.select({ grantId: delegationGrants.grantId })
+    .from(delegationGrants)
+    .where(and(
+      eq(delegationGrants.ownerEmail, owner.toLowerCase()),
+      eq(delegationGrants.audience, audience),
+      isNull(delegationGrants.revokedAt),
+    ))
+    .limit(1)
+  return row[0]?.grantId ?? null
+}
+
+export async function upsertDelegationGrant(opts: { ownerEmail: string, audience: string, grantId: string }): Promise<void> {
+  const db = useDb()
+  const now = Math.floor(Date.now() / 1000)
+  // Manual upsert — drizzle's onConflictDoUpdate works on libsql but
+  // the wire shape here (clear revokedAt, set new grantId) is small
+  // enough to express directly.
+  await db.delete(delegationGrants)
+    .where(and(
+      eq(delegationGrants.ownerEmail, opts.ownerEmail.toLowerCase()),
+      eq(delegationGrants.audience, opts.audience),
+    ))
+  await db.insert(delegationGrants).values({
+    ownerEmail: opts.ownerEmail.toLowerCase(),
+    audience: opts.audience,
+    grantId: opts.grantId,
+    createdAt: now,
+  })
+}
+
+export async function revokeDelegationGrant(owner: string, audience: string): Promise<void> {
+  const db = useDb()
+  await db.update(delegationGrants)
+    .set({ revokedAt: Math.floor(Date.now() / 1000) })
+    .where(and(
+      eq(delegationGrants.ownerEmail, owner.toLowerCase()),
+      eq(delegationGrants.audience, audience),
+    ))
+}

--- a/apps/openape-org/server/utils/role-defaults.ts
+++ b/apps/openape-org/server/utils/role-defaults.ts
@@ -1,0 +1,81 @@
+// Per-role spawn defaults: which Recipe ref + which params + which
+// system-prompt fallback every newly-spawned member of a given role
+// should get on troop. Owner can override at spawn-time via the chart
+// UI later; for v1 we use these as the one-click default.
+//
+// Keep this file as the *single source of truth* — both the spawn API
+// (M4-3) and the chart UI ("what will this spawn produce?") read it.
+
+export interface RoleDefaults {
+  /**
+   * Optional Recipe @ref (github.com/owner/repo@tag). When omitted,
+   *  the spawn uses no recipe and falls back to systemPrompt.
+   */
+  recipeRef?: string
+  /**
+   * Recipe params (only used when recipeRef is set). Can include
+   *  template variables {{org_id}} / {{org_name}} which the spawn
+   *  endpoint substitutes from the actual organization.
+   */
+  recipeParams?: Record<string, string>
+  /**
+   * Free-text system prompt — used when there's no recipe, or as
+   *  the user_addendum on top of a recipe's intent.
+   */
+  systemPrompt?: string
+}
+
+export function getRoleDefaults(role: string): RoleDefaults {
+  switch (role) {
+    case 'ceo':
+      return {
+        recipeRef: 'github.com/openape-ai/openape/examples/agent-recipes/ceo@main',
+        recipeParams: { org_id: '{{org_id}}', org_name: '{{org_name}}' },
+      }
+
+    // Sanierer recipe not yet authored (will land in plan
+    // 01KSYCHBQ7WNE5GS338PH89DFM M3). Until then, spawn with a
+    // role-defining system prompt and Owner can wire it up later.
+    case 'sanierer':
+      return {
+        systemPrompt: `Du bist der Sanierer für {{org_name}} (org_id={{org_id}}).
+Deine einzige Aufgabe: das Budget und Output/Cost-Ratio dieser Organisation überwachen und dem Owner direkt berichten — nie über den CEO. Lies LiteLLM-Kostenlogs + org.openape.ai/api/orgs/{{org_id}}/cost-snapshots. Bei Schwellenüberschreitung sofort den Owner alarmieren.`,
+      }
+
+    case 'teamlead':
+      return {
+        systemPrompt: `Du bist Teamlead in {{org_name}} (org_id={{org_id}}).
+Deine Aufgabe: Decomposition + Delegation + Status. KEINE technischen Design-Entscheidungen — die gehören dem Implementer. Lies vom CEO zugewiesene Objectives, brich sie in Stories runter, weise sie an Specialists zu, reporte Status zurück an den CEO.`,
+      }
+
+    case 'specialist':
+      return {
+        systemPrompt: `Du bist Specialist in {{org_name}} (org_id={{org_id}}).
+Deine Aufgabe: Stories ausführen die dir der Teamlead zuweist. Lies bei jeder Story zuerst die CONTRIBUTING.md des betroffenen Repos. Mach kleine, fokussierte Edits + verifizier. Eskalier an den Teamlead wenn unklar.`,
+      }
+
+    default:
+      return {}
+  }
+}
+
+/**
+ * Substitute {{org_id}} / {{org_name}} placeholders in a defaults
+ *  object so the same RoleDefaults shape is usable for any org.
+ */
+export function instantiateRoleDefaults(
+  defaults: RoleDefaults,
+  ctx: { org_id: string, org_name: string },
+): RoleDefaults {
+  function sub(s?: string) {
+    if (!s) return s
+    return s.replace(/\{\{org_id\}\}/g, ctx.org_id).replace(/\{\{org_name\}\}/g, ctx.org_name)
+  }
+  return {
+    recipeRef: defaults.recipeRef,
+    recipeParams: defaults.recipeParams
+      ? Object.fromEntries(Object.entries(defaults.recipeParams).map(([k, v]) => [k, sub(v)!]))
+      : undefined,
+    systemPrompt: sub(defaults.systemPrompt),
+  }
+}

--- a/apps/openape-org/server/utils/token-exchange.ts
+++ b/apps/openape-org/server/utils/token-exchange.ts
@@ -1,0 +1,57 @@
+// Cross-SP token-exchange via id.openape.ai's RFC 8693 endpoint.
+//
+// The pattern: org has its own IdP-issued agent access token
+// (`ORG_IDP_ACCESS_TOKEN` env, minted once via `apes enroll` on
+// chatty during bootstrap). When Owner asks org to do something on
+// troop (e.g. spawn an agent), org calls:
+//
+//   POST id.openape.ai/api/oauth/token-exchange
+//        grant_type=urn:ietf:params:oauth:grant-type:token-exchange
+//        actor_token=<ORG_IDP_ACCESS_TOKEN>
+//        delegation_grant_id=<delegation grant owner created>
+//        audience=apes-cli
+//
+// IdP verifies + returns a Bearer with sub=ownerEmail, act={sub:org}.
+// org then calls troop with that Bearer; troop's requireOwner
+// extracts sub=ownerEmail and treats the call as if Owner did it.
+
+import { useRuntimeConfig } from 'nitropack/runtime'
+
+const TOKEN_EXCHANGE_GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:token-exchange'
+
+export interface ExchangedToken {
+  access_token: string
+  token_type: string
+  expires_in: number
+  issued_token_type: string
+}
+
+/**
+ * Exchange the calling SP's own access token + a delegator's
+ * delegation grant for a Bearer scoped to `audience` with sub set
+ * to the delegator. Throws on any IdP error.
+ */
+export async function exchangeForOwnerBearer(opts: {
+  delegationGrantId: string
+  audience?: string
+}): Promise<ExchangedToken> {
+  const config = useRuntimeConfig()
+  const idpUrl = (config.public as { idpUrl?: string }).idpUrl as string
+  const actorToken = (config as { orgIdpAccessToken?: string }).orgIdpAccessToken
+  if (!actorToken) {
+    throw new Error('ORG_IDP_ACCESS_TOKEN is not set — org has not been enrolled as an agent at the IdP. Run scripts/enroll-org-as-agent.sh.')
+  }
+
+  const res = await $fetch<ExchangedToken>(`${idpUrl}/api/oauth/token-exchange`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: {
+      grant_type: TOKEN_EXCHANGE_GRANT_TYPE,
+      actor_token: actorToken,
+      delegation_grant_id: opts.delegationGrantId,
+      audience: opts.audience ?? 'apes-cli',
+    },
+  })
+
+  return res
+}

--- a/scripts/enroll-org-as-agent.sh
+++ b/scripts/enroll-org-as-agent.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#
+# One-time bootstrap: enroll org.openape.ai as a DDISA agent at
+# id.openape.ai so it can act as a delegate for owners (RFC 8693
+# token-exchange in M4).
+#
+# Runs INTERACTIVELY on chatty as the openape user. Opens a browser
+# URL Patrick needs to approve in his iPhone DDISA app. After
+# approval, persists the agent's access token into org's shared/.env
+# so future deploys pick it up automatically.
+#
+# Re-run safe: if the agent identity already exists at the IdP, the
+# existing access_token is just re-extracted from the local auth file.
+#
+# Usage: ssh openape@chatty.delta-mind.at "bash -s" < scripts/enroll-org-as-agent.sh
+
+set -euo pipefail
+
+ORG_BASE=/home/openape/projects/openape-org
+SHARED=$ORG_BASE/shared
+AGENT_NAME=openape-org
+IDP=https://id.openape.ai
+KEY_PATH=$SHARED/.ddisa/agent-ed25519
+AUTH_PATH=$SHARED/.ddisa/auth.json
+
+mkdir -p "$SHARED/.ddisa"
+chmod 700 "$SHARED/.ddisa"
+
+if [ ! -f "$AUTH_PATH" ]; then
+  echo "→ Running apes enroll for $AGENT_NAME at $IDP"
+  echo "  (You'll get an iPhone DDISA approval prompt — approve to continue.)"
+  apes enroll --idp "$IDP" --name "$AGENT_NAME" --key "$KEY_PATH"
+  # apes writes auth.json to ~/.openape/<idp-slug>/auth.json by default.
+  # Move it to our org-scoped location so it doesn't leak into other apes
+  # invocations as the openape user.
+  IDP_SLUG=$(echo "$IDP" | sed 's|https\?://||; s|/.*||; s|\.|-|g')
+  DEFAULT_AUTH="$HOME/.openape/$IDP_SLUG/auth.json"
+  if [ -f "$DEFAULT_AUTH" ]; then
+    cp "$DEFAULT_AUTH" "$AUTH_PATH"
+    chmod 600 "$AUTH_PATH"
+    echo "  ✓ auth.json copied to $AUTH_PATH"
+  else
+    echo "  ✗ apes enroll didn't produce $DEFAULT_AUTH — check the apes output"
+    exit 1
+  fi
+fi
+
+ACCESS_TOKEN=$(jq -r '.token // .access_token // empty' "$AUTH_PATH")
+AGENT_EMAIL=$(jq -r '.email // .agent_email // empty' "$AUTH_PATH")
+if [ -z "$ACCESS_TOKEN" ] || [ -z "$AGENT_EMAIL" ]; then
+  echo "✗ Could not extract token/email from $AUTH_PATH"
+  exit 1
+fi
+
+ENV_FILE=$SHARED/.env
+
+# Replace (or append) NUXT_ORG_IDP_ACCESS_TOKEN + NUXT_ORG_IDP_AGENT_EMAIL.
+# sed -i variants differ across BSD/GNU; use a temp file for portability.
+{
+  grep -vE '^NUXT_ORG_IDP_(ACCESS_TOKEN|AGENT_EMAIL)=' "$ENV_FILE" 2>/dev/null || true
+  echo "NUXT_ORG_IDP_ACCESS_TOKEN=$ACCESS_TOKEN"
+  echo "NUXT_ORG_IDP_AGENT_EMAIL=$AGENT_EMAIL"
+} > "$ENV_FILE.tmp"
+mv "$ENV_FILE.tmp" "$ENV_FILE"
+chmod 600 "$ENV_FILE"
+
+echo
+echo "✓ org enrolled as $AGENT_EMAIL"
+echo "✓ $ENV_FILE updated with NUXT_ORG_IDP_ACCESS_TOKEN + NUXT_ORG_IDP_AGENT_EMAIL"
+echo
+echo "Next steps:"
+echo "  1. Restart the service: sudo systemctl restart openape-org.service"
+echo "  2. Owner side: 'apes grants delegate --to $AGENT_EMAIL --at apes-cli --approval always'"
+echo "     Paste the resulting grant_id in /orgs/<id>/settings → Delegation grants"

--- a/scripts/enroll-org-as-agent.sh
+++ b/scripts/enroll-org-as-agent.sh
@@ -16,6 +16,18 @@
 
 set -euo pipefail
 
+# apes CLI must be on PATH. Install per-user if missing — keeps the
+# enroll script truly one-shot.
+if ! command -v apes >/dev/null 2>&1; then
+  echo "→ Installing @openape/apes (per-user, ~/.npm-global)"
+  export NPM_CONFIG_PREFIX="$HOME/.npm-global"
+  export PATH="$NPM_CONFIG_PREFIX/bin:$PATH"
+  npm install --silent -g @openape/apes
+  if [ -f "$HOME/.bashrc" ] && ! grep -q 'npm-global/bin' "$HOME/.bashrc"; then
+    echo 'export PATH="$HOME/.npm-global/bin:$PATH"' >> "$HOME/.bashrc"
+  fi
+fi
+
 ORG_BASE=/home/openape/projects/openape-org
 SHARED=$ORG_BASE/shared
 AGENT_NAME=openape-org


### PR DESCRIPTION
Replaces the placeholder+paste workaround. Owner clicks 'Spawn agent' → org server token-exchanges Owner's delegation grant for an apes-cli Bearer → POSTs troop spawn-intent → polling auto-updates the chart when troop reports done. Full DDISA-grant approval is preserved (Owner still taps approve on iPhone for each spawn); only the cross-SP plumbing is invisible.

## Bootstrap (one-time per deploy)
1. ssh openape@chatty 'bash -s' < scripts/enroll-org-as-agent.sh
2. Owner-side: apes grants delegate --to <NUXT_ORG_IDP_AGENT_EMAIL> --at apes-cli --approval always — paste grant_id in /orgs/X/settings

## What ships in this PR
- delegation_grants table + spawn columns on org_members
- token-exchange util + delegation-grant helpers + per-role-defaults
- POST .../spawn + GET .../spawn-status endpoints
- delegation-grants CRUD endpoints
- MemberCard extraction + spinner/failure states + Spawn CTA
- DelegationGrantManager UI (Settings tab)
- enroll script + DEPLOY.md doc