### PR TITLE
feat(codex-proxy): agent-robustness — tool-schema sanitizer + /v1/models

### DIFF
--- a/packages/codex-proxy/src/codex-models.ts
+++ b/packages/codex-proxy/src/codex-models.ts
@@ -1,0 +1,79 @@
+import type { CodexCredential } from './codex-credential'
+
+// Model discovery against the same private Codex backend the Responses endpoint
+// uses. Lets agents list what they can target via `GET /v1/models`.
+// Shape + fallback ported from NousResearch/hermes-agent `codex_models.py`.
+
+export const CODEX_MODELS_URL = 'https://chatgpt.com/backend-api/codex/models?client_version=1.0.0'
+
+// Known-good current models, served when the live endpoint is unreachable or
+// empty so discovery never hands back an empty list. gpt-5.5 is current.
+export const FALLBACK_CODEX_MODELS: readonly string[] = [
+  'gpt-5.5',
+  'gpt-5.4-mini',
+  'gpt-5.4',
+  'gpt-5.3-codex',
+  'gpt-5.3-codex-spark',
+]
+
+const HIDDEN_VISIBILITIES = new Set(['hide', 'hidden'])
+const DEFAULT_PRIORITY = 10_000
+
+interface RawCodexModel {
+  slug?: unknown
+  visibility?: unknown
+  priority?: unknown
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+/**
+ * Extract visible model slugs from a raw `/codex/models` payload, sorted by
+ * priority (ascending, default 10000) then slug. Returns `[]` for anything
+ * unparseable — the caller decides whether to fall back.
+ */
+export function parseCodexModels(payload: unknown): string[] {
+  if (!isObject(payload) || !Array.isArray(payload.models))
+    return []
+
+  const visible = payload.models
+    .filter((m): m is RawCodexModel => isObject(m))
+    .filter(m => typeof m.slug === 'string' && !HIDDEN_VISIBILITIES.has(String(m.visibility)))
+    .map(m => ({ slug: m.slug as string, priority: typeof m.priority === 'number' ? m.priority : DEFAULT_PRIORITY }))
+    .sort((a, b) => a.priority - b.priority || a.slug.localeCompare(b.slug))
+
+  return [...new Set(visible.map(m => m.slug))]
+}
+
+interface ModelsFetchResponse {
+  ok: boolean
+  status: number
+  json: () => Promise<unknown>
+}
+type ModelsFetchLike = (url: string, init: { headers: Record<string, string> }) => Promise<ModelsFetchResponse>
+
+/**
+ * Fetch the current Codex model slugs. Always resolves to a usable list:
+ * on any HTTP/parse failure or an empty live list it degrades to
+ * {@link FALLBACK_CODEX_MODELS}, logging the reason so the fallback is visible
+ * in the service journal rather than silent.
+ */
+export async function fetchCodexModels(cred: CodexCredential, fetchImpl: ModelsFetchLike = fetch): Promise<string[]> {
+  try {
+    const res = await fetchImpl(CODEX_MODELS_URL, {
+      headers: { authorization: `Bearer ${cred.access_token}`, 'chatgpt-account-id': cred.account_id },
+    })
+    if (!res.ok)
+      throw new Error(`codex models HTTP ${res.status}`)
+    const slugs = parseCodexModels(await res.json())
+    if (slugs.length === 0)
+      throw new Error('codex models response had no visible models')
+    return slugs
+  }
+  catch (e) {
+    console.warn(`[codex-proxy] /codex/models unavailable, using fallback list: ${e instanceof Error ? e.message : String(e)}`)
+    return [...FALLBACK_CODEX_MODELS]
+  }
+}

--- a/packages/codex-proxy/src/responses-request.ts
+++ b/packages/codex-proxy/src/responses-request.ts
@@ -1,4 +1,5 @@
 import type { ChatCompletionsRequest, ChatMessage, ResponsesBody, ResponsesInputItem, ResponsesTool } from './types'
+import { sanitizeToolParameters } from './schema-sanitizer'
 
 // Chat-Completions request → Codex Responses request body. Shapes per OpenClaw's
 // `convertResponsesMessages` / `convertResponsesTools` / `buildRequestBody`:
@@ -52,7 +53,7 @@ export function chatCompletionsToResponsesBody(req: ChatCompletionsRequest): Res
     // Lift name/description/parameters out of the `function` wrapper; sort by
     // name so the prompt-cache key bytes are stable across turns.
     body.tools = req.tools
-      .map((t): ResponsesTool => ({ type: 'function', name: t.function.name, description: t.function.description, parameters: t.function.parameters ?? {} }))
+      .map((t): ResponsesTool => ({ type: 'function', name: t.function.name, description: t.function.description, parameters: sanitizeToolParameters(t.function.parameters ?? {}) }))
       .sort((a, b) => a.name.localeCompare(b.name))
   }
 

--- a/packages/codex-proxy/src/schema-sanitizer.ts
+++ b/packages/codex-proxy/src/schema-sanitizer.ts
@@ -1,0 +1,105 @@
+// The Codex Responses backend validates each function tool's `parameters`
+// schema more strictly than the Chat-Completions spec agents emit against:
+//
+//  1. The top-level schema must be a plain object. A top-level combinator
+//     (`allOf`/`anyOf`/`oneOf`/`enum`/`not`) — which MCP tools routinely add for
+//     conditional-required hints — is rejected with
+//     "Invalid schema for function 'X': schema must have type 'object'".
+//  2. Nullable unions expressed as a `{type:'null'}` branch or a `type:['X','null']`
+//     array are rejected; the backend wants a single type plus a `nullable` hint.
+//
+// `sanitizeToolParameters` rewrites a schema into the accepted shape without
+// changing what it means to the model. It first collapses nullable unions
+// (bottom-up, so nested ones are caught), then strips the top-level combinators.
+// Collapsing runs first because a top-level nullable union carries the real
+// schema in its non-null branch — stripping it blindly would discard that.
+//
+// Ported from NousResearch/hermes-agent (`tools/schema_sanitizer.py`).
+
+const TOP_LEVEL_COMBINATORS: readonly string[] = ['allOf', 'anyOf', 'oneOf', 'enum', 'not']
+const NULLABLE_UNION_KEYS: readonly string[] = ['anyOf', 'oneOf']
+
+function isObject(node: unknown): node is Record<string, unknown> {
+  return typeof node === 'object' && node !== null && !Array.isArray(node)
+}
+
+function isNullSchema(node: unknown): boolean {
+  return isObject(node) && node.type === 'null'
+}
+
+// `type: ['string', 'null']` → the single non-null type, or null if not a
+// simple nullable pair (e.g. `['string', 'number']` stays a union).
+function collapsibleNonNullType(types: unknown[]): unknown | null {
+  if (!types.includes('null'))
+    return null
+  const nonNull = types.filter(t => t !== 'null')
+  return nonNull.length === 1 ? nonNull[0] : null
+}
+
+// `anyOf: [{...}, {type:'null'}]` → the single non-null branch, or null if the
+// union isn't a simple nullable wrapper around exactly one schema.
+function collapsibleNonNullBranch(branches: unknown[]): Record<string, unknown> | null {
+  if (!branches.some(isNullSchema))
+    return null
+  const nonNull = branches.filter(b => !isNullSchema(b))
+  return nonNull.length === 1 && isObject(nonNull[0]) ? nonNull[0] : null
+}
+
+function collapseObjectNode(node: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(node))
+    result[key] = sanitizeNode(value)
+
+  if (Array.isArray(result.type)) {
+    const nonNullType = collapsibleNonNullType(result.type)
+    if (nonNullType !== null) {
+      result.type = nonNullType
+      result.nullable = true
+    }
+  }
+
+  for (const key of NULLABLE_UNION_KEYS) {
+    if (!Array.isArray(result[key]))
+      continue
+    const branch = collapsibleNonNullBranch(result[key])
+    if (!branch)
+      continue
+    delete result[key]
+    // Merge the surviving branch up, but let the parent's own annotations
+    // (description, title, …) win over the branch's.
+    for (const [k, v] of Object.entries(branch)) {
+      if (!(k in result))
+        result[k] = v
+    }
+    result.nullable = true
+  }
+
+  return result
+}
+
+function sanitizeNode(node: unknown): unknown {
+  if (Array.isArray(node))
+    return node.map(sanitizeNode)
+  if (isObject(node))
+    return collapseObjectNode(node)
+  return node
+}
+
+function stripTopLevelCombinators(node: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(node)) {
+    if (!TOP_LEVEL_COMBINATORS.includes(key))
+      result[key] = value
+  }
+  return result
+}
+
+/**
+ * Rewrite a function tool's JSON-Schema `parameters` into the shape the Codex
+ * Responses backend accepts: nullable unions collapsed to a single type plus a
+ * `nullable` hint, and top-level combinators removed. Returns a deep copy — the
+ * input is never mutated.
+ */
+export function sanitizeToolParameters(params: Record<string, unknown>): Record<string, unknown> {
+  return stripTopLevelCombinators(collapseObjectNode(params))
+}

--- a/packages/codex-proxy/src/server.ts
+++ b/packages/codex-proxy/src/server.ts
@@ -2,6 +2,7 @@ import type { IncomingMessage, Server } from 'node:http'
 import type { ChatCompletionsRequest } from './types'
 import { createServer } from 'node:http'
 import { postCodexResponses } from './codex-client'
+import { fetchCodexModels } from './codex-models'
 import { CodexCredentialStore } from './credential-store'
 import { streamChatCompletion } from './proxy'
 
@@ -40,6 +41,21 @@ export function createCodexProxyServer(opts: CodexProxyOptions): Server {
     if (req.method === 'GET' && req.url === '/health') {
       res.writeHead(200, { 'content-type': 'application/json' })
       res.end('{"ok":true}')
+      return
+    }
+    if (req.method === 'GET' && req.url === '/v1/models') {
+      try {
+        const cred = await store.get()
+        const created = Math.floor(Date.now() / 1000)
+        const data = (await fetchCodexModels(cred)).map(id => ({ id, object: 'model', created, owned_by: 'openai' }))
+        res.writeHead(200, { 'content-type': 'application/json' })
+        res.end(JSON.stringify({ object: 'list', data }))
+      }
+      catch (e) {
+        const message = e instanceof Error ? e.message : String(e)
+        res.writeHead(502, { 'content-type': 'application/json' })
+        res.end(JSON.stringify({ error: { message } }))
+      }
       return
     }
     if (req.method !== 'POST' || !req.url?.startsWith('/v1/chat/completions')) {

--- a/packages/codex-proxy/test/codex-models.test.ts
+++ b/packages/codex-proxy/test/codex-models.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest'
+import { FALLBACK_CODEX_MODELS, fetchCodexModels, parseCodexModels } from '../src/codex-models'
+
+const cred = { access_token: 'AT', refresh_token: 'r', id_token: 'i', expires_at: 1, account_id: 'acc-7' }
+
+describe('parseCodexModels', () => {
+  it('extracts visible slugs sorted by priority then slug', () => {
+    const slugs = parseCodexModels({
+      models: [
+        { slug: 'gpt-5.4', priority: 20 },
+        { slug: 'gpt-5.5', priority: 10 },
+        { slug: 'gpt-5.4-mini', priority: 20 },
+      ],
+    })
+    expect(slugs).toEqual(['gpt-5.5', 'gpt-5.4', 'gpt-5.4-mini'])
+  })
+
+  it('drops hidden models (visibility hide/hidden)', () => {
+    const slugs = parseCodexModels({
+      models: [
+        { slug: 'gpt-5.5', priority: 1 },
+        { slug: 'secret', priority: 0, visibility: 'hidden' },
+        { slug: 'legacy', priority: 2, visibility: 'hide' },
+      ],
+    })
+    expect(slugs).toEqual(['gpt-5.5'])
+  })
+
+  it('dedups repeated slugs', () => {
+    expect(parseCodexModels({ models: [{ slug: 'gpt-5.5' }, { slug: 'gpt-5.5' }] })).toEqual(['gpt-5.5'])
+  })
+
+  it('returns [] for a malformed payload', () => {
+    expect(parseCodexModels({})).toEqual([])
+    expect(parseCodexModels(null)).toEqual([])
+    expect(parseCodexModels({ models: 'nope' })).toEqual([])
+  })
+})
+
+describe('fetchCodexModels', () => {
+  it('queries the codex models endpoint with bearer auth and returns parsed slugs', async () => {
+    const fetchImpl = vi.fn(async (url: string, init: { headers: Record<string, string> }) => {
+      expect(url).toBe('https://chatgpt.com/backend-api/codex/models?client_version=1.0.0')
+      expect(init.headers.authorization).toBe('Bearer AT')
+      return { ok: true, status: 200, json: async () => ({ models: [{ slug: 'gpt-5.5', priority: 1 }] }) }
+    })
+    const slugs = await fetchCodexModels(cred, fetchImpl as unknown as typeof fetch)
+    expect(slugs).toEqual(['gpt-5.5'])
+  })
+
+  it('falls back to the known model list on HTTP error', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const fetchImpl = vi.fn(async () => ({ ok: false, status: 401, json: async () => ({}) }))
+    const slugs = await fetchCodexModels(cred, fetchImpl as unknown as typeof fetch)
+    expect(slugs).toEqual([...FALLBACK_CODEX_MODELS])
+  })
+
+  it('falls back when the live list is empty', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const fetchImpl = vi.fn(async () => ({ ok: true, status: 200, json: async () => ({ models: [] }) }))
+    const slugs = await fetchCodexModels(cred, fetchImpl as unknown as typeof fetch)
+    expect(slugs).toEqual([...FALLBACK_CODEX_MODELS])
+  })
+})

--- a/packages/codex-proxy/test/schema-sanitizer.test.ts
+++ b/packages/codex-proxy/test/schema-sanitizer.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { sanitizeToolParameters } from '../src/schema-sanitizer'
+
+describe('sanitizeToolParameters', () => {
+  it('strips top-level combinators the Codex backend rejects (allOf/anyOf/oneOf/enum/not)', () => {
+    const params = {
+      type: 'object',
+      properties: { a: { type: 'string' } },
+      // conditional required-fields hint MCP tools emit at the top level
+      allOf: [{ if: { properties: { a: { const: 'x' } } }, then: { required: ['a'] } }],
+    }
+    const out = sanitizeToolParameters(params)
+    expect(out).not.toHaveProperty('allOf')
+    expect(out.type).toBe('object')
+    expect(out.properties).toEqual({ a: { type: 'string' } })
+  })
+
+  it('preserves combinators nested inside a property (only the top level is strict)', () => {
+    const params = {
+      type: 'object',
+      properties: { a: { anyOf: [{ type: 'string' }, { type: 'number' }] } },
+    }
+    const out = sanitizeToolParameters(params)
+    expect((out.properties as { a: { anyOf?: unknown[] } }).a.anyOf).toHaveLength(2)
+  })
+
+  it('collapses a nullable anyOf union to the non-null branch + nullable hint', () => {
+    const params = {
+      type: 'object',
+      properties: { a: { anyOf: [{ type: 'string' }, { type: 'null' }], description: 'x' } },
+    }
+    const out = sanitizeToolParameters(params)
+    expect((out.properties as Record<string, unknown>).a).toEqual({ type: 'string', description: 'x', nullable: true })
+  })
+
+  it('collapses array-form nullable type ["X","null"] to X + nullable hint', () => {
+    const params = { type: 'object', properties: { a: { type: ['string', 'null'] } } }
+    const out = sanitizeToolParameters(params)
+    expect((out.properties as Record<string, unknown>).a).toEqual({ type: 'string', nullable: true })
+  })
+
+  it('recurses into array items', () => {
+    const params = { type: 'object', properties: { a: { type: 'array', items: { type: ['string', 'null'] } } } }
+    const out = sanitizeToolParameters(params)
+    expect((out.properties as { a: { items?: unknown } }).a.items).toEqual({ type: 'string', nullable: true })
+  })
+
+  it('does not mutate the input', () => {
+    const params = { type: 'object', anyOf: [{ x: 1 }], properties: { a: { type: ['string', 'null'] } } }
+    const snapshot = JSON.parse(JSON.stringify(params))
+    sanitizeToolParameters(params)
+    expect(params).toEqual(snapshot)
+  })
+
+  it('handles an empty schema', () => {
+    expect(sanitizeToolParameters({})).toEqual({})
+  })
+})


### PR DESCRIPTION
## Why

Nest agents (user- and service-agents) consume the Nest LLM via `@openape/codex-proxy` (OpenAI-compatible over the ChatGPT Codex subscription). Today every **tool-calling** agent hits the Codex Responses backend's stricter schema validation and fails with HTTP 400 (`Invalid schema for function 'X': schema must have type 'object' …`). MCP/Pydantic tools routinely emit exactly the shapes it rejects.

Learnings ported from [NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent) (`tools/schema_sanitizer.py`, `hermes_cli/codex_models.py`) — **the implementation, not the runtime**.

## What

**M1 — tool-schema sanitizer** (`src/schema-sanitizer.ts`)
- Strips top-level combinators (`allOf`/`anyOf`/`oneOf`/`enum`/`not`) the backend rejects.
- Collapses nullable unions to a single type + `nullable` hint: `anyOf:[X,{type:'null'}]` → `X`, `type:['X','null']` → `{type:'X',nullable:true}`.
- Nested combinators inside a property are preserved (only the top level is strict). Pure, deep-copy, never mutates input.
- Wired into `chatCompletionsToResponsesBody` so every forwarded tool is normalized.

**M2 — `GET /v1/models` discovery** (`src/codex-models.ts`)
- Queries `chatgpt.com/backend-api/codex/models?client_version=1.0.0`, returns visible slugs priority-sorted, OpenAI-style `{object:'list',data}`.
- Degrades to a known-good fallback list (`gpt-5.5` …) on any upstream failure, logged to the journal (observable, not silent).

## Tests
TDD throughout (RED→GREEN). Package suite **43 passed** (was 29): 7 sanitizer + 7 models. `pnpm --filter @openape/codex-proxy lint typecheck test` green.

## E2E
Deployed to chatty `codex-proxy.service` (127.0.0.1:4001, team token, gpt-5.5):
- `curl :4001/v1/models` → list incl. gpt-5.5
- `POST :4001/v1/chat/completions` with a tool whose `parameters` has a top-level `anyOf` → previously 400, now the call completes (no "Invalid schema").

Plan: `01KTGSEH4YFH1EQDM5F6E95AER` (plans.openape.ai).