### PR TITLE
feat(nuxt-auth-idp): origin-allowlist CORS with credentials (M4β prerequisite)

### DIFF
--- a/modules/nuxt-auth-idp/src/runtime/server/plugins/cors-preflight.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/plugins/cors-preflight.ts
@@ -1,21 +1,94 @@
 import type { NitroApp } from 'nitropack'
 
-// Paths that should allow CORS (matching the routeRules patterns)
+// Paths CORS applies to (matches existing routeRules patterns).
 const CORS_PATHS = /^\/(?:\.well-known\/|token\b|userinfo\b|api\/(?:auth|agent|grants|delegations)\/)/
 
+/**
+ * Parse the comma-separated allowlist from env. Empty / unset → empty
+ * Set (back-compat: behaves like the legacy `Allow-Origin: *`
+ * no-credentials mode). Trims, strips trailing slashes, lowercases.
+ *
+ * Read once at module-load. Changing the env requires a restart, same
+ * as every other env-driven config in the IdP.
+ */
+function readAllowedOrigins(): Set<string> {
+  const raw = process.env.NUXT_OPENAPE_IDP_CORS_ALLOWED_ORIGINS ?? ''
+  return new Set(
+    raw
+      .split(',')
+      .map(s => s.trim().replace(/\/$/, '').toLowerCase())
+      .filter(Boolean),
+  )
+}
+const ALLOWED_ORIGINS = readAllowedOrigins()
+
+function isAllowedOrigin(origin: string | undefined): boolean {
+  if (!origin) return false
+  return ALLOWED_ORIGINS.has(origin.toLowerCase().replace(/\/$/, ''))
+}
+
+/**
+ * CORS plugin with two modes:
+ *
+ *   - **Legacy** (env unset): `Access-Control-Allow-Origin: *` on
+ *     preflight only. No credentials. Matches pre-M4 behaviour for
+ *     CLI tools that send Bearer Authorization (no cookies needed).
+ *
+ *   - **Allowlist** (env set): for requests whose `Origin` header is
+ *     in `NUXT_OPENAPE_IDP_CORS_ALLOWED_ORIGINS`, echo that origin +
+ *     `Allow-Credentials: true` on BOTH preflight AND actual response.
+ *     Enables Receiver SPs (e.g. org.openape.ai) to call IdP endpoints
+ *     from the Owner's browser using their IdP session cookie (the
+ *     sp-data-access.md flow). Requests from non-allowlisted origins
+ *     fall back to the legacy wildcard on preflight (and get no CORS
+ *     headers on the actual response, so the browser blocks them).
+ *
+ * The non-OPTIONS branch is new: we have to set CORS headers on the
+ * actual response too, otherwise the browser blocks reading the body
+ * even though the preflight passed.
+ *
+ * Pairs with `getAppSession`'s sameSite='none' switch (also keyed on
+ * the same env var) — both are required for cross-origin cookie sends.
+ */
 export default (nitroApp: NitroApp) => {
   nitroApp.hooks.hook('request', (event) => {
-    if (event.method !== 'OPTIONS') return
-
     const path = event.path || ''
     if (!CORS_PATHS.test(path)) return
 
+    const origin = event.node.req.headers.origin
     const res = event.node.res
-    res.setHeader('Access-Control-Allow-Origin', '*')
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS')
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
-    res.setHeader('Access-Control-Max-Age', '86400')
-    res.statusCode = 204
-    res.end()
+    const useAllowlist = isAllowedOrigin(origin)
+
+    if (event.method === 'OPTIONS') {
+      if (useAllowlist) {
+        res.setHeader('Access-Control-Allow-Origin', origin!)
+        res.setHeader('Access-Control-Allow-Credentials', 'true')
+        // When echoing a specific origin, Vary tells caches the response
+        // depends on Origin so a different origin's preflight doesn't
+        // get an incorrect cached response served.
+        res.setHeader('Vary', 'Origin')
+      }
+      else {
+        res.setHeader('Access-Control-Allow-Origin', '*')
+      }
+      res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS')
+      res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
+      res.setHeader('Access-Control-Max-Age', '86400')
+      res.statusCode = 204
+      res.end()
+      return
+    }
+
+    // Non-OPTIONS: tag the actual response with CORS headers so the
+    // browser permits the caller to read the body.
+    if (useAllowlist) {
+      res.setHeader('Access-Control-Allow-Origin', origin!)
+      res.setHeader('Access-Control-Allow-Credentials', 'true')
+      res.setHeader('Vary', 'Origin')
+    }
+    // No `*` here on the response path: setting Allow-Origin:* on a
+    // non-OPTIONS response without an explicit caller request could
+    // mask a misconfigured deployment. The legacy `*` wildcard only
+    // ever applied to preflight, and we preserve that above.
   })
 }

--- a/modules/nuxt-auth-idp/src/runtime/server/utils/agent-token.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/utils/agent-token.ts
@@ -16,15 +16,18 @@ export const DEFAULT_CLI_AUDIENCE = 'apes-cli'
 
 export interface AuthTokenPayload {
   sub: string
-  /** Either a simple actor-type string ('human' | 'agent') for direct
+  /**
+   * Either a simple actor-type string ('human' | 'agent') for direct
    * tokens, or a structured DDISA DelegationActClaim object for
    * delegated tokens minted via /api/oauth/token-exchange. The
    * structured form's `sub` field is the email of the actor (delegate).
    */
   act: ActorType | DelegationActClaim
   aud?: string
-  /** Set on delegated tokens — the id of the delegation grant that
-   * authorised this token-exchange. */
+  /**
+   * Set on delegated tokens — the id of the delegation grant that
+   * authorised this token-exchange.
+   */
   delegation_grant?: string
 }
 

--- a/modules/nuxt-auth-idp/src/runtime/server/utils/session.ts
+++ b/modules/nuxt-auth-idp/src/runtime/server/utils/session.ts
@@ -11,6 +11,14 @@ export async function getAppSession(event: H3Event) {
   // cookies must use sameSite: 'none' or the browser will reject them in
   // the cross-origin context. 'none' requires secure: true (already set).
   const embeddable = !!(process.env.NUXT_OPENAPE_IDP_ALLOWED_FRAME_ANCESTORS || idpConfig.allowedFrameAncestors)
+  // When a CORS allowlist is configured (M4β cross-SP flow per
+  // sp-data-access.md), Receiver SPs need to fetch IdP endpoints
+  // from the Owner's browser with credentials:'include'. The browser
+  // only sends the IdP cookie on those cross-origin XHRs if
+  // sameSite='none'. The CORS plugin pairs with this — both
+  // strict-equality on the same env so they can't drift.
+  const corsAllowlist = !!(process.env.NUXT_OPENAPE_IDP_CORS_ALLOWED_ORIGINS)
+  const crossOrigin = embeddable || corsAllowlist
   return await useSession(event, {
     name: sessionName,
     password: idpConfig.sessionSecret as string,
@@ -18,7 +26,7 @@ export async function getAppSession(event: H3Event) {
     cookie: {
       secure: true,
       httpOnly: true,
-      sameSite: embeddable ? 'none' : 'lax',
+      sameSite: crossOrigin ? 'none' : 'lax',
     },
   })
 }


### PR DESCRIPTION
Unblocks the openape-ai/protocol sp-data-access.md cross-SP delegation flow. Allows Receiver SPs to call IdP endpoints (e.g. /api/grants/:id/token) from the Owner's browser using their IdP session cookie, via a per-origin allowlist + Allow-Credentials + sameSite=none cookie. Both settings driven by 'NUXT_OPENAPE_IDP_CORS_ALLOWED_ORIGINS' so they can't drift.

Legacy behaviour preserved when env is unset (CLI tools using Bearer continue to work). 134 tests green.