### PR TITLE
feat(ape-troop): M4δ-2 — owner CLI for nests + agents (apes SSO)

### DIFF
--- a/packages/ape-troop/package.json
+++ b/packages/ape-troop/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@openape/ape-troop",
+  "version": "0.1.0",
+  "turbo": {
+    "tags": [
+      "publishable"
+    ]
+  },
+  "description": "Owner CLI for troop.openape.ai — manage bound devices (nests) and agents. Authenticates via `apes login` SSO.",
+  "type": "module",
+  "bin": {
+    "ape-troop": "./dist/cli.js"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@openape/cli-auth": "workspace:*",
+    "citty": "^0.2.2",
+    "consola": "^3.4.2"
+  },
+  "devDependencies": {
+    "@types/node": "^25.3.5",
+    "tsup": "^8.5.1",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.7"
+  },
+  "license": "MIT",
+  "author": "Patrick Hofmann <phofmann@delta-mind.at>",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/openape-ai/openape.git",
+    "directory": "packages/ape-troop"
+  }
+}

--- a/packages/ape-troop/src/cli.ts
+++ b/packages/ape-troop/src/cli.ts
@@ -1,0 +1,38 @@
+import { defineCommand, runMain } from 'citty'
+import consola from 'consola'
+import { agentsCommand } from './commands/agents'
+import { loginCommand, logoutCommand, whoamiCommand } from './commands/auth'
+import { nestsCommand } from './commands/nests'
+import { CliError } from './errors'
+
+// Gracefully handle EPIPE when stdout is closed early (e.g. piped to `head`).
+process.stdout.on('error', (err: NodeJS.ErrnoException) => {
+  if (err.code === 'EPIPE') process.exit(0)
+  throw err
+})
+
+declare const __VERSION__: string
+
+const main = defineCommand({
+  meta: {
+    name: 'ape-troop',
+    version: __VERSION__,
+    description: 'Owner CLI for troop.openape.ai — manage bound devices (nests) and agents. Authenticates via `apes login` SSO.',
+  },
+  subCommands: {
+    nests: nestsCommand,
+    agents: agentsCommand,
+    whoami: whoamiCommand,
+    login: loginCommand,
+    logout: logoutCommand,
+  },
+})
+
+runMain(main).catch((err: unknown) => {
+  if (err instanceof CliError) {
+    consola.error(err.message)
+    process.exit(err.exitCode)
+  }
+  consola.error(err instanceof Error ? err.message : String(err))
+  process.exit(1)
+})

--- a/packages/ape-troop/src/commands/agents.ts
+++ b/packages/ape-troop/src/commands/agents.ts
@@ -1,0 +1,137 @@
+import { defineCommand } from 'citty'
+import consola from 'consola'
+import { CliError } from '../errors'
+import { TroopApi } from '../troop-api'
+
+const POLL_INTERVAL_MS = 2000
+const POLL_TIMEOUT_MS = 180_000
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+const listCommand = defineCommand({
+  meta: { name: 'list', description: 'List agents owned by the current user on this troop' },
+  args: {
+    json: { type: 'boolean', description: 'Output as JSON' },
+  },
+  async run({ args }) {
+    const api = new TroopApi()
+    const rows = await api.listAgents()
+    if (args.json) {
+      process.stdout.write(`${JSON.stringify(rows, null, 2)}\n`)
+      return
+    }
+    if (rows.length === 0) {
+      consola.info('No agents found.')
+      return
+    }
+    const nameW = Math.max(4, ...rows.map(r => r.agentName.length))
+    const emailW = Math.max(5, ...rows.map(r => r.email.length))
+    const header = `${'NAME'.padEnd(nameW)}  ${'EMAIL'.padEnd(emailW)}  TASKS  LAST-RUN`
+    console.log(header)
+    console.log('-'.repeat(header.length))
+    for (const r of rows) {
+      console.log(`${r.agentName.padEnd(nameW)}  ${r.email.padEnd(emailW)}  ${String(r.taskCount).padEnd(5)}  ${r.lastRunStatus ?? '—'}`)
+    }
+  },
+})
+
+const spawnCommand = defineCommand({
+  meta: { name: 'spawn', description: 'Spawn a new agent on a bound device (requires DDISA approval on your device)' },
+  args: {
+    'name': { type: 'positional', required: true, description: 'Agent short name, /^[a-z][a-z0-9-]{0,23}$/' },
+    'host-id': { type: 'string', description: 'Target device host_id (default: first connected nest)' },
+    'system-prompt': { type: 'string', description: 'Persona / behaviour rules for the agent' },
+    'wait': { type: 'boolean', description: 'Poll until the spawn completes or fails' },
+    'json': { type: 'boolean', description: 'Output as JSON' },
+  },
+  async run({ args }) {
+    const api = new TroopApi()
+    const intent = await api.spawnAgent({
+      name: String(args.name),
+      hostId: args['host-id'] ? String(args['host-id']) : undefined,
+      systemPrompt: args['system-prompt'] ? String(args['system-prompt']) : undefined,
+    })
+
+    if (!args.wait) {
+      if (args.json) {
+        process.stdout.write(`${JSON.stringify(intent, null, 2)}\n`)
+        return
+      }
+      consola.info(`Spawn requested on ${intent.hostname} (${intent.host_id}). Approve on your device. intent_id=${intent.intent_id}`)
+      consola.info('Run with --wait to block until it completes.')
+      return
+    }
+
+    consola.start(`Waiting for spawn approval on ${intent.hostname}…`)
+    const deadline = Date.now() + POLL_TIMEOUT_MS
+    while (Date.now() < deadline) {
+      const poll = await api.pollSpawn(intent.intent_id)
+      if (!poll.pending) {
+        if (poll.ok) {
+          if (args.json) {
+            process.stdout.write(`${JSON.stringify(poll, null, 2)}\n`)
+            return
+          }
+          consola.success(`Spawned ${poll.agent_email}`)
+          return
+        }
+        throw new CliError(`Spawn failed: ${poll.error ?? 'unknown error'}`)
+      }
+      await sleep(POLL_INTERVAL_MS)
+    }
+    throw new CliError(`Timed out after ${POLL_TIMEOUT_MS / 1000}s waiting for spawn. intent_id=${intent.intent_id}`)
+  },
+})
+
+const destroyCommand = defineCommand({
+  meta: { name: 'destroy', description: 'Destroy an agent on the device where it lives (requires DDISA approval)' },
+  args: {
+    'name': { type: 'positional', required: true, description: 'Agent short name' },
+    'host-id': { type: 'string', description: 'Target device host_id (default: first connected nest)' },
+    'wait': { type: 'boolean', description: 'Poll until the destroy completes or fails' },
+    'json': { type: 'boolean', description: 'Output as JSON' },
+  },
+  async run({ args }) {
+    const api = new TroopApi()
+    const intent = await api.destroyAgent({
+      name: String(args.name),
+      hostId: args['host-id'] ? String(args['host-id']) : undefined,
+    })
+
+    if (!args.wait) {
+      if (args.json) {
+        process.stdout.write(`${JSON.stringify(intent, null, 2)}\n`)
+        return
+      }
+      consola.info(`Destroy requested on ${intent.hostname} (${intent.host_id}). Approve on your device. intent_id=${intent.intent_id}`)
+      consola.info('Run with --wait to block until it completes.')
+      return
+    }
+
+    consola.start(`Waiting for destroy approval on ${intent.hostname}…`)
+    const deadline = Date.now() + POLL_TIMEOUT_MS
+    while (Date.now() < deadline) {
+      const poll = await api.pollDestroy(intent.intent_id)
+      if (!poll.pending) {
+        if (poll.ok) {
+          consola.success(`Destroyed ${args.name}`)
+          return
+        }
+        throw new CliError(`Destroy failed: ${poll.error ?? 'unknown error'}`)
+      }
+      await sleep(POLL_INTERVAL_MS)
+    }
+    throw new CliError(`Timed out after ${POLL_TIMEOUT_MS / 1000}s waiting for destroy. intent_id=${intent.intent_id}`)
+  },
+})
+
+export const agentsCommand = defineCommand({
+  meta: { name: 'agents', description: 'Manage agents on this troop (list, spawn, destroy)' },
+  subCommands: {
+    list: listCommand,
+    spawn: spawnCommand,
+    destroy: destroyCommand,
+  },
+})

--- a/packages/ape-troop/src/commands/auth.ts
+++ b/packages/ape-troop/src/commands/auth.ts
@@ -1,0 +1,42 @@
+import { clearSpToken, loadIdpAuth } from '@openape/cli-auth'
+import { defineCommand } from 'citty'
+import consola from 'consola'
+import { CliError } from '../errors'
+import { resolveTroopUrl } from '../troop-api'
+
+// ape-troop does NOT own a login. Identity is the shared OpenApe SSO
+// session created once per device by `apes login`; every OpenApe CLI
+// reads it via @openape/cli-auth. These stubs mirror the
+// ape-plans / ape-tasks convention so `ape-troop login` gives a helpful
+// pointer instead of a "command not found".
+
+export const loginCommand = defineCommand({
+  meta: { name: 'login', description: '(stub) use `apes login <email>` — all OpenApe CLIs share one session' },
+  run() {
+    throw new CliError('ape-troop has no separate login. Run `apes login <email>` once on this device; ape-troop reuses that session via SSO.')
+  },
+})
+
+export const logoutCommand = defineCommand({
+  meta: { name: 'logout', description: 'Clear ape-troop\'s cached troop SP-token (does not touch the IdP session)' },
+  run() {
+    const aud = new URL(resolveTroopUrl()).host
+    clearSpToken(aud)
+    consola.success(`Cleared cached troop token for ${aud}. The shared IdP session is untouched — run \`apes logout\` to end it.`)
+  },
+})
+
+export const whoamiCommand = defineCommand({
+  meta: { name: 'whoami', description: 'Show the current OpenApe identity (from the shared apes session)' },
+  run() {
+    const auth = loadIdpAuth()
+    if (!auth) {
+      throw new CliError('Not logged in. Run `apes login <email>` first.')
+    }
+    const expiresAt = new Date(auth.expires_at * 1000).toISOString()
+    const isExpired = Date.now() / 1000 > auth.expires_at
+    console.log(`Email: ${auth.email}`)
+    console.log(`IdP:   ${auth.idp}`)
+    console.log(`Token: ${isExpired ? '⚠ expired (auto-refreshes on next call)' : 'valid'} (until ${expiresAt})`)
+  },
+})

--- a/packages/ape-troop/src/commands/nests.ts
+++ b/packages/ape-troop/src/commands/nests.ts
@@ -1,0 +1,89 @@
+import { defineCommand } from 'citty'
+import consola from 'consola'
+import { TroopApi } from '../troop-api'
+
+function fmtTime(secOrMs: number | null): string {
+  if (!secOrMs) return 'never'
+  // troop stores epoch-ms; tolerate seconds just in case.
+  const ms = secOrMs < 1e12 ? secOrMs * 1000 : secOrMs
+  return new Date(ms).toISOString().replace('T', ' ').slice(0, 16)
+}
+
+const bindCommand = defineCommand({
+  meta: { name: 'bind', description: 'Bind a device (pod) to your account and mint its host_id' },
+  args: {
+    'display-name': { type: 'positional', required: true, description: 'Human-readable name for the device, e.g. "mbp-home"' },
+    'pod-uuid': { type: 'string', description: 'Optional pod/container UUID — re-binding with the same uuid is idempotent' },
+    'json': { type: 'boolean', description: 'Output as JSON' },
+  },
+  async run({ args }) {
+    const api = new TroopApi()
+    const res = await api.bindNest(String(args['display-name']), args['pod-uuid'] ? String(args['pod-uuid']) : undefined)
+    if (args.json) {
+      process.stdout.write(`${JSON.stringify(res, null, 2)}\n`)
+      return
+    }
+    if (res.reused) {
+      consola.info(`Device already bound — reusing host_id ${res.host_id}`)
+    }
+    else {
+      consola.success(`Bound "${res.display_name}" → host_id ${res.host_id}`)
+    }
+  },
+})
+
+const listCommand = defineCommand({
+  meta: { name: 'list', description: 'List devices bound to your account' },
+  args: {
+    all: { type: 'boolean', description: 'Include revoked devices (default shows active only)' },
+    json: { type: 'boolean', description: 'Output as JSON' },
+  },
+  async run({ args }) {
+    const api = new TroopApi()
+    const all = await api.listNests()
+    const rows = args.all ? all : all.filter(n => n.status === 'active')
+
+    if (args.json) {
+      process.stdout.write(`${JSON.stringify(rows, null, 2)}\n`)
+      return
+    }
+    if (rows.length === 0) {
+      consola.info(args.all ? 'No devices bound.' : 'No active devices. Use --all to show revoked.')
+      return
+    }
+    const hostW = Math.max(7, ...rows.map(r => r.host_id.length))
+    const nameW = Math.max(4, ...rows.map(r => r.display_name.length))
+    const header = `${'HOST_ID'.padEnd(hostW)}  ${'NAME'.padEnd(nameW)}  STATUS   LAST-SEEN`
+    console.log(header)
+    console.log('-'.repeat(header.length))
+    for (const r of rows) {
+      console.log(`${r.host_id.padEnd(hostW)}  ${r.display_name.padEnd(nameW)}  ${r.status.padEnd(7)}  ${fmtTime(r.last_seen_at)}`)
+    }
+  },
+})
+
+const removeCommand = defineCommand({
+  meta: { name: 'remove', description: 'Revoke a device binding (soft — keeps history, instantly cuts the device off)' },
+  args: {
+    host_id: { type: 'positional', required: true, description: 'host_id of the device to revoke' },
+    json: { type: 'boolean', description: 'Output as JSON' },
+  },
+  async run({ args }) {
+    const api = new TroopApi()
+    const res = await api.removeNest(String(args.host_id))
+    if (args.json) {
+      process.stdout.write(`${JSON.stringify(res, null, 2)}\n`)
+      return
+    }
+    consola.success(`Revoked device ${res.host_id}`)
+  },
+})
+
+export const nestsCommand = defineCommand({
+  meta: { name: 'nests', description: 'Manage devices (pods) bound to your account' },
+  subCommands: {
+    bind: bindCommand,
+    list: listCommand,
+    remove: removeCommand,
+  },
+})

--- a/packages/ape-troop/src/errors.ts
+++ b/packages/ape-troop/src/errors.ts
@@ -1,0 +1,6 @@
+export class CliError extends Error {
+  constructor(message: string, public exitCode: number = 1) {
+    super(message)
+    this.name = 'CliError'
+  }
+}

--- a/packages/ape-troop/src/troop-api.ts
+++ b/packages/ape-troop/src/troop-api.ts
@@ -1,0 +1,147 @@
+import { getAuthorizedBearer, NotLoggedInError } from '@openape/cli-auth'
+import { CliError } from './errors'
+
+// Thin owner-side client for troop.openape.ai. Every request carries an
+// SP-scoped Bearer minted from the shared `apes login` session via
+// @openape/cli-auth (RFC 8693 token-exchange, cached under
+// ~/.config/apes/sp-tokens/). No per-CLI login — `ape-troop login` is a
+// stub that points at `apes login` (see commands/auth.ts).
+//
+// First-party owner tokens are unbounded server-side, so we don't request
+// specific scopes here; troop's requireOwnerWithScope auto-passes them.
+
+const DEFAULT_TROOP_URL = 'https://troop.openape.ai'
+
+export function resolveTroopUrl(override?: string): string {
+  const raw = override || process.env.OPENAPE_TROOP_URL || DEFAULT_TROOP_URL
+  return raw.replace(/\/$/, '')
+}
+
+export interface NestRow {
+  host_id: string
+  display_name: string
+  pod_uuid: string | null
+  status: 'active' | 'revoked'
+  created_at: number
+  last_seen_at: number | null
+}
+
+export interface BindResult {
+  host_id: string
+  display_name: string
+  reused: boolean
+}
+
+export interface AgentRow {
+  email: string
+  agentName: string
+  hostId: string | null
+  hostname: string | null
+  lastSeenAt: number | null
+  createdAt: number
+  taskCount: number
+  lastRunStatus: string | null
+  lastRunAt: number | null
+}
+
+export interface IntentResult {
+  intent_id: string
+  host_id: string
+  hostname: string
+}
+
+export interface SpawnPoll {
+  pending: boolean
+  ok?: boolean
+  agent_email?: string
+  error?: string
+}
+
+export interface DestroyPoll {
+  pending: boolean
+  ok?: boolean
+  error?: string
+}
+
+export class TroopApi {
+  readonly url: string
+  readonly aud: string
+
+  constructor(troopUrl?: string) {
+    this.url = resolveTroopUrl(troopUrl)
+    this.aud = new URL(this.url).host
+  }
+
+  private async request<T>(path: string, init?: RequestInit): Promise<T> {
+    let bearer: string
+    try {
+      bearer = await getAuthorizedBearer({ endpoint: this.url, aud: this.aud })
+    }
+    catch (err) {
+      if (err instanceof NotLoggedInError) {
+        throw new CliError('Not authenticated. Run `apes login <email>` first.')
+      }
+      throw err
+    }
+
+    const res = await fetch(`${this.url}${path}`, {
+      ...init,
+      headers: {
+        'Authorization': bearer,
+        'Content-Type': 'application/json',
+        ...(init?.headers ?? {}),
+      },
+    })
+    if (!res.ok) {
+      const text = await res.text().catch(() => '')
+      throw new CliError(`troop ${init?.method ?? 'GET'} ${path} failed: ${res.status} ${text}`)
+    }
+    if (res.status === 204) return undefined as T
+    return await res.json() as T
+  }
+
+  listNests(): Promise<NestRow[]> {
+    return this.request('/api/nests')
+  }
+
+  bindNest(displayName: string, podUuid?: string): Promise<BindResult> {
+    return this.request('/api/nests/bind', {
+      method: 'POST',
+      body: JSON.stringify({ display_name: displayName, ...(podUuid ? { pod_uuid: podUuid } : {}) }),
+    })
+  }
+
+  removeNest(hostId: string): Promise<{ host_id: string, status: string }> {
+    return this.request(`/api/nests/${encodeURIComponent(hostId)}`, { method: 'DELETE' })
+  }
+
+  listAgents(): Promise<AgentRow[]> {
+    return this.request('/api/agents')
+  }
+
+  spawnAgent(input: { name: string, hostId?: string, systemPrompt?: string }): Promise<IntentResult> {
+    return this.request('/api/agents/spawn-intent', {
+      method: 'POST',
+      body: JSON.stringify({
+        name: input.name,
+        ...(input.hostId ? { host_id: input.hostId } : {}),
+        ...(input.systemPrompt ? { system_prompt: input.systemPrompt } : {}),
+      }),
+    })
+  }
+
+  pollSpawn(intentId: string): Promise<SpawnPoll> {
+    return this.request(`/api/agents/spawn-intent/${encodeURIComponent(intentId)}`)
+  }
+
+  destroyAgent(input: { name: string, hostId?: string }): Promise<IntentResult> {
+    return this.request('/api/agents/destroy-intent', {
+      method: 'POST',
+      body: JSON.stringify({ name: input.name, ...(input.hostId ? { host_id: input.hostId } : {}) }),
+    })
+  }
+
+  pollDestroy(intentId: string): Promise<DestroyPoll> {
+    return this.request(`/api/agents/destroy-intent/${encodeURIComponent(intentId)}`)
+  }
+}

--- a/packages/ape-troop/test/troop-api.test.ts
+++ b/packages/ape-troop/test/troop-api.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { resolveTroopUrl, TroopApi } from '../src/troop-api'
+
+const ORIGINAL = process.env.OPENAPE_TROOP_URL
+
+afterEach(() => {
+  if (ORIGINAL === undefined) delete process.env.OPENAPE_TROOP_URL
+  else process.env.OPENAPE_TROOP_URL = ORIGINAL
+})
+
+describe('resolveTroopUrl', () => {
+  it('defaults to the prod troop URL', () => {
+    delete process.env.OPENAPE_TROOP_URL
+    expect(resolveTroopUrl()).toBe('https://troop.openape.ai')
+  })
+
+  it('honors an explicit override and strips trailing slash', () => {
+    expect(resolveTroopUrl('https://staging.troop.example/')).toBe('https://staging.troop.example')
+  })
+
+  it('falls back to OPENAPE_TROOP_URL env', () => {
+    process.env.OPENAPE_TROOP_URL = 'http://127.0.0.1:9091/'
+    expect(resolveTroopUrl()).toBe('http://127.0.0.1:9091')
+  })
+
+  it('explicit override wins over env', () => {
+    process.env.OPENAPE_TROOP_URL = 'http://env-host:1234'
+    expect(resolveTroopUrl('https://explicit.example')).toBe('https://explicit.example')
+  })
+})
+
+describe('TroopApi', () => {
+  it('derives aud from the host', () => {
+    const api = new TroopApi('https://troop.openape.ai')
+    expect(api.aud).toBe('troop.openape.ai')
+    expect(api.url).toBe('https://troop.openape.ai')
+  })
+})

--- a/packages/ape-troop/tsconfig.json
+++ b/packages/ape-troop/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "declaration": false,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*", "test/**/*"]
+}

--- a/packages/ape-troop/tsup.config.ts
+++ b/packages/ape-troop/tsup.config.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs'
+import { defineConfig } from 'tsup'
+
+const { version } = JSON.parse(readFileSync('./package.json', 'utf-8'))
+
+export default defineConfig({
+  entry: ['src/cli.ts'],
+  format: ['esm'],
+  target: 'node20',
+  platform: 'node',
+  clean: true,
+  sourcemap: true,
+  // No library export — this package only ships a bin. Skipping DTS also
+  // sidesteps the parallel-build DTS race that packages/apes works around
+  // via turbo `cache:false`.
+  dts: false,
+  splitting: false,
+  define: {
+    __VERSION__: JSON.stringify(version),
+  },
+  banner: {
+    js: '#!/usr/bin/env node',
+  },
+})

--- a/packages/ape-troop/turbo.json
+++ b/packages/ape-troop/turbo.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://turborepo.com/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"],
+      "cache": false
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -757,6 +757,31 @@ importers:
         specifier: ^3.3.1
         version: 3.3.1(typescript@5.9.3)
 
+  packages/ape-troop:
+    dependencies:
+      '@openape/cli-auth':
+        specifier: workspace:*
+        version: link:../cli-auth
+      citty:
+        specifier: ^0.2.2
+        version: 0.2.2
+      consola:
+        specifier: ^3.4.2
+        version: 3.4.2
+    devDependencies:
+      '@types/node':
+        specifier: ^25.3.5
+        version: 25.8.0
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.2)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.7
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.8.0)(@vitest/coverage-istanbul@4.1.7)(happy-dom@18.0.1)(vite@8.0.14(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2)(yaml@2.9.0))
+
   packages/apes:
     dependencies:
       '@lydell/node-pty':


### PR DESCRIPTION
## Summary
Second additive milestone of **M4δ — Nest as Device**. New `@openape/ape-troop` CLI lets an Owner manage their bound devices and agents from the terminal, authenticating through the shared `apes login` session (no per-CLI login), mirroring the `ape-plans` / `ape-tasks` convention.

> Stacked on #528 (M4δ-1). Base is `feat/m4d-1-nests-table` so the diff shows only the CLI package.

Commands:
- `ape-troop nests bind|list|remove` → troop `/api/nests/*` (the M4δ-1 endpoints)
- `ape-troop agents list|spawn|destroy` → troop owner-side API; `spawn`/`destroy` fire an intent and, with `--wait`, poll until the on-device DDISA approval resolves
- `ape-troop whoami` reads the shared IdP session; `login` is a stub pointing at `apes login`; `logout` clears only the cached troop SP-token
- Auth via `@openape/cli-auth` `getAuthorizedBearer` (RFC 8693 token-exchange, cached under `~/.config/apes/sp-tokens/`)

## Test plan
- [x] `pnpm --filter @openape/ape-troop typecheck` clean
- [x] `pnpm --filter @openape/ape-troop lint` clean
- [x] `pnpm --filter @openape/ape-troop build` → `dist/cli.js`
- [x] `pnpm --filter @openape/ape-troop test` — 5 pass (`resolveTroopUrl` + `TroopApi` aud)
- [x] `node dist/cli.js --help` / `whoami` resolve the shared `apes` session
- [ ] Post-deploy (needs #528 live): after `apes login`, `ape-troop nests list --json` returns the bound row; `ape-troop agents list` matches the owner's agents