### PR TITLE
feat(nest): M4δ-4 device-credential troop auth

### DIFF
--- a/apps/openape-nest/src/lib/nest-device.ts
+++ b/apps/openape-nest/src/lib/nest-device.ts
@@ -1,0 +1,74 @@
+// Device-credential source + short-lived troop-token mint for the nest
+// daemon (M4δ-4). The nest is a *device* bound to an Owner, not a DDISA
+// agent: it has no keypair and no IdP identity. Its only credential is
+// the high-entropy `device_secret` the Owner minted at bind time
+// (`ape-troop nests bind`) and injected here. On each (re)connect the
+// daemon presents `{host_id, device_secret}` to POST /api/nests/token
+// and gets a short-lived, nest:*-scoped troop token.
+//
+// The Owner injects the creds out-of-band — env vars (primary, for
+// container injection) or a 0600 file. The secret lives on disk/env;
+// the minted token is held in memory only (see troop-ws.ts), never
+// persisted, and re-minted on restart.
+
+import { existsSync, readFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { ofetch } from 'ofetch'
+
+export interface NestDeviceCreds {
+  hostId: string
+  deviceSecret: string
+}
+
+// `OPENAPE_NEST_DEVICE_PATH` overrides the default file location, mirroring
+// the registry's `OPENAPE_NEST_REGISTRY_PATH` convention.
+export function resolveDevicePath(): string {
+  return process.env.OPENAPE_NEST_DEVICE_PATH ?? join(homedir(), 'nest-device.json')
+}
+
+// Env vars win over the file so a container can inject creds without a
+// writable home. Returns null when neither source yields a usable pair —
+// the daemon then fails closed (no IdP fallback; device identity is the
+// only identity).
+export function readDeviceCreds(): NestDeviceCreds | null {
+  const envHost = process.env.OPENAPE_NEST_HOST_ID?.trim()
+  const envSecret = process.env.OPENAPE_NEST_DEVICE_SECRET?.trim()
+  if (envHost && envSecret) return { hostId: envHost, deviceSecret: envSecret }
+
+  const path = resolveDevicePath()
+  if (!existsSync(path)) return null
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf8')) as { host_id?: unknown, device_secret?: unknown }
+    const hostId = typeof parsed.host_id === 'string' ? parsed.host_id.trim() : ''
+    const deviceSecret = typeof parsed.device_secret === 'string' ? parsed.device_secret : ''
+    if (!hostId || !deviceSecret) return null
+    return { hostId, deviceSecret }
+  }
+  catch {
+    return null
+  }
+}
+
+// The WS URL (wss://troop.openape.ai) and the mint endpoint share a host
+// but differ in scheme.
+export function troopHttpUrl(troopWsUrl: string): string {
+  return troopWsUrl.replace(/^wss:\/\//, 'https://').replace(/^ws:\/\//, 'http://')
+}
+
+export interface MintedToken {
+  token: string
+  /** Unix epoch *seconds* (matches the token's `exp`/`iat`). */
+  expiresAt: number
+}
+
+// Exchange the device secret for a short-lived troop token. Throws on a
+// non-2xx response (401 = bad secret or the nest was revoked); the caller
+// logs and retries on the normal reconnect backoff.
+export async function mintNestToken(troopWsUrl: string, creds: NestDeviceCreds): Promise<MintedToken> {
+  const res = await ofetch<{ access_token: string, expires_at: number }>(
+    `${troopHttpUrl(troopWsUrl)}/api/nests/token`,
+    { method: 'POST', body: { host_id: creds.hostId, device_secret: creds.deviceSecret } },
+  )
+  return { token: res.access_token, expiresAt: res.expires_at }
+}

--- a/apps/openape-nest/src/lib/troop-ws.ts
+++ b/apps/openape-nest/src/lib/troop-ws.ts
@@ -28,12 +28,12 @@
 // a cold-path fallback for whenever the WS connection is down (Mac
 // sleeping, troop deploying, flaky network).
 
-import { execFile, execFileSync, spawn } from 'node:child_process'
-import { createHash } from 'node:crypto'
+import { execFile, spawn } from 'node:child_process'
 import { readFileSync } from 'node:fs'
-import { hostname, networkInterfaces } from 'node:os'
-import { ensureFreshIdpAuth, NotLoggedInError } from '@openape/cli-auth'
+import { hostname } from 'node:os'
 import WebSocket from 'ws'
+import { mintNestToken,  readDeviceCreds } from './nest-device'
+import type { NestDeviceCreds } from './nest-device'
 import { agentNameFromEmail, planSecretRevoke, planSecretWrite } from './secret-relay'
 
 const HEARTBEAT_INTERVAL_MS = 30_000
@@ -102,12 +102,17 @@ export class TroopWs {
   private reconnectAttempts = 0
   private stopped = false
   private readonly troopUrl: string
-  private readonly hostId: string
+  // Set from the device creds on each connect (troop is authoritative for
+  // host_id now; the daemon no longer self-fingerprints).
+  private hostId = ''
   private readonly hostname: string
+  // Short-lived device token, held in memory only and re-minted before
+  // expiry. Never persisted — only the long-lived device_secret is on disk.
+  private cachedToken: string | null = null
+  private cachedTokenExp = 0
 
   constructor(private opts: TroopWsOptions) {
     this.troopUrl = (opts.troopUrl ?? process.env.OPENAPE_TROOP_WS_URL ?? 'wss://troop.openape.ai').replace(/\/$/, '')
-    this.hostId = readHostId()
     this.hostname = hostname()
   }
 
@@ -129,20 +134,34 @@ export class TroopWs {
     }
   }
 
+  // Mint (or reuse) a short-lived device token. Cached in memory and
+  // re-minted ~1 min before expiry; never written to disk.
+  private async mintToken(creds: NestDeviceCreds): Promise<string> {
+    const nowSec = Math.floor(Date.now() / 1000)
+    if (this.cachedToken && this.cachedTokenExp - nowSec > 60) return this.cachedToken
+    const { token, expiresAt } = await mintNestToken(this.troopUrl, creds)
+    this.cachedToken = token
+    this.cachedTokenExp = expiresAt
+    return token
+  }
+
   private async connect(): Promise<void> {
     if (this.stopped) return
+    // Re-read on every attempt so creds injected after boot are picked up
+    // without a restart.
+    const creds = readDeviceCreds()
+    if (!creds) {
+      this.opts.log('troop-ws: no device creds (set OPENAPE_NEST_HOST_ID + OPENAPE_NEST_DEVICE_SECRET, or ~/nest-device.json) — not connecting, will retry')
+      this.scheduleReconnect()
+      return
+    }
+    this.hostId = creds.hostId
     let token: string
     try {
-      const auth = await ensureFreshIdpAuth()
-      token = auth.access_token
+      token = await this.mintToken(creds)
     }
     catch (err) {
-      if (err instanceof NotLoggedInError) {
-        this.opts.log('troop-ws: not logged in (apes login) — skip connect, will retry')
-      }
-      else {
-        this.opts.log(`troop-ws: auth refresh failed: ${err instanceof Error ? err.message : String(err)}`)
-      }
+      this.opts.log(`troop-ws: token mint failed (nest revoked or bad secret?): ${err instanceof Error ? err.message : String(err)}`)
       this.scheduleReconnect()
       return
     }
@@ -409,38 +428,6 @@ function runWithInput(bin: string, args: string[], input: string): Promise<void>
     child.stdin?.on('error', () => { /* child may exit before we finish writing; close handler reports it */ })
     child.stdin?.end(input)
   })
-}
-
-/**
- * Stable per-host identifier. On macOS we read `IOPlatformUUID` via
- * ioreg if available (same source `apes agents sync` pins on). As a
- * portable fallback we hash MAC addresses + hostname — gives a stable
- * value across boots on Linux/CI without requiring elevated privs.
- */
-function readHostId(): string {
-  try {
-    if (process.platform === 'darwin') {
-      const out = execFileSync('/usr/sbin/ioreg', ['-d2', '-c', 'IOPlatformExpertDevice'], { encoding: 'utf8' })
-      const match = out.match(/"IOPlatformUUID"\s*=\s*"([^"]+)"/)
-      if (match) return match[1]!
-    }
-  }
-  catch { /* fall through to hash-based id */ }
-  return hashBasedHostId()
-}
-
-function hashBasedHostId(): string {
-  const nics = networkInterfaces()
-  const macs: string[] = []
-  for (const list of Object.values(nics)) {
-    if (!list) continue
-    for (const nic of list) {
-      if (!nic.mac || nic.mac === '00:00:00:00:00:00' || nic.internal) continue
-      macs.push(nic.mac)
-    }
-  }
-  const seed = `${hostname()}|${macs.toSorted().join(',')}`
-  return createHash('sha256').update(seed).digest('hex').slice(0, 32)
 }
 
 // Read this package's version once at boot. Falls back to 'unknown'

--- a/apps/openape-nest/test/nest-device.test.ts
+++ b/apps/openape-nest/test/nest-device.test.ts
@@ -1,0 +1,96 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const ofetchMock = vi.fn()
+vi.mock('ofetch', () => ({ ofetch: (...args: unknown[]) => ofetchMock(...args) }))
+
+const { mintNestToken, readDeviceCreds, troopHttpUrl } = await import('../src/lib/nest-device')
+
+const ENV_KEYS = ['OPENAPE_NEST_HOST_ID', 'OPENAPE_NEST_DEVICE_SECRET', 'OPENAPE_NEST_DEVICE_PATH'] as const
+let saved: Record<string, string | undefined>
+let dir: string
+
+beforeEach(() => {
+  saved = Object.fromEntries(ENV_KEYS.map(k => [k, process.env[k]]))
+  for (const k of ENV_KEYS) delete process.env[k]
+  dir = mkdtempSync(join(tmpdir(), 'nest-device-'))
+  ofetchMock.mockReset()
+})
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (saved[k] === undefined) delete process.env[k]
+    else process.env[k] = saved[k]
+  }
+  rmSync(dir, { recursive: true, force: true })
+})
+
+function writeCredsFile(body: unknown): string {
+  const p = join(dir, 'nest-device.json')
+  writeFileSync(p, JSON.stringify(body))
+  return p
+}
+
+describe('readDeviceCreds', () => {
+  it('reads creds from env vars', () => {
+    process.env.OPENAPE_NEST_HOST_ID = 'mbp-home'
+    process.env.OPENAPE_NEST_DEVICE_SECRET = 'sekret'
+    expect(readDeviceCreds()).toEqual({ hostId: 'mbp-home', deviceSecret: 'sekret' })
+  })
+
+  it('env vars win over the file', () => {
+    process.env.OPENAPE_NEST_HOST_ID = 'from-env'
+    process.env.OPENAPE_NEST_DEVICE_SECRET = 'env-secret'
+    process.env.OPENAPE_NEST_DEVICE_PATH = writeCredsFile({ host_id: 'from-file', device_secret: 'file-secret' })
+    expect(readDeviceCreds()).toEqual({ hostId: 'from-env', deviceSecret: 'env-secret' })
+  })
+
+  it('falls back to the file when env vars are absent', () => {
+    process.env.OPENAPE_NEST_DEVICE_PATH = writeCredsFile({ host_id: 'mbp-home', device_secret: 'file-secret' })
+    expect(readDeviceCreds()).toEqual({ hostId: 'mbp-home', deviceSecret: 'file-secret' })
+  })
+
+  it('returns null when neither source is present', () => {
+    process.env.OPENAPE_NEST_DEVICE_PATH = join(dir, 'does-not-exist.json')
+    expect(readDeviceCreds()).toBeNull()
+  })
+
+  it('returns null when the file is missing a field', () => {
+    process.env.OPENAPE_NEST_DEVICE_PATH = writeCredsFile({ host_id: 'mbp-home' })
+    expect(readDeviceCreds()).toBeNull()
+  })
+
+  it('returns null for a half-set env (host only)', () => {
+    process.env.OPENAPE_NEST_HOST_ID = 'mbp-home'
+    process.env.OPENAPE_NEST_DEVICE_PATH = join(dir, 'does-not-exist.json')
+    expect(readDeviceCreds()).toBeNull()
+  })
+})
+
+describe('troopHttpUrl', () => {
+  it('rewrites wss/ws to https/http', () => {
+    expect(troopHttpUrl('wss://troop.openape.ai')).toBe('https://troop.openape.ai')
+    expect(troopHttpUrl('ws://localhost:3000')).toBe('http://localhost:3000')
+  })
+})
+
+describe('mintNestToken', () => {
+  it('posts host_id+device_secret to the https mint endpoint and returns the token', async () => {
+    ofetchMock.mockResolvedValue({ access_token: 'tok-123', expires_at: 1781234567 })
+    const out = await mintNestToken('wss://troop.openape.ai', { hostId: 'mbp-home', deviceSecret: 'sekret' })
+    expect(out).toEqual({ token: 'tok-123', expiresAt: 1781234567 })
+    expect(ofetchMock).toHaveBeenCalledWith(
+      'https://troop.openape.ai/api/nests/token',
+      { method: 'POST', body: { host_id: 'mbp-home', device_secret: 'sekret' } },
+    )
+  })
+
+  it('surfaces a mint failure (401 → revoked/bad secret) as a throw', async () => {
+    ofetchMock.mockRejectedValue(new Error('401 Unauthorized'))
+    await expect(mintNestToken('wss://troop.openape.ai', { hostId: 'x', deviceSecret: 'y' }))
+      .rejects
+      .toThrow('401')
+  })
+})


### PR DESCRIPTION
## Summary
- Nest authenticates as a **device**, not a DDISA agent: it mints a short-lived `nest:*` troop token per connect from an injected `device_secret` (`OPENAPE_NEST_HOST_ID` + `OPENAPE_NEST_DEVICE_SECRET`, or `~/nest-device.json`) via `POST /api/nests/token` (the endpoint shipped in M4δ-3).
- `host_id` now comes from troop (the bind-time value), replacing the ioreg/MAC self-fingerprint — troop is the canonical issuer.
- **No IdP fallback, no flag** (per the "Nest Identity Not optional" decision): creds absent → fail closed (log + retry). Token held in memory only, re-minted ~1 min before the 15-min expiry; only the long-lived secret touches disk.
- New `src/lib/nest-device.ts` (creds source + mint); `troop-ws.ts` cut over; dead `readHostId`/`hashBasedHostId` removed.

## Safety
Additive — no deploy. `deploy-troop.yml` does not watch `apps/openape-nest/**`, and there is no deploy-nest workflow. Live hosts keep their current binary on the IdP path until manually updated in the **gated M4δ-5 cutover** (owner binds + injects creds + swaps the binary, needs DDISA approvals).

## Test plan
- [x] `pnpm --filter @openape/nest test` — 25 passed (11 new in `nest-device.test.ts`)
- [x] `pnpm --filter @openape/nest typecheck` — exit 0
- [x] `pnpm --filter @openape/nest lint` — exit 0
- [x] `pnpm --filter @openape/nest build` — exit 0
- [ ] M4δ-5 (gated): hand-run on a host with a bound nest's creds → "troop-ws: connected"; `ape-troop nests list` shows it online; revoke → WS drops within ≤15 min.