### PR TITLE
chore: release shapes 0.7.0 + agent-runtime 0.2.0 + apes 1.29.0

### DIFF
--- a/.changeset/agent-http-ssrf-guard.md
+++ b/.changeset/agent-http-ssrf-guard.md
@@ -1,5 +1,0 @@
----
-"@openape/agent-runtime": patch
----
-
-Add an SSRF guard to the agent `http.get`/`http.post` tools: validate the URL scheme, DNS-resolve the host and reject private/loopback/link-local/CGNAT/ULA/cloud-metadata targets, and re-validate every redirect hop (manual redirect following). Prevents a prompt-injected agent from reaching internal infrastructure via the HTTP tool.

--- a/.changeset/extract-agent-runtime.md
+++ b/.changeset/extract-agent-runtime.md
@@ -1,6 +1,0 @@
----
-"@openape/agent-runtime": minor
-"@openape/apes": minor
----
-
-Extract the agent-execution cluster (in-process run loop, agent tools, coding agent) from `@openape/apes` into a new dependency-light `@openape/agent-runtime` package. apes re-exports the surface, so `@openape/ape-agent` is unaffected. No behaviour change.

--- a/.changeset/extract-shapes-package.md
+++ b/.changeset/extract-shapes-package.md
@@ -1,6 +1,0 @@
----
-"@openape/shapes": minor
-"@openape/apes": minor
----
-
-Extract the pure Shapes library core (parser, adapters, registry, installer, toml, capabilities, request-builders, shell-parser, types, audit, http, config) from `@openape/apes` into a new `@openape/shapes` package. Grant-orchestration and CLI glue stay in apes and consume the package. No behaviour change.

--- a/apps/openape-ape-agent/CHANGELOG.md
+++ b/apps/openape-ape-agent/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @openape/ape-agent
 
+## 2.8.15
+
+### Patch Changes
+
+- Updated dependencies [bb4a318]
+- Updated dependencies [a0d8506]
+  - @openape/apes@1.29.0
+
 ## 2.8.14
 
 ### Patch Changes

--- a/apps/openape-ape-agent/package.json
+++ b/apps/openape-ape-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openape/ape-agent",
-  "version": "2.8.14",
+  "version": "2.8.15",
   "description": "OpenApe agent runtime: per-agent process that connects to chat.openape.ai, runs the LLM loop with tools + cron tasks, and streams replies back to owners.",
   "type": "module",
   "license": "MIT",

--- a/packages/agent-runtime/CHANGELOG.md
+++ b/packages/agent-runtime/CHANGELOG.md
@@ -1,0 +1,11 @@
+# @openape/agent-runtime
+
+## 0.2.0
+
+### Minor Changes
+
+- bb4a318: Extract the agent-execution cluster (in-process run loop, agent tools, coding agent) from `@openape/apes` into a new dependency-light `@openape/agent-runtime` package. apes re-exports the surface, so `@openape/ape-agent` is unaffected. No behaviour change.
+
+### Patch Changes
+
+- 2d5f64b: Add an SSRF guard to the agent `http.get`/`http.post` tools: validate the URL scheme, DNS-resolve the host and reject private/loopback/link-local/CGNAT/ULA/cloud-metadata targets, and re-validate every redirect hop (manual redirect following). Prevents a prompt-injected agent from reaching internal infrastructure via the HTTP tool.

--- a/packages/agent-runtime/package.json
+++ b/packages/agent-runtime/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openape/agent-runtime",
   "type": "module",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "turbo": {
     "tags": [
       "publishable"

--- a/packages/apes/CHANGELOG.md
+++ b/packages/apes/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @openape/apes
 
+## 1.29.0
+
+### Minor Changes
+
+- bb4a318: Extract the agent-execution cluster (in-process run loop, agent tools, coding agent) from `@openape/apes` into a new dependency-light `@openape/agent-runtime` package. apes re-exports the surface, so `@openape/ape-agent` is unaffected. No behaviour change.
+- a0d8506: Extract the pure Shapes library core (parser, adapters, registry, installer, toml, capabilities, request-builders, shell-parser, types, audit, http, config) from `@openape/apes` into a new `@openape/shapes` package. Grant-orchestration and CLI glue stay in apes and consume the package. No behaviour change.
+
+### Patch Changes
+
+- Updated dependencies [2d5f64b]
+- Updated dependencies [bb4a318]
+- Updated dependencies [a0d8506]
+  - @openape/agent-runtime@0.2.0
+  - @openape/shapes@0.2.0
+
 ## 1.28.13
 
 ### Patch Changes

--- a/packages/apes/package.json
+++ b/packages/apes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openape/apes",
-  "version": "1.28.13",
+  "version": "1.29.0",
   "turbo": {
     "tags": [
       "publishable"

--- a/packages/shapes/CHANGELOG.md
+++ b/packages/shapes/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @openape/shapes
+
+## 0.7.0
+
+### Minor Changes
+
+- a0d8506: Extract the pure Shapes library core (parser, adapters, registry, installer, toml, capabilities, request-builders, shell-parser, types, audit, http, config) from `@openape/apes` into a new `@openape/shapes` package. Grant-orchestration and CLI glue stay in apes and consume the package. No behaviour change.

--- a/packages/shapes/package.json
+++ b/packages/shapes/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openape/shapes",
   "type": "module",
-  "version": "0.1.0",
+  "version": "0.7.0",
   "turbo": {
     "tags": [
       "publishable"

--- a/scripts/publish-chain.mjs
+++ b/scripts/publish-chain.mjs
@@ -38,6 +38,8 @@ const PACKAGES = [
   { name: '@openape/server', dir: 'packages/server' },
   { name: '@openape/browser', dir: 'packages/browser' },
   { name: '@openape/vue-components', dir: 'packages/vue-components' },
+  { name: '@openape/shapes', dir: 'packages/shapes' },
+  { name: '@openape/agent-runtime', dir: 'packages/agent-runtime' },
   { name: '@openape/apes', dir: 'packages/apes' },
   { name: '@openape/unstorage-s3-driver', dir: 'packages/s3-driver' },
   { name: '@openape/prompt-injection-detector', dir: 'packages/prompt-injection-detector' },


### PR DESCRIPTION
Version-Bump + publish-chain-Fix für die zwei neuen Pakete. shapes als 0.7.0 wiederbelebt (war deprecated @0.6.2 → jetzt latest, nicht deprecated), agent-runtime 0.2.0 (neu), apes 1.29.0 (re-exportiert beide), ape-agent 2.8.15. Alle 4 auf npm publiziert + verifiziert (apes-Deps lösen auf). publish-chain.mjs um shapes+agent-runtime ergänzt.