### PR TITLE
feat(codex-proxy): Codex credential store + refresh (M3.1)

### DIFF
--- a/packages/codex-proxy/README.md
+++ b/packages/codex-proxy/README.md
@@ -1,0 +1,12 @@
+# @openape/codex-proxy
+
+Subscription-only access to ChatGPT (via OpenAI **Codex** auth) for OpenApe agents.
+
+Owns the Codex OAuth credential (device flow + refresh) and exposes a thin
+**OpenAI-compatible** `/v1/chat/completions` proxy over the Codex **Responses**
+backend, so `@openape/agent-runtime` keeps speaking Chat Completions while the
+model runs on the owner's ChatGPT subscription.
+
+Pattern adapted from OpenClaw (own the token, don't shell out to `codex login`).
+No API keys, no keyed fallback — agents need the subscription. See ape-plan
+`01KTCBFW…` (M3).

--- a/packages/codex-proxy/package.json
+++ b/packages/codex-proxy/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@openape/codex-proxy",
+  "version": "0.1.0",
+  "turbo": {
+    "tags": [
+      "publishable"
+    ]
+  },
+  "description": "Subscription-only ChatGPT (Codex) credential + thin OpenAI-compatible proxy over the Codex Responses backend. Lets agents speak /v1/chat/completions against a ChatGPT subscription.",
+  "type": "module",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/openape-ai/openape.git",
+    "directory": "packages/codex-proxy"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run --no-coverage"
+  },
+  "devDependencies": {
+    "@types/node": "^25.3.5",
+    "tsup": "^8.3.0",
+    "typescript": "^5.9.0",
+    "vitest": "^4.1.7"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "keywords": [
+    "openape",
+    "codex",
+    "chatgpt",
+    "openai",
+    "proxy"
+  ]
+}

--- a/packages/codex-proxy/src/codex-credential.ts
+++ b/packages/codex-proxy/src/codex-credential.ts
@@ -1,0 +1,103 @@
+// Codex (ChatGPT-subscription) credential: we own the token and refresh it
+// ourselves. Pattern from OpenClaw — never depend on the Codex CLI to keep the
+// token live (its refresh would race ours and the last writer wins).
+
+export interface CodexCredential {
+  access_token: string
+  refresh_token: string
+  id_token: string
+  /** epoch seconds — the access-token `exp`. */
+  expires_at: number
+  /** ChatGPT account id (from the access-token claim); sent as `chatgpt-account-id`. */
+  account_id: string
+}
+
+export interface CodexTokenResponse {
+  access_token: string
+  refresh_token: string
+  id_token: string
+}
+
+const CHATGPT_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann'
+const TOKEN_ENDPOINT = 'https://auth.openai.com/oauth/token'
+/** Refresh this many ms before the access token actually expires. */
+const REFRESH_SKEW_MS = 60_000
+
+interface FetchResponse {
+  ok: boolean
+  status: number
+  json: () => Promise<unknown>
+}
+type FetchLike = (url: string, init: { method: string, headers: Record<string, string>, body: string }) => Promise<FetchResponse>
+
+function decodeJwtPayload(token: string): Record<string, unknown> {
+  const payload = token.split('.')[1]
+  if (!payload)
+    throw new TypeError('access_token is not a JWT')
+  return JSON.parse(Buffer.from(payload, 'base64url').toString()) as Record<string, unknown>
+}
+
+/** Read the two claims we need from a Codex access token: `exp` + `chatgpt_account_id`. */
+export function decodeCodexClaims(accessToken: string): { exp: number, account_id: string } {
+  const claims = decodeJwtPayload(accessToken)
+  const auth = claims['https://api.openai.com/auth'] as { chatgpt_account_id?: unknown } | undefined
+  const accountId = auth?.chatgpt_account_id
+  if (typeof accountId !== 'string')
+    throw new TypeError('access_token has no chatgpt_account_id (https://api.openai.com/auth claim)')
+  if (typeof claims.exp !== 'number')
+    throw new TypeError('access_token has no numeric exp claim')
+  return { exp: claims.exp, account_id: accountId }
+}
+
+/** Build a credential from an OAuth token response, deriving exp + account_id from the access token. */
+export function credentialFromTokenResponse(token: CodexTokenResponse): CodexCredential {
+  const { exp, account_id } = decodeCodexClaims(token.access_token)
+  return {
+    access_token: token.access_token,
+    refresh_token: token.refresh_token,
+    id_token: token.id_token,
+    expires_at: exp,
+    account_id,
+  }
+}
+
+export function isCodexCredentialExpired(cred: CodexCredential, nowMs: number, skewMs = REFRESH_SKEW_MS): boolean {
+  return nowMs >= cred.expires_at * 1000 - skewMs
+}
+
+function form(fields: Record<string, string>) {
+  return {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams(fields).toString(),
+  }
+}
+
+/** Exchange the refresh token for a fresh access token. Throws loudly on failure. */
+export async function refreshCodexCredential(cred: CodexCredential, fetchImpl: FetchLike): Promise<CodexCredential> {
+  const res = await fetchImpl(TOKEN_ENDPOINT, form({
+    grant_type: 'refresh_token',
+    refresh_token: cred.refresh_token,
+    client_id: CHATGPT_CLIENT_ID,
+  }))
+  const data = await res.json() as Record<string, unknown>
+  if (!res.ok) {
+    const err = typeof data.error === 'string' ? data.error : `HTTP ${res.status}`
+    throw new Error(`codex token refresh failed: ${err}`)
+  }
+  if (typeof data.access_token !== 'string')
+    throw new TypeError('codex token refresh returned no access_token')
+  // The grant may rotate the refresh/id token; keep the prior one when omitted.
+  return credentialFromTokenResponse({
+    access_token: data.access_token,
+    refresh_token: typeof data.refresh_token === 'string' ? data.refresh_token : cred.refresh_token,
+    id_token: typeof data.id_token === 'string' ? data.id_token : cred.id_token,
+  })
+}
+
+/** Return a non-expired credential, refreshing via the refresh_token grant if needed. */
+export async function ensureFreshCodexCredential(cred: CodexCredential, fetchImpl: FetchLike, nowMs: number): Promise<CodexCredential> {
+  if (!isCodexCredentialExpired(cred, nowMs))
+    return cred
+  return refreshCodexCredential(cred, fetchImpl)
+}

--- a/packages/codex-proxy/src/index.ts
+++ b/packages/codex-proxy/src/index.ts
@@ -1,0 +1,1 @@
+export * from './codex-credential'

--- a/packages/codex-proxy/test/codex-credential.test.ts
+++ b/packages/codex-proxy/test/codex-credential.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+import {
+  credentialFromTokenResponse,
+  decodeCodexClaims,
+  ensureFreshCodexCredential,
+  isCodexCredentialExpired,
+} from '../src/codex-credential'
+
+// Build a JWT whose payload carries the claims (signature irrelevant — we only
+// read claims, we don't verify the token).
+function jwt(payload: Record<string, unknown>): string {
+  const b64 = (o: object) => Buffer.from(JSON.stringify(o)).toString('base64url')
+  return `${b64({ alg: 'none', typ: 'JWT' })}.${b64(payload)}.sig`
+}
+function accessToken(exp: number, accountId = 'acc-1'): string {
+  return jwt({ exp, 'https://api.openai.com/auth': { chatgpt_account_id: accountId } })
+}
+
+describe('decodeCodexClaims', () => {
+  it('reads exp + chatgpt_account_id from the access token', () => {
+    expect(decodeCodexClaims(accessToken(1781465881, 'acc-9'))).toEqual({ exp: 1781465881, account_id: 'acc-9' })
+  })
+  it('throws when chatgpt_account_id is missing', () => {
+    expect(() => decodeCodexClaims(jwt({ exp: 1 }))).toThrow(/account_id/i)
+  })
+})
+
+describe('credentialFromTokenResponse', () => {
+  it('builds a credential, deriving exp + account_id from the access token', () => {
+    const at = accessToken(1781465881, 'acc-2')
+    expect(credentialFromTokenResponse({ access_token: at, refresh_token: 'rt', id_token: 'idt' })).toEqual({
+      access_token: at,
+      refresh_token: 'rt',
+      id_token: 'idt',
+      expires_at: 1781465881,
+      account_id: 'acc-2',
+    })
+  })
+})
+
+describe('isCodexCredentialExpired', () => {
+  const cred = { access_token: 'a', refresh_token: 'r', id_token: 'i', expires_at: 2000, account_id: 'x' }
+  it('is expired once now is at/after expires_at', () => {
+    expect(isCodexCredentialExpired(cred, 5_000_000)).toBe(true) // now=5000s ≥ 2000s
+  })
+  it('is fresh while now is well before expires_at', () => {
+    expect(isCodexCredentialExpired(cred, 0)).toBe(false)
+  })
+})
+
+describe('ensureFreshCodexCredential', () => {
+  const stale = { access_token: accessToken(1000), refresh_token: 'old-rt', id_token: 'old-idt', expires_at: 1000, account_id: 'acc-1' }
+
+  it('returns the same credential without fetching when still fresh', async () => {
+    const fresh = { ...stale, expires_at: 9_999_999_999 }
+    const out = await ensureFreshCodexCredential(fresh, () => Promise.reject(new Error('should not fetch')), 0)
+    expect(out).toBe(fresh)
+  })
+
+  it('refreshes via the refresh_token grant when expired, rotating tokens', async () => {
+    const newAt = accessToken(9_999_999_999, 'acc-1')
+    const fetchImpl = async () => ({ ok: true, status: 200, json: async () => ({ access_token: newAt, refresh_token: 'new-rt', id_token: 'new-idt' }) })
+    const out = await ensureFreshCodexCredential(stale, fetchImpl, 5_000_000_000)
+    expect(out.access_token).toBe(newAt)
+    expect(out.refresh_token).toBe('new-rt')
+    expect(out.expires_at).toBe(9_999_999_999)
+  })
+
+  it('keeps the old refresh_token / id_token when the grant omits them', async () => {
+    const newAt = accessToken(9_999_999_999, 'acc-1')
+    const fetchImpl = async () => ({ ok: true, status: 200, json: async () => ({ access_token: newAt }) })
+    const out = await ensureFreshCodexCredential(stale, fetchImpl, 5_000_000_000)
+    expect(out.refresh_token).toBe('old-rt')
+    expect(out.id_token).toBe('old-idt')
+  })
+
+  it('throws on a failed refresh (never returns a stale credential silently)', async () => {
+    const fetchImpl = async () => ({ ok: false, status: 400, json: async () => ({ error: 'invalid_grant' }) })
+    await expect(ensureFreshCodexCredential(stale, fetchImpl, 5_000_000_000)).rejects.toThrow(/refresh|invalid_grant|400/i)
+  })
+})

--- a/packages/codex-proxy/tsconfig.json
+++ b/packages/codex-proxy/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": false,
+    "declaration": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*", "test/**/*"]
+}

--- a/packages/codex-proxy/tsup.config.ts
+++ b/packages/codex-proxy/tsup.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  target: 'node20',
+  platform: 'node',
+  clean: true,
+  shims: false,
+  dts: true,
+  splitting: false,
+  sourcemap: false,
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -199,7 +199,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/coverage-istanbul@4.1.7)(happy-dom@18.0.1)(vite@8.0.14(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2)(yaml@2.9.0))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/coverage-istanbul@4.1.7)(happy-dom@18.0.1)(vite@8.0.14(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2)(yaml@2.9.0))
 
   apps/openape-chat:
     dependencies:
@@ -871,6 +871,21 @@ importers:
       vitest:
         specifier: ^4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.8.0)(@vitest/coverage-istanbul@4.1.7)(happy-dom@18.0.1)(vite@8.0.14(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2)(yaml@2.9.0))
+
+  packages/codex-proxy:
+    devDependencies:
+      '@types/node':
+        specifier: ^25.3.5
+        version: 25.8.0
+      tsup:
+        specifier: ^8.3.0
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.2)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: ^5.9.0
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.7
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.8.0)(@vitest/coverage-istanbul@4.1.7)(happy-dom@18.0.1)(vite@8.0.14(@types/node@25.8.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2)(yaml@2.9.0))
 
   packages/core:
     dependencies:
@@ -16660,7 +16675,7 @@ snapshots:
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.59.3(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       typescript: 5.9.3
-      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/coverage-istanbul@4.1.7)(happy-dom@18.0.1)(vite@8.0.14(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2)(yaml@2.9.0))
+      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/coverage-istanbul@4.1.7)(happy-dom@18.0.1)(vite@8.0.14(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -16672,14 +16687,6 @@ snapshots:
       '@vitest/utils': 4.1.7
       chai: 6.2.2
       tinyrainbow: 3.1.0
-
-  '@vitest/mocker@4.1.7(vite@8.0.14(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2)(yaml@2.9.0))':
-    dependencies:
-      '@vitest/spy': 4.1.7
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 8.0.14(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2)(yaml@2.9.0)
 
   '@vitest/mocker@4.1.7(vite@8.0.14(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2)(yaml@2.9.0))':
     dependencies:
@@ -23563,22 +23570,6 @@ snapshots:
       tsx: 4.22.2
       yaml: 2.9.0
 
-  vite@8.0.14(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2)(yaml@2.9.0):
-    dependencies:
-      lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.5.15
-      rolldown: 1.0.2
-      tinyglobby: 0.2.16
-    optionalDependencies:
-      '@types/node': 22.19.19
-      esbuild: 0.27.7
-      fsevents: 2.3.3
-      jiti: 2.7.0
-      terser: 5.47.1
-      tsx: 4.22.2
-      yaml: 2.9.0
-
   vite@8.0.14(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
@@ -23626,36 +23617,6 @@ snapshots:
       terser: 5.47.1
       tsx: 4.22.2
       yaml: 2.9.0
-
-  vitest@4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/coverage-istanbul@4.1.7)(happy-dom@18.0.1)(vite@8.0.14(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2)(yaml@2.9.0)):
-    dependencies:
-      '@vitest/expect': 4.1.7
-      '@vitest/mocker': 4.1.7(vite@8.0.14(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.7
-      '@vitest/runner': 4.1.7
-      '@vitest/snapshot': 4.1.7
-      '@vitest/spy': 4.1.7
-      '@vitest/utils': 4.1.7
-      es-module-lexer: 2.1.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.1.2
-      tinyglobby: 0.2.16
-      tinyrainbow: 3.1.0
-      vite: 8.0.14(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2)(yaml@2.9.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.1
-      '@types/node': 22.19.19
-      '@vitest/coverage-istanbul': 4.1.7(vitest@4.1.7)
-      happy-dom: 18.0.1
-    transitivePeerDependencies:
-      - msw
 
   vitest@4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/coverage-istanbul@4.1.7)(happy-dom@18.0.1)(vite@8.0.14(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2)(yaml@2.9.0)):
     dependencies:


### PR DESCRIPTION
ape-plan `01KTCBFW55BKHY7F2HHE25TZ3G` — **M3.1** (first cut of the Codex-proxy pivot, subscription-only).

New package **`@openape/codex-proxy`** + its credential core (OpenClaw pattern — own the token, don't depend on the Codex CLI to keep it live):
- `CodexCredential` `{access_token, refresh_token, id_token, expires_at, account_id}`.
- `decodeCodexClaims` — `exp` + `chatgpt_account_id` from the access-token JWT (throws loud if missing).
- `credentialFromTokenResponse` — token response → credential.
- `isCodexCredentialExpired` (60s skew) + `refreshCodexCredential` (`grant_type=refresh_token` → `auth.openai.com/oauth/token`, client_id `app_EMoam…`, injectable fetch, rotates tokens, keeps prior on omit) + `ensureFreshCodexCredential`.

## Tests / checks
9 TDD unit tests (decode, build, expiry, refresh-rotate, refresh-keep-old, refresh-fails-loud). typecheck + lint + tsup build green.

## Next (this package, same milestone)
M3.2 Responses⇄ChatCompletions converters · M3.3 thin `/v1/chat/completions` proxy · M3.4 nest integration (drop python/litellm, subscription-only).

Refs #571
