### PR TITLE
fix: complete safe Mac→Docker migration (M2 slice)

### DIFF
--- a/MIGRATION-mac-to-docker.md
+++ b/MIGRATION-mac-to-docker.md
@@ -1,0 +1,143 @@
+# Migration: Mac → Docker (M2 tracker)
+
+Tracks the safe/deferred split for the Mac-to-Docker nest migration.
+Search for `REMOVE-AFTER: cutover-verified` in the codebase to find all
+tagged deferral points.
+
+---
+
+## DONE (M2 — safe, behavior-preserving)
+
+### 1. Hatch bundles set `OPENAPE_BRIDGE_TARGET=troop`
+
+**Files changed:**
+- `apps/openape-troop/server/api/nest/hatch.post.ts` — `buildNestComposeYaml`
+- `apps/openape-troop/server/api/pod/hatch.post.ts` — `buildComposeYaml`
+
+**What:** Both hatch endpoints now emit `OPENAPE_BRIDGE_TARGET: troop` in the
+`openape-nest` service `environment:` block of the generated docker-compose YAML.
+
+**Why:** The bridge reads `process.env.OPENAPE_BRIDGE_TARGET` at startup. Its
+default is `'chat'` (deferred, see below). New Docker nests that don't set it
+would silently connect to `chat.openape.ai` instead of the troop WS — they'd
+appear online but be unreachable via troop. The compose environment block is
+the correct injection point because it takes precedence over `process.env` and
+is set before the bridge process starts.
+
+**Test:** `apps/openape-troop/tests/hatch-bundle.test.ts` asserts both bundles
+contain `OPENAPE_BRIDGE_TARGET: troop` and do NOT reference `chat.openape.ai`.
+
+### 2. Exoscale adapter: explicit 501 Not Implemented
+
+**File changed:** `apps/openape-troop/server/utils/cloud/exoscale.ts`
+
+**What:** `callExoscale` now throws `createError({ statusCode: 501,
+statusMessage: 'Exoscale provisioning not implemented' })` instead of a
+generic `Error('...scaffold — wire...')`.
+
+**Why:** A generic Error leaking through the API is worse than an explicit 501.
+The old message looked like an internal bug; the 501 is an intentional
+"not yet available" signal to any client that calls `/api/pod/hatch`.
+
+**Test:** `apps/openape-troop/tests/cloud-exoscale.test.ts` — added test that
+with credentials set, `createInstance` rejects with `statusCode: 501`.
+
+### 3. Cron comment cleanup (launchd → container cron runner)
+
+**Files changed:**
+- `apps/openape-troop/server/utils/task-validation.ts` — comment updated
+- `apps/openape-troop/server/api/agents/me/tasks.get.ts` — comment updated
+
+**What:** Comments that referenced "launchd reconciler" and "materialise launchd
+plists" updated to reflect that the cron is now driven by the bridge daemon's
+in-process `CronRunner` (no launchd, no per-task plist).
+
+**Validation logic unchanged** — the cron subset (5-field, `*`, `N`, `*/N`)
+is the same; only the explanatory comment changed.
+
+---
+
+## DEFERRED (cutover-dependent — do NOT remove yet)
+
+All deferred points are tagged `// REMOVE-AFTER: cutover-verified (see MIGRATION-mac-to-docker.md)`.
+
+### A. Bridge `OPENAPE_BRIDGE_TARGET` default + `ChatApi` dual backend
+
+**Tagged in:** `apps/openape-ape-agent/src/bridge.ts`
+- `readConfig()`: `process.env.OPENAPE_BRIDGE_TARGET ?? 'chat'` default
+- `Bridge` constructor: `ChatApi` vs `TroopChatApi` selection
+
+**Why deferred:** Changing the default from `'chat'` to `'troop'` would break
+any live Mac-based nest that does NOT set `OPENAPE_BRIDGE_TARGET`. The bridge
+reads this at startup; a wrong default silently routes messages to the wrong
+backend with no error until the first chat message fails.
+
+**Gate to remove:** Confirm via troop prod DB that NO active agent is connecting
+via the chat backend. Query: check nests whose bridge process does NOT pass
+`OPENAPE_BRIDGE_TARGET=troop` — identifiable by agents last seen via
+`chat.openape.ai` websocket sessions. Then:
+
+1. Flip default to `'troop'`
+2. Remove `ChatApi` import and `chat-api.ts`
+3. Remove the `TroopChatApi | ChatApi` union type; use `TroopChatApi` directly
+
+### B. Legacy keypair auth path in nest-ws.ts
+
+**Tagged in:** `apps/openape-troop/server/routes/api/nest-ws.ts`
+- `act: 'agent'` branch in `authenticateUpgrade`
+
+**Why deferred:** The legacy keypair path (`act=agent` IdP-signed JWT, owner
+resolved from `parseAgentEmail`) is still needed for nests that haven't
+migrated to device-token auth (M4δ). Removing it disconnects those nests.
+
+**Gate to remove:** Confirm via troop prod DB that NO nest connects with
+`device_secret_hash IS NULL` (null = legacy keypair auth, never bound via
+`POST /api/nests/bind`). Query example:
+```sql
+SELECT host_id, owner_email, last_seen_at
+FROM nests
+WHERE device_secret_hash IS NULL AND status = 'active';
+```
+If empty: remove the `act: 'agent'` branch and `parseAgentEmail` import.
+
+### C. Mac-path references in ape-agent (~/Library, launchd)
+
+**Tagged in:**
+- `apps/openape-ape-agent/src/bridge.ts` — `loadBridgeEnvFile` reads
+  `~/Library/Application Support/openape/bridge/.env`
+- `apps/openape-ape-agent/src/identity.ts` — error message mentioning launchd plist
+- `apps/openape-ape-agent/src/cron-runner.ts` — `TASK_CACHE_DIR` at `~/.openape/agent/tasks/`
+
+**Why deferred:** Docker nests don't use `~/Library/Application Support` (Linux
+container). The `loadBridgeEnvFile` path silently no-ops on Linux (file not
+found → early return), so it doesn't break Docker. But it's dead code there.
+`TASK_CACHE_DIR` works in Docker (it's under `~` which is `/root` in the
+container), but the canonical post-cutover location should be
+`/var/lib/openape/agent/tasks/`.
+
+**Gate to remove:** After confirming no live Mac nests remain:
+1. Remove `loadBridgeEnvFile` (Docker nests get env from compose `environment:`)
+2. Update `TASK_CACHE_DIR` to `/var/lib/openape/agent/tasks/` (or make it
+   configurable via `OPENAPE_AGENT_DATA_DIR`)
+3. Remove launchd references from `identity.ts` error message
+
+---
+
+## How to verify cutover is complete
+
+```sql
+-- troop prod DB (openape-troop.db on chatty)
+-- 1. Legacy keypair nests still active:
+SELECT host_id, owner_email, last_seen_at
+FROM nests
+WHERE device_secret_hash IS NULL AND status = 'active';
+
+-- 2. Agents last synced before the hatch fix was deployed
+--    (these might still be running the old bridge with no BRIDGE_TARGET):
+SELECT email, owner_email, last_seen_at
+FROM agents
+WHERE last_seen_at < <deploy_timestamp>;
+```
+
+Access: requires SSH to chatty + `sqlite3 ~/projects/openape-troop/shared/data/openape-troop.db`
+(prod DB access was not available during M2 — hence the deferral).

--- a/apps/openape-ape-agent/src/bridge.ts
+++ b/apps/openape-ape-agent/src/bridge.ts
@@ -147,6 +147,9 @@ interface BridgeConfig {
  * no-op if the file is missing (covers ad-hoc invocations + tests).
  */
 function loadBridgeEnvFile(): void {
+  // REMOVE-AFTER: cutover-verified (see MIGRATION-mac-to-docker.md)
+  // Mac-only path. Docker nests pass env via compose environment: block, not
+  // this file. Remove once all live nests are Docker-based.
   const path = join(homedir(), 'Library', 'Application Support', 'openape', 'bridge', '.env')
   if (!existsSync(path)) return
   try {
@@ -195,6 +198,11 @@ function readConfig(): BridgeConfig {
     )
   }
 
+  // REMOVE-AFTER: cutover-verified (see MIGRATION-mac-to-docker.md)
+  // Once all live nests pass OPENAPE_BRIDGE_TARGET=troop in their compose env
+  // (confirmed via troop prod DB: no nests with null device_secret_hash still
+  // connecting without the var), flip this default to 'troop' and remove the
+  // 'chat' fallback branch below together with ChatApi + chat-api.ts.
   const targetRaw = (process.env.OPENAPE_BRIDGE_TARGET ?? 'chat').toLowerCase()
   const target: BridgeConfig['target'] = targetRaw === 'troop' ? 'troop' : 'chat'
   return {
@@ -266,6 +274,10 @@ class Bridge {
       const idp = await ensureFreshIdpAuth()
       return `Bearer ${idp.access_token}`
     }
+    // REMOVE-AFTER: cutover-verified (see MIGRATION-mac-to-docker.md)
+    // The ChatApi branch (chat.openape.ai backend) stays until we confirm no
+    // live agent still uses it. Remove ChatApi import + chat-api.ts after
+    // cutover.
     this.chat = this.cfg.target === 'troop'
       ? new TroopChatApi(this.cfg.endpoint, this.bearer)
       : new ChatApi(this.cfg.endpoint, this.bearer)

--- a/apps/openape-ape-agent/src/cron-runner.ts
+++ b/apps/openape-ape-agent/src/cron-runner.ts
@@ -1,14 +1,18 @@
 // Cron task runner inside the chat-bridge daemon.
 //
-// Why in-process (not separate launchd plists per task): the bridge
-// already owns the agent's WebSocket to chat.openape.ai, the
-// `apes agents serve --rpc` subprocess, and the only LLM-config
-// resolution. Spawning a fresh `apes agents run` per task fire would
-// duplicate every one of those plus require a separate copy of the
-// LiteLLM env that's already in the bridge's working directory. So
-// we tick the cron in here instead — every 60s, read the cached
-// task specs, fire any whose cron expression matches the current
-// minute, post the streamed result back to the owner as a DM.
+// Why in-process (not separate processes per task): the bridge already
+// owns the agent's WebSocket connection, the LLM-config resolution,
+// and the LiteLLM env. Spawning a fresh process per task fire would
+// duplicate every one of those. So we tick the cron in here instead —
+// every 60s, read the cached task specs, fire any whose cron expression
+// matches the current minute, post the streamed result back to the owner
+// as a DM.
+//
+// REMOVE-AFTER: cutover-verified (see MIGRATION-mac-to-docker.md)
+// The ~/.openape/agent/tasks/ cache dir is a Mac-era path. Docker nests
+// write it into the container's home dir which works, but the canonical
+// location post-cutover should be /var/lib/openape/agent/tasks/. Defer
+// until the Mac path is confirmed unused.
 //
 // Cron subset: same as the troop SP enforces — `*`, `N`, `*/N`. No
 // lists, no ranges. Match is evaluated minute-by-minute against the

--- a/apps/openape-ape-agent/src/identity.ts
+++ b/apps/openape-ape-agent/src/identity.ts
@@ -56,9 +56,13 @@ export function readAgentIdentity(): AgentIdentity {
   if (!parsed.idp) throw new Error(`auth.json at ${path} missing 'idp'`)
   const ownerEmail = parsed.owner_email ?? process.env.OPENAPE_OWNER_EMAIL
   if (!ownerEmail) {
+    // REMOVE-AFTER: cutover-verified (see MIGRATION-mac-to-docker.md)
+    // The launchd plist fallback path is Mac-specific. Docker nests always
+    // have owner_email in auth.json (written at spawn time). Remove the env
+    // fallback once all live nests are confirmed Docker-based.
     throw new Error(
       `auth.json at ${path} missing 'owner_email' and no OPENAPE_OWNER_EMAIL env var set — `
-      + 're-spawn the agent with @openape/apes >= 0.28 or add OPENAPE_OWNER_EMAIL to the launchd plist',
+      + 're-spawn the agent with @openape/apes >= 0.28 or set OPENAPE_OWNER_EMAIL in the container env',
     )
   }
   return { email: parsed.email, ownerEmail, idp: parsed.idp }

--- a/apps/openape-troop/server/api/agents/me/tasks.get.ts
+++ b/apps/openape-troop/server/api/agents/me/tasks.get.ts
@@ -7,7 +7,7 @@ import { composeSystemPrompt } from '../../../utils/system-prompt'
 // Agent reads its own task list + agent-level config. No owner gate —
 // the JWT's sub is the agent email and we filter rows on it.
 // Returns the full spec the agent needs to:
-//   - materialise launchd plists for cron tasks
+//   - register cron tasks with the bridge's in-process cron runner
 //   - hydrate `~/.openape/agent/agent.json` (systemPrompt + tools)
 //   - hydrate `~/.openape/agent/SOUL.md` (always-on persona / rules)
 //   - hydrate `~/.openape/agent/skills/<name>/SKILL.md` (lazy-load

--- a/apps/openape-troop/server/api/nest/hatch.post.ts
+++ b/apps/openape-troop/server/api/nest/hatch.post.ts
@@ -1,5 +1,6 @@
 import { randomBytes } from 'node:crypto'
 import { requireOwner } from '../../utils/auth'
+import { buildNestComposeYaml, buildNestEnvFile } from '../../utils/hatch-bundle'
 import { rememberHatchToken } from '../../utils/hatch-tokens'
 
 // POST /api/nest/hatch — return everything a new operator host (or a
@@ -41,63 +42,10 @@ export default defineEventHandler<Promise<HatchResponse>>(async (event) => {
 
   const troopUrl = (useRuntimeConfig().troopUrl as string | undefined) ?? 'https://troop.openape.ai'
 
-  const composeYaml = `# Generated for ${ownerEmail} on ${new Date().toISOString()}.
-# Run on the target host:
-#   docker compose up -d
-# Then verify on this troop instance — the host appears in
-# /api/nest/hosts within ~5s of bootup.
-
-services:
-  openape-llm:
-    image: ghcr.io/openape-ai/openape-llm:latest
-    container_name: openape-llm
-    restart: unless-stopped
-    networks: [openape-pod]
-    ports: ["127.0.0.1:4000:4000"]
-    volumes: ["./litellm.yaml:/etc/litellm/config.yaml:ro"]
-    environment:
-      LITELLM_MASTER_KEY: \${LITELLM_MASTER_KEY}
-      ANTHROPIC_API_KEY: \${ANTHROPIC_API_KEY}
-      CHATGPT_OAUTH_TOKEN: \${CHATGPT_OAUTH_TOKEN}
-
-  openape-nest:
-    image: ghcr.io/openape-ai/openape-nest:latest
-    container_name: openape-nest
-    restart: unless-stopped
-    depends_on: [openape-llm]
-    networks: [openape-pod]
-    ports: ["127.0.0.1:9091:9091"]
-    volumes:
-      - openape-nest-data:/var/lib/openape/nest
-      - openape-homes:/var/lib/openape/homes
-    environment:
-      OPENAPE_NEST_PORT: "9091"
-      OPENAPE_TROOP_URL: ${troopUrl}
-      OPENAPE_HATCH_TOKEN: ${token}
-      OPENAPE_HATCH_OWNER: ${ownerEmail}
-      LITELLM_BASE_URL: http://openape-llm:4000/v1
-      LITELLM_API_KEY: \${LITELLM_MASTER_KEY}
-      APE_CHAT_BRIDGE_MODEL: \${APE_CHAT_BRIDGE_MODEL:-claude-haiku-4-5}
-
-volumes:
-  openape-nest-data:
-  openape-homes:
-networks:
-  openape-pod:
-    driver: bridge
-`
-
-  const envFile = `# Copy to .env next to docker-compose.yml. Fill in provider keys.
-LITELLM_MASTER_KEY=sk-litellm-${randomBytes(8).toString('hex')}
-ANTHROPIC_API_KEY=
-CHATGPT_OAUTH_TOKEN=
-APE_CHAT_BRIDGE_MODEL=claude-haiku-4-5
-`
-
   return {
     enrollment_token: token,
     expires_at: expiresAt,
-    compose_yaml: composeYaml,
-    env_file: envFile,
+    compose_yaml: buildNestComposeYaml({ troopUrl, ownerEmail, hatchToken: token }),
+    env_file: buildNestEnvFile(),
   }
 })

--- a/apps/openape-troop/server/api/pod/hatch.post.ts
+++ b/apps/openape-troop/server/api/pod/hatch.post.ts
@@ -1,7 +1,8 @@
 import { randomBytes } from 'node:crypto'
 import { requireOwner } from '../../utils/auth'
-import { getCloud } from '../../utils/cloud/index'
 import { buildExoscaleUserData } from '../../utils/cloud/exoscale'
+import { getCloud } from '../../utils/cloud/index'
+import { buildPodComposeYaml, buildPodEnvFile } from '../../utils/hatch-bundle'
 import { rememberHatchToken } from '../../utils/hatch-tokens'
 
 // POST /api/pod/hatch — provision a fresh OpenApe pod on a cloud
@@ -65,8 +66,8 @@ export default defineEventHandler<Promise<HatchPodResponse>>(async (event) => {
   rememberHatchToken({ token, ownerEmail, expiresAt })
 
   const troopUrl = (useRuntimeConfig().troopUrl as string | undefined) ?? 'https://troop.openape.ai'
-  const composeYaml = buildComposeYaml({ troopUrl, ownerEmail, hatchToken: token })
-  const envFile = buildEnvFile(body.llm_secrets)
+  const composeYaml = buildPodComposeYaml({ troopUrl, ownerEmail, hatchToken: token })
+  const envFile = buildPodEnvFile(body.llm_secrets)
 
   // Cloud-init user-data — the provider boots the VM, installs Docker,
   // materializes the bundle, runs `docker compose up -d`. ~90s to ready
@@ -93,54 +94,3 @@ export default defineEventHandler<Promise<HatchPodResponse>>(async (event) => {
     enrollment_token: token,
   }
 })
-
-function buildComposeYaml(opts: { troopUrl: string, ownerEmail: string, hatchToken: string }): string {
-  return `services:
-  openape-llm:
-    image: ghcr.io/openape-ai/openape-llm:latest
-    container_name: openape-llm
-    restart: unless-stopped
-    networks: [openape-pod]
-    ports: ["127.0.0.1:4000:4000"]
-    volumes: ["./litellm.yaml:/etc/litellm/config.yaml:ro"]
-    environment:
-      LITELLM_MASTER_KEY: \${LITELLM_MASTER_KEY}
-      ANTHROPIC_API_KEY: \${ANTHROPIC_API_KEY}
-      CHATGPT_OAUTH_TOKEN: \${CHATGPT_OAUTH_TOKEN}
-
-  openape-nest:
-    image: ghcr.io/openape-ai/openape-nest:latest
-    container_name: openape-nest
-    restart: unless-stopped
-    depends_on: [openape-llm]
-    networks: [openape-pod]
-    ports: ["127.0.0.1:9091:9091"]
-    volumes:
-      - openape-nest-data:/var/lib/openape/nest
-      - openape-homes:/var/lib/openape/homes
-    environment:
-      OPENAPE_NEST_PORT: "9091"
-      OPENAPE_TROOP_URL: ${opts.troopUrl}
-      OPENAPE_HATCH_TOKEN: ${opts.hatchToken}
-      OPENAPE_HATCH_OWNER: ${opts.ownerEmail}
-      LITELLM_BASE_URL: http://openape-llm:4000/v1
-      LITELLM_API_KEY: \${LITELLM_MASTER_KEY}
-
-volumes:
-  openape-nest-data:
-  openape-homes:
-networks:
-  openape-pod:
-    driver: bridge
-`
-}
-
-function buildEnvFile(secrets: Record<string, string>): string {
-  const lines = [
-    `LITELLM_MASTER_KEY=sk-litellm-${randomBytes(8).toString('hex')}`,
-    `ANTHROPIC_API_KEY=${secrets.ANTHROPIC_API_KEY ?? ''}`,
-    `CHATGPT_OAUTH_TOKEN=${secrets.CHATGPT_OAUTH_TOKEN ?? ''}`,
-    `APE_CHAT_BRIDGE_MODEL=${secrets.APE_CHAT_BRIDGE_MODEL ?? 'claude-haiku-4-5'}`,
-  ]
-  return `${lines.join('\n')}\n`
-}

--- a/apps/openape-troop/server/routes/api/nest-ws.ts
+++ b/apps/openape-troop/server/routes/api/nest-ws.ts
@@ -96,6 +96,11 @@ async function authenticateUpgrade(token: string): Promise<AuthCtx> {
   if (payload.act === 'human') {
     return { ownerEmail: payload.sub.toLowerCase() }
   }
+  // REMOVE-AFTER: cutover-verified (see MIGRATION-mac-to-docker.md)
+  // Legacy keypair nest path: agent JWT with act=agent encodes ownerEmail in
+  // the sub. Kept until we confirm no live nest still uses keypair auth
+  // (troop prod DB: nests with null device_secret_hash = legacy). After
+  // cutover: remove this branch and parseAgentEmail import.
   if (payload.act === 'agent') {
     const parsed = parseAgentEmail(payload.sub)
     if (!parsed) {

--- a/apps/openape-troop/server/utils/cloud/exoscale.ts
+++ b/apps/openape-troop/server/utils/cloud/exoscale.ts
@@ -92,10 +92,12 @@ ssh_authorized_keys:
 `
 }
 
-// Placeholder API-call helper. Replaced with a signed-URL implementation
-// (Exoscale v2 HMAC scheme) when the Exoscale SDK lands.
+// Placeholder API-call helper. Intentionally disabled until the
+// signed-URL HTTP client (Exoscale v2 HMAC) is wired. Throws a
+// 501 Not Implemented so callers get an explicit, intentional error
+// rather than a generic scaffold message leaking through the API.
 async function callExoscale<T>(_env: ExoscaleEnv, _verb: 'GET' | 'POST' | 'DELETE', _path: string, _body?: unknown): Promise<T> {
-  throw new Error('exoscale.callExoscale is a scaffold — wire the signed-URL HTTP client (PR follow-up).')
+  throw createError({ statusCode: 501, statusMessage: 'Exoscale provisioning not implemented' })
 }
 
 export const exoscaleAdapter: CloudAdapter = {

--- a/apps/openape-troop/server/utils/hatch-bundle.ts
+++ b/apps/openape-troop/server/utils/hatch-bundle.ts
@@ -1,0 +1,138 @@
+import { randomBytes } from 'node:crypto'
+
+// Pure builder functions for the hatch compose + env bundles.
+// Extracted from the handler files so they can be unit-tested without
+// Nitro auto-imports (defineEventHandler, useRuntimeConfig).
+
+/**
+ * Build the docker-compose YAML for a BYO nest bundle.
+ * Used by POST /api/nest/hatch (operator-provisioned Docker host).
+ */
+export function buildNestComposeYaml(opts: {
+  troopUrl: string
+  ownerEmail: string
+  hatchToken: string
+  generatedAt?: string
+}): string {
+  const ts = opts.generatedAt ?? new Date().toISOString()
+  return `# Generated for ${opts.ownerEmail} on ${ts}.
+# Run on the target host:
+#   docker compose up -d
+# Then verify on this troop instance — the host appears in
+# /api/nest/hosts within ~5s of bootup.
+
+services:
+  openape-llm:
+    image: ghcr.io/openape-ai/openape-llm:latest
+    container_name: openape-llm
+    restart: unless-stopped
+    networks: [openape-pod]
+    ports: ["127.0.0.1:4000:4000"]
+    volumes: ["./litellm.yaml:/etc/litellm/config.yaml:ro"]
+    environment:
+      LITELLM_MASTER_KEY: \${LITELLM_MASTER_KEY}
+      ANTHROPIC_API_KEY: \${ANTHROPIC_API_KEY}
+      CHATGPT_OAUTH_TOKEN: \${CHATGPT_OAUTH_TOKEN}
+
+  openape-nest:
+    image: ghcr.io/openape-ai/openape-nest:latest
+    container_name: openape-nest
+    restart: unless-stopped
+    depends_on: [openape-llm]
+    networks: [openape-pod]
+    ports: ["127.0.0.1:9091:9091"]
+    volumes:
+      - openape-nest-data:/var/lib/openape/nest
+      - openape-homes:/var/lib/openape/homes
+    environment:
+      OPENAPE_NEST_PORT: "9091"
+      OPENAPE_TROOP_URL: ${opts.troopUrl}
+      OPENAPE_HATCH_TOKEN: ${opts.hatchToken}
+      OPENAPE_HATCH_OWNER: ${opts.ownerEmail}
+      OPENAPE_BRIDGE_TARGET: troop
+      LITELLM_BASE_URL: http://openape-llm:4000/v1
+      LITELLM_API_KEY: \${LITELLM_MASTER_KEY}
+      APE_CHAT_BRIDGE_MODEL: \${APE_CHAT_BRIDGE_MODEL:-claude-haiku-4-5}
+
+volumes:
+  openape-nest-data:
+  openape-homes:
+networks:
+  openape-pod:
+    driver: bridge
+`
+}
+
+/**
+ * Build the docker-compose YAML for a cloud-provisioned pod bundle.
+ * Used by POST /api/pod/hatch (Exoscale and future cloud providers).
+ */
+export function buildPodComposeYaml(opts: { troopUrl: string, ownerEmail: string, hatchToken: string }): string {
+  return `services:
+  openape-llm:
+    image: ghcr.io/openape-ai/openape-llm:latest
+    container_name: openape-llm
+    restart: unless-stopped
+    networks: [openape-pod]
+    ports: ["127.0.0.1:4000:4000"]
+    volumes: ["./litellm.yaml:/etc/litellm/config.yaml:ro"]
+    environment:
+      LITELLM_MASTER_KEY: \${LITELLM_MASTER_KEY}
+      ANTHROPIC_API_KEY: \${ANTHROPIC_API_KEY}
+      CHATGPT_OAUTH_TOKEN: \${CHATGPT_OAUTH_TOKEN}
+
+  openape-nest:
+    image: ghcr.io/openape-ai/openape-nest:latest
+    container_name: openape-nest
+    restart: unless-stopped
+    depends_on: [openape-llm]
+    networks: [openape-pod]
+    ports: ["127.0.0.1:9091:9091"]
+    volumes:
+      - openape-nest-data:/var/lib/openape/nest
+      - openape-homes:/var/lib/openape/homes
+    environment:
+      OPENAPE_NEST_PORT: "9091"
+      OPENAPE_TROOP_URL: ${opts.troopUrl}
+      OPENAPE_HATCH_TOKEN: ${opts.hatchToken}
+      OPENAPE_HATCH_OWNER: ${opts.ownerEmail}
+      OPENAPE_BRIDGE_TARGET: troop
+      LITELLM_BASE_URL: http://openape-llm:4000/v1
+      LITELLM_API_KEY: \${LITELLM_MASTER_KEY}
+
+volumes:
+  openape-nest-data:
+  openape-homes:
+networks:
+  openape-pod:
+    driver: bridge
+`
+}
+
+/**
+ * Build the .env file for a pod bundle. Provider API keys are
+ * injected here; OPENAPE_* vars belong in the compose environment:
+ * block (not .env) so they can't be accidentally overridden.
+ */
+export function buildPodEnvFile(secrets: Record<string, string>): string {
+  const lines = [
+    `LITELLM_MASTER_KEY=sk-litellm-${randomBytes(8).toString('hex')}`,
+    `ANTHROPIC_API_KEY=${secrets.ANTHROPIC_API_KEY ?? ''}`,
+    `CHATGPT_OAUTH_TOKEN=${secrets.CHATGPT_OAUTH_TOKEN ?? ''}`,
+    `APE_CHAT_BRIDGE_MODEL=${secrets.APE_CHAT_BRIDGE_MODEL ?? 'claude-haiku-4-5'}`,
+  ]
+  return `${lines.join('\n')}\n`
+}
+
+/**
+ * Build the .env file for the BYO nest bundle. Intentionally minimal —
+ * provider keys that vary per operator are placeholders to fill in.
+ */
+export function buildNestEnvFile(): string {
+  return `# Copy to .env next to docker-compose.yml. Fill in provider keys.
+LITELLM_MASTER_KEY=sk-litellm-${randomBytes(8).toString('hex')}
+ANTHROPIC_API_KEY=
+CHATGPT_OAUTH_TOKEN=
+APE_CHAT_BRIDGE_MODEL=claude-haiku-4-5
+`
+}

--- a/apps/openape-troop/server/utils/task-validation.ts
+++ b/apps/openape-troop/server/utils/task-validation.ts
@@ -2,11 +2,11 @@ import catalog from '../tool-catalog.json'
 
 const KNOWN_TOOLS = new Set<string>(catalog.tools.map((t: { name: string }) => t.name))
 
-// Tiny cron-syntax subset that the apes-runtime's launchd reconciler
-// can translate to `StartCalendarInterval`. We accept the 95% — every
-// other syntax (lists, ranges, step on day fields, @-shortcuts) gets
-// rejected at create time so the agent host doesn't end up with a
-// task it can't actually schedule.
+// Tiny cron-syntax subset that the apes-runtime's cron runner inside the
+// bridge daemon can evaluate. We accept the 95% — every other syntax
+// (lists, ranges, step on day fields, @-shortcuts) gets rejected at
+// create time so the agent host doesn't end up with a task it can't
+// actually schedule.
 //
 // Supported patterns (5 fields: minute hour day-of-month month day-of-week):
 //   *                 every value

--- a/apps/openape-troop/tests/cloud-exoscale.test.ts
+++ b/apps/openape-troop/tests/cloud-exoscale.test.ts
@@ -1,7 +1,17 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 import { buildExoscaleUserData, exoscaleAdapter } from '../server/utils/cloud/exoscale'
-import { getCloud, listClouds, registerCloud  } from '../server/utils/cloud/index'
+import { getCloud, listClouds, registerCloud } from '../server/utils/cloud/index'
 import type { CloudAdapter } from '../server/utils/cloud/index'
+
+// exoscale.ts uses the Nitro auto-imported createError global. Stub it so
+// callExoscale's 501 throw is testable in the plain-node vitest environment.
+beforeAll(() => {
+  ;(globalThis as Record<string, unknown>).createError = (opts: { statusCode: number, statusMessage: string }) => {
+    const err = new Error(opts.statusMessage) as Error & { statusCode: number }
+    err.statusCode = opts.statusCode
+    return err
+  }
+})
 
 afterEach(() => {
   vi.resetAllMocks()
@@ -121,6 +131,33 @@ describe('exoscale adapter', () => {
     finally {
       if (prev.key) process.env.EXOSCALE_API_KEY = prev.key
       if (prev.secret) process.env.EXOSCALE_API_SECRET = prev.secret
+    }
+  })
+
+  it('createInstance returns a 501 (not implemented) when credentials are present but API client is not wired', async () => {
+    // callExoscale is explicitly disabled until the signed-URL HTTP client
+    // lands. With credentials set, readEnv() passes and callExoscale throws
+    // a 501 createError — confirming the intentional disable is in place.
+    const prev = { key: process.env.EXOSCALE_API_KEY, secret: process.env.EXOSCALE_API_SECRET }
+    process.env.EXOSCALE_API_KEY = 'test-key'
+    process.env.EXOSCALE_API_SECRET = 'test-secret'
+    try {
+      const err = await exoscaleAdapter.createInstance({
+        name: 'test',
+        region: 'ch-gva-2',
+        instanceType: 'standard.small',
+        image: 'ubuntu-24.04',
+        sshPublicKey: 'ssh-ed25519 X',
+      }).catch(e => e)
+      expect(err).toBeInstanceOf(Error)
+      expect((err as Error & { statusCode?: number }).statusCode).toBe(501)
+      expect((err as Error).message).toContain('not implemented')
+    }
+    finally {
+      if (prev.key !== undefined) process.env.EXOSCALE_API_KEY = prev.key
+      else delete process.env.EXOSCALE_API_KEY
+      if (prev.secret !== undefined) process.env.EXOSCALE_API_SECRET = prev.secret
+      else delete process.env.EXOSCALE_API_SECRET
     }
   })
 })

--- a/apps/openape-troop/tests/hatch-bundle.test.ts
+++ b/apps/openape-troop/tests/hatch-bundle.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+import { buildNestComposeYaml, buildPodComposeYaml, buildPodEnvFile } from '../server/utils/hatch-bundle'
+
+// These tests verify that every hatch bundle that ships to a new Docker nest
+// includes OPENAPE_BRIDGE_TARGET=troop. Without it the bridge defaults to
+// 'chat', connecting to chat.openape.ai instead of the troop WS — the nest
+// would appear online but never be controlled by the troop owner.
+
+describe('nest/hatch bundle (BYO Docker path)', () => {
+  const yaml = buildNestComposeYaml({
+    troopUrl: 'https://troop.openape.ai',
+    ownerEmail: 'owner@example.com',
+    hatchToken: 'nest-hatch-test',
+    generatedAt: '2026-06-03T00:00:00.000Z',
+  })
+
+  it('sets OPENAPE_BRIDGE_TARGET=troop in the openape-nest service env', () => {
+    expect(yaml).toContain('OPENAPE_BRIDGE_TARGET: troop')
+  })
+
+  it('includes the troop URL', () => {
+    expect(yaml).toContain('OPENAPE_TROOP_URL: https://troop.openape.ai')
+  })
+
+  it('includes the hatch token', () => {
+    expect(yaml).toContain('OPENAPE_HATCH_TOKEN: nest-hatch-test')
+  })
+
+  it('includes the owner email', () => {
+    expect(yaml).toContain('OPENAPE_HATCH_OWNER: owner@example.com')
+  })
+
+  it('does not reference chat.openape.ai (bridge target is troop, not chat)', () => {
+    expect(yaml).not.toContain('chat.openape.ai')
+  })
+})
+
+describe('pod/hatch bundle (cloud-provisioned Docker path)', () => {
+  const yaml = buildPodComposeYaml({
+    troopUrl: 'https://troop.openape.ai',
+    ownerEmail: 'owner@example.com',
+    hatchToken: 'nest-hatch-pod-test',
+  })
+
+  it('sets OPENAPE_BRIDGE_TARGET=troop in the openape-nest service env', () => {
+    expect(yaml).toContain('OPENAPE_BRIDGE_TARGET: troop')
+  })
+
+  it('includes the troop URL', () => {
+    expect(yaml).toContain('OPENAPE_TROOP_URL: https://troop.openape.ai')
+  })
+
+  it('includes the hatch token', () => {
+    expect(yaml).toContain('OPENAPE_HATCH_TOKEN: nest-hatch-pod-test')
+  })
+
+  it('does not reference chat.openape.ai (bridge target is troop, not chat)', () => {
+    expect(yaml).not.toContain('chat.openape.ai')
+  })
+})
+
+describe('pod/hatch env file', () => {
+  it('does not embed OPENAPE_BRIDGE_TARGET (it belongs in compose environment block, not .env)', () => {
+    // The bridge reads OPENAPE_BRIDGE_TARGET from the container environment,
+    // not from the .env file. If it were in .env it could be accidentally
+    // overridden. The compose environment: block takes precedence anyway, but
+    // this confirms the split is intentional.
+    const env = buildPodEnvFile({ ANTHROPIC_API_KEY: 'sk-ant-x', CHATGPT_OAUTH_TOKEN: '' })
+    expect(env).not.toContain('OPENAPE_BRIDGE_TARGET')
+  })
+
+  it('includes model key from secrets', () => {
+    const env = buildPodEnvFile({ APE_CHAT_BRIDGE_MODEL: 'gpt-5.4' })
+    expect(env).toContain('APE_CHAT_BRIDGE_MODEL=gpt-5.4')
+  })
+
+  it('defaults model to claude-haiku-4-5 when not in secrets', () => {
+    const env = buildPodEnvFile({})
+    expect(env).toContain('APE_CHAT_BRIDGE_MODEL=claude-haiku-4-5')
+  })
+})


### PR DESCRIPTION
## M2 — Mac→Docker (safe slice)

- **fix(troop):** hatch bundles (nest + pod) now set `OPENAPE_BRIDGE_TARGET=troop` — fixes new Docker nests wrongly starting in `chat` mode. Builders extracted to `hatch-bundle.ts` + 12 tests.
- **refactor(troop):** Exoscale adapter now fails with an explicit `501 not implemented` instead of a generic throwing stub (a reachable endpoint that pretends-crashes is worse than an honest 501).
- **docs(troop):** launchd → container cron-runner comments.
- **docs:** `MIGRATION-mac-to-docker.md` tracker + `// REMOVE-AFTER: cutover-verified` tags.

**Deferred (cutover-gated):** removing the ape-agent dual chat backend + the `nest-ws.ts` legacy keypair auth + Mac paths — these need confirmation that no live nest/agent still uses chat/keypair (read of the troop prod DB; access was denied to the agent). Exact post-cutover removals are documented in the migration tracker. Gate green; troop builds.