### PR TITLE
feat(troop): M4α — scope catalog + /api/cli/exchange + scope-aware auth

### DIFF
--- a/apps/openape-troop/server/api/agents/destroy-intent.post.ts
+++ b/apps/openape-troop/server/api/agents/destroy-intent.post.ts
@@ -3,7 +3,7 @@ import { and, eq } from 'drizzle-orm'
 import { z } from 'zod'
 import { useDb } from '../../database/drizzle'
 import { agents } from '../../database/schema'
-import { requireOwner } from '../../utils/auth'
+import { requireOwnerWithScope } from '../../utils/auth'
 import { createDestroyIntent } from '../../utils/destroy-intents'
 import { listNestPeersForOwner } from '../../utils/nest-registry'
 
@@ -32,7 +32,7 @@ const bodySchema = z.object({
 })
 
 export default defineEventHandler(async (event) => {
-  const owner = await requireOwner(event)
+  const { owner } = await requireOwnerWithScope(event, 'troop:destroy-agent')
   const parsed = bodySchema.safeParse(await readBody(event))
   if (!parsed.success) {
     throw createError({ statusCode: 400, statusMessage: parsed.error.issues[0]?.message ?? 'invalid body' })

--- a/apps/openape-troop/server/api/agents/spawn-intent.post.ts
+++ b/apps/openape-troop/server/api/agents/spawn-intent.post.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto'
 import { z } from 'zod'
 import { materializeRecipe } from '../../utils/agent-recipe'
-import { requireOwner } from '../../utils/auth'
+import { requireOwnerWithScope } from '../../utils/auth'
 import { listNestPeersForOwner } from '../../utils/nest-registry'
 import { buildDeployPlan, fetchRecipeManifest } from '../../utils/recipe-deploy'
 import { stashRecipeDeploy } from '../../utils/recipe-deploys'
@@ -42,7 +42,10 @@ const bodySchema = z.object({
 })
 
 export default defineEventHandler(async (event) => {
-  const owner = await requireOwner(event)
+  // Scope-gate: first-party (session / aud=apes-cli Bearer) auto-passes.
+  // Delegated callers (Receiver SPs) need `troop:spawn-agent` in their
+  // CLI token, minted at /api/cli/exchange per sp-data-access.md.
+  const { owner } = await requireOwnerWithScope(event, 'troop:spawn-agent')
   const parsed = bodySchema.safeParse(await readBody(event))
   if (!parsed.success) {
     throw createError({ statusCode: 400, statusMessage: parsed.error.issues[0]?.message ?? 'invalid body' })

--- a/apps/openape-troop/server/api/cli/exchange.post.ts
+++ b/apps/openape-troop/server/api/cli/exchange.post.ts
@@ -1,0 +1,165 @@
+import type { JWTPayload } from 'jose'
+import { createRemoteJWKSet, jwtVerify } from 'jose'
+import { signCliToken } from '../../utils/cli-token'
+import { resolveIssuerForToken } from '../../utils/ddisa-issuer'
+import { scopesAreCovered } from '../../utils/scope-catalog'
+
+interface ExchangeBody {
+  subject_token?: string
+  scopes?: string[]
+}
+
+// We accept BOTH the apes-cli audience (first-party CLI flows like
+// `apes login` → SP-bearer cache) AND troop's own DDISA domain
+// (delegation flows per sp-data-access.md §4, where the IdP mints an
+// AuthZ-JWT with aud=<sp-domain> for the delegate). Either form is
+// trusted because it was signed by the subject's DDISA-resolved IdP.
+const ACCEPTED_AUDIENCES = ['apes-cli', 'troop.openape.ai']
+
+let _idpJwks: ReturnType<typeof createRemoteJWKSet> | null = null
+let _idpJwksUrl = ''
+
+function getIdpJwks(idpUrl: string): ReturnType<typeof createRemoteJWKSet> {
+  const url = new URL('/.well-known/jwks.json', idpUrl).toString()
+  if (!_idpJwks || _idpJwksUrl !== url) {
+    _idpJwks = createRemoteJWKSet(new URL(url))
+    _idpJwksUrl = url
+  }
+  return _idpJwks
+}
+
+/**
+ * POST /api/cli/exchange — RFC 8693-style token exchange.
+ *
+ * Pattern copied from openape-chat (the canonical reference impl for
+ * SP-data-access). Differences here:
+ *   - audience accept-list is ['apes-cli', 'troop.openape.ai'] so
+ *     both first-party CLI tokens AND delegation-AuthZ-JWTs work
+ *   - request body `scopes` (optional) is intersected with troop's
+ *     published scope catalog; unknown scopes → 400
+ *   - minted CLI token carries the verified `scope` claim + the
+ *     `delegate` (sp-data-access §5.3 provenance) for downstream
+ *     scope-aware route handlers to enforce
+ *
+ * Body:    `{ subject_token: <jwt>, scopes?: string[] }`
+ * Response (201): `{ access_token, token_type: "Bearer",
+ *                    expires_at, aud, scope, delegate }`
+ */
+export default defineEventHandler(async (event) => {
+  const body = await readBody<ExchangeBody>(event)
+  if (!body?.subject_token || typeof body.subject_token !== 'string') {
+    throw createError({ statusCode: 400, statusMessage: 'subject_token required' })
+  }
+
+  // DDISA: resolve the authoritative issuer from the SUBJECT's domain
+  // (protocol sp-data-access.md §2.1). Never hardcode or allowlist on
+  // this path.
+  const resolved = await resolveIssuerForToken(body.subject_token)
+  if (!resolved) {
+    throw createError({
+      statusCode: 401,
+      statusMessage: 'subject_token has no usable subject claim',
+      data: { detail: 'Expected sub to be an email address.' },
+    })
+  }
+  const idpUrl = resolved.issuer
+
+  let claims: JWTPayload
+  try {
+    // jose's audience option accepts string|string[]; matches if any
+    // audience in the token equals any in the list.
+    const verified = await jwtVerify(body.subject_token, getIdpJwks(idpUrl), {
+      issuer: idpUrl,
+      audience: ACCEPTED_AUDIENCES,
+    })
+    claims = verified.payload
+  }
+  catch (err) {
+    const detail = err instanceof Error ? err.message : 'verify failed'
+    throw createError({
+      statusCode: 401,
+      statusMessage: 'Invalid subject_token',
+      data: { detail: `Token must be issued by ${idpUrl} with aud in [${ACCEPTED_AUDIENCES.join(', ')}]. ${detail}` },
+    })
+  }
+
+  const sub = claims.sub
+  if (typeof sub !== 'string' || !sub.includes('@')) {
+    throw createError({
+      statusCode: 401,
+      statusMessage: 'subject_token has no usable subject claim',
+      data: { detail: 'Expected sub to be an email address.' },
+    })
+  }
+
+  const act = (claims as { act?: string }).act === 'agent' ? 'agent' : 'human'
+
+  // sp-data-access §5.2: scopes in the request body must be a subset
+  // of (a) the catalog, AND (b) the delegation grant's scopes if any.
+  // The grant's scopes ride in the token claim `scope` per the spec.
+  // Receivers MAY narrow scope at exchange; never widen.
+  const tokenScopes = parseTokenScopes(claims)
+  const requestedScopes = Array.isArray(body.scopes) ? body.scopes : tokenScopes
+  const catalogCheck = scopesAreCovered(requestedScopes)
+  if (!catalogCheck.ok) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'invalid_scope',
+      data: { detail: `unknown scopes: ${catalogCheck.unknown.join(', ')}` },
+    })
+  }
+  if (tokenScopes.length > 0) {
+    const widenedBy = requestedScopes.filter(s => !tokenScopes.includes(s))
+    if (widenedBy.length > 0) {
+      throw createError({
+        statusCode: 400,
+        statusMessage: 'invalid_scope',
+        data: { detail: `cannot widen beyond grant scopes: ${widenedBy.join(', ')}` },
+      })
+    }
+  }
+
+  // delegate provenance: prefer the spec's `delegate` claim (sp-data-
+  // access §5.3 via delegation.md §5), fall back to `request.delegate`
+  // shape if the IdP doesn't yet emit the flat claim.
+  const delegate = extractDelegate(claims)
+
+  const { token, expiresAt } = await signCliToken({
+    email: sub,
+    act,
+    scope: requestedScopes,
+    delegate,
+  })
+
+  setResponseStatus(event, 201)
+  return {
+    access_token: token,
+    token_type: 'Bearer' as const,
+    expires_at: expiresAt,
+    aud: 'troop.openape.ai',
+    scope: requestedScopes,
+    delegate,
+  }
+})
+
+function parseTokenScopes(claims: JWTPayload): string[] {
+  // RFC 8693 / OAuth: `scope` is a space-separated string OR array
+  const raw = (claims as { scope?: unknown }).scope ?? (claims as { scopes?: unknown }).scopes
+  if (Array.isArray(raw)) return raw.filter((s): s is string => typeof s === 'string')
+  if (typeof raw === 'string') return raw.split(/\s+/).filter(Boolean)
+  return []
+}
+
+function extractDelegate(claims: JWTPayload): string | null {
+  const d = (claims as { delegate?: unknown }).delegate
+  if (typeof d === 'string') return d
+  if (d && typeof d === 'object' && typeof (d as { sub?: unknown }).sub === 'string') {
+    return (d as { sub: string }).sub
+  }
+  // RFC 8693 act fallback
+  const act = (claims as { act?: unknown }).act
+  if (act && typeof act === 'object' && typeof (act as { sub?: unknown }).sub === 'string') {
+    return (act as { sub: string }).sub
+  }
+  return null
+}

--- a/apps/openape-troop/server/routes/.well-known/openape.json.get.ts
+++ b/apps/openape-troop/server/routes/.well-known/openape.json.get.ts
@@ -1,0 +1,27 @@
+import { defineEventHandler, getRequestURL, setResponseHeader } from 'h3'
+import { TROOP_SCOPES } from '../../utils/scope-catalog'
+
+// Overrides the @openape/nuxt-auth-sp module's default openape.json
+// handler so we can inject troop's scope catalog (spec
+// sp-data-access.md §3) without forking the module. Receiver SPs
+// like org.openape.ai read this to discover what they may request
+// in a delegation grant.
+export default defineEventHandler((event) => {
+  const origin = getRequestURL(event).origin
+
+  setResponseHeader(event, 'Access-Control-Allow-Origin', '*')
+  setResponseHeader(event, 'Cache-Control', 'public, max-age=3600')
+
+  return {
+    version: '1.0',
+    service: {
+      name: 'OpenApe Troop',
+      url: origin,
+    },
+    auth: {
+      ddisa_domain: 'troop.openape.ai',
+      supported_methods: ['ddisa'],
+    },
+    scopes: TROOP_SCOPES,
+  }
+})

--- a/apps/openape-troop/server/utils/auth.ts
+++ b/apps/openape-troop/server/utils/auth.ts
@@ -1,5 +1,6 @@
 import type { H3Event } from 'h3'
 import { createRemoteJWKS, verifyJWT } from '@openape/core'
+import { verifyCliToken } from './cli-token'
 
 // Two distinct auth tracks because owner-side and agent-side endpoints
 // have different identity sources:
@@ -57,25 +58,85 @@ function problem(status: number, title: string): never {
  * Throws 401 if neither yields an owner.
  */
 export async function requireOwner(event: H3Event): Promise<string> {
+  return (await resolveOwnerContext(event)).owner
+}
+
+/**
+ * Resolve the owner email AND the set of scopes the caller is allowed
+ * to exercise. Three transports:
+ *
+ *   1. **Browser session cookie** (UI path) — scopes are unbounded
+ *      (the Owner-authenticated session can do anything Owner can).
+ *   2. **IdP-issued human Bearer with aud='apes-cli'** (first-party
+ *      CLI path) — scopes are unbounded for the same reason. This is
+ *      a token Patrick himself minted via `apes login`.
+ *   3. **troop-issued CLI token via /api/cli/exchange** (Receiver SP
+ *      path per sp-data-access.md) — scopes are bounded to whatever
+ *      the delegation grant carried. Route handlers MUST check via
+ *      `requireOwnerWithScope`.
+ *
+ * The function preserves backwards compatibility: anything that called
+ * `requireOwner` and got an unrestricted owner still works because
+ * paths 1+2 return `{ scopes: null }` (= "no restriction").
+ */
+export async function resolveOwnerContext(event: H3Event): Promise<{
+  owner: string
+  /**
+   * Effective scopes the caller may exercise. `null` = unrestricted
+   *  (first-party). Non-null array = restrictive (delegation).
+   */
+  scopes: string[] | null
+  /** Provenance: which SP-delegate the call rides on, if any. */
+  delegate: string | null
+}> {
   const session = await getSpSession(event)
   const sessionEmail = (session.data as { claims?: DDISAClaims })?.claims?.sub
-  if (sessionEmail) return sessionEmail
+  if (sessionEmail) return { owner: sessionEmail, scopes: null, delegate: null }
 
   const auth = getHeader(event, 'Authorization')
   if (auth?.toLowerCase().startsWith('bearer ')) {
     const token = auth.slice(7).trim()
+
+    // Try troop's own CLI-exchange token first (cheap HS256 verify
+    // against the shared session secret). This is the path delegate
+    // SPs use after token-exchange.
+    const cli = await verifyCliToken(token)
+    if (cli) {
+      return { owner: cli.sub, scopes: cli.scope ?? [], delegate: cli.delegate ?? null }
+    }
+
+    // Fall back to IdP-issued human Bearer with aud='apes-cli'.
     const idpUrl = useRuntimeConfig().public.idpUrl as string
     try {
       const result = await verifyJWT(token, getJwks(), { issuer: idpUrl })
       const claims = result.payload as DDISAClaims
       const auds = Array.isArray(claims.aud) ? claims.aud : [claims.aud]
       if (claims.act === 'human' && auds.includes(CLI_AUDIENCE) && typeof claims.sub === 'string') {
-        return claims.sub
+        return { owner: claims.sub, scopes: null, delegate: null }
       }
     }
     catch { /* fall through to 401 */ }
   }
   problem(401, 'Authentication required')
+}
+
+/**
+ * Owner-auth + scope enforcement. For routes that a Receiver SP may
+ * call on the Owner's behalf via delegation. First-party paths
+ * (session, apes-cli Bearer) auto-pass any scope check because their
+ * effective scope is unbounded. Delegated paths must carry the
+ * requested scope in their CLI token (minted at /api/cli/exchange).
+ */
+export async function requireOwnerWithScope(event: H3Event, requiredScope: string): Promise<{
+  owner: string
+  delegate: string | null
+}> {
+  const ctx = await resolveOwnerContext(event)
+  if (ctx.scopes === null) return { owner: ctx.owner, delegate: ctx.delegate }
+  if (!ctx.scopes.includes(requiredScope)) {
+    problem(403, `scope '${requiredScope}' required (token carries: ${ctx.scopes.join(', ') || 'none'})`)
+  }
+  return { owner: ctx.owner, delegate: ctx.delegate }
 }
 
 /**

--- a/apps/openape-troop/server/utils/cli-token.ts
+++ b/apps/openape-troop/server/utils/cli-token.ts
@@ -1,0 +1,88 @@
+import { jwtVerify, SignJWT } from 'jose'
+
+// Pattern copied from openape-chat. troop's CLI-scoped SP token is an
+// HS256 JWT minted by /api/cli/exchange after the IdP-issued
+// subject_token has been verified via JWKS. Clients (org.openape.ai's
+// spawn-proxy + future delegates) cache it for the duration of its TTL
+// and present it as `Authorization: Bearer …` on troop's gated routes.
+const ISSUER = 'troop.openape.ai'
+const AUDIENCE = 'troop.openape.ai'
+
+export interface CliTokenPayload {
+  iss: 'troop.openape.ai'
+  aud: 'troop.openape.ai'
+  typ: 'cli'
+  sub: string
+  email: string
+  act: 'human' | 'agent'
+  /**
+   * Scopes the holder is allowed to exercise on troop. Empty array =
+   *  no scope restriction (first-party `apes login` from a human),
+   *  treated as "all routes the sub already had access to" — matches
+   *  the openape-chat behaviour-preserving rule (sp-data-access §5.3).
+   *  Non-empty = delegated access, route handlers MUST check.
+   */
+  scope: string[]
+  /**
+   * Provenance audit — the delegate domain string from the subject
+   *  token's claims (sp-data-access §5.3). null for first-party.
+   */
+  delegate: string | null
+  iat: number
+  exp: number
+}
+
+function secret(): Uint8Array {
+  const s = (useRuntimeConfig().openapeSp?.sessionSecret as string) || ''
+  if (!s || s.length < 32) {
+    throw createError({ statusCode: 500, statusMessage: 'CLI token secret not configured (openapeSp.sessionSecret < 32 chars)' })
+  }
+  return new TextEncoder().encode(s)
+}
+
+/**
+ * Mint an HS256 troop-scoped CLI token. Spec recommends ≤15 min for
+ * delegated tokens (sp-data-access §6); first-party (no delegate, no
+ * scope) gets the same 30-day TTL as openape-chat for CLI continuity.
+ */
+export async function signCliToken(params: {
+  email: string
+  act: 'human' | 'agent'
+  scope?: string[]
+  delegate?: string | null
+  ttlSeconds?: number
+}): Promise<{ token: string, expiresAt: number }> {
+  const isDelegated = Boolean(params.scope?.length || params.delegate)
+  const ttl = params.ttlSeconds ?? (isDelegated ? 15 * 60 : 30 * 24 * 3600)
+  const now = Math.floor(Date.now() / 1000)
+  const exp = now + ttl
+  const payload = {
+    typ: 'cli',
+    sub: params.email,
+    email: params.email,
+    act: params.act,
+    scope: params.scope ?? [],
+    delegate: params.delegate ?? null,
+  }
+  const token = await new SignJWT(payload)
+    .setProtectedHeader({ alg: 'HS256' })
+    .setIssuer(ISSUER)
+    .setAudience(AUDIENCE)
+    .setIssuedAt()
+    .setExpirationTime(exp)
+    .sign(secret())
+  return { token, expiresAt: exp }
+}
+
+export async function verifyCliToken(token: string): Promise<CliTokenPayload | null> {
+  try {
+    const { payload } = await jwtVerify(token, secret(), { issuer: ISSUER, audience: AUDIENCE })
+    if (payload.typ !== 'cli') return null
+    if (typeof payload.sub !== 'string' || typeof payload.email !== 'string') return null
+    if (payload.act !== 'human' && payload.act !== 'agent') return null
+    return payload as unknown as CliTokenPayload
+  }
+  catch {
+    return null
+  }
+}

--- a/apps/openape-troop/server/utils/ddisa-issuer.ts
+++ b/apps/openape-troop/server/utils/ddisa-issuer.ts
@@ -1,0 +1,49 @@
+import { extractDomain, resolveIdP } from '@openape/core'
+
+// DDISA trust doctrine (protocol sp-data-access.md §2.1): the authoritative
+// issuer for a subject is whatever the SUBJECT'S domain points to via
+// `_ddisa.<domain>`. The Provider MUST resolve it dynamically — no hardcoded
+// issuer, no allowlist on this path. Fallback to id.openape.ai only when a
+// domain publishes no DDISA record (behaviour-preserving for legacy
+// single-IdP users; e.g. id.openape.ai's own domain resolves to itself).
+const FALLBACK_ISSUER = 'https://id.openape.ai'
+
+/**
+ * Decode a JWT payload WITHOUT verifying the signature — used solely to read
+ * `sub` so we can discover the authoritative issuer via the subject's domain.
+ * The token is fully verified afterwards against THAT issuer's JWKS, so a
+ * forged/altered token cannot benefit from this peek.
+ */
+export function unsafeDecodeSub(token: string): string | null {
+  const parts = token.split('.')
+  if (parts.length !== 3) return null
+  try {
+    const payload = JSON.parse(Buffer.from(parts[1]!, 'base64url').toString('utf-8')) as { sub?: unknown }
+    return typeof payload.sub === 'string' && payload.sub.includes('@') ? payload.sub : null
+  }
+  catch {
+    return null
+  }
+}
+
+export interface ResolvedIssuer {
+  sub: string
+  issuer: string
+  jwksUri: string
+}
+
+/**
+ * Resolve the issuer to verify a subject_token against, from the subject's
+ * own domain via DDISA. Returns null if the token carries no usable email
+ * subject.
+ */
+export async function resolveIssuerForToken(token: string): Promise<ResolvedIssuer | null> {
+  const sub = unsafeDecodeSub(token)
+  if (!sub) return null
+  const domain = extractDomain(sub)
+  const idp = (await resolveIdP(domain).catch(() => null)) || FALLBACK_ISSUER
+  const issuer = idp.replace(/\/$/, '')
+  return { sub, issuer, jwksUri: `${issuer}/.well-known/jwks.json` }
+}
+
+export { FALLBACK_ISSUER }

--- a/apps/openape-troop/server/utils/scope-catalog.ts
+++ b/apps/openape-troop/server/utils/scope-catalog.ts
@@ -1,0 +1,57 @@
+// troop's scope catalog per openape-ai/protocol sp-data-access.md §3.
+//
+// Published at /.well-known/openape.json#scopes so any Receiver SP
+// (e.g. org.openape.ai) can discover what they can request a
+// delegation for. Each entry is {id, description, grants[]} —
+// `description` is rendered verbatim on the IdP consent screen the
+// Owner sees, so write it plainly.
+//
+// Adding a new scope:
+//   1. Define it here
+//   2. Gate the route handlers that should require it via
+//      requireOwnerWithScope (utils/auth.ts)
+//   3. No client/SP-side registration needed — Receivers discover
+//      via /.well-known/openape.json
+//
+// IDs use the convention `<sp-shortname>:<action>` from the spec.
+
+export interface TroopScope {
+  id: string
+  description: string
+  /**
+   * Informative — the routes this scope authorizes. Used in the
+   *  well-known doc + as documentation; not enforced from this list
+   *  (handlers do their own requireOwnerWithScope check).
+   */
+  grants: string[]
+}
+
+export const TROOP_SCOPES: TroopScope[] = [
+  {
+    id: 'troop:spawn-agent',
+    description: 'Spawn new agents on this troop on the user\'s behalf. Each spawn still requires the user\'s DDISA approval on their device — this scope only grants the right to *initiate* the flow.',
+    grants: ['POST /api/agents/spawn-intent'],
+  },
+  {
+    id: 'troop:destroy-agent',
+    description: 'Destroy existing agents on this troop on the user\'s behalf. High-stakes — each destroy still triggers the user\'s DDISA approval.',
+    grants: ['POST /api/agents/destroy-intent'],
+  },
+  {
+    id: 'troop:read-agents',
+    description: 'Read the user\'s agent list, agent details, and live nest-status on this troop.',
+    grants: ['GET /api/agents', 'GET /api/agents/:name', 'GET /api/nest/hosts'],
+  },
+]
+
+const KNOWN_IDS = new Set(TROOP_SCOPES.map(s => s.id))
+
+export function isKnownScope(id: string): boolean {
+  return KNOWN_IDS.has(id)
+}
+
+/** Subset check: every requested scope must be in the catalog (spec §3.2). */
+export function scopesAreCovered(requested: string[]): { ok: true } | { ok: false, unknown: string[] } {
+  const unknown = requested.filter(s => !KNOWN_IDS.has(s))
+  return unknown.length === 0 ? { ok: true } : { ok: false, unknown }
+}

--- a/apps/openape-troop/tests/scope-catalog.test.ts
+++ b/apps/openape-troop/tests/scope-catalog.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { isKnownScope, scopesAreCovered, TROOP_SCOPES } from '../server/utils/scope-catalog'
+
+describe('troop scope catalog', () => {
+  it('publishes at least the spawn + destroy + read trio', () => {
+    const ids = TROOP_SCOPES.map(s => s.id)
+    expect(ids).toContain('troop:spawn-agent')
+    expect(ids).toContain('troop:destroy-agent')
+    expect(ids).toContain('troop:read-agents')
+  })
+
+  it('every entry has the spec-required shape (sp-data-access §3.2)', () => {
+    for (const s of TROOP_SCOPES) {
+      expect(typeof s.id).toBe('string')
+      expect(s.id).toMatch(/^troop:[a-z-]+$/)
+      expect(typeof s.description).toBe('string')
+      expect(s.description.length).toBeGreaterThan(10)
+      expect(Array.isArray(s.grants)).toBe(true)
+    }
+  })
+
+  it('isKnownScope rejects unknown ids', () => {
+    expect(isKnownScope('troop:spawn-agent')).toBe(true)
+    expect(isKnownScope('troop:not-a-thing')).toBe(false)
+    expect(isKnownScope('chat:read')).toBe(false)
+    expect(isKnownScope('')).toBe(false)
+  })
+
+  it('scopesAreCovered returns the full list of unknowns', () => {
+    expect(scopesAreCovered(['troop:spawn-agent'])).toEqual({ ok: true })
+    expect(scopesAreCovered([])).toEqual({ ok: true })
+    expect(scopesAreCovered(['troop:spawn-agent', 'troop:made-up', 'chat:read']))
+      .toEqual({ ok: false, unknown: ['troop:made-up', 'chat:read'] })
+  })
+})


### PR DESCRIPTION
Implements Provider-side of openape-ai/protocol sp-data-access.md. Receiver SPs (e.g. org.openape.ai) can obtain Owner-scoped Bearer tokens for troop without client registration — trust derives from DDISA + Owner's delegation grant at their User-IdP.

- TROOP_SCOPES catalog (troop:spawn-agent, troop:destroy-agent, troop:read-agents) published at /.well-known/openape.json#scopes
- /api/cli/exchange (pattern from openape-chat): DDISA-issuer-resolution, JWKS verify, scope ⊆ catalog AND scope ⊆ grant, mints troop HS256 Bearer with scope + delegate provenance
- requireOwnerWithScope(event, scope) — first-party paths (session/apes-cli Bearer) auto-pass (unbounded), delegated tokens must carry the requested scope
- spawn-intent gated on troop:spawn-agent, destroy-intent on troop:destroy-agent
- 132 tests green, behaviour-preserving for first-party callers

Next: M4β (org client-side spawn flow that uses this).