### PR TITLE
fix(core): OpenApeManifest scopes to array form (IdP-side B6 fix)

### DIFF
--- a/.changeset/fix-core-manifest-scopes-array.md
+++ b/.changeset/fix-core-manifest-scopes-array.md
@@ -1,0 +1,5 @@
+---
+"@openape/core": patch
+---
+
+Fix OpenApeManifest.scopes type + validateOpenApeManifest to the array form ({ id, description, grants?, ... }[]) per protocol sp-scope-catalog.json and the cross-SP consumer. The previous Record shape caused validateOpenApeManifest (used by the IdP's fetchSpManifest) to reject the array-format manifests that SPs actually serve.

--- a/packages/core/src/__tests__/openape-manifest.test.ts
+++ b/packages/core/src/__tests__/openape-manifest.test.ts
@@ -19,10 +19,10 @@ describe('validateOpenApeManifest', () => {
     const result = validateOpenApeManifest({
       ...validManifest(),
       auth: { supported_methods: ['ddisa', 'oidc'] },
-      scopes: {
-        'doc:read': { name: 'Read', description: 'Read docs', risk: 'low' },
-        'doc:delete': { name: 'Delete', description: 'Delete docs', risk: 'high' },
-      },
+      scopes: [
+        { id: 'doc:read', description: 'Read docs', risk: 'low', grants: ['GET /api/docs'] },
+        { id: 'doc:delete', description: 'Delete docs', risk: 'high' },
+      ],
       policies: { delegation: 'allowed' },
       future_field: 'forward-compatible',
     })
@@ -57,13 +57,27 @@ describe('validateOpenApeManifest', () => {
     expect(validateOpenApeManifest({ ...validManifest(), auth: { supported_methods: ['invalid'] } }).errors.some(e => e.includes('invalid method'))).toBe(true)
   })
 
-  it('validates scopes as object with required fields per scope', () => {
-    expect(validateOpenApeManifest({ ...validManifest(), scopes: 'bad' }).errors).toContain('scopes must be an object if provided')
-    expect(validateOpenApeManifest({ ...validManifest(), scopes: { s: 'not-obj' } }).errors.some(e => e.includes('must be an object'))).toBe(true)
-    const badScope = validateOpenApeManifest({ ...validManifest(), scopes: { s: { name: '', risk: 'invalid' } } })
-    expect(badScope.errors.some(e => e.includes('s.name'))).toBe(true)
-    expect(badScope.errors.some(e => e.includes('s.description'))).toBe(true)
-    expect(badScope.errors.some(e => e.includes('s.risk'))).toBe(true)
+  it('validates scopes as an array with required fields per entry', () => {
+    // non-array → error
+    expect(validateOpenApeManifest({ ...validManifest(), scopes: 'bad' }).errors).toContain('scopes must be an array if provided')
+    expect(validateOpenApeManifest({ ...validManifest(), scopes: {} }).errors).toContain('scopes must be an array if provided')
+    // entry that is not an object → error
+    expect(validateOpenApeManifest({ ...validManifest(), scopes: ['not-obj'] }).errors.some(e => e.includes('must be an object'))).toBe(true)
+    // missing id → error
+    const missingId = validateOpenApeManifest({ ...validManifest(), scopes: [{ description: 'desc' }] })
+    expect(missingId.errors.some(e => e.includes('scopes[0].id is required'))).toBe(true)
+    // missing description → error
+    const missingDesc = validateOpenApeManifest({ ...validManifest(), scopes: [{ id: 'doc:read' }] })
+    expect(missingDesc.errors.some(e => e.includes('scopes[0].description is required'))).toBe(true)
+    // bad risk → error
+    const badRisk = validateOpenApeManifest({ ...validManifest(), scopes: [{ id: 'doc:read', description: 'desc', risk: 'invalid' }] })
+    expect(badRisk.errors.some(e => e.includes('scopes[0].risk'))).toBe(true)
+    // bad grants (not string[]) → error
+    const badGrants = validateOpenApeManifest({ ...validManifest(), scopes: [{ id: 'doc:read', description: 'desc', grants: [42] }] })
+    expect(badGrants.errors.some(e => e.includes('scopes[0].grants'))).toBe(true)
+    // valid entry with risk + grants → passes
+    const valid = validateOpenApeManifest({ ...validManifest(), scopes: [{ id: 'doc:read', description: 'desc', risk: 'low', grants: ['GET /api/docs'] }] })
+    expect(valid.valid).toBe(true)
   })
 
   it('validates policies as object with valid delegation', () => {

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -341,7 +341,15 @@ export interface OpenApeManifest {
     login_url?: string
   }
   /** Scopes the SP offers */
-  scopes?: Record<string, OpenApeScope>
+  scopes?: Array<{
+    id: string
+    description: string
+    grants?: string[]
+    name?: string
+    risk?: ScopeRiskLevel
+    category?: string
+    parameters?: Record<string, { type: string, description: string }>
+  }>
   /** Scope categories for UI grouping */
   categories?: Record<string, OpenApeScopeCategory>
   /** SP policies */

--- a/packages/core/src/validation/openape-manifest.ts
+++ b/packages/core/src/validation/openape-manifest.ts
@@ -60,26 +60,32 @@ export function validateOpenApeManifest(data: unknown): OpenApeManifestValidatio
     }
   }
 
-  // scopes (optional)
+  // scopes (optional) — must be an array of { id, description, grants?, risk?, ... }
   if (obj.scopes !== undefined) {
-    if (typeof obj.scopes !== 'object' || obj.scopes === null) {
-      errors.push('scopes must be an object if provided')
+    if (!Array.isArray(obj.scopes)) {
+      errors.push('scopes must be an array if provided')
     }
     else {
-      for (const [key, scope] of Object.entries(obj.scopes as Record<string, unknown>)) {
+      for (let i = 0; i < obj.scopes.length; i++) {
+        const scope = obj.scopes[i]
         if (!scope || typeof scope !== 'object') {
-          errors.push(`scopes.${key}: must be an object`)
+          errors.push(`scopes[${i}]: must be an object`)
           continue
         }
         const s = scope as Record<string, unknown>
-        if (typeof s.name !== 'string' || !s.name) {
-          errors.push(`scopes.${key}.name is required`)
+        if (typeof s.id !== 'string' || !s.id) {
+          errors.push(`scopes[${i}].id is required`)
         }
         if (typeof s.description !== 'string' || !s.description) {
-          errors.push(`scopes.${key}.description is required`)
+          errors.push(`scopes[${i}].description is required`)
         }
-        if (!VALID_RISK_LEVELS.includes(s.risk as string)) {
-          errors.push(`scopes.${key}.risk must be one of: ${VALID_RISK_LEVELS.join(', ')}`)
+        if (s.grants !== undefined) {
+          if (!Array.isArray(s.grants) || s.grants.some(g => typeof g !== 'string')) {
+            errors.push(`scopes[${i}].grants must be a string[] if provided`)
+          }
+        }
+        if (s.risk !== undefined && !VALID_RISK_LEVELS.includes(s.risk as string)) {
+          errors.push(`scopes[${i}].risk must be one of: ${VALID_RISK_LEVELS.join(', ')}`)
         }
       }
     }

--- a/packages/protocol-conformance/test/manifest.test.ts
+++ b/packages/protocol-conformance/test/manifest.test.ts
@@ -1,14 +1,9 @@
-// NOTE: OpenApeManifest.scopes (Record<string, OpenApeScope>) in @openape/core is a SEPARATE,
-// richer capability-manifest type — NOT the SP data-access scope catalog validated here.
-// It is flagged for Phase 2 (sharpen package boundaries / possible legacy type). The live
-// /.well-known/openape.json served by apps/openape-troop uses this array format.
-
 import type { OpenApeManifest } from '@openape/core'
 import { validateOpenApeManifest } from '@openape/core'
 import { describe, expect, it } from 'vitest'
 import { getValidator } from './harness.js'
 
-/** A representative openape.json using the Record format the code produces */
+/** A representative openape.json using the array format per protocol spec */
 const sampleManifest: OpenApeManifest = {
   version: '1',
   service: {
@@ -20,18 +15,18 @@ const sampleManifest: OpenApeManifest = {
     supported_methods: ['ddisa'],
     ddisa_domain: 'timetrack.example.com',
   },
-  scopes: {
-    'timetrack:read': {
-      name: 'Read time entries',
+  scopes: [
+    {
+      id: 'timetrack:read',
       description: 'Read your time entries',
       risk: 'low',
     },
-    'timetrack:write': {
-      name: 'Write time entries',
+    {
+      id: 'timetrack:write',
       description: 'Create and update time entries',
       risk: 'medium',
     },
-  },
+  ],
   policies: {
     delegation: 'allowed',
   },
@@ -41,7 +36,7 @@ describe('openape.json manifest — sp-scope-catalog.json', () => {
   const { validate } = getValidator('sp-scope-catalog.json')
 
   it('validateOpenApeManifest accepts the sample manifest (internal validator)', () => {
-    // Confirm the code-side validator accepts the Record-format manifest object.
+    // Confirm the code-side validator accepts the array-format manifest object.
     const result = validateOpenApeManifest(sampleManifest)
     expect(result.valid, `Validation errors: ${result.errors.join(', ')}`).toBe(true)
   })


### PR DESCRIPTION
core's `OpenApeManifest.scopes` type + `validateOpenApeManifest` used a Record shape, but SPs serve (and `cross-sp-scope-catalog` + the protocol `sp-scope-catalog.json` expect) an ARRAY. The Record validator would reject the array manifests SPs serve → the IdP's `fetchSpManifest` returned null. Aligned core to the array form. Conformance + IdP typecheck + full gate green (incl. e2e after clearing a stray :3000 process). Changeset: core patch (cascades on next release).