### PR TITLE
fix(troop): pull nest image from registry.openape.ai (not ghcr)

### DIFF
--- a/apps/openape-troop/server/utils/hatch-bundle.ts
+++ b/apps/openape-troop/server/utils/hatch-bundle.ts
@@ -16,6 +16,9 @@ const CODEX_PROXY_BASE_URL = 'http://127.0.0.1:4000/v1'
 const CODEX_PROXY_API_KEY = 'sk-codex-loopback'
 // Default subscription model served over the Codex Responses backend.
 const DEFAULT_BRIDGE_MODEL = 'gpt-5'
+// Nest image, pulled from our self-hosted registry on chatty. Anonymous pull,
+// so hatched pods need no registry credentials (replaced ghcr.io).
+const NEST_IMAGE = 'registry.openape.ai/openape-nest:latest'
 
 /**
  * Build the docker-compose YAML for a BYO nest bundle.
@@ -40,7 +43,7 @@ export function buildNestComposeYaml(opts: {
 
 services:
   openape-nest:
-    image: ghcr.io/openape-ai/openape-nest:latest
+    image: ${NEST_IMAGE}
     container_name: openape-nest
     restart: unless-stopped
     networks: [openape-pod]
@@ -74,7 +77,7 @@ networks:
 export function buildPodComposeYaml(opts: { troopUrl: string, ownerEmail: string, hatchToken: string }): string {
   return `services:
   openape-nest:
-    image: ghcr.io/openape-ai/openape-nest:latest
+    image: ${NEST_IMAGE}
     container_name: openape-nest
     restart: unless-stopped
     networks: [openape-pod]

--- a/apps/openape-troop/tests/hatch-bundle.test.ts
+++ b/apps/openape-troop/tests/hatch-bundle.test.ts
@@ -52,6 +52,11 @@ describe('nest/hatch bundle (BYO Docker path)', () => {
     expect(yaml).toContain('gpt-5')
     expect(yaml).not.toContain('claude-haiku')
   })
+
+  it('pulls the nest image from the self-hosted registry (not ghcr)', () => {
+    expect(yaml).toContain('image: registry.openape.ai/openape-nest:latest')
+    expect(yaml).not.toContain('ghcr.io')
+  })
 })
 
 describe('pod/hatch bundle (cloud-provisioned Docker path)', () => {
@@ -84,6 +89,11 @@ describe('pod/hatch bundle (cloud-provisioned Docker path)', () => {
 
   it('points the bridge at the in-nest codex-proxy on loopback', () => {
     expect(yaml).toContain('LITELLM_BASE_URL: http://127.0.0.1:4000/v1')
+  })
+
+  it('pulls the nest image from the self-hosted registry (not ghcr)', () => {
+    expect(yaml).toContain('image: registry.openape.ai/openape-nest:latest')
+    expect(yaml).not.toContain('ghcr.io')
   })
 })
 


### PR DESCRIPTION
Now that we self-host a container registry on chatty (`registry.openape.ai`, anonymous-pull / authed-push, behind nginx+certbot), the hatch-bundle compose builders pull the nest image from there instead of ghcr.

- Both `buildNestComposeYaml` + `buildPodComposeYaml` use one shared `NEST_IMAGE = registry.openape.ai/openape-nest:latest` constant (was `ghcr.io/openape-ai/openape-nest:latest`, duplicated).
- Anonymous pull ⇒ hatched pods need no registry credentials.

**Verify:** troop 178 tests (incl. new registry-image assertions on both bundles) + lint + typecheck green. Rendered pod compose shows `image: registry.openape.ai/openape-nest:latest`. The registry already serves the amd64 image (`/v2/openape-nest/tags/list` → `[5a79eda7, latest]`).

Closes #578.