### PR TITLE
chore: add @openape/ape-troop to publish-chain + README

### DIFF
--- a/packages/ape-troop/README.md
+++ b/packages/ape-troop/README.md
@@ -1,0 +1,30 @@
+# @openape/ape-troop
+
+Owner CLI for [troop.openape.ai](https://troop.openape.ai) — manage the devices
+(nests) bound to your account and the agents running on them. Authenticates via
+the shared `apes login` SSO session (no separate login).
+
+## Install
+
+```bash
+npm i -g @openape/ape-troop
+apes login you@example.com   # shared OpenApe SSO — covers ape-troop too
+```
+
+## Commands
+
+```bash
+ape-troop nests bind <display-name> [--pod-uuid <uuid>] [--json]  # bind a device, mint its host_id + device_secret
+ape-troop nests list [--json]                                     # list bound devices
+ape-troop nests remove <host-id>                                  # revoke a binding (soft)
+
+ape-troop agents list [--json]                                    # agents on this troop
+ape-troop agents spawn <host-id> <name>                           # spawn an agent on a nest (DDISA-approved)
+ape-troop agents destroy <agent-id>
+
+ape-troop whoami                                                  # current OpenApe identity
+```
+
+`login` / `logout` are stubs — all OpenApe CLIs share one session; use
+`apes login` / `apes logout`. `ape-troop logout` only clears the cached troop
+SP-token.

--- a/scripts/publish-chain.mjs
+++ b/scripts/publish-chain.mjs
@@ -46,6 +46,7 @@ const PACKAGES = [
   { name: '@openape/ape-chat', dir: 'apps/openape-chat-cli' },
   { name: '@openape/ape-agent', dir: 'apps/openape-ape-agent' },
   { name: '@openape/nest', dir: 'apps/openape-nest' },
+  { name: '@openape/ape-troop', dir: 'packages/ape-troop' },
 ]
 
 const dryRun = process.argv.includes('--dry-run')


### PR DESCRIPTION
## Summary
- `@openape/ape-troop@0.1.0` is now published to npm (Owner CLI for the M4δ nest cutover — `nests bind|list|remove`, `agents …`).
- Adds it to `scripts/publish-chain.mjs` so future `pnpm release:local` runs keep it in sync.
- Adds a minimal `packages/ape-troop/README.md` (referenced by `files`, was missing → empty npm page).

## Context
Needed for the M4δ-5 per-host cutover: the Owner runs `ape-troop nests bind` from their machine. Package was published directly via `publish-chain` (first publish); this PR records the source change.

## Test plan
- [x] `npm i -g @openape/ape-troop && ape-troop --help` works
- [x] `pnpm release:dry` lists ape-troop in dependency order