### PR TITLE
feat(troop): ChatGPT OAuth device-flow + seed sealed auth.json to agent

### DIFF
--- a/apps/openape-troop/app/components/ChatgptConnect.vue
+++ b/apps/openape-troop/app/components/ChatgptConnect.vue
@@ -1,0 +1,92 @@
+<script setup lang="ts">
+import { onUnmounted, ref } from 'vue'
+
+// "Sign in with ChatGPT" device flow for one agent. Owner clicks Connect →
+// we start the flow (initiate), show the user_code + verification link, and
+// poll until ChatGPT confirms. On success the sealed auth.json is pushed to
+// the agent (server side) and the agent appears connected.
+const props = defineProps<{ agentName: string }>()
+const emit = defineEmits<{ connected: [] }>()
+
+type State = 'idle' | 'pending' | 'connected' | 'error'
+const state = ref<State>('idle')
+const userCode = ref('')
+const verificationUri = ref('')
+const accountId = ref('')
+const error = ref('')
+let timer: ReturnType<typeof setTimeout> | null = null
+
+async function connect() {
+  error.value = ''
+  state.value = 'pending'
+  try {
+    const res = await ($fetch as any)(`/api/agents/${props.agentName}/oauth/chatgpt/initiate`, { method: 'POST' })
+    userCode.value = res.user_code
+    verificationUri.value = res.verification_uri
+    schedule((res.interval ?? 5) * 1000)
+  }
+  catch (e: any) {
+    state.value = 'error'
+    error.value = e?.data?.statusMessage || e?.message || 'failed to start'
+  }
+}
+
+function schedule(ms: number) {
+  timer = setTimeout(poll, ms)
+}
+
+async function poll() {
+  try {
+    const res = await ($fetch as any)(`/api/agents/${props.agentName}/oauth/chatgpt/poll`, { method: 'POST' })
+    if (res.status === 'connected') {
+      state.value = 'connected'
+      accountId.value = res.account_id
+      emit('connected')
+    }
+    else if (res.status === 'denied') {
+      state.value = 'error'
+      error.value = res.error || 'denied'
+    }
+    else {
+      schedule(res.status === 'slow_down' ? 8000 : 5000)
+    }
+  }
+  catch (e: any) {
+    state.value = 'error'
+    error.value = e?.data?.statusMessage || e?.message || 'poll failed'
+  }
+}
+
+onUnmounted(() => {
+  if (timer) clearTimeout(timer)
+})
+</script>
+
+<template>
+  <div class="px-4 py-3 border-b border-(--ui-border)">
+    <div v-if="state === 'connected'" class="flex items-center gap-2 text-sm">
+      <UIcon name="i-lucide-circle-check" class="text-success size-4" />
+      <span>{{ $t('agentDetail.chatgpt.connected', { account: accountId }) }}</span>
+    </div>
+    <div v-else-if="state === 'pending'" class="space-y-2">
+      <p class="text-sm">
+        {{ $t('agentDetail.chatgpt.enterCode') }}
+        <a :href="verificationUri" target="_blank" rel="noopener" class="text-primary underline">{{ verificationUri }}</a>
+      </p>
+      <div class="font-mono text-xl tracking-widest">
+        {{ userCode }}
+      </div>
+      <p class="text-xs text-muted flex items-center gap-1">
+        <UIcon name="i-lucide-loader-circle" class="size-3 animate-spin" />
+        {{ $t('agentDetail.chatgpt.waiting') }}
+      </p>
+    </div>
+    <div v-else class="flex flex-wrap items-center gap-2">
+      <UButton color="primary" variant="subtle" icon="i-lucide-sparkles" @click="connect">
+        {{ $t('agentDetail.chatgpt.connectButton') }}
+      </UButton>
+      <span class="text-xs text-muted">{{ $t('agentDetail.chatgpt.hint') }}</span>
+    </div>
+    <UAlert v-if="state === 'error'" color="error" :title="error" class="mt-2" />
+  </div>
+</template>

--- a/apps/openape-troop/app/pages/agents/[name].vue
+++ b/apps/openape-troop/app/pages/agents/[name].vue
@@ -822,6 +822,7 @@ onBeforeUnmount(() => { if (destroyPollTimer) clearTimeout(destroyPollTimer) })
               <p class="text-xs text-muted px-4 py-3">
                 {{ $t('agentDetail.secrets.hint') }}
               </p>
+              <ChatgptConnect :agent-name="agentName" @connected="loadSecrets" />
               <UAlert v-if="secretsError" color="error" :title="secretsError" class="m-4" />
               <ul v-if="secrets.length > 0" class="divide-y divide-(--ui-border)">
                 <li v-for="s in secrets" :key="s.env" class="px-4 py-3 flex items-center gap-3">

--- a/apps/openape-troop/i18n/locales/de.json
+++ b/apps/openape-troop/i18n/locales/de.json
@@ -164,6 +164,13 @@
         }
       }
     },
+    "chatgpt": {
+      "connectButton": "ChatGPT verbinden",
+      "hint": "Einmal anmelden — der Agent nutzt dann dein ChatGPT-Abo.",
+      "enterCode": "Öffne und gib den Code ein:",
+      "waiting": "Warte auf Bestätigung im Browser …",
+      "connected": "ChatGPT verbunden (Account {account})"
+    },
     "secrets": {
       "title": "Secrets",
       "hint": "Capability-Values für diesen Agent. Der Wert wird vor dem Speichern auf den Schlüssel des Agents sealed — Troop kennt den Klartext nie und kann ihn nicht mehr anzeigen. Wert nochmal setzen = rotieren.",

--- a/apps/openape-troop/i18n/locales/en.json
+++ b/apps/openape-troop/i18n/locales/en.json
@@ -164,6 +164,13 @@
         }
       }
     },
+    "chatgpt": {
+      "connectButton": "Connect ChatGPT",
+      "hint": "Sign in once — the agent then uses your ChatGPT subscription.",
+      "enterCode": "Open and enter the code:",
+      "waiting": "Waiting for browser confirmation …",
+      "connected": "ChatGPT connected (account {account})"
+    },
     "secrets": {
       "title": "Secrets",
       "hint": "Capability values for this agent. The value is sealed to the agent's key before it's stored — Troop never keeps the plaintext and can't show it back. Set a value again to rotate it.",

--- a/apps/openape-troop/server/api/agents/[name]/oauth/[provider]/initiate.post.ts
+++ b/apps/openape-troop/server/api/agents/[name]/oauth/[provider]/initiate.post.ts
@@ -1,0 +1,65 @@
+import { and, eq } from 'drizzle-orm'
+import { useDb } from '../../../../../database/drizzle'
+import { agents, oauthCredentials } from '../../../../../database/schema'
+import { requireOwner } from '../../../../../utils/auth'
+import { initiateChatgptDeviceFlow } from '../../../../../utils/oauth-chatgpt'
+
+// Start the "Sign in with ChatGPT" device flow for an agent. Returns the
+// user_code + verification URI the owner enters in a browser; the device_code
+// is kept server-side (oauth_credentials) so /poll completes without ever
+// exposing it to the browser.
+export default defineEventHandler(async (event) => {
+  const owner = await requireOwner(event)
+  const name = getRouterParam(event, 'name')
+  const provider = getRouterParam(event, 'provider')
+  if (!name || !provider) throw createError({ statusCode: 400, statusMessage: 'name and provider are required' })
+  if (provider !== 'chatgpt') throw createError({ statusCode: 400, statusMessage: 'unsupported provider' })
+
+  const db = useDb()
+  const agent = await db
+    .select({ email: agents.email })
+    .from(agents)
+    .where(and(eq(agents.ownerEmail, owner.toLowerCase()), eq(agents.agentName, name)))
+    .get()
+  if (!agent) throw createError({ statusCode: 404, statusMessage: 'agent not found' })
+
+  let start
+  try {
+    start = await initiateChatgptDeviceFlow(globalThis.fetch)
+  }
+  catch (e) {
+    throw createError({ statusCode: 502, statusMessage: `device flow failed: ${(e as Error).message}` })
+  }
+
+  const now = Math.floor(Date.now() / 1000)
+  const fields = {
+    status: 'pending',
+    deviceCode: start.device_code,
+    userCode: start.user_code,
+    verificationUri: start.verification_uri_complete ?? start.verification_uri,
+    deviceExpiresAt: now + start.expires_in,
+    accountId: null,
+    expiresAt: null,
+    updatedAt: now,
+  }
+  const existing = await db
+    .select({ agentEmail: oauthCredentials.agentEmail })
+    .from(oauthCredentials)
+    .where(and(eq(oauthCredentials.agentEmail, agent.email), eq(oauthCredentials.provider, provider)))
+    .get()
+  if (existing) {
+    await db.update(oauthCredentials).set(fields).where(and(eq(oauthCredentials.agentEmail, agent.email), eq(oauthCredentials.provider, provider)))
+  }
+  else {
+    await db.insert(oauthCredentials).values({ agentEmail: agent.email, provider, createdAt: now, ...fields })
+  }
+
+  setHeader(event, 'Cache-Control', 'no-store')
+  return {
+    status: 'pending',
+    user_code: start.user_code,
+    verification_uri: fields.verificationUri,
+    interval: start.interval,
+    expires_in: start.expires_in,
+  }
+})

--- a/apps/openape-troop/server/api/agents/[name]/oauth/[provider]/poll.post.ts
+++ b/apps/openape-troop/server/api/agents/[name]/oauth/[provider]/poll.post.ts
@@ -1,0 +1,87 @@
+import { and, eq } from 'drizzle-orm'
+import { useDb } from '../../../../../database/drizzle'
+import { agents, agentSecrets, oauthCredentials } from '../../../../../database/schema'
+import { buildSecretUpdateFrame, sealSecret, serializeSealed } from '../../../../../utils/agent-secrets'
+import { requireOwner } from '../../../../../utils/auth'
+import { broadcastToOwner } from '../../../../../utils/nest-registry'
+import { CHATGPT_AUTH_FILE_PATH, CHATGPT_SECRET_ENV, pollChatgptToken, toLitellmAuthJson } from '../../../../../utils/oauth-chatgpt'
+
+// Poll the device flow once. On `pending`/`slow_down` the UI keeps polling.
+// On success: serialize the token → seal the auth.json to the agent's X25519
+// pubkey → persist as a file-target agent_secret (CHATGPT_AUTH_JSON) and push
+// it over the nest WS. The agent's broker (M1/S1) writes it to the litellm
+// auth.json with seed-once; litellm refreshes it in place thereafter.
+export default defineEventHandler(async (event) => {
+  const owner = await requireOwner(event)
+  const name = getRouterParam(event, 'name')
+  const provider = getRouterParam(event, 'provider')
+  if (!name || !provider) throw createError({ statusCode: 400, statusMessage: 'name and provider are required' })
+  if (provider !== 'chatgpt') throw createError({ statusCode: 400, statusMessage: 'unsupported provider' })
+
+  const db = useDb()
+  const agent = await db
+    .select({ email: agents.email, pubkeyX25519: agents.pubkeyX25519 })
+    .from(agents)
+    .where(and(eq(agents.ownerEmail, owner.toLowerCase()), eq(agents.agentName, name)))
+    .get()
+  if (!agent) throw createError({ statusCode: 404, statusMessage: 'agent not found' })
+
+  const cred = await db
+    .select()
+    .from(oauthCredentials)
+    .where(and(eq(oauthCredentials.agentEmail, agent.email), eq(oauthCredentials.provider, provider)))
+    .get()
+  if (!cred?.deviceCode) throw createError({ statusCode: 409, statusMessage: 'no device flow in progress — call initiate first' })
+
+  setHeader(event, 'Cache-Control', 'no-store')
+  const now = Math.floor(Date.now() / 1000)
+
+  let result
+  try {
+    result = await pollChatgptToken(globalThis.fetch, cred.deviceCode)
+  }
+  catch (e) {
+    throw createError({ statusCode: 502, statusMessage: `token poll failed: ${(e as Error).message}` })
+  }
+
+  if (result.status === 'denied') {
+    await db.update(oauthCredentials).set({ status: 'denied', deviceCode: null, updatedAt: now }).where(and(eq(oauthCredentials.agentEmail, agent.email), eq(oauthCredentials.provider, provider)))
+    return { status: 'denied', error: result.error }
+  }
+  if (result.status !== 'token') {
+    return { status: result.status } // pending | slow_down
+  }
+
+  const auth = toLitellmAuthJson(result.token)
+  let box
+  try {
+    box = sealSecret(agent.pubkeyX25519, JSON.stringify(auth))
+  }
+  catch (e) {
+    throw createError({ statusCode: 409, statusMessage: (e as Error).message })
+  }
+  // Carry the file target in the sealed blob so S1's broker writes a file
+  // (not an env var). buildSecretUpdateFrame serializes the same blob.
+  const fileBox = { ...box, materializeTo: CHATGPT_AUTH_FILE_PATH }
+  const sealed = serializeSealed(fileBox)
+
+  const existingSecret = await db
+    .select({ env: agentSecrets.env })
+    .from(agentSecrets)
+    .where(and(eq(agentSecrets.agentEmail, agent.email), eq(agentSecrets.env, CHATGPT_SECRET_ENV)))
+    .get()
+  if (existingSecret) {
+    await db.update(agentSecrets).set({ sealed, updatedAt: now, revokedAt: null }).where(and(eq(agentSecrets.agentEmail, agent.email), eq(agentSecrets.env, CHATGPT_SECRET_ENV)))
+  }
+  else {
+    await db.insert(agentSecrets).values({ agentEmail: agent.email, env: CHATGPT_SECRET_ENV, sealed, createdAt: now, updatedAt: now, revokedAt: null })
+  }
+
+  await db.update(oauthCredentials)
+    .set({ status: 'connected', deviceCode: null, accountId: auth.account_id, expiresAt: auth.expires_at, updatedAt: now })
+    .where(and(eq(oauthCredentials.agentEmail, agent.email), eq(oauthCredentials.provider, provider)))
+
+  broadcastToOwner(owner.toLowerCase(), buildSecretUpdateFrame(agent.email, CHATGPT_SECRET_ENV, fileBox) as unknown as Record<string, unknown>)
+
+  return { status: 'connected', account_id: auth.account_id, expires_at: auth.expires_at }
+})

--- a/apps/openape-troop/server/database/schema.ts
+++ b/apps/openape-troop/server/database/schema.ts
@@ -136,6 +136,28 @@ export const agentSecrets = sqliteTable('agent_secrets', {
   primaryKey({ columns: [table.agentEmail, table.env] }),
 ])
 
+// oauth_credentials — per-agent external-provider OAuth state (currently
+// ChatGPT "Sign in with ChatGPT"). Holds only the transient device-flow code
+// + connection status + non-secret metadata (account_id, expiry) for the UI.
+// The sealed auth.json itself rides the normal agent_secrets path (env
+// CHATGPT_AUTH_JSON, file-target) so it re-syncs + seeds via the M2 broker.
+// Composite PK (agent_email, provider).
+export const oauthCredentials = sqliteTable('oauth_credentials', {
+  agentEmail: text('agent_email').notNull(),
+  provider: text('provider').notNull(),
+  status: text('status').notNull(), // 'pending' | 'connected' | 'denied'
+  deviceCode: text('device_code'),
+  userCode: text('user_code'),
+  verificationUri: text('verification_uri'),
+  deviceExpiresAt: integer('device_expires_at'),
+  accountId: text('account_id'),
+  expiresAt: integer('expires_at'),
+  createdAt: integer('created_at').notNull(),
+  updatedAt: integer('updated_at').notNull(),
+}, table => [
+  primaryKey({ columns: [table.agentEmail, table.provider] }),
+])
+
 // chats — one persistent "main session" per (owner, agent) pair. Mirrors
 // what chat.openape.ai modelled as a DM room + main thread, but flat and
 // agent-scoped (the owner is implicit from the agent row's ownerEmail).

--- a/apps/openape-troop/server/plugins/02.database.ts
+++ b/apps/openape-troop/server/plugins/02.database.ts
@@ -120,6 +120,24 @@ export default defineNitroPlugin(async () => {
       PRIMARY KEY (agent_email, env)
     )`)
 
+    // ChatGPT (and future) OAuth device-flow state + connection status. The
+    // sealed credential itself lives in agent_secrets (CHATGPT_AUTH_JSON);
+    // this table is only the flow/UI state. (ape-plan 01KTCBFW M1/S2.)
+    await db.run(sql`CREATE TABLE IF NOT EXISTS oauth_credentials (
+      agent_email TEXT NOT NULL,
+      provider TEXT NOT NULL,
+      status TEXT NOT NULL,
+      device_code TEXT,
+      user_code TEXT,
+      verification_uri TEXT,
+      device_expires_at INTEGER,
+      account_id TEXT,
+      expires_at INTEGER,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      PRIMARY KEY (agent_email, provider)
+    )`)
+
     // chats — one persistent "main session" per (owner, agent) pair.
     // Lazily inserted on first message either side sends.
     await db.run(sql`CREATE TABLE IF NOT EXISTS chats (

--- a/apps/openape-troop/server/utils/oauth-chatgpt.ts
+++ b/apps/openape-troop/server/utils/oauth-chatgpt.ts
@@ -1,0 +1,130 @@
+// Token-endpoint response (Codex "Sign in with ChatGPT") → litellm's chatgpt
+// auth.json shape. litellm reads ~/.config/litellm/chatgpt/auth.json and
+// refreshes it in place; Troop only seeds the initial file (ape-plan M1/S2).
+
+export interface ChatgptTokenResponse {
+  access_token: string
+  refresh_token: string
+  id_token: string
+}
+
+export interface LitellmChatgptAuth {
+  access_token: string
+  refresh_token: string
+  id_token: string
+  expires_at: number
+  account_id: string
+}
+
+function decodeJwtClaims(token: string): Record<string, unknown> {
+  const payload = token.split('.')[1]
+  if (!payload)
+    throw new TypeError('access_token is not a JWT')
+  return JSON.parse(Buffer.from(payload, 'base64url').toString()) as Record<string, unknown>
+}
+
+/**
+ * Map an OpenAI token response to the on-disk shape litellm's chatgpt provider
+ * expects. `expires_at` and `account_id` are read from the access-token claims
+ * (`exp` and the `https://api.openai.com/auth.chatgpt_account_id` claim). Throws
+ * loudly rather than emit an auth.json litellm would choke on.
+ */
+export function toLitellmAuthJson(token: ChatgptTokenResponse): LitellmChatgptAuth {
+  const claims = decodeJwtClaims(token.access_token)
+  const auth = claims['https://api.openai.com/auth'] as { chatgpt_account_id?: unknown } | undefined
+  const accountId = auth?.chatgpt_account_id
+  if (typeof accountId !== 'string')
+    throw new TypeError('access_token has no chatgpt_account_id (https://api.openai.com/auth claim)')
+  if (typeof claims.exp !== 'number')
+    throw new TypeError('access_token has no numeric exp claim')
+  return {
+    access_token: token.access_token,
+    refresh_token: token.refresh_token,
+    id_token: token.id_token,
+    expires_at: claims.exp,
+    account_id: accountId,
+  }
+}
+
+// --- Device flow (Codex "Sign in with ChatGPT", Auth0 behind auth.openai.com) ---
+
+const CHATGPT_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann'
+const DEVICE_CODE_ENDPOINT = 'https://auth0.openai.com/oauth/device/code'
+const TOKEN_ENDPOINT = 'https://auth0.openai.com/oauth/token'
+const SCOPE = 'openid profile email offline_access'
+const DEVICE_GRANT = 'urn:ietf:params:oauth:grant-type:device_code'
+
+/** Agent-secret env name carrying the sealed ChatGPT auth.json (a file target, not an env var). */
+export const CHATGPT_SECRET_ENV = 'CHATGPT_AUTH_JSON'
+/**
+ * Container path litellm reads. The host's `~/.config/litellm/chatgpt` is
+ * mounted into openape-llm at /root/.config/litellm/chatgpt. The nest↔llm
+ * shared volume so the agent's write lands here is wired in M1/S4 (or removed
+ * by M3 when openape-llm collapses into the nest).
+ */
+export const CHATGPT_AUTH_FILE_PATH = '/root/.config/litellm/chatgpt/auth.json'
+
+export interface DeviceFlowStart {
+  device_code: string
+  user_code: string
+  verification_uri: string
+  verification_uri_complete?: string
+  interval: number
+  expires_in: number
+}
+
+interface FetchResponse {
+  ok: boolean
+  status: number
+  json: () => Promise<unknown>
+}
+type FetchLike = (url: string, init: { method: string, headers: Record<string, string>, body: string }) => Promise<FetchResponse>
+
+function form(fields: Record<string, string>) {
+  return {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams(fields).toString(),
+  }
+}
+
+/** Start the device-authorization flow → the user_code + verification URI the owner enters in a browser. */
+export async function initiateChatgptDeviceFlow(fetchImpl: FetchLike): Promise<DeviceFlowStart> {
+  const res = await fetchImpl(DEVICE_CODE_ENDPOINT, form({ client_id: CHATGPT_CLIENT_ID, scope: SCOPE }))
+  if (!res.ok)
+    throw new Error(`device/code failed (HTTP ${res.status})`)
+  const data = await res.json() as Partial<DeviceFlowStart>
+  if (typeof data.device_code !== 'string' || typeof data.user_code !== 'string')
+    throw new TypeError('device/code response missing device_code/user_code')
+  return {
+    device_code: data.device_code,
+    user_code: data.user_code,
+    verification_uri: data.verification_uri ?? 'https://chatgpt.com/activate',
+    verification_uri_complete: data.verification_uri_complete,
+    interval: typeof data.interval === 'number' ? data.interval : 5,
+    expires_in: typeof data.expires_in === 'number' ? data.expires_in : 900,
+  }
+}
+
+export type PollResult =
+  | { status: 'pending' }
+  | { status: 'slow_down' }
+  | { status: 'denied', error: string }
+  | { status: 'token', token: ChatgptTokenResponse }
+
+/** Poll the token endpoint once with a device_code. The caller loops on `pending`/`slow_down`. */
+export async function pollChatgptToken(fetchImpl: FetchLike, deviceCode: string): Promise<PollResult> {
+  const res = await fetchImpl(TOKEN_ENDPOINT, form({ client_id: CHATGPT_CLIENT_ID, grant_type: DEVICE_GRANT, device_code: deviceCode }))
+  const data = await res.json() as Record<string, unknown>
+  if (res.ok) {
+    if (typeof data.access_token !== 'string' || typeof data.refresh_token !== 'string' || typeof data.id_token !== 'string')
+      throw new TypeError('token response missing access_token/refresh_token/id_token')
+    return { status: 'token', token: { access_token: data.access_token, refresh_token: data.refresh_token, id_token: data.id_token } }
+  }
+  const error = typeof data.error === 'string' ? data.error : `token failed (HTTP ${res.status})`
+  if (error === 'authorization_pending')
+    return { status: 'pending' }
+  if (error === 'slow_down')
+    return { status: 'slow_down' }
+  return { status: 'denied', error }
+}

--- a/apps/openape-troop/tests/oauth-chatgpt.test.ts
+++ b/apps/openape-troop/tests/oauth-chatgpt.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import { initiateChatgptDeviceFlow, pollChatgptToken, toLitellmAuthJson } from '../server/utils/oauth-chatgpt'
+
+// A fetch double that always answers with the given status + JSON body.
+function fetchReturning(status: number, body: unknown) {
+  return async () => ({ ok: status >= 200 && status < 300, status, json: async () => body })
+}
+
+// Build a JWT whose payload carries the given claims (signature is irrelevant —
+// the serializer only reads claims, it does not verify the token).
+function makeJwt(payload: Record<string, unknown>): string {
+  const b64 = (o: object) => Buffer.from(JSON.stringify(o)).toString('base64url')
+  return `${b64({ alg: 'none', typ: 'JWT' })}.${b64(payload)}.sig`
+}
+
+describe('toLitellmAuthJson', () => {
+  it('maps a token response to litellm auth.json (exp + chatgpt_account_id from the access token)', () => {
+    const accessToken = makeJwt({
+      exp: 1781465881,
+      'https://api.openai.com/auth': { chatgpt_account_id: 'acc-123' },
+    })
+    const out = toLitellmAuthJson({ access_token: accessToken, refresh_token: 'rt_x', id_token: 'idt' })
+    expect(out).toEqual({
+      access_token: accessToken,
+      refresh_token: 'rt_x',
+      id_token: 'idt',
+      expires_at: 1781465881,
+      account_id: 'acc-123',
+    })
+  })
+
+  it('throws when the access token lacks chatgpt_account_id (never write a broken auth.json)', () => {
+    const accessToken = makeJwt({ exp: 1781465881 })
+    expect(() => toLitellmAuthJson({ access_token: accessToken, refresh_token: 'rt_x', id_token: 'idt' }))
+      .toThrow(/account_id/i)
+  })
+})
+
+describe('initiateChatgptDeviceFlow', () => {
+  it('parses the device/code response', async () => {
+    const r = await initiateChatgptDeviceFlow(fetchReturning(200, {
+      device_code: 'dc', user_code: 'WXYZ-1234', verification_uri: 'https://chatgpt.com/activate', interval: 5, expires_in: 900,
+    }))
+    expect(r.device_code).toBe('dc')
+    expect(r.user_code).toBe('WXYZ-1234')
+    expect(r.interval).toBe(5)
+  })
+
+  it('throws when device_code is missing', async () => {
+    await expect(initiateChatgptDeviceFlow(fetchReturning(200, { user_code: 'x' }))).rejects.toThrow(/device_code/i)
+  })
+})
+
+describe('pollChatgptToken', () => {
+  it('returns pending on authorization_pending', async () => {
+    const r = await pollChatgptToken(fetchReturning(400, { error: 'authorization_pending' }), 'dc')
+    expect(r.status).toBe('pending')
+  })
+
+  it('returns the token on success', async () => {
+    const r = await pollChatgptToken(fetchReturning(200, { access_token: 'at', refresh_token: 'rt', id_token: 'idt' }), 'dc')
+    expect(r).toEqual({ status: 'token', token: { access_token: 'at', refresh_token: 'rt', id_token: 'idt' } })
+  })
+
+  it('returns denied on access_denied', async () => {
+    const r = await pollChatgptToken(fetchReturning(400, { error: 'access_denied' }), 'dc')
+    expect(r.status).toBe('denied')
+  })
+})


### PR DESCRIPTION
ape-plan `01KTCBFW55BKHY7F2HHE25TZ3G` — Milestone **M1** (S2–S5). Builds on #564 (S1 broker file-materialization).

**"Connect ChatGPT" for an agent:** owner clicks Connect → device flow → the sealed ChatGPT `auth.json` is pushed to the agent; litellm uses + refreshes it in place.

## What
- **Serializer** `toLitellmAuthJson` — token response → litellm `auth.json` (`exp` + `chatgpt_account_id` from access-token claims). Throws loud on missing `account_id`.
- **Device-flow client** `initiateChatgptDeviceFlow` / `pollChatgptToken` — RFC 8628 against `auth0.openai.com` (Codex `client_id`), injectable fetch.
- **DB** `oauth_credentials` (transient device-flow state + connection status).
- **Endpoints** `POST /api/agents/[name]/oauth/chatgpt/{initiate,poll}` (owner-gated). On success: seal `auth.json` to the agent's X25519 pubkey, persist as a file-target `agent_secret` (`CHATGPT_AUTH_JSON`, `materializeTo`) + push via the existing `secret-update` path → S1's broker writes the file (seed-once).
- **UI** `ChatgptConnect.vue` folded into the agent's Secrets card (DE/EN i18n).

## Tests / checks
- 7 TDD unit tests (serializer + device client). Full `@openape/troop` suite **169 passed**. typecheck + lint + app build green.

## Out of scope / follow-up
- **S5 live E2E** needs a real ChatGPT browser login + a running pod (runbook in the plan).
- **Deploy:** nest↔llm must share the `chatgpt` volume so the agent's write reaches litellm (compose shared volume; or M3 collapse makes it moot). Path is code-complete.

Closes #565
