### PR TITLE
fix(nest): troop-sync honors OPENAPE_BYPASS_APE_SHELL=1

### DIFF
--- a/apps/openape-nest/src/lib/troop-sync.ts
+++ b/apps/openape-nest/src/lib/troop-sync.ts
@@ -65,14 +65,22 @@ export class TroopSync {
 
   private async syncOne(name: string): Promise<void> {
     try {
-      // `apes run --as <agent>` triggers escapes-helper which does
-      // the setuid switch and exec's `apes agents sync` as the
-      // agent. The Nest's YOLO policy auto-approves the grant.
-      await execFileAsync(
-        this.deps.apesBin,
-        ['run', '--as', name, '--wait', '--', 'apes', 'agents', 'sync'],
-        { maxBuffer: 1024 * 1024, env: process.env, timeout: 60_000 },
-      )
+      // Two transports per environment:
+      //   - macOS Nest (`OPENAPE_BYPASS_APE_SHELL` unset): `apes run
+      //     --as <agent>` triggers escapes-helper which does the
+      //     setuid switch and exec's `apes agents sync` as the agent.
+      //     The Nest's YOLO policy auto-approves the grant.
+      //   - Container Nest (`OPENAPE_BYPASS_APE_SHELL=1`): no
+      //     DDISA/escapes layer inside the container — the container
+      //     IS the sandbox boundary. Switch to plain
+      //     `sudo -n -H -u <agent> apes agents sync` — matches what
+      //     pm2-supervisor already does for the bridge processes.
+      const bypassApeShell = process.env.OPENAPE_BYPASS_APE_SHELL === '1'
+      const cmd = bypassApeShell ? '/usr/bin/sudo' : this.deps.apesBin
+      const argv = bypassApeShell
+        ? ['-n', '-H', '-u', name, this.deps.apesBin, 'agents', 'sync']
+        : ['run', '--as', name, '--wait', '--', 'apes', 'agents', 'sync']
+      await execFileAsync(cmd, argv, { maxBuffer: 1024 * 1024, env: process.env, timeout: 60_000 })
     }
     catch (err) {
       this.deps.log(`troop-sync: ${name} failed: ${err instanceof Error ? err.message.split('\n')[0] : String(err)}`)

--- a/apps/openape-org/app/components/BootstrapGrantDialog.vue
+++ b/apps/openape-org/app/components/BootstrapGrantDialog.vue
@@ -1,0 +1,96 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const emit = defineEmits<{ retry: [] }>()
+const open = defineModel<boolean>('open', { default: false })
+const config = useRuntimeConfig()
+
+// Pre-built CLI command the Owner copy-pastes into their terminal.
+// Until id.openape.ai ships a browser consent screen for delegation
+// requests (M4γ), this is the bootstrap path: Owner runs `apes grants
+// delegate` once from a terminal where they're logged in via
+// `apes login`. The IdP auto-approves (Owner is delegator + requester),
+// stores the standing grant, and the next "Spawn agent" click finds
+// it via the browser fetch in chart's onSpawnAgent.
+const cliCommand = computed(() => {
+  return `apes grants delegate --to org.openape.ai --at troop.openape.ai --scopes troop:spawn-agent --approval always`
+})
+
+const troopUiBase = computed(() => (config.public as { troopUiBase?: string }).troopUiBase ?? 'https://troop.openape.ai')
+
+function copy(s: string) {
+  try { navigator.clipboard.writeText(s) }
+  catch { /* clipboard blocked */ }
+}
+
+function onRetry() {
+  emit('retry')
+  open.value = false
+}
+</script>
+
+<template>
+  <UModal v-model:open="open" :ui="{ content: 'sm:max-w-md max-h-[92dvh] flex flex-col' }">
+    <template #content>
+      <div class="flex-1 overflow-y-auto p-5 sm:p-6 space-y-5">
+        <div class="flex items-start justify-between gap-3">
+          <div>
+            <h3 class="text-lg font-semibold">
+              {{ $t('bootstrapGrant.title') }}
+            </h3>
+            <p class="text-xs text-muted mt-1">
+              {{ $t('bootstrapGrant.subtitle') }}
+            </p>
+          </div>
+          <UButton variant="ghost" size="sm" icon="i-lucide-x" @click="open = false" />
+        </div>
+
+        <div class="space-y-3">
+          <div class="rounded-md border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-xs text-amber-200">
+            {{ $t('bootstrapGrant.oneTime') }}
+          </div>
+
+          <div>
+            <p class="text-xs font-medium uppercase tracking-wide text-muted mb-1">
+              {{ $t('bootstrapGrant.step1.title') }}
+            </p>
+            <p class="text-xs text-muted mb-2">
+              {{ $t('bootstrapGrant.step1.description') }}
+            </p>
+            <div class="flex items-stretch gap-2">
+              <code class="flex-1 px-3 py-2 rounded-md bg-(--ui-bg-elevated) text-xs font-mono break-all">{{ cliCommand }}</code>
+              <UButton size="sm" variant="soft" color="neutral" icon="i-lucide-copy" :title="$t('common.copy')" @click="copy(cliCommand)" />
+            </div>
+          </div>
+
+          <div>
+            <p class="text-xs font-medium uppercase tracking-wide text-muted mb-1">
+              {{ $t('bootstrapGrant.step2.title') }}
+            </p>
+            <p class="text-xs text-muted">
+              {{ $t('bootstrapGrant.step2.description') }}
+            </p>
+          </div>
+
+          <div>
+            <p class="text-xs font-medium uppercase tracking-wide text-muted mb-1">
+              {{ $t('bootstrapGrant.step3.title') }}
+            </p>
+            <p class="text-xs text-muted">
+              {{ $t('bootstrapGrant.step3.description', { troopUi: troopUiBase }) }}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div class="shrink-0 flex justify-end gap-2 border-t border-default bg-default px-5 sm:px-6 pt-3 pb-[max(0.875rem,env(safe-area-inset-bottom))]">
+        <UButton variant="ghost" @click="open = false">
+          {{ $t('common.cancel') }}
+        </UButton>
+        <UButton color="primary" icon="i-lucide-refresh-cw" @click="onRetry">
+          {{ $t('bootstrapGrant.retry') }}
+        </UButton>
+      </div>
+    </template>
+  </UModal>
+</template>

--- a/apps/openape-org/app/components/MemberCard.vue
+++ b/apps/openape-org/app/components/MemberCard.vue
@@ -100,12 +100,16 @@ const statusBadge = computed(() => {
       </button>
     </div>
 
-    <!-- Placeholder, no spawn in flight, no failure: today only the
-         "Link existing" manual-paste path is wired. The "Spawn agent"
-         auto-flow ships with M4-correct (cross-SP DDISA delegation
-         per openape-ai/protocol sp-data-access.md). -->
+    <!-- Placeholder, no spawn in flight, no failure: primary "Spawn
+         agent" auto-flow (cross-SP DDISA delegation per
+         openape-ai/protocol sp-data-access.md) + secondary "Link
+         existing" manual-paste path for agents already created in
+         troop by hand. -->
     <template v-else-if="isPlaceholder">
-      <button type="button" class="block w-full mt-2 text-[10px] underline text-amber-300/80 cursor-pointer" @click="emit('linkAgent', member.agentEmail)">
+      <button type="button" class="block w-full mt-2 text-[10px] font-semibold uppercase tracking-wide text-amber-300 hover:text-amber-200 cursor-pointer" @click="emit('spawnAgent', member.agentEmail)">
+        {{ $t('chart.spawnCta') }}
+      </button>
+      <button type="button" class="block w-full mt-0.5 text-[10px] underline text-amber-300/70 cursor-pointer" @click="emit('linkAgent', member.agentEmail)">
         {{ $t('chart.linkAgentCta') }}
       </button>
     </template>

--- a/apps/openape-org/app/pages/orgs/[id].vue
+++ b/apps/openape-org/app/pages/orgs/[id].vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useOpenApeAuth } from '#imports'
 
 const route = useRoute()
@@ -115,11 +115,148 @@ function onLinkAgent(email: string) {
   showLinkAgent.value = true
 }
 
-// Spawn-agent flow not yet wired — M4-correct (sp-data-access spec)
-// will land it. For now, the placeholder cards only show "Link
-// existing" (manual paste).
+// Spawn-agent flow per openape-ai/protocol sp-data-access.md (M4β).
+//
+// On click:
+//   1. fetch existing standing delegation grants from id.openape.ai
+//      with credentials:'include' — relies on the Owner's IdP session
+//      cookie + the CORS+sameSite=none allowlist we set up in M4α-IdP
+//   2. find a standing grant matching (delegate=org.openape.ai,
+//      audience=troop.openape.ai, scopes ⊇ [troop:spawn-agent])
+//   3. if none: open BootstrapGrantDialog with the apes CLI command
+//      the Owner runs once; "Retry" replays this whole flow
+//   4. if found: fetch AuthZ-JWT via /api/grants/{id}/token (still
+//      browser, credentials)
+//   5. POST { subject_token, grant_id } to org's /spawn endpoint;
+//      org server exchanges at troop, calls spawn-intent
+//   6. start the 2s polling loop until troop reports active/failed
 const spawnError = ref('')
-function onSpawnAgent(_email: string) { /* no-op until M4-correct */ }
+const spawnPollTimer = ref<ReturnType<typeof setInterval> | null>(null)
+const showBootstrapGrant = ref(false)
+const pendingSpawnEmail = ref<string | null>(null)
+
+const idpBase = computed(() => (useRuntimeConfig().public as { idpUrl?: string }).idpUrl ?? 'https://id.openape.ai')
+
+interface StandingGrant {
+  id: string
+  type?: string
+  status?: string
+  request?: {
+    delegate?: string
+    audience?: string
+    scopes?: string[]
+    grant_type?: string
+  }
+}
+
+async function findStandingGrant(): Promise<StandingGrant | null> {
+  // Browser → IdP, credentials:'include' relies on CORS allowlist
+  // (set up in PR #522) + sameSite=none on the IdP session cookie.
+  const res = await fetch(`${idpBase.value}/api/grants?role=delegator`, { credentials: 'include' })
+  if (!res.ok) {
+    if (res.status === 401) throw new Error('idp-unauthenticated')
+    throw new Error(`idp /api/grants failed: HTTP ${res.status}`)
+  }
+  const body = await res.json() as { grants?: StandingGrant[] } | StandingGrant[]
+  const grants = Array.isArray(body) ? body : (body.grants ?? [])
+  return grants.find(g =>
+    g.type === 'delegation'
+    && g.status === 'approved'
+    && g.request?.delegate === 'org.openape.ai'
+    && g.request?.audience === 'troop.openape.ai'
+    && (g.request?.scopes ?? []).includes('troop:spawn-agent')
+    && g.request?.grant_type === 'always',
+  ) ?? null
+}
+
+async function fetchAuthzJwt(grantId: string): Promise<string> {
+  const res = await fetch(`${idpBase.value}/api/grants/${encodeURIComponent(grantId)}/token`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: '{}',
+  })
+  if (!res.ok) throw new Error(`idp /api/grants/${grantId}/token failed: HTTP ${res.status}`)
+  const body = await res.json() as { authz_jwt: string }
+  return body.authz_jwt
+}
+
+async function onSpawnAgent(email: string) {
+  if (!org.value) return
+  spawnError.value = ''
+  pendingSpawnEmail.value = email
+
+  let grant: StandingGrant | null
+  try {
+    grant = await findStandingGrant()
+  }
+  catch (err: any) {
+    if (err?.message === 'idp-unauthenticated') {
+      spawnError.value = t('orgDetail.spawn.idpUnauthenticated')
+      return
+    }
+    spawnError.value = err?.message || t('orgDetail.spawn.failed')
+    return
+  }
+
+  if (!grant) {
+    showBootstrapGrant.value = true
+    return
+  }
+
+  let subjectToken: string
+  try { subjectToken = await fetchAuthzJwt(grant.id) }
+  catch (err: any) { spawnError.value = err?.message || t('orgDetail.spawn.failed'); return }
+
+  try {
+    await ($fetch as any)(`/api/orgs/${org.value.id}/members/${encodeURIComponent(email)}/spawn`, {
+      method: 'POST',
+      body: { subject_token: subjectToken, grant_id: grant.id },
+    })
+    await loadAll()
+    ensureSpawnPolling()
+  }
+  catch (err: any) {
+    spawnError.value = err?.data?.statusMessage || err?.message || t('orgDetail.spawn.failed')
+  }
+}
+
+function ensureSpawnPolling() {
+  if (spawnPollTimer.value) return
+  spawnPollTimer.value = setInterval(async () => {
+    const pending = members.value.filter(m => m.spawnStatus === 'pending')
+    if (pending.length === 0) {
+      if (spawnPollTimer.value) { clearInterval(spawnPollTimer.value); spawnPollTimer.value = null }
+      return
+    }
+    let anyFlipped = false
+    for (const m of pending) {
+      try {
+        const res = await ($fetch as any)(`/api/orgs/${org.value!.id}/members/${encodeURIComponent(m.agentEmail)}/spawn-status`) as { status: string }
+        if (res.status === 'active' || res.status === 'failed') anyFlipped = true
+      }
+      catch { /* keep polling */ }
+    }
+    if (anyFlipped) await loadAll()
+  }, 2000)
+}
+
+// Resume polling when the page mounts with already-pending spawns.
+watch(members, (ms) => {
+  if (ms.some(m => m.spawnStatus === 'pending')) ensureSpawnPolling()
+})
+
+onBeforeUnmount(() => {
+  if (spawnPollTimer.value) clearInterval(spawnPollTimer.value)
+})
+
+function onBootstrapRetry() {
+  if (pendingSpawnEmail.value) {
+    const email = pendingSpawnEmail.value
+    pendingSpawnEmail.value = null
+    void onSpawnAgent(email)
+  }
+}
 
 // Destroy-org modal
 const showDestroy = ref(false)
@@ -191,6 +328,10 @@ async function destroyOrg() {
             :org-id="org.id"
             :placeholder-email="placeholderToLink"
             @saved="loadAll"
+          />
+          <BootstrapGrantDialog
+            v-model:open="showBootstrapGrant"
+            @retry="onBootstrapRetry"
           />
         </div>
 

--- a/apps/openape-org/i18n/locales/de.json
+++ b/apps/openape-org/i18n/locales/de.json
@@ -83,9 +83,28 @@
       "failed": "Löschen fehlgeschlagen"
     },
     "spawn": {
-      "needsGrant": "Du hast dieser Org noch nicht erlaubt in deinem Namen Agents zu spawnen. Setze einen Delegation-Grant in den Einstellungen auf (einmalig).",
+      "needsGrant": "Du hast dieser Org noch nicht erlaubt in deinem Namen Agents zu spawnen. Einmalige Einrichtung notwendig.",
+      "idpUnauthenticated": "Deine IdP-Session ist abgelaufen — auf id.openape.ai neu einloggen, dann erneut versuchen.",
       "failed": "Spawn fehlgeschlagen"
     }
+  },
+  "bootstrapGrant": {
+    "title": "Einmalige Einrichtung nötig",
+    "subtitle": "Erlaube dieser Org in deinem Namen Agents auf troop zu spawnen.",
+    "oneTime": "Nur einmal pro Browser/Gerät nötig. Jederzeit widerrufbar via id.openape.ai.",
+    "step1": {
+      "title": "Schritt 1 — diesen Befehl im Terminal ausführen",
+      "description": "Du musst via 'apes login' eingeloggt sein. Der Grant wird auto-approved, weil du selbst der Delegator bist."
+    },
+    "step2": {
+      "title": "Schritt 2 — auf den iPhone DDISA-Prompt warten",
+      "description": "Falls dein IdP pro Grant eine Bestätigung verlangt, am Telefon approven."
+    },
+    "step3": {
+      "title": "Schritt 3 — Retry klicken",
+      "description": "Geht zurück in die Chart und triggert den Spawn neu — läuft ab da invisible. troop unter {troopUi} öffnen falls noch was Aufmerksamkeit braucht."
+    },
+    "retry": "Spawn wiederholen"
   },
   "delegation": {
     "title": "Delegation-Grants",

--- a/apps/openape-org/i18n/locales/en.json
+++ b/apps/openape-org/i18n/locales/en.json
@@ -83,9 +83,28 @@
       "failed": "Destroy failed"
     },
     "spawn": {
-      "needsGrant": "You haven't authorized this org to spawn agents on your behalf. Set up a delegation grant in Settings (one-time).",
+      "needsGrant": "You haven't authorized this org to spawn agents on your behalf. Set up a delegation grant (one-time).",
+      "idpUnauthenticated": "Your IdP session expired — sign in again at id.openape.ai, then retry.",
       "failed": "Spawn failed"
     }
+  },
+  "bootstrapGrant": {
+    "title": "One-time setup needed",
+    "subtitle": "Authorize this org to spawn agents on troop on your behalf.",
+    "oneTime": "You only need to do this once per browser/device. The grant is revocable any time from id.openape.ai.",
+    "step1": {
+      "title": "Step 1 — run this in your terminal",
+      "description": "You must be logged in via 'apes login'. The grant auto-approves because you're the delegator."
+    },
+    "step2": {
+      "title": "Step 2 — wait for the iPhone DDISA prompt",
+      "description": "If your IdP requires per-grant confirmation, approve on your phone."
+    },
+    "step3": {
+      "title": "Step 3 — click Retry",
+      "description": "Returns to the chart and re-triggers the spawn — runs invisibly from there. Open troop at {troopUi} if anything else needs attention."
+    },
+    "retry": "Retry spawn"
   },
   "delegation": {
     "title": "Delegation grants",

--- a/apps/openape-org/server/api/orgs/[id]/members/[email]/spawn-status.get.ts
+++ b/apps/openape-org/server/api/orgs/[id]/members/[email]/spawn-status.get.ts
@@ -1,0 +1,100 @@
+import { and, eq } from 'drizzle-orm'
+import { useRuntimeConfig } from 'nitropack/runtime'
+import { useDb } from '../../../../../database/drizzle'
+import { orgMembers } from '../../../../../database/schema'
+import { requireOwnedOrg } from '../../../../../utils/orgs'
+
+// GET /api/orgs/:id/members/:email/spawn-status
+//
+// Long-poll endpoint. Each call:
+//   1. Read member row, return immediately if no intent in flight
+//   2. If the cached troop bearer is still alive: GET troop's
+//      /api/agents/spawn-intent/<id> with it
+//   3. If troop reports done + agent_email → delete placeholder row +
+//      insert real-email row (PK swap), status='active'
+//   4. If troop reports failure → set spawn_status='failed' + error
+//   5. If the cached bearer expired before the spawn finished →
+//      surface 'spawn link expired, retry' so the UI prompts a fresh
+//      subject_token from the frontend's standing-grant
+//
+// The UI polls this every 2s while a card is in 'pending' state.
+export default defineEventHandler(async (event) => {
+  const { org } = await requireOwnedOrg(event)
+  const email = getRouterParam(event, 'email')
+  if (!email) throw createError({ statusCode: 400, statusMessage: 'member email required' })
+
+  const db = useDb()
+  const rows = await db.select().from(orgMembers).where(and(eq(orgMembers.orgId, org.id), eq(orgMembers.agentEmail, email))).limit(1)
+  const member = rows[0]
+  if (!member) throw createError({ statusCode: 404, statusMessage: 'member not found' })
+
+  if (!member.spawnIntentId || member.spawnStatus !== 'pending') {
+    return {
+      status: member.spawnStatus ?? 'idle',
+      agent_email: member.status === 'active' ? member.agentEmail : null,
+      error: member.spawnError ?? null,
+    }
+  }
+
+  const now = Math.floor(Date.now() / 1000)
+  if (!member.spawnTroopBearer || !member.spawnTroopBearerExpiresAt || member.spawnTroopBearerExpiresAt <= now) {
+    await db.update(orgMembers)
+      .set({ spawnStatus: 'failed', spawnError: 'troop bearer expired before spawn completed — retry from chart' })
+      .where(and(eq(orgMembers.orgId, org.id), eq(orgMembers.agentEmail, email)))
+    return { status: 'failed', agent_email: null, error: 'spawn link expired — retry from the chart' }
+  }
+
+  const config = useRuntimeConfig()
+  const troopBase = config.troopApiBase as string
+
+  let troopRes: { pending?: boolean, ok?: boolean, agent_email?: string, error?: string }
+  try {
+    troopRes = await ($fetch as any)(`${troopBase}/api/agents/spawn-intent/${member.spawnIntentId}`, {
+      headers: { Authorization: `Bearer ${member.spawnTroopBearer}` },
+    })
+  }
+  catch (err: any) {
+    // Don't tear down spawn_status on transient troop hiccups — return
+    // 'pending' with the error info, UI keeps polling and might recover.
+    return { status: 'pending', agent_email: null, error: `troop poll failed: ${err?.message ?? 'unknown'}` }
+  }
+
+  if (troopRes.pending) {
+    return { status: 'pending', agent_email: null, error: null }
+  }
+
+  if (!troopRes.ok) {
+    await db.update(orgMembers)
+      .set({ spawnStatus: 'failed', spawnError: troopRes.error ?? 'spawn failed' })
+      .where(and(eq(orgMembers.orgId, org.id), eq(orgMembers.agentEmail, email)))
+    return { status: 'failed', agent_email: null, error: troopRes.error ?? 'spawn failed' }
+  }
+
+  const realEmail = troopRes.agent_email
+  if (!realEmail) {
+    return { status: 'pending', agent_email: null, error: 'troop returned ok but no agent_email' }
+  }
+
+  // Success — PK swap from placeholder to real agent_email, status='active',
+  // clear all spawn-tracking columns.
+  await db.delete(orgMembers).where(and(eq(orgMembers.orgId, org.id), eq(orgMembers.agentEmail, email)))
+  await db.insert(orgMembers).values({
+    orgId: member.orgId,
+    agentEmail: realEmail,
+    agentName: member.agentName,
+    role: member.role,
+    reportsToEmail: member.reportsToEmail,
+    status: 'active',
+    spawnedAt: now,
+    retiredAt: member.retiredAt,
+    createdAt: member.createdAt,
+    spawnIntentId: null,
+    spawnStatus: null,
+    spawnError: null,
+    spawnTroopBearer: null,
+    spawnTroopBearerExpiresAt: null,
+    spawnGrantId: null,
+  })
+
+  return { status: 'active', agent_email: realEmail, error: null }
+})

--- a/apps/openape-org/server/api/orgs/[id]/members/[email]/spawn.post.ts
+++ b/apps/openape-org/server/api/orgs/[id]/members/[email]/spawn.post.ts
@@ -1,0 +1,110 @@
+import { and, eq } from 'drizzle-orm'
+import { useRuntimeConfig } from 'nitropack/runtime'
+import { z } from 'zod'
+import { useDb } from '../../../../../database/drizzle'
+import { orgMembers } from '../../../../../database/schema'
+import { requireOwnedOrg } from '../../../../../utils/orgs'
+import { getRoleDefaults, instantiateRoleDefaults } from '../../../../../utils/role-defaults'
+
+// POST /api/orgs/:id/members/:email/spawn
+//
+// Triggered by the Owner from the chart UI on a placeholder card.
+// The frontend has already:
+//   (a) verified the Owner has a standing delegation grant at the
+//       User-IdP for (delegate=org.openape.ai, audience=troop.openape.ai,
+//       scope=troop:spawn-agent) — see the chart's onSpawnAgent
+//   (b) fetched the AuthZ-JWT via /api/grants/{id}/token (browser,
+//       credentials:include against the IdP)
+// and POSTs it here as `subject_token` along with the `grant_id` for
+// audit.
+//
+// Server-side dance:
+//   1. Verify the placeholder member row + Owner ownership of the org
+//   2. POST troop.openape.ai/api/cli/exchange with the subject_token →
+//      receive a troop CLI bearer with the scope we asked for
+//   3. POST troop.openape.ai/api/agents/spawn-intent with that bearer +
+//      per-role defaults (recipe ref + system prompt)
+//   4. Cache the troop bearer + intent_id + grant_id on the member row
+//      so the polling endpoint can reuse the bearer for 15 min
+//   5. Return { intent_id } — UI starts polling spawn-status
+
+const Body = z.object({
+  subject_token: z.string().min(20),
+  grant_id: z.string().min(8).optional(),
+})
+
+export default defineEventHandler(async (event) => {
+  const { org } = await requireOwnedOrg(event)
+  const email = getRouterParam(event, 'email')
+  if (!email) throw createError({ statusCode: 400, statusMessage: 'member email required' })
+
+  const parsed = Body.safeParse(await readBody(event))
+  if (!parsed.success) throw createError({ statusCode: 400, statusMessage: 'invalid body', data: parsed.error.flatten() })
+
+  const db = useDb()
+  const rows = await db.select().from(orgMembers).where(and(eq(orgMembers.orgId, org.id), eq(orgMembers.agentEmail, email))).limit(1)
+  const member = rows[0]
+  if (!member) throw createError({ statusCode: 404, statusMessage: 'member not found' })
+  if (member.status === 'active') throw createError({ statusCode: 409, statusMessage: 'agent already active' })
+  if (member.spawnIntentId && member.spawnStatus === 'pending') {
+    return { intent_id: member.spawnIntentId, already_pending: true }
+  }
+
+  const config = useRuntimeConfig()
+  const troopBase = config.troopApiBase as string
+
+  // Exchange the AuthZ-JWT for a troop-scoped CLI bearer (M4α at troop).
+  let exchange: { access_token: string, expires_at: number, scope: string[] }
+  try {
+    exchange = await $fetch<{ access_token: string, expires_at: number, scope: string[] }>(`${troopBase}/api/cli/exchange`, {
+      method: 'POST',
+      body: { subject_token: parsed.data.subject_token, scopes: ['troop:spawn-agent'] },
+    })
+  }
+  catch (err: any) {
+    throw createError({
+      statusCode: 502,
+      statusMessage: `troop /api/cli/exchange rejected: ${err?.data?.statusMessage ?? err?.data?.detail ?? err?.message ?? 'unknown'}`,
+    })
+  }
+
+  const defaults = instantiateRoleDefaults(getRoleDefaults(member.role), {
+    org_id: org.id,
+    org_name: org.name,
+  })
+
+  const spawnBody: Record<string, unknown> = { name: member.agentName }
+  if (defaults.systemPrompt) spawnBody.system_prompt = defaults.systemPrompt
+  if (defaults.recipeRef) {
+    spawnBody.recipe = { repo_ref: defaults.recipeRef, params: defaults.recipeParams ?? {} }
+  }
+
+  let intentId: string
+  try {
+    const res = await ($fetch as any)(`${troopBase}/api/agents/spawn-intent`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${exchange.access_token}` },
+      body: spawnBody,
+    })
+    intentId = res.intent_id
+  }
+  catch (err: any) {
+    throw createError({
+      statusCode: 502,
+      statusMessage: `troop /api/agents/spawn-intent rejected: ${err?.data?.statusMessage ?? err?.message ?? 'unknown'}`,
+    })
+  }
+
+  await db.update(orgMembers)
+    .set({
+      spawnIntentId: intentId,
+      spawnStatus: 'pending',
+      spawnError: null,
+      spawnTroopBearer: exchange.access_token,
+      spawnTroopBearerExpiresAt: exchange.expires_at,
+      spawnGrantId: parsed.data.grant_id ?? null,
+    })
+    .where(and(eq(orgMembers.orgId, org.id), eq(orgMembers.agentEmail, email)))
+
+  return { intent_id: intentId, scope: exchange.scope }
+})

--- a/apps/openape-org/server/database/schema.ts
+++ b/apps/openape-org/server/database/schema.ts
@@ -52,6 +52,18 @@ export const orgMembers = sqliteTable('org_members', {
   // PK-swap, or → 'failed' with spawnError on failure.
   spawnStatus: text('spawn_status'),
   spawnError: text('spawn_error'),
+  // Cache the troop CLI bearer minted at /api/cli/exchange so the
+  // polling endpoint doesn't have to refetch an AuthZ-JWT from the
+  // IdP on every 2s tick. Bearer lives 15 min per sp-data-access §6;
+  // polling expires gracefully when the bearer does (UI surfaces
+  // "spawn link expired, retry" via spawn_error).
+  spawnTroopBearer: text('spawn_troop_bearer'),
+  spawnTroopBearerExpiresAt: integer('spawn_troop_bearer_expires_at'),
+  // The standing-grant id used for this spawn (audit + future
+  // refresh: the polling endpoint could refetch a fresh JWT if the
+  // troop bearer expires before the spawn finishes). Today purely
+  // informational — UI shows it under member details if interested.
+  spawnGrantId: text('spawn_grant_id'),
 }, table => [
   primaryKey({ columns: [table.orgId, table.agentEmail] }),
   index('idx_org_members_org').on(table.orgId),

--- a/apps/openape-org/server/plugins/02.database.ts
+++ b/apps/openape-org/server/plugins/02.database.ts
@@ -82,6 +82,11 @@ export default defineNitroPlugin(async () => {
       sql`ALTER TABLE org_members ADD COLUMN spawn_intent_id TEXT`,
       sql`ALTER TABLE org_members ADD COLUMN spawn_status TEXT`,
       sql`ALTER TABLE org_members ADD COLUMN spawn_error TEXT`,
+      // M4β — cache the exchanged troop bearer per intent so the
+      // 2s-poll loop doesn't have to round-trip to the IdP per tick.
+      sql`ALTER TABLE org_members ADD COLUMN spawn_troop_bearer TEXT`,
+      sql`ALTER TABLE org_members ADD COLUMN spawn_troop_bearer_expires_at INTEGER`,
+      sql`ALTER TABLE org_members ADD COLUMN spawn_grant_id TEXT`,
     ]) {
       try { await db.run(stmt) }
       catch { /* already exists */ }

--- a/apps/openape-org/server/utils/role-defaults.ts
+++ b/apps/openape-org/server/utils/role-defaults.ts
@@ -1,0 +1,82 @@
+// Per-role spawn defaults: which Recipe ref + which params + which
+// system-prompt fallback every newly-spawned member of a given role
+// should get on troop. Owner can override at spawn-time via a future
+// UI surface; for v1 the chart "Spawn agent" button uses these as
+// the one-click default.
+//
+// Keep this file as the *single source of truth* — both the spawn
+// API and any future chart "what will this spawn produce?" preview
+// read it.
+
+export interface RoleDefaults {
+  /**
+   * Optional Recipe @ref (github.com/owner/repo@tag). When omitted,
+   *  the spawn uses no recipe and falls back to systemPrompt.
+   */
+  recipeRef?: string
+  /**
+   * Recipe params (only used when recipeRef is set). Can include
+   *  template variables {{org_id}} / {{org_name}} which the spawn
+   *  endpoint substitutes from the actual organization.
+   */
+  recipeParams?: Record<string, string>
+  /**
+   * Free-text system prompt — used when there's no recipe, or as
+   *  the user_addendum on top of a recipe's intent.
+   */
+  systemPrompt?: string
+}
+
+export function getRoleDefaults(role: string): RoleDefaults {
+  switch (role) {
+    case 'ceo':
+      return {
+        recipeRef: 'github.com/openape-ai/openape/examples/agent-recipes/ceo@main',
+        recipeParams: { org_id: '{{org_id}}', org_name: '{{org_name}}' },
+      }
+
+    // Sanierer recipe not yet authored (plan 01KSYCHBQ7WNE5GS338PH89DFM M3).
+    // Until then, spawn with a role-defining system prompt.
+    case 'sanierer':
+      return {
+        systemPrompt: `Du bist der Sanierer für {{org_name}} (org_id={{org_id}}).
+Deine einzige Aufgabe: das Budget und Output/Cost-Ratio dieser Organisation überwachen und dem Owner direkt berichten — nie über den CEO. Lies LiteLLM-Kostenlogs + org.openape.ai/api/orgs/{{org_id}}/cost-snapshots. Bei Schwellenüberschreitung sofort den Owner alarmieren.`,
+      }
+
+    case 'teamlead':
+      return {
+        systemPrompt: `Du bist Teamlead in {{org_name}} (org_id={{org_id}}).
+Deine Aufgabe: Decomposition + Delegation + Status. KEINE technischen Design-Entscheidungen — die gehören dem Implementer. Lies vom CEO zugewiesene Objectives, brich sie in Stories runter, weise sie an Specialists zu, reporte Status zurück an den CEO.`,
+      }
+
+    case 'specialist':
+      return {
+        systemPrompt: `Du bist Specialist in {{org_name}} (org_id={{org_id}}).
+Deine Aufgabe: Stories ausführen die dir der Teamlead zuweist. Lies bei jeder Story zuerst die CONTRIBUTING.md des betroffenen Repos. Mach kleine, fokussierte Edits + verifizier. Eskalier an den Teamlead wenn unklar.`,
+      }
+
+    default:
+      return {}
+  }
+}
+
+/**
+ * Substitute {{org_id}} / {{org_name}} placeholders in a defaults
+ *  object so the same RoleDefaults shape is usable for any org.
+ */
+export function instantiateRoleDefaults(
+  defaults: RoleDefaults,
+  ctx: { org_id: string, org_name: string },
+): RoleDefaults {
+  function sub(s?: string) {
+    if (!s) return s
+    return s.replace(/\{\{org_id\}\}/g, ctx.org_id).replace(/\{\{org_name\}\}/g, ctx.org_name)
+  }
+  return {
+    recipeRef: defaults.recipeRef,
+    recipeParams: defaults.recipeParams
+      ? Object.fromEntries(Object.entries(defaults.recipeParams).map(([k, v]) => [k, sub(v)!]))
+      : undefined,
+    systemPrompt: sub(defaults.systemPrompt),
+  }
+}

--- a/packages/apes/turbo.json
+++ b/packages/apes/turbo.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://turborepo.com/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"],
+      "cache": false
+    }
+  }
+}


### PR DESCRIPTION
Same fix pattern as pm2-supervisor. In the container nest there's no escapes runtime to back 'apes run --as'; switch to plain 'sudo -n -H -u <agent>' when BYPASS env is set. macOS nest behaviour unchanged.