### PR TITLE
chore: release sp-sdk (cli-auth 0.5.0, nuxt-auth-sp 0.11.0)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.0.5/schema.json",
-  "changelog": ["@changesets/changelog-github", { "repo": "openape-ai/openape" }],
+  "changelog": "@changesets/cli/changelog",
   "commit": false,
   "fixed": [],
   "linked": [],

--- a/.changeset/sp-sdk-cli-auth.md
+++ b/.changeset/sp-sdk-cli-auth.md
@@ -1,5 +1,0 @@
----
-"@openape/cli-auth": minor
----
-
-Add `createSpClient({ defaultEndpoint, envVar, configFile, defaultAud })` factory plus shared output helpers (`printJson`, `printLine`, `printNdjson`, `fmtTime`), so SP CLIs stop copy-pasting `apiCall`/`config`/`output` boilerplate. `apiCall` builds requests via the existing `getAuthorizedBearer`; endpoint resolution precedence is explicit arg > env var > stored session > default.

--- a/.changeset/sp-sdk-cli-auth.md
+++ b/.changeset/sp-sdk-cli-auth.md
@@ -1,0 +1,5 @@
+---
+"@openape/cli-auth": minor
+---
+
+Add `createSpClient({ defaultEndpoint, envVar, configFile, defaultAud })` factory plus shared output helpers (`printJson`, `printLine`, `printNdjson`, `fmtTime`), so SP CLIs stop copy-pasting `apiCall`/`config`/`output` boilerplate. `apiCall` builds requests via the existing `getAuthorizedBearer`; endpoint resolution precedence is explicit arg > env var > stored session > default.

--- a/.changeset/sp-sdk-nuxt-auth-sp.md
+++ b/.changeset/sp-sdk-nuxt-auth-sp.md
@@ -1,5 +1,0 @@
----
-"@openape/nuxt-auth-sp": minor
----
-
-Provide shared CLI token-exchange server utilities so SPs no longer copy `cli-token.ts`/`ddisa-issuer.ts`/the `/api/cli/exchange` handler: `signCliToken`/`verifyCliToken`, `resolveIssuerForToken`/`unsafeDecodeSub`, and `createCliExchangeHandler()` (issuer/audience taken from `openapeSp.clientId`). Hardened with an SSRF guard on the DDISA-resolved IdP issuer (`assertSafeIdpUrl`: https-only, blocks loopback/RFC1918/link-local/CGNAT/IPv6-ULA, 5s JWKS-fetch timeout). Dev hatch: `OPENAPE_SP_ALLOW_INSECURE_IDP=1`.

--- a/.changeset/sp-sdk-nuxt-auth-sp.md
+++ b/.changeset/sp-sdk-nuxt-auth-sp.md
@@ -1,0 +1,5 @@
+---
+"@openape/nuxt-auth-sp": minor
+---
+
+Provide shared CLI token-exchange server utilities so SPs no longer copy `cli-token.ts`/`ddisa-issuer.ts`/the `/api/cli/exchange` handler: `signCliToken`/`verifyCliToken`, `resolveIssuerForToken`/`unsafeDecodeSub`, and `createCliExchangeHandler()` (issuer/audience taken from `openapeSp.clientId`). Hardened with an SSRF guard on the DDISA-resolved IdP issuer (`assertSafeIdpUrl`: https-only, blocks loopback/RFC1918/link-local/CGNAT/IPv6-ULA, 5s JWKS-fetch timeout). Dev hatch: `OPENAPE_SP_ALLOW_INSECURE_IDP=1`.

--- a/apps/openape-ape-agent/CHANGELOG.md
+++ b/apps/openape-ape-agent/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @openape/ape-agent
 
+## 2.8.13
+
+### Patch Changes
+
+- Updated dependencies [2ea39ac]
+  - @openape/cli-auth@0.5.0
+  - @openape/apes@1.28.12
+
 ## 2.8.12
 
 ### Patch Changes

--- a/apps/openape-ape-agent/package.json
+++ b/apps/openape-ape-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openape/ape-agent",
-  "version": "2.8.12",
+  "version": "2.8.13",
   "description": "OpenApe agent runtime: per-agent process that connects to chat.openape.ai, runs the LLM loop with tools + cron tasks, and streams replies back to owners.",
   "type": "module",
   "license": "MIT",

--- a/apps/openape-chat-cli/CHANGELOG.md
+++ b/apps/openape-chat-cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openape/ape-chat
 
+## 0.4.3
+
+### Patch Changes
+
+- Updated dependencies [2ea39ac]
+  - @openape/cli-auth@0.5.0
+
 ## 0.4.2
 
 ### Patch Changes

--- a/apps/openape-chat-cli/package.json
+++ b/apps/openape-chat-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openape/ape-chat",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "CLI for chat.openape.ai — shared rooms for humans and agents",
   "type": "module",
   "license": "MIT",

--- a/apps/openape-chat/CHANGELOG.md
+++ b/apps/openape-chat/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openape/chat
 
+## 0.2.17
+
+### Patch Changes
+
+- Updated dependencies [2ea39ac]
+  - @openape/nuxt-auth-sp@0.11.0
+
 ## 0.2.16
 
 ### Patch Changes

--- a/apps/openape-chat/package.json
+++ b/apps/openape-chat/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openape/chat",
   "type": "module",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "private": true,
   "scripts": {
     "postinstall": "nuxt prepare",

--- a/apps/openape-nest/CHANGELOG.md
+++ b/apps/openape-nest/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openape/nest
 
+## 2.3.3
+
+### Patch Changes
+
+- Updated dependencies [2ea39ac]
+  - @openape/cli-auth@0.5.0
+
 ## 2.3.1
 
 ### Patch Changes

--- a/apps/openape-nest/package.json
+++ b/apps/openape-nest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openape/nest",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "OpenApe Nest — local control-plane daemon that supervises agent processes on this computer. Talks to troop SP for ownership state, spawns/destroys agents via DDISA always-grants, supervises chat-bridge children (replacing per-agent launchd plists).",
   "type": "module",
   "license": "MIT",

--- a/apps/openape-org/CHANGELOG.md
+++ b/apps/openape-org/CHANGELOG.md
@@ -1,0 +1,8 @@
+# @openape/org
+
+## 0.1.1
+
+### Patch Changes
+
+- Updated dependencies [2ea39ac]
+  - @openape/nuxt-auth-sp@0.11.0

--- a/apps/openape-org/package.json
+++ b/apps/openape-org/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openape/org",
   "type": "module",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "turbo": {
     "tags": [

--- a/apps/openape-troop/CHANGELOG.md
+++ b/apps/openape-troop/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openape/troop
 
+## 0.1.5
+
+### Patch Changes
+
+- Updated dependencies [2ea39ac]
+  - @openape/nuxt-auth-sp@0.11.0
+
 ## 0.1.4
 
 ### Patch Changes

--- a/apps/openape-troop/package.json
+++ b/apps/openape-troop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openape/troop",
   "type": "module",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "turbo": {
     "tags": [

--- a/modules/nuxt-auth-sp/CHANGELOG.md
+++ b/modules/nuxt-auth-sp/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.11.0
+
+### Minor Changes
+
+- 2ea39ac: Provide shared CLI token-exchange server utilities so SPs no longer copy `cli-token.ts`/`ddisa-issuer.ts`/the `/api/cli/exchange` handler: `signCliToken`/`verifyCliToken`, `resolveIssuerForToken`/`unsafeDecodeSub`, and `createCliExchangeHandler()` (issuer/audience taken from `openapeSp.clientId`). Hardened with an SSRF guard on the DDISA-resolved IdP issuer (`assertSafeIdpUrl`: https-only, blocks loopback/RFC1918/link-local/CGNAT/IPv6-ULA, 5s JWKS-fetch timeout). Dev hatch: `OPENAPE_SP_ALLOW_INSECURE_IDP=1`.
+
 ## 0.10.2
 
 ### Patch Changes

--- a/modules/nuxt-auth-sp/package.json
+++ b/modules/nuxt-auth-sp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openape/nuxt-auth-sp",
   "type": "module",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "turbo": {
     "tags": [
       "publishable"

--- a/packages/ape-troop/CHANGELOG.md
+++ b/packages/ape-troop/CHANGELOG.md
@@ -1,0 +1,8 @@
+# @openape/ape-troop
+
+## 0.1.1
+
+### Patch Changes
+
+- Updated dependencies [2ea39ac]
+  - @openape/cli-auth@0.5.0

--- a/packages/ape-troop/package.json
+++ b/packages/ape-troop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openape/ape-troop",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "turbo": {
     "tags": [
       "publishable"

--- a/packages/apes/CHANGELOG.md
+++ b/packages/apes/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openape/apes
 
+## 1.28.12
+
+### Patch Changes
+
+- Updated dependencies [2ea39ac]
+  - @openape/cli-auth@0.5.0
+
 ## 1.28.11
 
 ### Patch Changes

--- a/packages/apes/package.json
+++ b/packages/apes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openape/apes",
-  "version": "1.28.11",
+  "version": "1.28.12",
   "turbo": {
     "tags": [
       "publishable"

--- a/packages/cli-auth/CHANGELOG.md
+++ b/packages/cli-auth/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openape/cli-auth
 
+## 0.5.0
+
+### Minor Changes
+
+- 2ea39ac: Add `createSpClient({ defaultEndpoint, envVar, configFile, defaultAud })` factory plus shared output helpers (`printJson`, `printLine`, `printNdjson`, `fmtTime`), so SP CLIs stop copy-pasting `apiCall`/`config`/`output` boilerplate. `apiCall` builds requests via the existing `getAuthorizedBearer`; endpoint resolution precedence is explicit arg > env var > stored session > default.
+
 ## 0.4.1
 
 ### Patch Changes

--- a/packages/cli-auth/package.json
+++ b/packages/cli-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openape/cli-auth",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "turbo": {
     "tags": [
       "publishable"


### PR DESCRIPTION
Versioniert + publiziert die M4-Libs. Enthält: Changesets, API-freien Changelog-Generator (CI-lokal), und den `changeset version`-Bump (cli-auth 0.5.0, nuxt-auth-sp 0.11.0 + 5 patch-Dependents). Alle 7 Pakete sind bereits auf npm publiziert.