### PR TITLE
fix(troop): first-party human apes-cli token is unbounded scope

### DIFF
--- a/apps/openape-troop/server/utils/auth.ts
+++ b/apps/openape-troop/server/utils/auth.ts
@@ -102,6 +102,14 @@ export async function resolveOwnerContext(event: H3Event): Promise<{
     // SPs use after token-exchange.
     const cli = await verifyCliToken(token)
     if (cli) {
+      // A first-party human token (the Owner's own apes-cli session,
+      // exchanged to a troop token) is unbounded — same status as the
+      // session and IdP-human paths. Only delegated/agent tokens are
+      // scope-bounded to what their token carries; a human's exchanged
+      // token has scope=[] and must NOT collapse to "no scopes".
+      if (cli.act === 'human' && !cli.delegate) {
+        return { owner: cli.sub, scopes: null, delegate: null }
+      }
       return { owner: cli.sub, scopes: cli.scope ?? [], delegate: cli.delegate ?? null }
     }
 


### PR DESCRIPTION
## Summary
- The Owner's `apes login` session is exchanged into a troop HS256 token (`act=human, scope=[], delegate=null`). `resolveOwnerContext` verified it on the cheap `verifyCliToken` branch and returned `scopes: []` — so `requireOwnerWithScope` 403'd the Owner on their own scope-gated nest routes (`nests list/bind/remove`).
- This was latent since M4α (#521) and only surfaced now that M4δ added the first owner routes using `requireOwnerWithScope`.
- Fix matches the documented intent (auth.ts lines 71, 126-127): a first-party human token (`act=human` && no `delegate`) is unbounded, same as the browser-session and IdP-human Bearer paths. Delegated/agent tokens stay scope-bounded.

## Test plan
- [x] `pnpm --filter @openape/troop typecheck` — exit 0
- [x] `pnpm --filter @openape/troop lint` — exit 0
- [ ] Post-deploy: `ape-troop nests list` returns 200 (was 403); full bind → POST /api/nests/token → revoke → 401 cycle.