### PR TITLE
feat(troop): M4δ-3 — session-less device token mint via bind-grant

### DIFF
--- a/apps/openape-troop/server/api/nests/bind.post.ts
+++ b/apps/openape-troop/server/api/nests/bind.post.ts
@@ -2,6 +2,7 @@ import { and, eq } from 'drizzle-orm'
 import { useDb } from '../../database/drizzle'
 import { nests } from '../../database/schema'
 import { requireOwnerWithScope } from '../../utils/auth'
+import { generateDeviceSecret, hashDeviceSecret } from '../../utils/nest-credential'
 import { pickUniqueHostId, slugifyHostId } from '../../utils/nest-slug'
 
 // POST /api/nests/bind  { display_name, pod_uuid? }
@@ -60,6 +61,11 @@ export default defineEventHandler(async (event) => {
   )
   const hostId = pickUniqueHostId(slugifyHostId(displayName), taken)
 
+  // Mint the device secret. Plaintext is returned to the pod exactly once
+  // (below); troop only persists its SHA-256. The pod presents the plaintext
+  // to POST /api/nests/token on each reconnect to mint a nest:* troop token.
+  const deviceSecret = generateDeviceSecret()
+
   await db.insert(nests).values({
     ownerEmail,
     hostId,
@@ -67,8 +73,9 @@ export default defineEventHandler(async (event) => {
     podUuid,
     status: 'active',
     createdAt: Date.now(),
+    deviceSecretHash: hashDeviceSecret(deviceSecret),
   })
 
   setResponseStatus(event, 201)
-  return { host_id: hostId, display_name: displayName, reused: false }
+  return { host_id: hostId, display_name: displayName, device_secret: deviceSecret, reused: false }
 })

--- a/apps/openape-troop/server/api/nests/token.post.ts
+++ b/apps/openape-troop/server/api/nests/token.post.ts
@@ -1,0 +1,70 @@
+import { and, eq } from 'drizzle-orm'
+import { useDb } from '../../database/drizzle'
+import { nests } from '../../database/schema'
+import { signCliToken } from '../../utils/cli-token'
+import { hashDeviceSecret, NEST_DEVICE_SCOPES, NEST_TOKEN_TTL_SECONDS } from '../../utils/nest-credential'
+
+// POST /api/nests/token  { host_id, device_secret }
+//
+// Session-less device → troop-token mint (M4δ-3). This is the endpoint a
+// keypair-less pod hits on every reconnect. It is intentionally NOT
+// behind requireOwner*: the pod has no Owner session and no DDISA agent
+// identity. Its only credential is the device secret minted at bind time
+// (see bind.post.ts), which troop stores as a SHA-256.
+//
+// The "standing grant" is the troop-side nests row itself, not an IdP M4γ
+// grant — troop is the canonical issuer. Lookup is by the secret hash
+// (256-bit, collision-free) cross-checked against host_id; the row yields
+// the owner_email. A revoked nest (status != 'active') fails the lookup,
+// so an Owner's DELETE /api/nests/:host_id cuts the device off within one
+// token TTL.
+//
+// The minted token carries act='agent', the bounded NEST_DEVICE_SCOPES,
+// and delegate='nest:<host_id>' for provenance. requireOwnerWithScope on
+// the operational routes enforces the scope cap.
+
+export default defineEventHandler(async (event) => {
+  const body = await readBody<{ host_id?: unknown, device_secret?: unknown }>(event)
+  const hostId = String(body?.host_id ?? '').trim()
+  const deviceSecret = String(body?.device_secret ?? '')
+  if (!hostId || !deviceSecret) {
+    throw createError({ statusCode: 400, statusMessage: 'host_id and device_secret required' })
+  }
+
+  const db = useDb()
+  const rows = await db
+    .select({ ownerEmail: nests.ownerEmail, hostId: nests.hostId })
+    .from(nests)
+    .where(and(
+      eq(nests.hostId, hostId),
+      eq(nests.deviceSecretHash, hashDeviceSecret(deviceSecret)),
+      eq(nests.status, 'active'),
+    ))
+    .limit(1)
+
+  const nest = rows[0]
+  if (!nest) {
+    throw createError({ statusCode: 401, statusMessage: 'invalid host_id or device_secret, or nest revoked' })
+  }
+
+  await db
+    .update(nests)
+    .set({ lastSeenAt: Date.now() })
+    .where(and(eq(nests.ownerEmail, nest.ownerEmail), eq(nests.hostId, nest.hostId)))
+
+  const { token, expiresAt } = await signCliToken({
+    email: nest.ownerEmail,
+    act: 'agent',
+    scope: [...NEST_DEVICE_SCOPES],
+    delegate: `nest:${nest.hostId}`,
+    ttlSeconds: NEST_TOKEN_TTL_SECONDS,
+  })
+
+  return {
+    access_token: token,
+    token_type: 'Bearer',
+    expires_in: NEST_TOKEN_TTL_SECONDS,
+    expires_at: expiresAt,
+    scope: [...NEST_DEVICE_SCOPES],
+  }
+})

--- a/apps/openape-troop/server/database/schema.ts
+++ b/apps/openape-troop/server/database/schema.ts
@@ -213,6 +213,12 @@ export const nests = sqliteTable('nests', {
   status: text('status', { enum: ['active', 'revoked'] }).notNull().default('active'),
   createdAt: integer('created_at').notNull(),
   lastSeenAt: integer('last_seen_at'),
+  // SHA-256 (hex) of the device secret minted at bind time. The plaintext
+  // is shown to the pod exactly once in the bind response; troop only ever
+  // stores this hash. The pod presents the plaintext to POST /api/nests/token
+  // on every reconnect to mint a short-lived nest:* troop token. Revoking the
+  // nest (status='revoked') makes that exchange fail — one-click cut-off.
+  deviceSecretHash: text('device_secret_hash'),
 }, table => [
   primaryKey({ columns: [table.ownerEmail, table.hostId] }),
   index('idx_nests_owner').on(table.ownerEmail),

--- a/apps/openape-troop/server/plugins/02.database.ts
+++ b/apps/openape-troop/server/plugins/02.database.ts
@@ -169,9 +169,16 @@ export default defineNitroPlugin(async () => {
       status TEXT NOT NULL DEFAULT 'active',
       created_at INTEGER NOT NULL,
       last_seen_at INTEGER,
+      device_secret_hash TEXT,
       PRIMARY KEY (owner_email, host_id)
     )`)
     await db.run(sql`CREATE INDEX IF NOT EXISTS idx_nests_owner ON nests(owner_email)`)
+    // device_secret_hash was added after the initial nests CREATE; ALTER is
+    // idempotent-by-try (SQLite has no ADD COLUMN IF NOT EXISTS).
+    try {
+      await db.run(sql`ALTER TABLE nests ADD COLUMN device_secret_hash TEXT`)
+    }
+    catch { /* column already exists */ }
   }
   catch (err) {
     console.error('[troop/database] table init failed:', err)

--- a/apps/openape-troop/server/routes/api/nest-ws.ts
+++ b/apps/openape-troop/server/routes/api/nest-ws.ts
@@ -3,9 +3,11 @@ import { and, eq } from 'drizzle-orm'
 import { useRuntimeConfig } from 'nitropack/runtime'
 import toolCatalog from '../../tool-catalog.json'
 import { useDb } from '../../database/drizzle'
-import { agents, tasks } from '../../database/schema'
+import { agents, nests, tasks } from '../../database/schema'
 import { parseAgentEmail } from '../../utils/agent-email'
+import { verifyCliToken } from '../../utils/cli-token'
 import { resolveDestroyIntent } from '../../utils/destroy-intents'
+import { parseNestDeviceToken } from '../../utils/nest-credential'
 import { registerNestPeer, touchNestPeer, unregisterNestPeerById } from '../../utils/nest-registry'
 import { takeRecipeDeploy } from '../../utils/recipe-deploys'
 import { resolveSpawnIntent } from '../../utils/spawn-intents'
@@ -28,18 +30,22 @@ const ALL_TOOL_NAMES: string[] = (toolCatalog as { tools: Array<{ name: string }
 //   - destroy-intent { intent_id, name }     — `apes agents destroy --force`
 //   - reload-bridge { name }                 — pm2 reload, no fresh sync
 //
-// Auth model: same DDISA-JWT pattern as chat's WS — bearer signed
-// by id.openape.ai's JWKS. We accept two flavours of caller:
+// Auth model: three flavours of caller.
 //
-//   - `act: human` — owner-direct connection (UI/dev tooling).
+//   - **troop device token** (M4δ — the nest-as-device path). A
+//     troop-issued HS256 CLI token with act='agent' and
+//     delegate='nest:<host_id>'. The keypair-less pod mints it from its
+//     bind-time device secret at POST /api/nests/token. We verify it with
+//     troop's own secret (verifyCliToken), pull (ownerEmail, host_id) off
+//     the token, and require an *active* nests row — so revoking the nest
+//     (status='revoked') drops the connection at the next (re)connect. The
+//     host_id is token-authoritative; we ignore the self-reported one.
+//   - `act: human` — owner-direct connection (UI/dev tooling), IdP-signed.
 //     ownerEmail = JWT `sub`.
-//   - `act: agent` — the nest itself, signed with its own DDISA
-//     keypair (see `apes nest enroll`). The agent email encodes
-//     its owner (`<name>-<hash>+<owner-local>+<owner-domain>@id…`),
-//     so we resolve ownerEmail from parseAgentEmail. This is the
-//     normal daemon path — the nest reads its act:agent JWT from
-//     `~/.openape/nest/.config/apes/auth.json` and uses it as
-//     bearer here.
+//   - `act: agent` (IdP-signed) — the legacy keypair nest. The agent email
+//     encodes its owner (`<name>-<hash>+<owner-local>+<owner-domain>@id…`),
+//     so we resolve ownerEmail from parseAgentEmail. Kept until the live
+//     nests are cut over to device identity.
 //
 // Either way the WS connection is owner-scoped — broadcasts and
 // spawn-intents fan out per ownerEmail.
@@ -58,10 +64,33 @@ function jwks() {
   return _jwks
 }
 
-interface AuthCtx { ownerEmail: string }
+interface AuthCtx {
+  ownerEmail: string
+  /** Set only for device-token nests — the token-authoritative host_id. */
+  hostId?: string
+}
 const authByPeerId = new Map<string, AuthCtx>()
 
 async function authenticateUpgrade(token: string): Promise<AuthCtx> {
+  // Device-token path first: a troop-issued HS256 token verifies cheaply
+  // and fails fast (verifyCliToken → null) for any IdP-signed token, so
+  // legacy nests fall straight through to the JWKS path below.
+  const device = parseNestDeviceToken(await verifyCliToken(token))
+  if (device) {
+    const db = useDb()
+    const rows = await db
+      .select({ hostId: nests.hostId })
+      .from(nests)
+      .where(and(
+        eq(nests.ownerEmail, device.ownerEmail),
+        eq(nests.hostId, device.hostId),
+        eq(nests.status, 'active'),
+      ))
+      .limit(1)
+    if (!rows[0]) throw new Error('nest is revoked or unknown')
+    return { ownerEmail: device.ownerEmail, hostId: device.hostId }
+  }
+
   const { payload } = await verifyJWT<DDISAClaims>(token, jwks())
   if (!payload.sub) throw new Error('token missing sub')
   if (payload.act === 'human') {
@@ -152,10 +181,13 @@ export default defineWebSocketHandler({
     if (!frame) return
     if (frame.type === 'hello') {
       const f = frame as HelloFrame
-      if (!f.host_id || !f.hostname) return
+      // Device-token nests: the host_id is bound into the token, so trust
+      // that over the self-reported one (no more host fingerprinting).
+      const hostId = ctx.hostId ?? f.host_id
+      if (!hostId || !f.hostname) return
       registerNestPeer({
         ownerEmail: ctx.ownerEmail,
-        hostId: f.host_id,
+        hostId,
         hostname: f.hostname,
         version: f.version ?? 'unknown',
         lastSeenAt: Math.floor(Date.now() / 1000),

--- a/apps/openape-troop/server/utils/nest-credential.ts
+++ b/apps/openape-troop/server/utils/nest-credential.ts
@@ -1,0 +1,33 @@
+import { createHash, randomBytes } from 'node:crypto'
+
+// Device-credential primitives for the nest-as-device model (M4δ-3).
+//
+// A keypair-less pod has no DDISA agent identity, so it can't drive the
+// IdP token-exchange (which requires an actor_token with act='agent').
+// Instead troop — the canonical issuer of host_ids — hands the pod a
+// high-entropy *device secret* at bind time and stores only its SHA-256.
+// On every reconnect the pod presents the plaintext to
+// POST /api/nests/token and gets a short-lived, nest:*-scoped troop token.
+//
+// Why plain SHA-256 and not a slow KDF (bcrypt/scrypt): those defend
+// low-entropy human passwords against offline brute force. A 256-bit
+// random secret has no brute-force surface, so a single fast hash is the
+// correct, standard choice for opaque API credentials.
+
+// Operational scopes a bound device may exercise. Deliberately excludes
+// `nest:bind` — binding is a one-time Owner action; a device must not be
+// able to re-bind (mint new host_ids) using its own credential.
+export const NEST_DEVICE_SCOPES = ['nest:spawn-agent', 'nest:report-status'] as const
+
+// TTL for a minted device token. Short by design: the pod re-mints on
+// reconnect, and a revoke takes effect within this window for any token
+// already in flight.
+export const NEST_TOKEN_TTL_SECONDS = 15 * 60
+
+export function generateDeviceSecret(): string {
+  return randomBytes(32).toString('base64url')
+}
+
+export function hashDeviceSecret(secret: string): string {
+  return createHash('sha256').update(secret, 'utf8').digest('hex')
+}

--- a/apps/openape-troop/server/utils/nest-credential.ts
+++ b/apps/openape-troop/server/utils/nest-credential.ts
@@ -1,3 +1,4 @@
+import type { CliTokenPayload } from './cli-token'
 import { createHash, randomBytes } from 'node:crypto'
 
 // Device-credential primitives for the nest-as-device model (M4δ-3).
@@ -30,4 +31,30 @@ export function generateDeviceSecret(): string {
 
 export function hashDeviceSecret(secret: string): string {
   return createHash('sha256').update(secret, 'utf8').digest('hex')
+}
+
+export interface NestDeviceIdentity {
+  ownerEmail: string
+  hostId: string
+}
+
+// `delegate` provenance prefix for a minted device token: `nest:<host_id>`.
+const DELEGATE_PREFIX = 'nest:'
+
+// Narrow a *verified* troop CLI token to a nest device identity. Returns
+// null when the token isn't a device token (a first-party human token, or
+// an IdP-signed token that verifyCliToken couldn't verify) so the caller
+// can fall back to the IdP auth path. The host_id rides in `delegate`
+// (`nest:<host_id>`) and is token-authoritative — troop never has to trust
+// a nest's self-reported host_id in the hello frame. Note this does NOT
+// check the nest is still active; the caller must verify the (owner,
+// host_id) row against the nests table so a revoke takes effect.
+export function parseNestDeviceToken(claims: CliTokenPayload | null): NestDeviceIdentity | null {
+  if (!claims) return null
+  if (claims.act !== 'agent') return null
+  if (!claims.delegate?.startsWith(DELEGATE_PREFIX)) return null
+  const hostId = claims.delegate.slice(DELEGATE_PREFIX.length)
+  if (!hostId) return null
+  if (!claims.scope?.includes('nest:report-status')) return null
+  return { ownerEmail: claims.sub.toLowerCase(), hostId }
 }

--- a/apps/openape-troop/tests/nest-credential.test.ts
+++ b/apps/openape-troop/tests/nest-credential.test.ts
@@ -1,0 +1,71 @@
+import { beforeAll, describe, expect, it } from 'vitest'
+import { signCliToken, verifyCliToken } from '../server/utils/cli-token'
+import {
+  generateDeviceSecret,
+  hashDeviceSecret,
+  NEST_DEVICE_SCOPES,
+  NEST_TOKEN_TTL_SECONDS,
+} from '../server/utils/nest-credential'
+
+// cli-token.ts reads two Nuxt auto-imported globals at call time. Stub them
+// so the mint round-trip can run under the plain-node vitest env.
+beforeAll(() => {
+  ;(globalThis as Record<string, unknown>).useRuntimeConfig = () => ({
+    openapeSp: { sessionSecret: 'x'.repeat(48) },
+  })
+  ;(globalThis as Record<string, unknown>).createError = (e: unknown) => new Error(JSON.stringify(e))
+})
+
+describe('nest device credential', () => {
+  it('generates a high-entropy, url-safe secret', () => {
+    const s = generateDeviceSecret()
+    expect(s).toMatch(/^[\w-]+$/)
+    // 32 random bytes → 43 base64url chars
+    expect(s.length).toBeGreaterThanOrEqual(43)
+  })
+
+  it('generates distinct secrets each call', () => {
+    const set = new Set(Array.from({ length: 100 }, () => generateDeviceSecret()))
+    expect(set.size).toBe(100)
+  })
+
+  it('hashes deterministically and diverges per secret', () => {
+    const a = generateDeviceSecret()
+    expect(hashDeviceSecret(a)).toBe(hashDeviceSecret(a))
+    expect(hashDeviceSecret(a)).not.toBe(hashDeviceSecret(generateDeviceSecret()))
+    expect(hashDeviceSecret(a)).toMatch(/^[0-9a-f]{64}$/)
+  })
+
+  it('device scopes are operational only — never nest:bind', () => {
+    expect(NEST_DEVICE_SCOPES).toContain('nest:spawn-agent')
+    expect(NEST_DEVICE_SCOPES).toContain('nest:report-status')
+    expect(NEST_DEVICE_SCOPES).not.toContain('nest:bind')
+  })
+})
+
+describe('session-less device token mint (M4δ-3 core)', () => {
+  it('mints a bounded, owner-attributed agent token a device can present', async () => {
+    const hostId = 'mbp-home'
+    const owner = 'patrick@example.com'
+
+    // This is exactly what POST /api/nests/token mints after matching the
+    // device secret against the active nest row — no IdP round-trip, no
+    // session, fully non-interactive.
+    const { token, expiresAt } = await signCliToken({
+      email: owner,
+      act: 'agent',
+      scope: [...NEST_DEVICE_SCOPES],
+      delegate: `nest:${hostId}`,
+      ttlSeconds: NEST_TOKEN_TTL_SECONDS,
+    })
+
+    const claims = await verifyCliToken(token)
+    expect(claims).not.toBeNull()
+    expect(claims!.sub).toBe(owner)
+    expect(claims!.act).toBe('agent')
+    expect(claims!.scope).toEqual([...NEST_DEVICE_SCOPES])
+    expect(claims!.delegate).toBe(`nest:${hostId}`)
+    // Short-lived by design: the cap is enforced, not the 30-day first-party TTL.
+    expect(expiresAt - claims!.iat).toBeLessThanOrEqual(NEST_TOKEN_TTL_SECONDS)
+  })
+})

--- a/apps/openape-troop/tests/nest-credential.test.ts
+++ b/apps/openape-troop/tests/nest-credential.test.ts
@@ -1,3 +1,4 @@
+import type { CliTokenPayload } from '../server/utils/cli-token'
 import { beforeAll, describe, expect, it } from 'vitest'
 import { signCliToken, verifyCliToken } from '../server/utils/cli-token'
 import {
@@ -5,7 +6,24 @@ import {
   hashDeviceSecret,
   NEST_DEVICE_SCOPES,
   NEST_TOKEN_TTL_SECONDS,
+  parseNestDeviceToken,
 } from '../server/utils/nest-credential'
+
+function deviceClaims(over: Partial<CliTokenPayload> = {}): CliTokenPayload {
+  return {
+    iss: 'troop.openape.ai',
+    aud: 'troop.openape.ai',
+    typ: 'cli',
+    sub: 'patrick@example.com',
+    email: 'patrick@example.com',
+    act: 'agent',
+    scope: [...NEST_DEVICE_SCOPES],
+    delegate: 'nest:mbp-home',
+    iat: 0,
+    exp: 0,
+    ...over,
+  }
+}
 
 // cli-token.ts reads two Nuxt auto-imported globals at call time. Stub them
 // so the mint round-trip can run under the plain-node vitest env.
@@ -67,5 +85,32 @@ describe('session-less device token mint (M4δ-3 core)', () => {
     expect(claims!.delegate).toBe(`nest:${hostId}`)
     // Short-lived by design: the cap is enforced, not the 30-day first-party TTL.
     expect(expiresAt - claims!.iat).toBeLessThanOrEqual(NEST_TOKEN_TTL_SECONDS)
+  })
+})
+
+describe('parseNestDeviceToken (troop WS accept path)', () => {
+  it('narrows a valid device token to (owner, host_id), lowercasing owner', () => {
+    const id = parseNestDeviceToken(deviceClaims({ sub: 'Patrick@Example.Com' }))
+    expect(id).toEqual({ ownerEmail: 'patrick@example.com', hostId: 'mbp-home' })
+  })
+
+  it('returns null for a null token (verify failed → fall back to IdP)', () => {
+    expect(parseNestDeviceToken(null)).toBeNull()
+  })
+
+  it('returns null for a first-party human token (no nest delegate)', () => {
+    expect(parseNestDeviceToken(deviceClaims({ act: 'human', delegate: null }))).toBeNull()
+  })
+
+  it('returns null when delegate is not a nest provenance', () => {
+    expect(parseNestDeviceToken(deviceClaims({ delegate: 'org.openape.ai' }))).toBeNull()
+  })
+
+  it('returns null for an empty host_id', () => {
+    expect(parseNestDeviceToken(deviceClaims({ delegate: 'nest:' }))).toBeNull()
+  })
+
+  it('returns null when the report-status scope is absent', () => {
+    expect(parseNestDeviceToken(deviceClaims({ scope: ['nest:spawn-agent'] }))).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary
- **Resolves the M4δ-3 OPEN QUESTION** — and the answer is *neither* option the plan sketched. The IdP token-exchange (`token-exchange.post.ts`) hard-requires an `actor_token` with `act='agent'`; a keypair-less device has no IdP identity and can never produce one. So the IdP M4γ-grant path is a dead end for a device by design.
- The mechanism is fully **troop-local**: troop is the canonical `host_id` issuer, so the "standing grant" is the troop-side `nests` row itself. At bind, troop mints a 256-bit **device secret**, returns the plaintext once, and stores only its SHA-256.
- New `POST /api/nests/token` exchanges `{host_id, device_secret}` for a short-lived (15 min) `nest:*`-scoped, `act='agent'` troop token. No session, no IdP, non-interactive on every reconnect.
- Bounded scopes `['nest:spawn-agent','nest:report-status']` (deliberately **not** `nest:bind` — a device can't re-bind itself). `delegate='nest:<host_id>'` for provenance.
- Revoke story: `DELETE /api/nests/:host_id` flips `status='revoked'`, which fails the token lookup → device cut off within one token TTL.

## Changes
- `schema.ts` + `02.database.ts`: nullable `device_secret_hash` column (CREATE + idempotent ALTER).
- `bind.post.ts`: mint + hash-store the device secret; return plaintext once.
- `server/api/nests/token.post.ts` (new): the session-less mint endpoint.
- `server/utils/nest-credential.ts` (new): pure secret/hash/scope primitives.
- `tests/nest-credential.test.ts` (new): 5 tests incl. a full mint→verify round-trip.

## Design decisions (approved by Patrick)
- **Plain SHA-256** for the device secret — it's 256-bit random, no brute-force surface, so a slow KDF would be cargo-culting.
- **15-min token TTL**, pod re-mints on reconnect.

Note: endpoint is in place but not yet wired into the nest startup / troop WS (that's the rest of M4δ-3) and is not behind the `OPENAPE_NEST_IDENTITY` flag yet.

## Test plan
- [x] `vitest run` — 143/143 green (5 new)
- [x] `nuxt typecheck` clean
- [x] lint clean
- [ ] Post-deploy: `curl POST /api/nests/bind` → take `device_secret` → `curl POST /api/nests/token` returns a token that `verifyCliToken` accepts; then `DELETE` the nest and confirm the same secret now 401s.

Stacked on #529.