### PR TITLE
feat(apes): materialize sealed blob to a file path with seed-once

### DIFF
--- a/packages/apes/src/lib/agent-secrets-runtime.ts
+++ b/packages/apes/src/lib/agent-secrets-runtime.ts
@@ -1,7 +1,7 @@
 import type { SealedBox } from '@openape/core'
-import { existsSync, readdirSync, readFileSync, watch } from 'node:fs'
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, watch, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { openString } from '@openape/core'
 
 // Agent-side of the capability broker. troop seals a secret to this
@@ -72,8 +72,21 @@ export function materializeSecrets(opts: MaterializeOptions = {}): MaterializeRe
     const name = envNameFromFile(file)
     if (!name) continue
     try {
-      const box = JSON.parse(readFileSync(join(dir, file), 'utf8')) as SealedBox
-      env[name] = openString(box, key!)
+      const box = JSON.parse(readFileSync(join(dir, file), 'utf8')) as SealedBox & { materializeTo?: unknown }
+      const plaintext = openString(box, key!)
+      const target = typeof box.materializeTo === 'string' ? box.materializeTo : null
+      if (target) {
+        // Seed-once: write only on first seed or a newer blob (re-verify).
+        // Never clobber a file litellm refreshed in place (file > blob mtime).
+        const blobMtime = statSync(join(dir, file)).mtimeMs
+        if (!existsSync(target) || statSync(target).mtimeMs < blobMtime) {
+          mkdirSync(dirname(target), { recursive: true })
+          writeFileSync(target, plaintext, { mode: 0o600 })
+        }
+      }
+      else {
+        env[name] = plaintext
+      }
       applied.push(name)
     }
     catch (e) {

--- a/packages/apes/test/agent-secrets-runtime.test.ts
+++ b/packages/apes/test/agent-secrets-runtime.test.ts
@@ -1,5 +1,5 @@
 import { generateX25519KeyPair, seal } from '@openape/core'
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, readFileSync, rmSync, statSync, utimesSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
@@ -67,5 +67,42 @@ describe('materializeSecrets', () => {
     expect(r.applied).toEqual(['KEEP'])
     expect(env.KEEP).toBe('k')
     expect(env.GONE).toBeUndefined()
+  })
+})
+
+describe('materializeSecrets — file targets', () => {
+  function writeFileBlob(name: string, value: string, materializeTo: string): void {
+    writeFileSync(join(dir, `${name}.blob`), JSON.stringify({ ...seal(value, kp.publicKey), materializeTo }))
+  }
+
+  it('writes the unsealed content to the target file (mode 0600), not the env', () => {
+    const target = join(dir, 'out', 'auth.json')
+    writeFileBlob('CHATGPT_AUTH_JSON', '{"token":"abc"}', target)
+    const env: NodeJS.ProcessEnv = {}
+    const r = materializeSecrets({ dir, keyPath, env })
+    expect(r.applied).toEqual(['CHATGPT_AUTH_JSON'])
+    expect(readFileSync(target, 'utf8')).toBe('{"token":"abc"}')
+    expect(statSync(target).mode & 0o777).toBe(0o600)
+    expect(env.CHATGPT_AUTH_JSON).toBeUndefined()
+  })
+
+  it('seed-once: leaves a target file that is newer than the blob untouched', () => {
+    const target = join(dir, 'auth.json')
+    writeFileSync(target, 'LIVE-refreshed-by-litellm')
+    writeFileBlob('CHATGPT_AUTH_JSON', 'STALE-from-troop', target)
+    utimesSync(join(dir, 'CHATGPT_AUTH_JSON.blob'), new Date('2026-01-01T00:00:00Z'), new Date('2026-01-01T00:00:00Z'))
+    utimesSync(target, new Date('2026-01-02T00:00:00Z'), new Date('2026-01-02T00:00:00Z'))
+    materializeSecrets({ dir, keyPath, env: {} })
+    expect(readFileSync(target, 'utf8')).toBe('LIVE-refreshed-by-litellm')
+  })
+
+  it('re-verify: a blob newer than the target overwrites it', () => {
+    const target = join(dir, 'auth.json')
+    writeFileSync(target, 'OLD')
+    writeFileBlob('CHATGPT_AUTH_JSON', 'FRESH-reverify', target)
+    utimesSync(target, new Date('2026-01-01T00:00:00Z'), new Date('2026-01-01T00:00:00Z'))
+    utimesSync(join(dir, 'CHATGPT_AUTH_JSON.blob'), new Date('2026-01-02T00:00:00Z'), new Date('2026-01-02T00:00:00Z'))
+    materializeSecrets({ dir, keyPath, env: {} })
+    expect(readFileSync(target, 'utf8')).toBe('FRESH-reverify')
   })
 })


### PR DESCRIPTION
Part of ape-plan `01KTCBFW55BKHY7F2HHE25TZ3G` (ChatGPT-Subscription: Troop-Onboarding + Nest als Holder) — Milestone **M1**, Sub-Step **S1**.

Extends the capability broker so a sealed blob can materialize to a **file** at a configured path (for the ChatGPT `auth.json`), with **mtime-based seed-once**:
- blob carries an optional cleartext `materializeTo` path; env-var blobs unchanged.
- write only on first seed or a **newer** blob (re-verify); never clobber a file litellm refreshed in place (file mtime > blob mtime).
- file written mode `0600`, parent dirs created.

## Tests (TDD, each RED→GREEN)
`packages/apes/test/agent-secrets-runtime.test.ts`: file write + mode 0600 + env-not-set · seed-once (newer file untouched) · re-verify (newer blob overwrites). Existing 5 unchanged.

Full `@openape/apes` suite: **565 passed / 3 skipped**. typecheck + lint green.

Closes #563
