### PR TITLE
fix(troop): subscription-only hatch bundles, drop litellm provisioning (M3.4)

### DIFF
--- a/apps/openape-troop/server/utils/hatch-bundle.ts
+++ b/apps/openape-troop/server/utils/hatch-bundle.ts
@@ -1,8 +1,21 @@
-import { randomBytes } from 'node:crypto'
-
 // Pure builder functions for the hatch compose + env bundles.
 // Extracted from the handler files so they can be unit-tested without
 // Nitro auto-imports (defineEventHandler, useRuntimeConfig).
+//
+// Subscription-only (M3.4): the nest image runs an in-process Codex proxy on
+// its own loopback:4000, so a hatched pod is a SINGLE container — no separate
+// litellm/LLM service, no provider API keys. The ChatGPT credential is seeded
+// via troop's "Connect ChatGPT" flow once the nest is online.
+
+// OpenAI-compatible base URL the per-agent bridges talk to: the in-nest
+// codex-proxy on loopback. (Env name stays LITELLM_* for bridge back-compat;
+// the target is the codex-proxy, not litellm.) The API key is a loopback dummy
+// — the proxy ignores Authorization and authenticates to OpenAI with the
+// seeded ChatGPT credential.
+const CODEX_PROXY_BASE_URL = 'http://127.0.0.1:4000/v1'
+const CODEX_PROXY_API_KEY = 'sk-codex-loopback'
+// Default subscription model served over the Codex Responses backend.
+const DEFAULT_BRIDGE_MODEL = 'gpt-5'
 
 /**
  * Build the docker-compose YAML for a BYO nest bundle.
@@ -20,25 +33,16 @@ export function buildNestComposeYaml(opts: {
 #   docker compose up -d
 # Then verify on this troop instance — the host appears in
 # /api/nest/hosts within ~5s of bootup.
+#
+# Subscription-only: the nest runs an in-process Codex proxy on its own
+# loopback:4000 — no separate LLM container. The ChatGPT credential is
+# seeded via troop's "Connect ChatGPT" flow after the nest is online.
 
 services:
-  openape-llm:
-    image: ghcr.io/openape-ai/openape-llm:latest
-    container_name: openape-llm
-    restart: unless-stopped
-    networks: [openape-pod]
-    ports: ["127.0.0.1:4000:4000"]
-    volumes: ["./litellm.yaml:/etc/litellm/config.yaml:ro"]
-    environment:
-      LITELLM_MASTER_KEY: \${LITELLM_MASTER_KEY}
-      ANTHROPIC_API_KEY: \${ANTHROPIC_API_KEY}
-      CHATGPT_OAUTH_TOKEN: \${CHATGPT_OAUTH_TOKEN}
-
   openape-nest:
     image: ghcr.io/openape-ai/openape-nest:latest
     container_name: openape-nest
     restart: unless-stopped
-    depends_on: [openape-llm]
     networks: [openape-pod]
     ports: ["127.0.0.1:9091:9091"]
     volumes:
@@ -50,9 +54,9 @@ services:
       OPENAPE_HATCH_TOKEN: ${opts.hatchToken}
       OPENAPE_HATCH_OWNER: ${opts.ownerEmail}
       OPENAPE_BRIDGE_TARGET: troop
-      LITELLM_BASE_URL: http://openape-llm:4000/v1
-      LITELLM_API_KEY: \${LITELLM_MASTER_KEY}
-      APE_CHAT_BRIDGE_MODEL: \${APE_CHAT_BRIDGE_MODEL:-claude-haiku-4-5}
+      LITELLM_BASE_URL: ${CODEX_PROXY_BASE_URL}
+      LITELLM_API_KEY: ${CODEX_PROXY_API_KEY}
+      APE_CHAT_BRIDGE_MODEL: \${APE_CHAT_BRIDGE_MODEL:-${DEFAULT_BRIDGE_MODEL}}
 
 volumes:
   openape-nest-data:
@@ -69,23 +73,10 @@ networks:
  */
 export function buildPodComposeYaml(opts: { troopUrl: string, ownerEmail: string, hatchToken: string }): string {
   return `services:
-  openape-llm:
-    image: ghcr.io/openape-ai/openape-llm:latest
-    container_name: openape-llm
-    restart: unless-stopped
-    networks: [openape-pod]
-    ports: ["127.0.0.1:4000:4000"]
-    volumes: ["./litellm.yaml:/etc/litellm/config.yaml:ro"]
-    environment:
-      LITELLM_MASTER_KEY: \${LITELLM_MASTER_KEY}
-      ANTHROPIC_API_KEY: \${ANTHROPIC_API_KEY}
-      CHATGPT_OAUTH_TOKEN: \${CHATGPT_OAUTH_TOKEN}
-
   openape-nest:
     image: ghcr.io/openape-ai/openape-nest:latest
     container_name: openape-nest
     restart: unless-stopped
-    depends_on: [openape-llm]
     networks: [openape-pod]
     ports: ["127.0.0.1:9091:9091"]
     volumes:
@@ -97,8 +88,9 @@ export function buildPodComposeYaml(opts: { troopUrl: string, ownerEmail: string
       OPENAPE_HATCH_TOKEN: ${opts.hatchToken}
       OPENAPE_HATCH_OWNER: ${opts.ownerEmail}
       OPENAPE_BRIDGE_TARGET: troop
-      LITELLM_BASE_URL: http://openape-llm:4000/v1
-      LITELLM_API_KEY: \${LITELLM_MASTER_KEY}
+      LITELLM_BASE_URL: ${CODEX_PROXY_BASE_URL}
+      LITELLM_API_KEY: ${CODEX_PROXY_API_KEY}
+      APE_CHAT_BRIDGE_MODEL: \${APE_CHAT_BRIDGE_MODEL:-${DEFAULT_BRIDGE_MODEL}}
 
 volumes:
   openape-nest-data:
@@ -110,29 +102,21 @@ networks:
 }
 
 /**
- * Build the .env file for a pod bundle. Provider API keys are
- * injected here; OPENAPE_* vars belong in the compose environment:
+ * Build the .env file for a pod bundle. Subscription-only: the model is the
+ * only knob — no provider API keys (agents run on the ChatGPT subscription via
+ * the in-nest codex-proxy). OPENAPE_* vars belong in the compose environment:
  * block (not .env) so they can't be accidentally overridden.
  */
 export function buildPodEnvFile(secrets: Record<string, string>): string {
-  const lines = [
-    `LITELLM_MASTER_KEY=sk-litellm-${randomBytes(8).toString('hex')}`,
-    `ANTHROPIC_API_KEY=${secrets.ANTHROPIC_API_KEY ?? ''}`,
-    `CHATGPT_OAUTH_TOKEN=${secrets.CHATGPT_OAUTH_TOKEN ?? ''}`,
-    `APE_CHAT_BRIDGE_MODEL=${secrets.APE_CHAT_BRIDGE_MODEL ?? 'claude-haiku-4-5'}`,
-  ]
-  return `${lines.join('\n')}\n`
+  return `APE_CHAT_BRIDGE_MODEL=${secrets.APE_CHAT_BRIDGE_MODEL ?? DEFAULT_BRIDGE_MODEL}\n`
 }
 
 /**
- * Build the .env file for the BYO nest bundle. Intentionally minimal —
- * provider keys that vary per operator are placeholders to fill in.
+ * Build the .env file for the BYO nest bundle. Subscription-only — the only
+ * knob is the model; override it before `docker compose up` if you like.
  */
 export function buildNestEnvFile(): string {
-  return `# Copy to .env next to docker-compose.yml. Fill in provider keys.
-LITELLM_MASTER_KEY=sk-litellm-${randomBytes(8).toString('hex')}
-ANTHROPIC_API_KEY=
-CHATGPT_OAUTH_TOKEN=
-APE_CHAT_BRIDGE_MODEL=claude-haiku-4-5
+  return `# Copy to .env next to docker-compose.yml. Override the model if you like.
+APE_CHAT_BRIDGE_MODEL=${DEFAULT_BRIDGE_MODEL}
 `
 }

--- a/apps/openape-troop/tests/hatch-bundle.test.ts
+++ b/apps/openape-troop/tests/hatch-bundle.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import { buildNestComposeYaml, buildPodComposeYaml, buildPodEnvFile } from '../server/utils/hatch-bundle'
 
-// These tests verify that every hatch bundle that ships to a new Docker nest
-// includes OPENAPE_BRIDGE_TARGET=troop. Without it the bridge defaults to
-// 'chat', connecting to chat.openape.ai instead of the troop WS — the nest
-// would appear online but never be controlled by the troop owner.
+// These tests verify the hatch bundles that ship to a new Docker nest:
+// (1) the bridge targets troop (not chat), and (2) the bundle is
+// subscription-only — no separate litellm container, the in-nest codex-proxy
+// on 127.0.0.1:4000 is the model source (M3.4: #575 for compose, #576 here).
 
 describe('nest/hatch bundle (BYO Docker path)', () => {
   const yaml = buildNestComposeYaml({
@@ -33,6 +33,25 @@ describe('nest/hatch bundle (BYO Docker path)', () => {
   it('does not reference chat.openape.ai (bridge target is troop, not chat)', () => {
     expect(yaml).not.toContain('chat.openape.ai')
   })
+
+  it('does not provision a separate litellm container (codex-proxy is in-nest)', () => {
+    expect(yaml).not.toContain('openape-llm')
+    expect(yaml).not.toContain('litellm.yaml')
+  })
+
+  it('points the bridge at the in-nest codex-proxy on loopback', () => {
+    expect(yaml).toContain('LITELLM_BASE_URL: http://127.0.0.1:4000/v1')
+  })
+
+  it('embeds no keyed provider secrets (subscription-only)', () => {
+    expect(yaml).not.toContain('ANTHROPIC_API_KEY')
+    expect(yaml).not.toContain('CHATGPT_OAUTH_TOKEN')
+  })
+
+  it('defaults the bridge model to gpt-5 (no Claude)', () => {
+    expect(yaml).toContain('gpt-5')
+    expect(yaml).not.toContain('claude-haiku')
+  })
 })
 
 describe('pod/hatch bundle (cloud-provisioned Docker path)', () => {
@@ -57,6 +76,15 @@ describe('pod/hatch bundle (cloud-provisioned Docker path)', () => {
   it('does not reference chat.openape.ai (bridge target is troop, not chat)', () => {
     expect(yaml).not.toContain('chat.openape.ai')
   })
+
+  it('does not provision a separate litellm container (codex-proxy is in-nest)', () => {
+    expect(yaml).not.toContain('openape-llm')
+    expect(yaml).not.toContain('litellm.yaml')
+  })
+
+  it('points the bridge at the in-nest codex-proxy on loopback', () => {
+    expect(yaml).toContain('LITELLM_BASE_URL: http://127.0.0.1:4000/v1')
+  })
 })
 
 describe('pod/hatch env file', () => {
@@ -65,7 +93,7 @@ describe('pod/hatch env file', () => {
     // not from the .env file. If it were in .env it could be accidentally
     // overridden. The compose environment: block takes precedence anyway, but
     // this confirms the split is intentional.
-    const env = buildPodEnvFile({ ANTHROPIC_API_KEY: 'sk-ant-x', CHATGPT_OAUTH_TOKEN: '' })
+    const env = buildPodEnvFile({ APE_CHAT_BRIDGE_MODEL: 'gpt-5' })
     expect(env).not.toContain('OPENAPE_BRIDGE_TARGET')
   })
 
@@ -74,8 +102,16 @@ describe('pod/hatch env file', () => {
     expect(env).toContain('APE_CHAT_BRIDGE_MODEL=gpt-5.4')
   })
 
-  it('defaults model to claude-haiku-4-5 when not in secrets', () => {
+  it('defaults model to gpt-5 when not in secrets (no Claude)', () => {
     const env = buildPodEnvFile({})
-    expect(env).toContain('APE_CHAT_BRIDGE_MODEL=claude-haiku-4-5')
+    expect(env).toContain('APE_CHAT_BRIDGE_MODEL=gpt-5')
+    expect(env).not.toContain('claude-haiku')
+  })
+
+  it('embeds no keyed provider secrets (subscription-only)', () => {
+    const env = buildPodEnvFile({ ANTHROPIC_API_KEY: 'sk-ant-x', CHATGPT_OAUTH_TOKEN: 'tok-y' })
+    expect(env).not.toContain('ANTHROPIC_API_KEY')
+    expect(env).not.toContain('CHATGPT_OAUTH_TOKEN')
+    expect(env).not.toContain('sk-ant-x')
   })
 })


### PR DESCRIPTION
## Finish the litellm drop on the **provisioning** path (#576)

M3.4 (#575) collapsed litellm into the in-nest codex-proxy for the local dev compose, but `apps/openape-troop/server/utils/hatch-bundle.ts` — the builders Troop uses to provision **real** pods — still emitted a full `openape-llm` service + `LITELLM_BASE_URL: http://openape-llm:4000/v1` + `litellm.yaml` mount + keyed env + a `claude-haiku-4-5` default. So troop-provisioned pods would still run litellm and default to Claude.

### Changes (TDD on the unit-tested builders)
- `buildNestComposeYaml` + `buildPodComposeYaml`: single `openape-nest` container — drop the `openape-llm` service, `depends_on`, and `litellm.yaml` mount; `LITELLM_BASE_URL → http://127.0.0.1:4000/v1` (in-nest proxy); `LITELLM_API_KEY` loopback dummy; `APE_CHAT_BRIDGE_MODEL` default → `gpt-5`.
- `buildPodEnvFile` + `buildNestEnvFile`: subscription-only — drop `LITELLM_MASTER_KEY` / `ANTHROPIC_API_KEY` / `CHATGPT_OAUTH_TOKEN`; model knob only, default `gpt-5`.
- `hatch-bundle.test.ts`: assert no `openape-llm` / `litellm.yaml`, loopback URL, `gpt-5` default, and that legacy keyed secrets passed to `buildPodEnvFile` are dropped.

### Verification
- troop **176 tests** pass (incl. the new subscription-only assertions), lint + typecheck clean.
- Rendered `buildPodComposeYaml` is a single `openape-nest` service with `LITELLM_BASE_URL: http://127.0.0.1:4000/v1` + `APE_CHAT_BRIDGE_MODEL: ${APE_CHAT_BRIDGE_MODEL:-gpt-5}`; `buildPodEnvFile({ANTHROPIC_API_KEY,CHATGPT_OAUTH_TOKEN})` → `APE_CHAT_BRIDGE_MODEL=gpt-5` only (keyed secrets dropped).

### Out of scope (follow-up cleanup)
The now-dead `litellm_yaml` cloud-init plumbing in `pod/hatch.post.ts` + `cloud/exoscale.ts` (a hatched pod just ignores the unused file), and removing the `apps/openape-llm` app dir.

Closes #576.
