### PR TITLE
feat(troop): M4δ-1 — nests table, owner-scoped host_ids, nest:* scopes

### DIFF
--- a/apps/openape-troop/server/api/nests/[host_id].delete.ts
+++ b/apps/openape-troop/server/api/nests/[host_id].delete.ts
@@ -1,0 +1,34 @@
+import { and, eq } from 'drizzle-orm'
+import { useDb } from '../../database/drizzle'
+import { nests } from '../../database/schema'
+import { requireOwnerWithScope } from '../../utils/auth'
+
+// DELETE /api/nests/:host_id — revoke a device binding (M4δ).
+//
+// Soft-revoke: flips status to 'revoked' rather than deleting the row,
+// so the binding stays auditable and an in-flight token referencing the
+// host_id resolves to a revoked row (→ 403 at the bind-grant check in
+// M4δ-3) instead of a missing one. Gated by `nest:bind` — revoking a
+// binding is the same authority as creating one.
+export default defineEventHandler(async (event) => {
+  const { owner } = await requireOwnerWithScope(event, 'nest:bind')
+  const hostId = getRouterParam(event, 'host_id')
+  if (!hostId) {
+    throw createError({ statusCode: 400, statusMessage: 'host_id required' })
+  }
+
+  const db = useDb()
+  const updated = await db
+    .update(nests)
+    .set({ status: 'revoked' })
+    .where(and(
+      eq(nests.ownerEmail, owner.toLowerCase()),
+      eq(nests.hostId, hostId),
+    ))
+    .returning({ hostId: nests.hostId })
+
+  if (!updated[0]) {
+    throw createError({ statusCode: 404, statusMessage: 'nest not found' })
+  }
+  return { host_id: updated[0].hostId, status: 'revoked' }
+})

--- a/apps/openape-troop/server/api/nests/bind.post.ts
+++ b/apps/openape-troop/server/api/nests/bind.post.ts
@@ -1,0 +1,74 @@
+import { and, eq } from 'drizzle-orm'
+import { useDb } from '../../database/drizzle'
+import { nests } from '../../database/schema'
+import { requireOwnerWithScope } from '../../utils/auth'
+import { pickUniqueHostId, slugifyHostId } from '../../utils/nest-slug'
+
+// POST /api/nests/bind  { display_name, pod_uuid? }
+//
+// Binds a device (pod) to the Owner (M4δ). Gated by the `nest:bind`
+// scope — reached either via the Owner's own session/CLI token, or via
+// the standing delegation grant the Owner approved on the M4γ consent
+// page when authorizing the pod.
+//
+// troop is the canonical issuer of host_id, and it's owner-scoped: we
+// slugify display_name and de-duplicate *within the owner* (mbp-home,
+// mbp-home-2, …). Two different Owners can each hold `mbp-home`.
+//
+// Idempotency: if pod_uuid is supplied and an active nest with that
+// pod_uuid already exists for this Owner, we return its existing host_id
+// instead of minting a second binding. This makes a pod's bind call
+// safe to retry (e.g. after a container recreate that reuses the same
+// pod_uuid) without spawning duplicate rows.
+
+export default defineEventHandler(async (event) => {
+  const { owner } = await requireOwnerWithScope(event, 'nest:bind')
+  const ownerEmail = owner.toLowerCase()
+
+  const body = await readBody<{ display_name?: unknown, pod_uuid?: unknown }>(event)
+  const displayName = String(body?.display_name ?? '').trim()
+  if (!displayName) {
+    throw createError({ statusCode: 400, statusMessage: 'display_name required' })
+  }
+  const podUuid = body?.pod_uuid == null ? null : String(body.pod_uuid).trim() || null
+
+  const db = useDb()
+
+  // Re-bind idempotency: same Owner + same pod_uuid + still active → reuse.
+  if (podUuid) {
+    const existing = await db
+      .select({ hostId: nests.hostId, displayName: nests.displayName })
+      .from(nests)
+      .where(and(
+        eq(nests.ownerEmail, ownerEmail),
+        eq(nests.podUuid, podUuid),
+        eq(nests.status, 'active'),
+      ))
+      .limit(1)
+    if (existing[0]) {
+      return { host_id: existing[0].hostId, display_name: existing[0].displayName, reused: true }
+    }
+  }
+
+  // Mint an owner-unique host_id from the display name.
+  const taken = new Set(
+    (await db
+      .select({ hostId: nests.hostId })
+      .from(nests)
+      .where(eq(nests.ownerEmail, ownerEmail)))
+      .map(r => r.hostId),
+  )
+  const hostId = pickUniqueHostId(slugifyHostId(displayName), taken)
+
+  await db.insert(nests).values({
+    ownerEmail,
+    hostId,
+    displayName,
+    podUuid,
+    status: 'active',
+    createdAt: Date.now(),
+  })
+
+  setResponseStatus(event, 201)
+  return { host_id: hostId, display_name: displayName, reused: false }
+})

--- a/apps/openape-troop/server/api/nests/index.get.ts
+++ b/apps/openape-troop/server/api/nests/index.get.ts
@@ -1,0 +1,37 @@
+import { and, desc, eq } from 'drizzle-orm'
+import { useDb } from '../../database/drizzle'
+import { nests } from '../../database/schema'
+import { requireOwnerWithScope } from '../../utils/auth'
+
+// GET /api/nests — list the Owner's bound devices (M4δ). Gated by
+// `nest:report-status` (a bound device reading its own siblings) — the
+// first-party Owner session/CLI token auto-passes the scope check.
+//
+// Revoked rows are included so the UI can show binding history; the
+// caller filters on `status` if it only wants live devices.
+export default defineEventHandler(async (event) => {
+  const { owner } = await requireOwnerWithScope(event, 'nest:report-status')
+  const db = useDb()
+
+  const rows = await db
+    .select({
+      hostId: nests.hostId,
+      displayName: nests.displayName,
+      podUuid: nests.podUuid,
+      status: nests.status,
+      createdAt: nests.createdAt,
+      lastSeenAt: nests.lastSeenAt,
+    })
+    .from(nests)
+    .where(and(eq(nests.ownerEmail, owner.toLowerCase())))
+    .orderBy(desc(nests.createdAt))
+
+  return rows.map(r => ({
+    host_id: r.hostId,
+    display_name: r.displayName,
+    pod_uuid: r.podUuid,
+    status: r.status,
+    created_at: r.createdAt,
+    last_seen_at: r.lastSeenAt,
+  }))
+})

--- a/apps/openape-troop/server/database/schema.ts
+++ b/apps/openape-troop/server/database/schema.ts
@@ -189,6 +189,38 @@ export const chatMessages = sqliteTable('chat_messages', {
   index('idx_chat_messages_chat_created').on(table.chatId, table.createdAt),
 ])
 
+// nests — one row per device (pod) bound to an Owner (M4δ).
+//
+// The architectural shift from agents: a nest is no longer a DDISA
+// *agent* with its own keypair + IdP enrollment. It's a *device* the
+// Owner authorizes via a standing delegation grant (M4γ consent). troop
+// is the canonical issuer of `hostId`, and that id is only unique
+// *within an owner* — the natural key is (ownerEmail, hostId), so two
+// different Owners can each have a `mbp-home` without colliding.
+//
+// `podUuid` is the container/pod's self-reported UUID at bind time —
+// purely informational (helps the Owner tell two pods apart in the UI
+// and debug a recreate). `status` is 'active' until the Owner revokes
+// (DELETE /api/nests/:host_id), which flips it to 'revoked' rather than
+// hard-deleting so the binding history stays auditable and an in-flight
+// token referencing the host_id resolves to a revoked row, not a
+// missing one.
+export const nests = sqliteTable('nests', {
+  ownerEmail: text('owner_email').notNull(),
+  hostId: text('host_id').notNull(),
+  displayName: text('display_name').notNull(),
+  podUuid: text('pod_uuid'),
+  status: text('status', { enum: ['active', 'revoked'] }).notNull().default('active'),
+  createdAt: integer('created_at').notNull(),
+  lastSeenAt: integer('last_seen_at'),
+}, table => [
+  primaryKey({ columns: [table.ownerEmail, table.hostId] }),
+  index('idx_nests_owner').on(table.ownerEmail),
+])
+
+export type Nest = typeof nests.$inferSelect
+export type NewNest = typeof nests.$inferInsert
+
 export type Chat = typeof chats.$inferSelect
 export type NewChat = typeof chats.$inferInsert
 export type ChatMessage = typeof chatMessages.$inferSelect

--- a/apps/openape-troop/server/plugins/02.database.ts
+++ b/apps/openape-troop/server/plugins/02.database.ts
@@ -157,6 +157,21 @@ export default defineNitroPlugin(async () => {
     )`)
     await db.run(sql`CREATE INDEX IF NOT EXISTS idx_chat_messages_chat_created
       ON chat_messages (chat_id, created_at)`)
+
+    // nests — devices (pods) bound to an Owner (M4δ). host_id is
+    // owner-scoped, so the PK is (owner_email, host_id). status flips
+    // to 'revoked' on DELETE rather than hard-deleting.
+    await db.run(sql`CREATE TABLE IF NOT EXISTS nests (
+      owner_email TEXT NOT NULL,
+      host_id TEXT NOT NULL,
+      display_name TEXT NOT NULL,
+      pod_uuid TEXT,
+      status TEXT NOT NULL DEFAULT 'active',
+      created_at INTEGER NOT NULL,
+      last_seen_at INTEGER,
+      PRIMARY KEY (owner_email, host_id)
+    )`)
+    await db.run(sql`CREATE INDEX IF NOT EXISTS idx_nests_owner ON nests(owner_email)`)
   }
   catch (err) {
     console.error('[troop/database] table init failed:', err)

--- a/apps/openape-troop/server/utils/nest-slug.ts
+++ b/apps/openape-troop/server/utils/nest-slug.ts
@@ -1,0 +1,23 @@
+// Owner-scoped host_id minting for bound devices (M4δ).
+//
+// troop is the canonical issuer of host_ids. The id is derived from the
+// device's display name and de-duplicated *within the owner* — so two
+// different Owners can each have a `mbp-home`, and one Owner binding two
+// machines both called "MacBook" gets `macbook` and `macbook-2`.
+
+export function slugifyHostId(input: string): string {
+  const s = input
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 48)
+  return s || 'pod'
+}
+
+/** Pick the first of base, base-2, base-3, … not already in `taken`. */
+export function pickUniqueHostId(base: string, taken: Set<string>): string {
+  let hostId = base
+  for (let n = 2; taken.has(hostId); n++) hostId = `${base}-${n}`
+  return hostId
+}

--- a/apps/openape-troop/server/utils/scope-catalog.ts
+++ b/apps/openape-troop/server/utils/scope-catalog.ts
@@ -42,6 +42,21 @@ export const TROOP_SCOPES: TroopScope[] = [
     description: 'Read the user\'s agent list, agent details, and live nest-status on this troop.',
     grants: ['GET /api/agents', 'GET /api/agents/:name', 'GET /api/nest/hosts'],
   },
+  {
+    id: 'nest:bind',
+    description: 'Bind a new device (pod) to your account on this troop. This lets the device run agents on your behalf without its own identity — you can revoke the binding any time, instantly cutting the device off.',
+    grants: ['POST /api/nests/bind'],
+  },
+  {
+    id: 'nest:spawn-agent',
+    description: 'Let a bound device spawn agents under your account. The device can only create agents — it cannot destroy them or read your other devices.',
+    grants: ['POST /api/agents/spawn-intent'],
+  },
+  {
+    id: 'nest:report-status',
+    description: 'Let a bound device report its status (online/offline, version) and read the list of your devices.',
+    grants: ['GET /api/nests', 'GET /api/nest/hosts'],
+  },
 ]
 
 const KNOWN_IDS = new Set(TROOP_SCOPES.map(s => s.id))

--- a/apps/openape-troop/tests/nest-slug.test.ts
+++ b/apps/openape-troop/tests/nest-slug.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { pickUniqueHostId, slugifyHostId } from '../server/utils/nest-slug'
+
+describe('nest host_id minting (M4δ)', () => {
+  it('slugifies a display name to a url-safe host_id', () => {
+    expect(slugifyHostId('MacBook Pro (home)')).toBe('macbook-pro-home')
+    expect(slugifyHostId('mbp-home')).toBe('mbp-home')
+    expect(slugifyHostId('  Patrick’s Mac mini  ')).toBe('patrick-s-mac-mini')
+  })
+
+  it('falls back to "pod" when nothing slugifiable remains', () => {
+    expect(slugifyHostId('!!!')).toBe('pod')
+    expect(slugifyHostId('')).toBe('pod')
+  })
+
+  it('caps length at 48 chars', () => {
+    expect(slugifyHostId('a'.repeat(100)).length).toBe(48)
+  })
+
+  it('picks base when unused', () => {
+    expect(pickUniqueHostId('macbook', new Set())).toBe('macbook')
+    expect(pickUniqueHostId('macbook', new Set(['laptop']))).toBe('macbook')
+  })
+
+  it('appends an incrementing suffix on collision', () => {
+    expect(pickUniqueHostId('macbook', new Set(['macbook']))).toBe('macbook-2')
+    expect(pickUniqueHostId('macbook', new Set(['macbook', 'macbook-2']))).toBe('macbook-3')
+  })
+})

--- a/apps/openape-troop/tests/scope-catalog.test.ts
+++ b/apps/openape-troop/tests/scope-catalog.test.ts
@@ -9,10 +9,17 @@ describe('troop scope catalog', () => {
     expect(ids).toContain('troop:read-agents')
   })
 
+  it('publishes the nest:* device-binding trio (M4δ)', () => {
+    const ids = TROOP_SCOPES.map(s => s.id)
+    expect(ids).toContain('nest:bind')
+    expect(ids).toContain('nest:spawn-agent')
+    expect(ids).toContain('nest:report-status')
+  })
+
   it('every entry has the spec-required shape (sp-data-access §3.2)', () => {
     for (const s of TROOP_SCOPES) {
       expect(typeof s.id).toBe('string')
-      expect(s.id).toMatch(/^troop:[a-z-]+$/)
+      expect(s.id).toMatch(/^(?:troop|nest):[a-z-]+$/)
       expect(typeof s.description).toBe('string')
       expect(s.description.length).toBeGreaterThan(10)
       expect(Array.isArray(s.grants)).toBe(true)


### PR DESCRIPTION
## Summary
First additive, non-breaking milestone of **M4δ — Nest as Device** ([plan](https://plans.openape.ai)). troop becomes the canonical issuer of owner-scoped `host_id`s and publishes the `nest:*` scope catalog the M4γ consent page will request.

- **`nests` table** (PK `(owner_email, host_id)`) — a nest is a *device* bound to an Owner, not a DDISA agent. Boot-time `CREATE TABLE IF NOT EXISTS` in `02.database.ts` + drizzle schema.
- **Scopes**: `nest:bind`, `nest:spawn-agent`, `nest:report-status` added to `TROOP_SCOPES` (discoverable at `/.well-known/openape.json#scopes`).
- **`POST /api/nests/bind`** (gate `nest:bind`): mints an owner-unique slug `host_id` from `display_name`; re-bind idempotency via `pod_uuid`.
- **`GET /api/nests`** (gate `nest:report-status`), **`DELETE /api/nests/:host_id`** soft-revoke (gate `nest:bind`).
- Slug minting extracted to `nest-slug` util + unit tests.

Existing keypair nests are untouched — this milestone adds capability without changing any current behavior.

## Test plan
- [x] `pnpm --filter @openape/troop test` — 138 pass (incl. new `nest-slug` + updated `scope-catalog`)
- [x] `pnpm --filter @openape/troop lint` clean
- [x] `pnpm --filter @openape/troop typecheck` clean
- [ ] Post-deploy: `curl -s https://troop.openape.ai/.well-known/openape.json | jq '.scopes[].id'` includes the three `nest:*` ids
- [ ] With owner Bearer: `POST /api/nests/bind {display_name:"mbp-home",pod_uuid:"x"}` returns a host_id; `GET /api/nests` lists it