### PR TITLE
fix(apes): run --as works on non-nest hosts (macOS)

### DIFF
--- a/.changeset/apes-run-as-macos.md
+++ b/.changeset/apes-run-as-macos.md
@@ -1,0 +1,5 @@
+---
+"@openape/apes": patch
+---
+
+fix(run --as): don't probe local host platform when dispatching as a remote requester. On macOS `apes run --as <user>` threw "unsupported host platform: darwin" because `resolveRunAsTarget` called `getHostPlatform()` for a Linux-only local username mapping that doesn't apply to a requester. Skip the mapping off-nest and pass the target through.

--- a/packages/apes/src/commands/run.ts
+++ b/packages/apes/src/commands/run.ts
@@ -26,7 +26,7 @@ import { CliError, CliExit } from '../errors'
 import { notifyGrantPending } from '../notifications'
 import { checkSudoRejection, isApesSelfDispatch } from '../shell/apes-self-dispatch'
 import { AGENT_NAME_REGEX } from '../lib/agent-bootstrap'
-import { getHostPlatform } from '../lib/host-platform'
+import { getHostPlatform, isLinux } from '../lib/host-platform'
 
 /**
  * Resolve an agent name (`igor`) to its OS-level username. On Linux the
@@ -46,6 +46,10 @@ function resolveRunAsTarget(runAs: string | undefined): string | undefined {
   if (!AGENT_NAME_REGEX.test(runAs)) return runAs
   // Already prefixed (operator typed the full prefixed username) — pass through.
   if (runAs.startsWith('openape-agent-')) return runAs
+  // Local agent-user prefix mapping only applies when the CLI runs on the
+  // nest host itself. As a remote requester (e.g. macOS) the target user is
+  // resolved on the nest — pass through instead of probing the local host.
+  if (!isLinux()) return runAs
   const platform = getHostPlatform()
   const prefixed = platform.agentUsername(runAs)
   if (platform.readAgentUser(prefixed)) return prefixed


### PR DESCRIPTION
## Problem
`apes run --as root --wait -- whoami` on macOS fails with:
```
Error: unsupported host platform: darwin — OpenApe nests are Linux-only
```

`resolveRunAsTarget` calls `getHostPlatform()` (Linux-only since #559) to do a *local* agent-user prefix mapping. But on the requester side the target user is resolved on the remote nest — the local mapping never applies. The throw kills any `--as` run from a Mac.

## Fix
Skip the local mapping when the CLI isn't running on a Linux nest; pass the target through.

## Verify
- `pnpm lint`/`pnpm typecheck` green
- Built CLI now proceeds to `Requesting escapes grant on …` instead of throwing