### PR TITLE
feat(nest): in-nest codex-proxy ersetzt litellm (M3.4)

### DIFF
--- a/.changeset/auth-declare-ofetch.md
+++ b/.changeset/auth-declare-ofetch.md
@@ -1,0 +1,8 @@
+---
+"@openape/auth": patch
+---
+
+Declare the `ofetch` runtime dependency. `idp/client-metadata.ts` imports it, but
+it was previously resolved only via workspace hoisting — which broke isolated
+installs and Docker builds (esbuild "Could not resolve ofetch" / TS2307) the
+moment the package was built outside the hoisted monorepo `node_modules`.

--- a/apps/openape-nest/Dockerfile
+++ b/apps/openape-nest/Dockerfile
@@ -40,21 +40,29 @@ COPY packages ./packages
 # is safe and cuts install time roughly in half.
 RUN pnpm install --frozen-lockfile --ignore-scripts
 
-# Build apes (the CLI nest invokes for privileged steps) + nest itself.
-# The --filter ... build invocation only builds the explicitly named
-# packages (and their workspace deps), so we don't drag the Nuxt apps
-# into the build at all.
-RUN pnpm --filter '@openape/apes' build && pnpm --filter '@openape/nest' build
+# Build the nest, the binaries it shells out to (apes, ape-agent), and the
+# in-nest codex-proxy. Drive it through turbo, NOT a hand-rolled
+# `pnpm --filter X build` chain: turbo's build task is `dependsOn: ["^build"]`,
+# so every @openape/* workspace dep (shapes, agent-runtime, core, grants,
+# proxy, server, cli-auth, …) is built FIRST, in topological order. The old
+# per-package chain didn't build deps first and broke the tsup dts step with
+# TS2307 the moment a target gained a new workspace dep (apes → shapes /
+# agent-runtime). Only the filtered targets + their deps build — no Nuxt apps.
+RUN pnpm turbo run build \
+      --filter='@openape/apes' \
+      --filter='@openape/nest' \
+      --filter='@openape/ape-agent' \
+      --filter='@openape/codex-proxy'
 
 # `pnpm deploy` materializes a self-contained subtree (workspace deps
 # flattened, no symlinks into the monorepo's .pnpm store) so the runtime
 # image gets a normal node_modules/ that resolves bare imports like
 # `import { ofetch } from 'ofetch'`. Without this step the tsup'd dist
 # can't find its external deps (tsup bundles only the entry's own code).
-RUN pnpm --filter '@openape/apes' build && pnpm --filter '@openape/ape-agent' build && pnpm --filter '@openape/nest' build
 RUN pnpm --filter '@openape/apes' deploy --legacy --prod /tmp/deploy/apes \
  && pnpm --filter '@openape/nest' deploy --legacy --prod /tmp/deploy/nest \
- && pnpm --filter '@openape/ape-agent' deploy --legacy --prod /tmp/deploy/ape-agent
+ && pnpm --filter '@openape/ape-agent' deploy --legacy --prod /tmp/deploy/ape-agent \
+ && pnpm --filter '@openape/codex-proxy' deploy --legacy --prod /tmp/deploy/codex-proxy
 
 # ---- Stage 2: runtime -----------------------------------------------------
 FROM node:22-bookworm-slim AS runtime
@@ -101,6 +109,7 @@ WORKDIR /opt/openape
 COPY --from=build /tmp/deploy/apes ./apes
 COPY --from=build /tmp/deploy/nest ./nest
 COPY --from=build /tmp/deploy/ape-agent ./ape-agent
+COPY --from=build /tmp/deploy/codex-proxy ./codex-proxy
 
 # pm2 is the per-agent process supervisor the nest uses — install
 # globally so `pm2 start ...` (invoked by lib/pm2-supervisor.ts) resolves

--- a/apps/openape-nest/docker-entrypoint.sh
+++ b/apps/openape-nest/docker-entrypoint.sh
@@ -57,4 +57,30 @@ for a in reg.get('agents', []):
 PY
 fi
 
+# --- Codex proxy ----------------------------------------------------------
+# The OpenAI-compatible shim the per-agent bridges talk to on loopback:4000,
+# replacing the openape-llm/litellm container that M3 collapsed into the nest.
+# Non-blocking by design: it serves /health immediately and only fails a chat
+# request (clear 502) until troop seeds the ChatGPT credential at
+# CODEX_CREDENTIAL_PATH. The seeding agent's broker writes that file once
+# (seed-once); the proxy refreshes it in place thereafter.
+#
+# The dir is world-writable + sticky (like /var/log/openape): the seeding agent
+# runs as a non-root, dynamically-uid'd user and must be able to create
+# auth.json here — the file itself stays 0600. Run under a restart loop so a
+# transient proxy crash doesn't strand model access; the nest stays PID 1 via
+# the exec below, and the loop is reaped with the container.
+mkdir -p /var/lib/openape/codex && chmod 1777 /var/lib/openape/codex
+
+(
+  while true; do
+    CODEX_CREDENTIAL_PATH=/var/lib/openape/codex/auth.json \
+    CODEX_PROXY_PORT=4000 \
+    CODEX_PROXY_HOST=127.0.0.1 \
+    node /opt/openape/codex-proxy/dist/bin.js
+    echo "[entrypoint] codex-proxy exited ($?) — restarting in 2s" >&2
+    sleep 2
+  done
+) >> /var/log/openape/codex-proxy.log 2>&1 &
+
 exec "$@"

--- a/apps/openape-troop/server/api/agents/[name]/oauth/[provider]/poll.post.ts
+++ b/apps/openape-troop/server/api/agents/[name]/oauth/[provider]/poll.post.ts
@@ -4,13 +4,13 @@ import { agents, agentSecrets, oauthCredentials } from '../../../../../database/
 import { buildSecretUpdateFrame, sealSecret, serializeSealed } from '../../../../../utils/agent-secrets'
 import { requireOwner } from '../../../../../utils/auth'
 import { broadcastToOwner } from '../../../../../utils/nest-registry'
-import { CHATGPT_AUTH_FILE_PATH, CHATGPT_SECRET_ENV, pollChatgptToken, toLitellmAuthJson } from '../../../../../utils/oauth-chatgpt'
+import { CHATGPT_AUTH_FILE_PATH, CHATGPT_SECRET_ENV, pollChatgptToken, toCodexAuthJson } from '../../../../../utils/oauth-chatgpt'
 
 // Poll the device flow once. On `pending`/`slow_down` the UI keeps polling.
 // On success: serialize the token → seal the auth.json to the agent's X25519
 // pubkey → persist as a file-target agent_secret (CHATGPT_AUTH_JSON) and push
-// it over the nest WS. The agent's broker (M1/S1) writes it to the litellm
-// auth.json with seed-once; litellm refreshes it in place thereafter.
+// it over the nest WS. The agent's broker (M1/S1) writes it to the codex-proxy
+// auth.json with seed-once; the in-nest codex-proxy refreshes it in place.
 export default defineEventHandler(async (event) => {
   const owner = await requireOwner(event)
   const name = getRouterParam(event, 'name')
@@ -52,7 +52,7 @@ export default defineEventHandler(async (event) => {
     return { status: result.status } // pending | slow_down
   }
 
-  const auth = toLitellmAuthJson(result.token)
+  const auth = toCodexAuthJson(result.token)
   let box
   try {
     box = sealSecret(agent.pubkeyX25519, JSON.stringify(auth))

--- a/apps/openape-troop/server/utils/oauth-chatgpt.ts
+++ b/apps/openape-troop/server/utils/oauth-chatgpt.ts
@@ -1,6 +1,8 @@
-// Token-endpoint response (Codex "Sign in with ChatGPT") → litellm's chatgpt
-// auth.json shape. litellm reads ~/.config/litellm/chatgpt/auth.json and
-// refreshes it in place; Troop only seeds the initial file (ape-plan M1/S2).
+// Token-endpoint response (Codex "Sign in with ChatGPT") → the on-disk auth.json
+// shape @openape/codex-proxy's CodexCredentialStore loads. The agent's broker
+// seeds the file once (ape-plan M1/S1); the in-nest codex-proxy refreshes it in
+// place thereafter. Fields match codex-proxy's CodexCredential exactly, so the
+// sealed JSON loads without a converter.
 
 export interface ChatgptTokenResponse {
   access_token: string
@@ -8,7 +10,7 @@ export interface ChatgptTokenResponse {
   id_token: string
 }
 
-export interface LitellmChatgptAuth {
+export interface CodexAuthJson {
   access_token: string
   refresh_token: string
   id_token: string
@@ -24,12 +26,12 @@ function decodeJwtClaims(token: string): Record<string, unknown> {
 }
 
 /**
- * Map an OpenAI token response to the on-disk shape litellm's chatgpt provider
- * expects. `expires_at` and `account_id` are read from the access-token claims
- * (`exp` and the `https://api.openai.com/auth.chatgpt_account_id` claim). Throws
- * loudly rather than emit an auth.json litellm would choke on.
+ * Map an OpenAI token response to the on-disk auth.json shape the codex-proxy
+ * loads (its CodexCredential). `expires_at` and `account_id` are read from the
+ * access-token claims (`exp` and the `https://api.openai.com/auth.chatgpt_account_id`
+ * claim). Throws loudly rather than emit an auth.json the proxy would choke on.
  */
-export function toLitellmAuthJson(token: ChatgptTokenResponse): LitellmChatgptAuth {
+export function toCodexAuthJson(token: ChatgptTokenResponse): CodexAuthJson {
   const claims = decodeJwtClaims(token.access_token)
   const auth = claims['https://api.openai.com/auth'] as { chatgpt_account_id?: unknown } | undefined
   const accountId = auth?.chatgpt_account_id
@@ -57,12 +59,12 @@ const DEVICE_GRANT = 'urn:ietf:params:oauth:grant-type:device_code'
 /** Agent-secret env name carrying the sealed ChatGPT auth.json (a file target, not an env var). */
 export const CHATGPT_SECRET_ENV = 'CHATGPT_AUTH_JSON'
 /**
- * Container path litellm reads. The host's `~/.config/litellm/chatgpt` is
- * mounted into openape-llm at /root/.config/litellm/chatgpt. The nest↔llm
- * shared volume so the agent's write lands here is wired in M1/S4 (or removed
- * by M3 when openape-llm collapses into the nest).
+ * Container path the codex-proxy reads (its CODEX_CREDENTIAL_PATH). The agent's
+ * broker materializes the sealed blob here once (seed-once); the codex-proxy —
+ * started by the nest entrypoint on 127.0.0.1:4000 — refreshes it in place. M3
+ * collapsed the openape-llm/litellm container into this single in-nest proxy.
  */
-export const CHATGPT_AUTH_FILE_PATH = '/root/.config/litellm/chatgpt/auth.json'
+export const CHATGPT_AUTH_FILE_PATH = '/var/lib/openape/codex/auth.json'
 
 export interface DeviceFlowStart {
   device_code: string

--- a/apps/openape-troop/tests/oauth-chatgpt.test.ts
+++ b/apps/openape-troop/tests/oauth-chatgpt.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { initiateChatgptDeviceFlow, pollChatgptToken, toLitellmAuthJson } from '../server/utils/oauth-chatgpt'
+import { initiateChatgptDeviceFlow, pollChatgptToken, toCodexAuthJson } from '../server/utils/oauth-chatgpt'
 
 // A fetch double that always answers with the given status + JSON body.
 function fetchReturning(status: number, body: unknown) {
@@ -13,13 +13,13 @@ function makeJwt(payload: Record<string, unknown>): string {
   return `${b64({ alg: 'none', typ: 'JWT' })}.${b64(payload)}.sig`
 }
 
-describe('toLitellmAuthJson', () => {
-  it('maps a token response to litellm auth.json (exp + chatgpt_account_id from the access token)', () => {
+describe('toCodexAuthJson', () => {
+  it('maps a token response to the codex-proxy auth.json (exp + chatgpt_account_id from the access token)', () => {
     const accessToken = makeJwt({
       exp: 1781465881,
       'https://api.openai.com/auth': { chatgpt_account_id: 'acc-123' },
     })
-    const out = toLitellmAuthJson({ access_token: accessToken, refresh_token: 'rt_x', id_token: 'idt' })
+    const out = toCodexAuthJson({ access_token: accessToken, refresh_token: 'rt_x', id_token: 'idt' })
     expect(out).toEqual({
       access_token: accessToken,
       refresh_token: 'rt_x',
@@ -31,7 +31,7 @@ describe('toLitellmAuthJson', () => {
 
   it('throws when the access token lacks chatgpt_account_id (never write a broken auth.json)', () => {
     const accessToken = makeJwt({ exp: 1781465881 })
-    expect(() => toLitellmAuthJson({ access_token: accessToken, refresh_token: 'rt_x', id_token: 'idt' }))
+    expect(() => toCodexAuthJson({ access_token: accessToken, refresh_token: 'rt_x', id_token: 'idt' }))
       .toThrow(/account_id/i)
   })
 })

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -1,60 +1,30 @@
 # OpenApe pod — local-dev compose.
 #
-# Brings up the two long-running services that historically lived on the
-# Mac host (nest + LiteLLM proxy) as containers. Designed to run on
-# OrbStack (Mac) or any Docker Engine (Linux), identically.
+# Brings up the nest as a single long-running container. The nest's entrypoint
+# starts an in-process Codex proxy (OpenAI-compatible, bound to its own
+# loopback:4000) so there is NO separate LLM container — M3 collapsed the old
+# openape-llm/litellm service into the nest. Designed to run on OrbStack (Mac)
+# or any Docker Engine (Linux), identically.
 #
 # Quickstart:
-#   1. cp apps/openape-llm/config.example.yaml compose/litellm.yaml
-#      → fill in the API key envs.
-#   2. cp compose/.env.example compose/.env
-#      → set ANTHROPIC_API_KEY etc.
-#   3. docker compose -f compose/docker-compose.yml up --build
-#   4. curl http://127.0.0.1:9091/health   # nest
-#      curl http://127.0.0.1:4000/health/liveliness  # litellm
+#   1. cp compose/.env.example compose/.env   → optional overrides.
+#   2. docker compose -f compose/docker-compose.yml up --build
+#   3. curl http://127.0.0.1:9091/health      # nest
+#   The codex-proxy listens on the nest's own loopback (not host-published);
+#   it answers chat once the ChatGPT credential is seeded via troop's
+#   "Connect ChatGPT" flow. No API keys needed — agents run on the
+#   subscription, not keyed providers.
 #
 # Volumes:
 #   openape-nest-data   → /var/lib/openape/nest (registry + auth.json)
 #   openape-homes       → /var/lib/openape/homes (per-agent homes)
 #
 # Network:
-#   openape-pod (bridge) → in-pod hostnames `openape-nest`, `openape-llm`
-#   work for service-to-service traffic. The host-published ports
-#   (9091, 4000) are bound to 127.0.0.1 only so a misconfigured firewall
-#   can't expose them to the LAN.
+#   openape-pod (bridge) → in-pod hostname `openape-nest`. The host-published
+#   port (9091) is bound to 127.0.0.1 only so a misconfigured firewall can't
+#   expose it to the LAN.
 
 services:
-  openape-llm:
-    build:
-      context: ..
-      dockerfile: apps/openape-llm/Dockerfile
-    image: openape-llm:dev
-    container_name: openape-llm
-    restart: unless-stopped
-    networks:
-      - openape-pod
-    ports:
-      - "127.0.0.1:4000:4000"
-    volumes:
-      - ./litellm.yaml:/etc/litellm/config.yaml:ro
-      # ChatGPT OAuth state — when the operator uses the `chatgpt/`
-      # litellm provider, this is where the access/refresh tokens
-      # live (litellm reads them from $HOME/.config/litellm/chatgpt/).
-      # Optional: omit for Anthropic/OpenAI-only setups.
-      # MUST be writable: litellm refreshes the access token in place and
-      # rewrites this file. A `:ro` mount makes refresh fail with
-      # "Read-only file system" → the token dies on expiry and every chat
-      # hangs. Read-write so refresh + device-login re-auth persist.
-      - ${HOME}/.config/litellm/chatgpt:/root/.config/litellm/chatgpt
-    environment:
-      LITELLM_HOST: 0.0.0.0
-      LITELLM_PORT: "4000"
-      LITELLM_MASTER_KEY: ${LITELLM_MASTER_KEY:-sk-litellm-loopback}
-      # API keys — set in compose/.env or inherit from the operator's
-      # shell. config.yaml expands these at LiteLLM load time.
-      CHATGPT_OAUTH_TOKEN: ${CHATGPT_OAUTH_TOKEN:-}
-      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
-
   openape-nest:
     build:
       context: ..
@@ -70,8 +40,6 @@ services:
     # troop's pin stays stable.
     hostname: openape-nest
     restart: unless-stopped
-    depends_on:
-      - openape-llm
     networks:
       - openape-pod
     # No host ports — the nest is a pure long-running WebSocket CLIENT
@@ -93,11 +61,16 @@ services:
       # ($HOME/agents.json vs $HOME/.openape/nest/agents.json) and a
       # spawned agent lands where the nest never looks → no bridge.
       OPENAPE_NEST_REGISTRY_PATH: /var/lib/openape/nest/agents.json
-      # Inside the pod the nest reaches the proxy at the service hostname.
-      # Agents under this nest inherit this URL via the bridge env file.
-      LITELLM_BASE_URL: http://openape-llm:4000/v1
-      LITELLM_API_KEY: ${LITELLM_MASTER_KEY:-sk-litellm-loopback}
-      APE_CHAT_BRIDGE_MODEL: ${APE_CHAT_BRIDGE_MODEL:-claude-haiku-4-5}
+      # The codex-proxy the nest starts on its own loopback. Agents under this
+      # nest inherit this URL via the bridge env file. (Env names stay
+      # LITELLM_* for bridge back-compat; the target is the in-nest codex-proxy,
+      # not litellm.) The API key is a loopback dummy — the proxy ignores
+      # Authorization and authenticates to OpenAI with the ChatGPT credential.
+      LITELLM_BASE_URL: http://127.0.0.1:4000/v1
+      LITELLM_API_KEY: ${LITELLM_API_KEY:-sk-codex-loopback}
+      # Subscription model served over the Codex Responses backend. Agents run
+      # on the ChatGPT subscription — no Claude, no keyed providers.
+      APE_CHAT_BRIDGE_MODEL: ${APE_CHAT_BRIDGE_MODEL:-gpt-5}
       # Container is the sandbox — no DDISA/escapes layer. Tells the
       # nest's pm2-supervisor to shell to `sudo -u <agent>` instead of
       # `apes run --as <agent>`, and the agent-tool runApeShell helper

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -42,7 +42,8 @@
     "@openape/core": "workspace:*",
     "@simplewebauthn/server": "^13",
     "@simplewebauthn/types": "^12",
-    "jose": "^5.9.0"
+    "jose": "^5.9.0",
+    "ofetch": "^1.4.1"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/codex-proxy/src/bin.ts
+++ b/packages/codex-proxy/src/bin.ts
@@ -1,0 +1,19 @@
+import { createCodexProxyServer } from './server'
+
+// Standalone entry: the nest starts this on loopback (replaces the litellm
+// container). Non-blocking — serves /health immediately and only fails a chat
+// request until the Codex credential is seeded at CODEX_CREDENTIAL_PATH.
+
+const port = Number(process.env.CODEX_PROXY_PORT ?? process.env.PORT ?? 4000)
+const host = process.env.CODEX_PROXY_HOST ?? '127.0.0.1'
+const credentialPath = process.env.CODEX_CREDENTIAL_PATH
+
+if (!credentialPath) {
+  console.error('codex-proxy: CODEX_CREDENTIAL_PATH is required')
+  process.exit(1)
+}
+
+const server = createCodexProxyServer({ credentialPath, originator: process.env.CODEX_ORIGINATOR })
+server.listen(port, host, () => {
+  console.log(`codex-proxy listening on http://${host}:${port} (credential: ${credentialPath})`)
+})

--- a/packages/codex-proxy/tsup.config.ts
+++ b/packages/codex-proxy/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup'
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  entry: ['src/index.ts', 'src/bin.ts'],
   format: ['esm'],
   target: 'node20',
   platform: 'node',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -199,7 +199,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/coverage-istanbul@4.1.7)(happy-dom@18.0.1)(vite@8.0.14(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2)(yaml@2.9.0))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/coverage-istanbul@4.1.7)(happy-dom@18.0.1)(vite@8.0.14(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2)(yaml@2.9.0))
 
   apps/openape-chat:
     dependencies:
@@ -808,6 +808,9 @@ importers:
       jose:
         specifier: ^5.9.0
         version: 5.10.0
+      ofetch:
+        specifier: ^1.4.1
+        version: 1.5.1
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -885,7 +888,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.8.0)(@vitest/coverage-istanbul@4.1.7)(happy-dom@18.0.1)(vite@8.0.14(@types/node@25.8.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2)(yaml@2.9.0))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.8.0)(@vitest/coverage-istanbul@4.1.7)(happy-dom@18.0.1)(vite@8.0.14(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2)(yaml@2.9.0))
 
   packages/core:
     dependencies:
@@ -16675,7 +16678,7 @@ snapshots:
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.59.3(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       typescript: 5.9.3
-      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/coverage-istanbul@4.1.7)(happy-dom@18.0.1)(vite@8.0.14(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2)(yaml@2.9.0))
+      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/coverage-istanbul@4.1.7)(happy-dom@18.0.1)(vite@8.0.14(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -16687,6 +16690,14 @@ snapshots:
       '@vitest/utils': 4.1.7
       chai: 6.2.2
       tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.7(vite@8.0.14(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.7
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.14(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2)(yaml@2.9.0)
 
   '@vitest/mocker@4.1.7(vite@8.0.14(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2)(yaml@2.9.0))':
     dependencies:
@@ -23570,6 +23581,22 @@ snapshots:
       tsx: 4.22.2
       yaml: 2.9.0
 
+  vite@8.0.14(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2)(yaml@2.9.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rolldown: 1.0.2
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 22.19.19
+      esbuild: 0.27.7
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      terser: 5.47.1
+      tsx: 4.22.2
+      yaml: 2.9.0
+
   vite@8.0.14(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
@@ -23617,6 +23644,36 @@ snapshots:
       terser: 5.47.1
       tsx: 4.22.2
       yaml: 2.9.0
+
+  vitest@4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/coverage-istanbul@4.1.7)(happy-dom@18.0.1)(vite@8.0.14(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.7
+      '@vitest/mocker': 4.1.7(vite@8.0.14(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/runner': 4.1.7
+      '@vitest/snapshot': 4.1.7
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.14(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 22.19.19
+      '@vitest/coverage-istanbul': 4.1.7(vitest@4.1.7)
+      happy-dom: 18.0.1
+    transitivePeerDependencies:
+      - msw
 
   vitest@4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/coverage-istanbul@4.1.7)(happy-dom@18.0.1)(vite@8.0.14(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.2)(yaml@2.9.0)):
     dependencies:


### PR DESCRIPTION
## M3.4 — Nest-Integration: in-nest Codex-Proxy ersetzt litellm

Schließt den **Codex-Pfad** ab (ape-plan `01KTCBFW55BKHY7F2HHE25TZ3G`). Der Nest startet jetzt `@openape/codex-proxy` auf seinem eigenen Loopback `127.0.0.1:4000` — ein dünner OpenAI-kompatibler Shim über das Codex-Responses-Backend einer **ChatGPT-Subscription**. Der separate `openape-llm`/litellm-Container fällt weg (er blockierte den Pod-Start mit einem Device-Code-Prompt). **Subscription-only — kein Claude, kein keyed Fallback.**

### Änderungen
- **codex-proxy**: zweiter tsup-Entry `src/bin.ts` → `dist/bin.js` (Standalone-Launcher; liest `CODEX_CREDENTIAL_PATH`/`CODEX_PROXY_PORT`/`HOST`).
- **nest entrypoint**: startet den Proxy auf `127.0.0.1:4000` vor `exec` des Nest, in einer Restart-Loop; Seed-Dir `1777` damit der non-root-Agent `auth.json` seeden kann. **Non-blocking**.
- **Dockerfile**: Build über **turbo** (dependency-graph-aware) statt der `pnpm --filter X build`-Kette, die apes' `shapes`/`agent-runtime`-Deps nicht zuerst baute → deterministischer **TS2307**. codex-proxy deploy + COPY ins Runtime-Image.
- **compose**: `openape-llm`-Service raus; `LITELLM_BASE_URL → http://127.0.0.1:4000/v1`; Default-Model `gpt-5`.
- **troop**: Seed-Ziel `CHATGPT_AUTH_FILE_PATH = /var/lib/openape/codex/auth.json`; litellm-Sediment umbenannt (`toCodexAuthJson`, `CodexAuthJson`).
- **auth**: deklariert die `ofetch`-Dependency, die `idp/client-metadata.ts` importiert (war nur via Hoisting auflösbar → brach den isolierten Docker-Build). Patch-Changeset.

### Verifikation
| Check | Ergebnis |
|---|---|
| codex-proxy build / 29 tests / typecheck / lint | ✅ grün |
| troop 169 tests / lint / typecheck | ✅ grün |
| nest Docker-Image build | ✅ 13/13 turbo-Tasks, image exported |
| Proxy startet **non-blocking** | ✅ `/health` → `{"ok":true}` |
| Chat ohne Credential **hängt nicht** | ✅ `HTTP 502 in 0.0008s` → `ENOENT … /var/lib/openape/codex/auth.json` |
| Seed-Dir Perms | ✅ `drwxrwxrwt` (1777) |

```
$ docker exec nest curl -s http://127.0.0.1:4000/health
{"ok":true}
$ docker exec nest curl -s -w "HTTP %{http_code} in %{time_total}s\n" \
    -XPOST http://127.0.0.1:4000/v1/chat/completions -d '{"model":"gpt-5","messages":[{"role":"user","content":"hi"}]}'
HTTP 502 in 0.000793s
{"error":{"message":"ENOENT: no such file or directory, open '/var/lib/openape/codex/auth.json'"}}
```

### Offen (M3.5 — Patricks Live-Test, nicht TDD-bar)
Connect ChatGPT → Device-Login bei OpenAI → Troop sealt auth.json an Agent-Pubkey → Agent seedet `/var/lib/openape/codex/auth.json` → Agent antwortet via GPT-5 über den Proxy. **Seed/Refresh-Edge:** Agent (non-root) seedet seed-once; Proxy (root) refresht in-place — erstes Refresh flippt das File auf `root:0600`, daher ist Rotation-nach-Refresh durch einen non-root-Agent der eine offene Live-Edge-Case.

Refs #573.
