### PR TITLE
fix(nest): pin container hostname so troop host_id stays stable

### DIFF
--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -57,6 +57,14 @@ services:
       dockerfile: apps/openape-nest/Dockerfile
     image: openape-nest:dev
     container_name: openape-nest
+    # Stable hostname across `docker compose up` recreates — otherwise
+    # the container's random short-id (`df560db1f58f`) becomes the
+    # `host_id` reported to troop, and the FIRST sync after every
+    # container recreate fails with 401 host_id mismatch (the agent's
+    # keypair "moved" to a new host as far as troop knows). Pinning
+    # the hostname makes the nest reuse the same host_id forever and
+    # troop's pin stays stable.
+    hostname: openape-nest
     restart: unless-stopped
     depends_on:
       - openape-llm


### PR DESCRIPTION
## Summary

Pins `hostname: openape-nest` in the compose service. Without it,
Docker assigns the container's short id as the kernel hostname
(e.g. `df560db1f58f`), which is what the nest's host-fingerprint
hashes into the `host_id` it reports to troop.

Every `docker compose up --build` (or recreate) generated a new
short id → new `host_id` → troop's pin saw "the agent keypair moved
to a different host" and 401'd the **first sync after every
recreate** until `host_id` was cleared on troop manually (or until
the second sync, after the host_id had drifted).

This was one of the seven causes chased down during the M4 nest-sync
debug chain. Pinning the name is the smallest fix that makes
recreates idempotent for troop.

The longer-term direction (Patrick's note from that session) is to
not pin agent identity to host at all — agents should have stable
identity independent of where they run. That work is deferred; this
just stops bleeding.

## Test plan

- [ ] `docker compose -f compose/docker-compose.yml down && docker compose -f compose/docker-compose.yml up -d`
- [ ] `docker exec openape-nest hostname` returns `openape-nest`
- [ ] `docker logs openape-nest` shows agent sync succeeding on the
      first attempt (no 401 host_id mismatch)
- [ ] Recreating the container again (`docker compose up -d --force-recreate openape-nest`) — first sync after still succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)